### PR TITLE
ヘルスレポートと調査のインストールをビルド設定で無効化

### DIFF
--- a/browser/moz.configure
+++ b/browser/moz.configure
@@ -5,11 +5,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 imply_option("MOZ_PLACES", True)
-imply_option("MOZ_SERVICES_HEALTHREPORT", True)
+imply_option("MOZ_SERVICES_HEALTHREPORT", False)
 imply_option("MOZ_SERVICES_SYNC", True)
 imply_option("MOZ_DEDICATED_PROFILES", True)
 imply_option("MOZ_BLOCK_PROFILE_DOWNGRADE", True)
-imply_option("MOZ_NORMANDY", True)
+imply_option("MOZ_NORMANDY", False)
 
 with only_when(target_is_linux & compile_environment):
     option(env="MOZ_NO_PIE_COMPAT", help="Enable non-PIE wrapper")


### PR DESCRIPTION
初回起動時に"Legacy automatically sends same data to Ablaze so that we can improve your experience."と表示される問題が直るはずです。(要検証)