### PR TITLE
Improve about:contributors tab

### DIFF
--- a/browser/components/aboutcontributor/contributor.html
+++ b/browser/components/aboutcontributor/contributor.html
@@ -16,7 +16,7 @@
     <hr />
     <h4>Floorp Projects Developers:</h4>
     <div class="contributors">
-      <ul class="display-nospace">
+      <ul>
         <li>すらーぷの妖精</li>
         <li>お餅のkerohira</li>
         <li>typeling1578</li>
@@ -29,13 +29,13 @@
         <li>中院ぴあの</li>
       </ul>
       <h4>Localizers:</h4>
-      <ul class="display-nospace">
+      <ul>
         <li>regularenthropy</li>
         <li>Sorakime</li>
         <li>GrapeApple</li>
       </ul>
       <h4>Other contributors:</h4>
-      <ul class="display-nospace">
+      <ul>
         <li>さらだぼぉうる</li>
         <li>kaonasi-biwa</li>
         <li>itta611</li>
@@ -43,13 +43,16 @@
     </div>
     <hr />
     <p>We would like to give special thanks to these contributors.</p>
-    <p>
-      <i>
-        This is the list of people, who have devoted significant time and
-        delivered useful results. Contributors who wish to be added to the list
-        should submit a Pull Request or consider joining the Floorp project!
-      </i>
-    </p>
+    <footer>
+      <p>
+        <i>
+          This is the list of people, who have devoted significant time and
+          delivered useful results. Contributors who wish to be added to the
+          list should submit a Pull Request or consider joining the Floorp
+          project!
+        </i>
+      </p>
+    </footer>
   </body>
 </html>
 
@@ -59,15 +62,15 @@
     font-size: 15px;
   }
 
-  .display-nospace {
-    list-style: none;
-    padding: 0;
-  }
-
   hr {
     height: 3px;
     background-color: black;
     border: none;
+  }
+
+  .contributors ul {
+    list-style: none;
+    padding: 0;
   }
 
   .contributors li {

--- a/browser/components/aboutcontributor/contributor.html
+++ b/browser/components/aboutcontributor/contributor.html
@@ -1,32 +1,76 @@
-<h1>Floorp Browser contributors</h1>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Floorp Browser Contributors</title>
+    <meta charset="UTF-8" />
+  </head>
 
-<h4>Floorp is an open source software & web browser. Floorp is made for everyone. Below is a list of contributors to Floorp.</h4>
+  <body>
+    <header>
+      <h1>Floorp Browser Contributors</h1>
+      <h3>
+        Floorp is an open-source software & web browser. Floorp is made for
+        everyone. Below is a list of the contributors to the Floorp Project.
+      </h3>
+    </header>
+    <hr />
+    <h4>Floorp Projects Developers:</h4>
+    <div class="contributors">
+      <ul class="display-nospace">
+        <li>すらーぷの妖精</li>
+        <li>お餅のkerohira</li>
+        <li>typeling1578</li>
+        <li>めろんわ～くす</li>
+        <li>( ⁠ '-' ) かったぁ</li>
+        <li>ライ🍊⚓</li>
+        <li>tukimi 🐈</li>
+        <li>nexryai</li>
+        <li>しゃねこ🐈</li>
+        <li>中院ぴあの</li>
+      </ul>
+      <h4>Localizers:</h4>
+      <ul class="display-nospace">
+        <li>regularenthropy</li>
+        <li>Sorakime</li>
+        <li>GrapeApple</li>
+      </ul>
+      <h4>Other contributors:</h4>
+      <ul class="display-nospace">
+        <li>さらだぼぉうる</li>
+        <li>kaonasi-biwa</li>
+        <li>itta611</li>
+      </ul>
+    </div>
+    <hr />
+    <p>We would like to give special thanks to these contributors.</p>
+    <p>
+      <i>
+        This is the list of people, who have devoted significant time and
+        delivered useful results. Contributors who wish to be added to the list
+        should submit a Pull Request or consider joining the Floorp project!
+      </i>
+    </p>
+  </body>
+</html>
 
-<p>
-<h5> Floorp Projects Developers</h5>
-すらーぷの妖精<br>
-お餅のkerohira<br>
-typeling1578<br>
-めろんわ～くす<br>
-( ⁠ '-' ) かったぁ<br>
-ライ🍊⚓<br>
-tukimi 🐈<br>
-nexryai<br>
-しゃねこ🐈<br>
-中院ぴあの
-</p>
+<style>
+  body {
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    font-size: 15px;
+  }
 
-<h5>Other contributors</h5>
-さらだぼぉうる<br>
-kaonasi-biwa<br>
-itta611
+  .display-nospace {
+    list-style: none;
+    padding: 0;
+  }
 
-<h5>Floorp Localizers</h5>
-regularenthropy,
-Sorakime,
-GrapeApple,
+  hr {
+    height: 3px;
+    background-color: black;
+    border: none;
+  }
 
-<p>We would like to give special thanks to these contributors.<br>
-This is a list of those, who have either influenced the source code of the Floorp browser or legally distributed it and profited from it under the "Floorp" brand<br></p>
-
-<strong>This is a list of people who have devoted significant time and delivered useful results. Contributors who wish to be added to the list should submit a Pull Request or consider joining the Floorp project!</strong>
+  .contributors li {
+    font-family: Georgia, "Times New Roman", Times, serif;
+  }
+</style>


### PR DESCRIPTION
This commit improves code and design of the about:contributors tab

Before:
![image](https://user-images.githubusercontent.com/89523758/187678886-f1568258-bdb0-4911-adf5-e76a09a2f63b.png)

After:
![image](https://user-images.githubusercontent.com/89523758/187678999-32ec7747-84e3-4bb8-a08a-f1a8c7c12ff4.png)