### PR TITLE
fix typo in a class name from "moreFromMozilla"

### DIFF
--- a/browser/components/preferences/moreFromMozilla.inc.xhtml
+++ b/browser/components/preferences/moreFromMozilla.inc.xhtml
@@ -18,7 +18,7 @@
         <description id="floorp-discription" data-l10n-id="ablaze-floorp"/>
        </hbox>
 
-      <description class="text-blurb aboutfloorp" id="communityDesc" data-l10n-id="about-floorp-discription">
+      <description class="text-blurb aboutfloorp" id="communityDesc" data-l10n-id="about-floorp-description">
           <label is="text-link" href="https://floorp.ablaze.one" data-l10n-name="floorp-browser-link"/>
           <label is="text-link" href="https://ablaze.one" data-l10n-name="ablaze-Link"/>
           <label is="text-link" href="https://github.com/sponsors/Ablaze-MIRAI" data-l10n-name="helpus-donateLink"/>

--- a/browser/locales/en-US/browser/preferences/moreFromMozilla.ftl
+++ b/browser/locales/en-US/browser/preferences/moreFromMozilla.ftl
@@ -16,7 +16,7 @@ about-floorp-sub-sub = Floorp
 about-floorp-browser = About Floorp Projects 
 ablaze-floorp = Ablaze Floorp 10 -Catostylus Mosaicus-
 
-about-floorp-discription = <label data-l10n-name="floorp-browser-link">{ -brand-product-name }</label> is one of the domestic browsers developed in Japan. It is based on Firefox and continues to operate under <label data-l10n-name="ablaze-Link">{ -vendor-short-name }</label>, to improve the web. Want to help? <label data-l10n-name="helpus-donateLink">Make a donation</label>
+about-floorp-description = <label data-l10n-name="floorp-browser-link">{ -brand-product-name }</label> is one of the domestic browsers developed in Japan. It is based on Firefox and continues to operate under <label data-l10n-name="ablaze-Link">{ -vendor-short-name }</label>, to improve the web. Want to help? <label data-l10n-name="helpus-donateLink">Make a donation</label>
 icon-creator = Icon creator <label data-l10n-name="browser-logo-twitter">@CutterKnife_</label> and <label data-l10n-name="brand-logo-twitter">@mwxdxx.</label>
 contributors = A list of <label data-l10n-name="about-contributor">contributors and Developers</label>
 


### PR DESCRIPTION
This PR changes “discription” to “description”