### PR TITLE
Browser Manager Sidebar

### DIFF
--- a/browser/components/preferences/main.inc.xhtml
+++ b/browser/components/preferences/main.inc.xhtml
@@ -142,6 +142,10 @@
    <checkbox preference="floorp.browser.sidebar.right" 
               id="sidebarposition" data-l10n-id="view-sidebar2-right"/>
   <hbox>
+    <description flex="1" data-l10n-id="sidebar2-global-widht"/>
+    <html:input type="number" min="186" value="0" id="GlobalWidth"/>
+  </hbox>
+  <hbox>
     <description flex="1" data-l10n-id="custom-URL-option"/>
     <button  data-l10n-id="set-custom-URL-button" is="highlightable-button"
              class="accessory-button" id="SetCustomURL"/>

--- a/browser/components/preferences/preferences.js
+++ b/browser/components/preferences/preferences.js
@@ -193,6 +193,7 @@ function init_all() {
   register_module("paneSearch", gSearchPane);
   register_module("panePrivacy", gPrivacyPane);
   register_module("paneLepton", gLeptonPane);
+  register_module("paneBSB", gBSBPane);
   register_module("paneContainers", gContainersPane);
   if (Services.prefs.getBoolPref("browser.preferences.experimental")) {
     // Set hidden based on previous load's hidden value.

--- a/browser/components/preferences/preferences.xhtml
+++ b/browser/components/preferences/preferences.xhtml
@@ -137,6 +137,12 @@
                       helpTopic="prefs-lepton"
                       style="display:none;"/>
 
+        <richlistitem id="category-BSB"
+                      class="category"
+                      value="paneBSB"
+                      helpTopic="prefs-BSB"
+                      style="display:none;"/>
+
         <richlistitem id="category-sync"
                       class="category"
                       hidden="true"
@@ -220,6 +226,7 @@
 #include search.inc.xhtml
 #include privacy.inc.xhtml
 #include ../../../floorp/browser/components/preferences/lepton.inc.xhtml
+#include ../../../floorp/browser/components/preferences/bsb.inc.xhtml
 #include containers.inc.xhtml
 #include sync.inc.xhtml
 #include experimental.inc.xhtml

--- a/floorp/browser/app/profile/000-floorp.js
+++ b/floorp/browser/app/profile/000-floorp.js
@@ -75,56 +75,12 @@ pref("floorp.multitab.bottommode", false);
 //max is 20
 pref("floorp.browser.sidebar.right", true);// サイドバーの右側を表示
 pref("floorp.browser.sidebar.enable", true);// サイドバーを表示
-pref("floorp.browser.sidebar2.mode", 0);// サイドバーのモード
-pref("floorp.browser.sidebar2.customurl0", "https://freasearch.org");
-pref("floorp.browser.sidebar2.customurl1", "https://translate.google.com");
-pref("floorp.browser.sidebar2.customurl2", "");
-pref("floorp.browser.sidebar2.customurl3", "");
-pref("floorp.browser.sidebar2.customurl4", "");
-pref("floorp.browser.sidebar2.customurl5", "");
-pref("floorp.browser.sidebar2.customurl6", "");
-pref("floorp.browser.sidebar2.customurl7", "");
-pref("floorp.browser.sidebar2.customurl8", "");
-pref("floorp.browser.sidebar2.customurl9", "");
-pref("floorp.browser.sidebar2.customurl10", "");
-pref("floorp.browser.sidebar2.customurl11", "");
-pref("floorp.browser.sidebar2.customurl12", "");
-pref("floorp.browser.sidebar2.customurl13", "");
-pref("floorp.browser.sidebar2.customurl14", "");
-pref("floorp.browser.sidebar2.customurl15", "");
-pref("floorp.browser.sidebar2.customurl16", "");
-pref("floorp.browser.sidebar2.customurl17", "");
-pref("floorp.browser.sidebar2.customurl18", "");
-pref("floorp.browser.sidebar2.customurl19", "");
+pref("floorp.browser.sidebar2.page", "");//サイドバーで開いているページ
 
-pref("floorp.browser.sidebar2.width.mode0", 600);	
-pref("floorp.browser.sidebar2.width.mode1", 415);
-pref("floorp.browser.sidebar2.width.mode2", 415);
-pref("floorp.browser.sidebar2.width.mode3", 415);
-pref("floorp.browser.sidebar2.width.mode4", 415);
+// url:URL width:幅 userAgent:userAgent usercontext:コンテナタブ
+pref("floorp.browser.sidebar2.data", "{\"data\":{\"1\":{\"url\":\"floorp//bmt\",\"width\":600},\"2\":{\"url\":\"floorp//bookmarks\",\"width\":415},\"3\":{\"url\":\"floorp//history\",\"width\":415},\"4\":{\"url\":\"floorp//downloads\",\"width\":415},\"5\":{\"url\":\"floorp//tst\",\"width\":415},\"w1\":{\"url\":\"https://freasearch.org\"},\"w2\":{\"url\":\"https://translate.google.com\"}},\"index\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"w1\",\"w2\"]}");
+
 pref("floorp.browser.sidebar2.global.webpanel.width", 400);
-
-//container tab for sidebar2 webpanel
-pref("floorp.browser.sidebar2.customurl0.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl1.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl2.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl3.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl4.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl5.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl6.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl7.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl8.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl9.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl10.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl11.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl12.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl13.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl14.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl15.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl16.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl17.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl18.usercontext", 0);
-pref("floorp.browser.sidebar2.customurl19.usercontext", 0);
 
 /*----------------------------------------------------------------------------------------------------------------------------------*/
 
@@ -146,46 +102,7 @@ pref("services.sync.prefs.sync.browser.tabs.warnOnClose", false, locked); //た�
 
 // 同期を有効にする
 pref("services.sync.prefs.sync.floorp.browser.sidebar.right", true);// サイドバーの右側を表示
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl0", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl1", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl2", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl3", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl4", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl5", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl6", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl7", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl8", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl9", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl10", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl11", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl12", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl13", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl14", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl15", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl16", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl17", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl18", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl19", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl0.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl1.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl2.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl3.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl4.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl5.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl6.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl7.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl8.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl9.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl10.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl11.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl12.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl13.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl14.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl15.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl16.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl17.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl18.usercontext", true);
-pref("services.sync.prefs.sync.floorp.browser.sidebar2.customurl19.usercontext", true);
+pref("services.sync.prefs.sync.floorp.browser.sidebar2.data", true);// サイドバーのデータ
 pref("services.sync.prefs.sync.floorp.optimized.msbutton.ope", true); //サイドボタン付きマウス操作にブラウザーを最適化
 pref("services.sync.prefs.sync.floorp.optimized.verticaltab", true); //ツリー型垂直タブ等に最適化。8.7.2 からフォーカスした際の動作は別に
 pref("services.sync.prefs.sync.floorp.browser.user.interface", true);// Floorp 10 系以降のインターフェーステーマ設定

--- a/floorp/browser/base/content/browser-command.js
+++ b/floorp/browser/base/content/browser-command.js
@@ -91,15 +91,25 @@ async function setTreeStyleTabURL() {
   }, 50);
 }
 
-function setSidebarMode() {
-  if (Services.prefs.getBoolPref("floorp.browser.sidebar.enable", false)) {
-    const webpanel_id = Services.prefs.getStringPref("floorp.browser.sidebar2.page", undefined);
-    const webpanelURL = BROWSER_SIDEBAR_DATA.data[webpanel_id].url
-    const sidebar2elem = document.getElementById("sidebar2");
-    const wibpanel_usercontext = BROWSER_SIDEBAR_DATA.data[webpanel_id].usercontext ?? 0
+function setSidebarWidth(){
+    const webpanel_id = Services.prefs.getStringPref("floorp.browser.sidebar2.page", "");
+  if (Services.prefs.getBoolPref("floorp.browser.sidebar.enable", false) && webpanel_id != "" && BROWSER_SIDEBAR_DATA.index.indexOf(webpanel_id) != -1) {
+
     const panelWidth = BROWSER_SIDEBAR_DATA.data[webpanel_id].width ?? Services.prefs.getIntPref("floorp.browser.sidebar2.global.webpanel.width", undefined);
 
     document.getElementById("sidebar2-box").setAttribute("width", panelWidth);
+}
+}
+
+function setSidebarMode() {
+    const webpanel_id = Services.prefs.getStringPref("floorp.browser.sidebar2.page", "");
+  if (Services.prefs.getBoolPref("floorp.browser.sidebar.enable", false) && webpanel_id != "" && BROWSER_SIDEBAR_DATA.index.indexOf(webpanel_id) != -1) {
+
+    const webpanelURL = BROWSER_SIDEBAR_DATA.data[webpanel_id].url
+    const sidebar2elem = document.getElementById("sidebar2");
+    const wibpanel_usercontext = BROWSER_SIDEBAR_DATA.data[webpanel_id].usercontext ?? 0
+
+setSidebarWidth()
 
     switch (webpanelURL) {
       case "floorp//bmt":
@@ -191,7 +201,7 @@ function displayBrowserManagerSidebar() {
 function setCustomURLFavicon(sbar_id) {
     let sData = BROWSER_SIDEBAR_DATA.data[sbar_id.slice(7)]
     var sbar_url = sData.url
-    document.getElementById(`${sbar_id}`).style.listStyleImage = `url(http://www.google.com/s2/favicons?domain=${sbar_url})`;
+    if(sbar_url.slice(0,7) != "floorp//") document.getElementById(`${sbar_id}`).style.listStyleImage = `url(http://www.google.com/s2/favicons?domain=${sbar_url})`;
 
     const wibpanel_usercontext = sData.usercontext ?? 0
     const container_list = ContextualIdentityService.getPublicIdentities()

--- a/floorp/browser/base/content/browser-command.js
+++ b/floorp/browser/base/content/browser-command.js
@@ -305,6 +305,18 @@ sidebarItemLabel.setAttribute("flex","1")
   let side = BROWSER_SIDEBAR_DATA.index.length
   if(sicon > side){
     for(let i = 0;i < (sicon - side);i++){
+      if(document.getElementById(siconAll[i].id.replace("select-","webpanel")) != null){
+        let sidebarsplit2 = document.getElementById("sidebar-splitter2");
+
+        if(Services.prefs.getStringPref("floorp.browser.sidebar2.page", "") == siconAll[i].id.replace("select-","")){
+          Services.prefs.setStringPref("floorp.browser.sidebar2.page", "");
+          if (sidebarsplit2.getAttribute("hidden") != "true") {
+            changeSidebarVisibility();
+          }
+        }
+        document.getElementById(siconAll[i].id.replace("select-","webpanel")).remove();
+      }
+	      
       siconAll[i].remove()
     }
   }

--- a/floorp/browser/base/content/browser-floorp.css
+++ b/floorp/browser/base/content/browser-floorp.css
@@ -121,15 +121,15 @@
     list-style-image: url("chrome://browser/skin/tabbrowser/tab-audio-muted-small.svg") !important;
   }
   
-  #select-browser-manager {
+  [data-l10n-id="show-browser-manager-sidebar"] {
     list-style-image: url("chrome://browser/skin/lepton/toolbox.svg");
   }
   
-  #select-bookmark{
+  [data-l10n-id="show-bookmark-sidebar"]{
     list-style-image: url("chrome://browser/skin/bookmark.svg");
   }
   
-  #select-history {
+  [data-l10n-id="show-history-sidebar"] {
     list-style-image: url("chrome://browser/skin/history.svg");
   }
   
@@ -137,11 +137,11 @@
     list-style-image: url("chrome://browser/skin/tab.svg");
   }
   
-  #select-download {
+  [data-l10n-id="show-download-sidebar"] {
     list-style-image: url("chrome://browser/skin/downloads/downloads.svg");
   }
   
-  #select-TST {
+  [data-l10n-id="show-TST-sidebar"] {
     list-style-image: url("chrome://browser/skin/TST-dark.svg");
     padding: 11px 7px 11px 9.5px !important;
   }

--- a/floorp/browser/base/content/browser-manager-sidebar.js
+++ b/floorp/browser/base/content/browser-manager-sidebar.js
@@ -2,9 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-if (Services.prefs.getPrefType("floorp.browser.sidebar2.customurl0") != 0) {
-    if (Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, "") == "{\"data\":{\"1\":{\"url\":\"floorp//bmt\",\"width\":600},\"2\":{\"url\":\"floorp//bookmarks\",\"width\":415},\"3\":{\"url\":\"floorp//history\",\"width\":415},\"4\":{\"url\":\"floorp//downloads\",\"width\":415},\"5\":{\"url\":\"floorp//tst\",\"width\":415},\"w1\":{\"url\":\"https://freasearch.org\"},\"w2\":{\"url\":\"https://translate.google.com\"}},\"index\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"w1\",\"w2\"]}") {
+if (Services.prefs.getPrefType("floorp.browser.sidebar2.customurl2") != 0) {
+    if (Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, "") == "{\"data\":{\"1\":{\"url\":\"floorp//bmt\",\"width\":600},\"2\":{\"url\":\"floorp//bookmarks\",\"width\":415},\"3\":{\"url\":\"floorp//history\",\"width\":415},\"4\":{\"url\":\"floorp//downloads\",\"width\":415},\"5\":{\"url\":\"floorp//tst\",\"width\":415},\"w1\":{\"url\":\"https://freasearch.org\"},\"w2\":{\"url\":\"https://translate.google.com\"}},\"index\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"w1\",\"w2\"]}" || Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, "") == "") {
         let updateObject = { "data": {}, "index": [] }
         let staticURL = ["floorp//bmt", "floorp//bookmarks", "floorp//history", "floorp//downloads", "floorp//tst"]
         for (let i = 0; i <= 4; i++) {
@@ -18,11 +17,11 @@ if (Services.prefs.getPrefType("floorp.browser.sidebar2.customurl0") != 0) {
             updateObject.data[String(i)] = objectInObject
             updateObject.index.push(String(i))
         }
-
+        let defaultURL = ["https://freasearch.org","https://translate.google.com"]
         for (let i = 0; i <= 19; i++) {
             let objectInObject = {}
-            if (Services.prefs.getStringPref(`floorp.browser.sidebar2.customurl${i}`, "") != "") {
-                objectInObject["url"] = Services.prefs.getStringPref(`floorp.browser.sidebar2.customurl${i}`, "")
+            if (Services.prefs.getStringPref(`floorp.browser.sidebar2.customurl${i}`, "") != "" || i < 2) {
+                objectInObject["url"] = Services.prefs.getStringPref(`floorp.browser.sidebar2.customurl${i}`, defaultURL[i] ?? "")
 
                 if (Services.prefs.getIntPref(`floorp.browser.sidebar2.customurl${i}.usercontext`, 0) != 0) {
                     objectInObject["usercontext"] = Services.prefs.getIntPref(`floorp.browser.sidebar2.customurl${i}.usercontext`, 0)
@@ -69,7 +68,7 @@ if (Services.prefs.getBoolPref("floorp.browser.sidebar.enable", false)) {
 
 if(Services.prefs.getStringPref("floorp.browser.sidebar2.page") != "") setSidebarMode();
  })};
-
+Services.prefs.addObserver("floorp.browser.sidebar2.global.webpanel.width", setSidebarWidth)
 const DEFAULT_STATIC_SIDEBAR_MODES_AMOUNT = 5 /* Static sidebar modes, that are unchangable by user. Starts from 0 */
 const DEFAULT_DYNAMIC_CUSTOMURL_MODES_AMOUNT = 19 /* CustomURL modes, that are editable by user. Starts from 0 */
 const STATIC_SIDEBAR_L10N_LIST = {
@@ -90,9 +89,10 @@ if (Services.prefs.getBoolPref("floorp.browser.sidebar.enable", false)) {
  }
 
 //startup functions
+const webpanel_id_ = Services.prefs.getStringPref("floorp.browser.sidebar2.page", "");
 setSidebarIconView();
-if(Services.prefs.getStringPref("floorp.browser.sidebar2.page") != "") setSidebarMode();
+if(webpanel_id_ != "" && BROWSER_SIDEBAR_DATA.index.indexOf(webpanel_id_) != -1) setSidebarMode();
 removeAttributeSelectedNode();
-if(Services.prefs.getStringPref("floorp.browser.sidebar2.page") != "") getSelectedNode().setAttribute("checked", "true");
+if(webpanel_id_ != "" && BROWSER_SIDEBAR_DATA.index.indexOf(webpanel_id_) != -1) getSelectedNode().setAttribute("checked", "true");
 setAllfavicons();
 changeSidebarVisibility();

--- a/floorp/browser/base/content/browser-manager-sidebar.js
+++ b/floorp/browser/base/content/browser-manager-sidebar.js
@@ -81,7 +81,13 @@ const STATIC_SIDEBAR_L10N_LIST = {
 let BROWSER_SIDEBAR_DATA = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
 if (Services.prefs.getBoolPref("floorp.browser.sidebar.enable", false)) {
   Services.prefs.addObserver(`floorp.browser.sidebar2.data`, function() {
+    let TEMP_BROWSER_SIDEBAR_DATA = JSON.parse(JSON.stringify(BROWSER_SIDEBAR_DATA))
     BROWSER_SIDEBAR_DATA = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
+    for(let elem of BROWSER_SIDEBAR_DATA.index){
+        if(JSON.stringify(BROWSER_SIDEBAR_DATA.data[elem]) != JSON.stringify(TEMP_BROWSER_SIDEBAR_DATA.data[elem])){
+            setSidebarPageSetting(elem)
+        }
+    }
     setSidebarIconView()
     setSidebarMode()
     setAllfavicons()

--- a/floorp/browser/base/content/browser-webpanel.inc.xhtml
+++ b/floorp/browser/base/content/browser-webpanel.inc.xhtml
@@ -4,34 +4,8 @@
 
 <vbox id="sidebar-select-box" style="height: 100vh !important; overflow: hidden auto; width: 3.8em; max-width: 3.8em; min-width: 3.8em;" class="webpanel-box chromeclass-extrachrome">
    <spacer flex="15" class="workspace"/>
-   <toolbarbutton id="select-browser-manager" class="sidepanel-icon" panel="0" data-l10n-id="show-browser-manager-sidebar" oncommand="setStaticSidebarMode(0);"/>
-   <toolbarbutton id="select-bookmark" class="sidepanel-icon" panel="1" data-l10n-id="show-bookmark-sidebar" oncommand="setStaticSidebarMode(1);"/>
-   <toolbarbutton id="select-history" class="sidepanel-icon" panel="2" data-l10n-id="show-history-sidebar" oncommand="setStaticSidebarMode(2);"/>
-   <toolbarbutton id="select-download" class="sidepanel-icon" panel="3" data-l10n-id="show-download-sidebar" oncommand="setStaticSidebarMode(3);"/>
-   <toolbarbutton id="select-TST" class="sidepanel-icon" panel="4" data-l10n-id="show-TST-sidebar" oncommand="setStaticSidebarMode(4);"/>
 
-   <toolbarbutton id="select-CustomURL0" class="sidepanel-icon webpanel-icon" panel="5" oncommand="setDynamicSidebarMode(0);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL1" class="sidepanel-icon webpanel-icon" panel="6" oncommand="setDynamicSidebarMode(1);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL2" class="sidepanel-icon webpanel-icon" panel="7" oncommand="setDynamicSidebarMode(2);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL3" class="sidepanel-icon webpanel-icon" panel="8" oncommand="setDynamicSidebarMode(3);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL4" class="sidepanel-icon webpanel-icon" panel="9" oncommand="setDynamicSidebarMode(4);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL5" class="sidepanel-icon webpanel-icon" panel="10" oncommand="setDynamicSidebarMode(5);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL6" class="sidepanel-icon webpanel-icon" panel="11" oncommand="setDynamicSidebarMode(6);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL7" class="sidepanel-icon webpanel-icon" panel="12" oncommand="setDynamicSidebarMode(7);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL8" class="sidepanel-icon webpanel-icon" panel="13" oncommand="setDynamicSidebarMode(8);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL9" class="sidepanel-icon webpanel-icon" panel="14" oncommand="setDynamicSidebarMode(9);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL10" class="sidepanel-icon webpanel-icon" panel="15" oncommand="setDynamicSidebarMode(10);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL11" class="sidepanel-icon webpanel-icon" panel="16" oncommand="setDynamicSidebarMode(11);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL12" class="sidepanel-icon webpanel-icon" panel="17" oncommand="setDynamicSidebarMode(12);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL13" class="sidepanel-icon webpanel-icon" panel="18" oncommand="setDynamicSidebarMode(13);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL14" class="sidepanel-icon webpanel-icon" panel="19" oncommand="setDynamicSidebarMode(14);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL15" class="sidepanel-icon webpanel-icon" panel="20" oncommand="setDynamicSidebarMode(15);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL16" class="sidepanel-icon webpanel-icon" panel="21" oncommand="setDynamicSidebarMode(16);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL17" class="sidepanel-icon webpanel-icon" panel="22" oncommand="setDynamicSidebarMode(17);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL18" class="sidepanel-icon webpanel-icon" panel="23" oncommand="setDynamicSidebarMode(18);" context="webpanel-context" hidden="true"/>
-   <toolbarbutton id="select-CustomURL19" class="sidepanel-icon webpanel-icon" panel="24" oncommand="setDynamicSidebarMode(19);" context="webpanel-context" hidden="true"/>
-
-    <spacer flex="1000"/>
+    <spacer flex="1000" id="bsb_spacer"/>
      <toolbarbutton class="sidepanel-browser-icon" data-l10n-id="sidebar-addons-button"  oncommand="BrowserOpenAddonsMgr();" id="addons-icon"/>
      <toolbarbutton class="sidepanel-browser-icon" data-l10n-id="sidebar-passwords-button"  oncommand="LoginHelper.openPasswordManager(window, { entryPoint: 'mainmenu' });" id="passwords-icon"/>
      <toolbarbutton class="sidepanel-browser-icon" data-l10n-id="sidebar-preferences-button"  oncommand="openPreferences();" id="preferences-icon"/>

--- a/floorp/browser/components/preferences/bsb.inc.xhtml
+++ b/floorp/browser/components/preferences/bsb.inc.xhtml
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+<script src="chrome://browser/content/preferences/bsb.js"/>
+
+<html:template id="template-paneBSB">
+
+  <hbox class="BSB-header-links" data-category="paneBSB" hidden="true">
+    <button id="backtogeneral_" class="back-button" data-l10n-id="containers-back-button2">
+      <hbox class="box-inherit button-box" align="center" pack="center" flex="1" anonid="button-box">
+        <image class="button-icon"/>
+        <label class="button-text"/>
+      </hbox>
+    </button>
+  </hbox>
+
+<groupbox data-category="paneBSB" hidden="true">
+  <vbox class="contentPane">
+    <html:h1 data-l10n-id="bsb-header"/>
+  </vbox>
+  <vbox id="BSBBox">
+    <richlistbox id="BSBView"/>
+  </vbox>
+
+ <vbox>
+    <hbox flex="1">
+      <button id="BSBAdd"
+              is="highlightable-button"
+              data-l10n-id="bsb-add"/>
+      <button id="BSBDefault"
+              is="highlightable-button"
+              data-l10n-id="home-restore-defaults"/>
+    </hbox>
+  </vbox>
+
+</groupbox>
+
+</html:template>

--- a/floorp/browser/components/preferences/bsb.js
+++ b/floorp/browser/components/preferences/bsb.js
@@ -38,6 +38,27 @@ gSubDialog.open(
 });
     document.getElementById("BSBDefault").addEventListener("command", function(){Services.prefs.clearUserPref(`floorp.browser.sidebar2.data`);});
   },
+  setURL(elemUrl,elem){
+switch(elemUrl){
+case "floorp//bmt":
+        elem.setAttribute("data-l10n-id","sidebar2-browser-manager-sidebar");
+        break;
+      case "floorp//bookmarks":
+        elem.setAttribute("data-l10n-id","sidebar2-bookmark-sidebar");
+        break;
+      case "floorp//history":
+        elem.setAttribute("data-l10n-id","sidebar2-history-sidebar");
+        break;
+      case "floorp//downloads":
+        elem.setAttribute("data-l10n-id","sidebar2-download-sidebar");
+        break;
+      case "floorp//tst":
+        elem.setAttribute("data-l10n-id","sidebar2-TST-sidebar");
+        break;
+      default:
+        elem.textContent = elemUrl
+      }
+  },
 
   panelSet(){
     this.BSBs = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
@@ -61,26 +82,9 @@ gSubDialog.open(
 
       let label = document.createXULElement("label");
       label.setAttribute("flex", 1);
+      label.classList.add("bsb_label")
       let BSBName = ""
-      switch(this.BSBs.data[container].url){
-case "floorp//bmt":
-        label.setAttribute("data-l10n-id","sidebar2-browser-manager-sidebar");
-        break;
-      case "floorp//bookmarks":
-        label.setAttribute("data-l10n-id","sidebar2-bookmark-sidebar");
-        break;
-      case "floorp//history":
-        label.setAttribute("data-l10n-id","sidebar2-history-sidebar");
-        break;
-      case "floorp//downloads":
-        label.setAttribute("data-l10n-id","sidebar2-download-sidebar");
-        break;
-      case "floorp//tst":
-        label.setAttribute("data-l10n-id","sidebar2-TST-sidebar");
-        break;
-      default:
-        label.textContent = this.BSBs.data[container].url
-      }
+this.setURL(this.BSBs.data[container].url,label)
       outer.appendChild(label);
 
       let containerButtons = document.createXULElement("hbox");
@@ -108,7 +112,7 @@ gSubDialog.open(
       containerButtons.appendChild(removeButton);
 
       this._list.appendChild(item);
-      }else{this._list.appendChild(document.getElementById(`BSB-${container}`))}
+      }else{this._list.appendChild(document.getElementById(`BSB-${container}`));this.setURL(this.BSBs.data[container].url,document.getElementById(`BSB-${container}`).querySelector(".bsb_label"))}
       }
        let BSBAll = document.querySelectorAll(".BSB-list")
        let sicon = BSBAll.length

--- a/floorp/browser/components/preferences/bsb.js
+++ b/floorp/browser/components/preferences/bsb.js
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* import-globals-from extensionControlled.js */
+/* import-globals-from preferences.js */
+
+var { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
+XPCOMUtils.defineLazyGetter(this, "L10n", () => {
+  return new Localization([
+    "branding/brand.ftl",
+    "browser/floorp",
+  ]);
+});
+
+var gBSBPane = {
+  _pane: null,
+  deleteWebpanel(id){this.BSBs.index = this.BSBs.index.filter(n => n != id);delete this.BSBs.data[id];Services.prefs.setStringPref(`floorp.browser.sidebar2.data`, JSON.stringify(this.BSBs))},
+
+  // called when the document is first parsed
+  init() {
+    Services.prefs.addObserver(`floorp.browser.sidebar2.data`, function() {
+    this.BSBs = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
+this.panelSet()
+  }.bind(this))
+    this._list = document.getElementById("BSBView");
+    this._pane = document.getElementById("paneBSB");
+    this.panelSet()
+    document.getElementById("backtogeneral_").addEventListener("command", function(){gotoPref("general");});
+    document.getElementById("BSBAdd").addEventListener("command", function(){
+  let updateNumberDate = new Date()
+  let updateNumber = `w${updateNumberDate.getFullYear()}${updateNumberDate.getMonth()}${updateNumberDate.getDate()}${updateNumberDate.getHours()}${updateNumberDate.getMinutes()}${updateNumberDate.getSeconds()}`
+gSubDialog.open(
+      "chrome://browser/content/preferences/dialogs/customURLs.xhtml",
+      undefined,
+      {id:updateNumber,new:true}
+    );
+});
+    document.getElementById("BSBDefault").addEventListener("command", function(){Services.prefs.clearUserPref(`floorp.browser.sidebar2.data`);});
+  },
+
+  panelSet(){
+    this.BSBs = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
+    for (let container of this.BSBs.index) {
+      if(document.getElementById(`BSB-${container}`) == null){
+      let item = document.createXULElement("richlistitem");
+      item.id = `BSB-${container}`
+      item.classList.add("BSB-list")
+
+      let outer = document.createXULElement("hbox");
+      outer.setAttribute("flex", 1);
+      outer.setAttribute("align", "center");
+      item.appendChild(outer);
+
+      let userContextIcon = document.createXULElement("hbox");
+      userContextIcon.className = "userContext-icon";
+      userContextIcon.setAttribute("width", 24);
+      userContextIcon.setAttribute("height", 24);
+      userContextIcon.classList.add("userContext-icon-inprefs");
+      outer.appendChild(userContextIcon);
+
+      let label = document.createXULElement("label");
+      label.setAttribute("flex", 1);
+      let BSBName = ""
+      switch(this.BSBs.data[container].url){
+case "floorp//bmt":
+        label.setAttribute("data-l10n-id","sidebar2-browser-manager-sidebar");
+        break;
+      case "floorp//bookmarks":
+        label.setAttribute("data-l10n-id","sidebar2-bookmark-sidebar");
+        break;
+      case "floorp//history":
+        label.setAttribute("data-l10n-id","sidebar2-history-sidebar");
+        break;
+      case "floorp//downloads":
+        label.setAttribute("data-l10n-id","sidebar2-download-sidebar");
+        break;
+      case "floorp//tst":
+        label.setAttribute("data-l10n-id","sidebar2-TST-sidebar");
+        break;
+      default:
+        label.textContent = this.BSBs.data[container].url
+      }
+      outer.appendChild(label);
+
+      let containerButtons = document.createXULElement("hbox");
+      containerButtons.className = "container-buttons";
+      item.appendChild(containerButtons);
+
+      let prefsButton = document.createXULElement("button");
+      prefsButton.addEventListener("command", function(event) {
+gSubDialog.open(
+      "chrome://browser/content/preferences/dialogs/customURLs.xhtml",
+      undefined,
+      {id:event.target.getAttribute("value"),new:false}
+    );
+      });
+      prefsButton.setAttribute("value", container);
+      document.l10n.setAttributes(prefsButton, "sidebar2-pref-setting");
+      containerButtons.appendChild(prefsButton);
+
+      let removeButton = document.createXULElement("button");
+      removeButton.addEventListener("command", function(event) {
+        this.deleteWebpanel(event.target.getAttribute("value"))
+      }.bind(this));
+      removeButton.setAttribute("value", container);
+      document.l10n.setAttributes(removeButton, "sidebar2-pref-delete");
+      containerButtons.appendChild(removeButton);
+
+      this._list.appendChild(item);
+      }else{this._list.appendChild(document.getElementById(`BSB-${container}`))}
+      }
+       let BSBAll = document.querySelectorAll(".BSB-list")
+       let sicon = BSBAll.length
+       let side = this.BSBs.index.length
+       if(sicon > side){
+       for(let i = 0;i < (sicon - side);i++){
+         BSBAll[i].remove()
+       }
+    }
+  }
+};

--- a/floorp/browser/components/preferences/bsb.js
+++ b/floorp/browser/components/preferences/bsb.js
@@ -56,7 +56,7 @@ case "floorp//bmt":
         elem.setAttribute("data-l10n-id","sidebar2-TST-sidebar");
         break;
       default:
-        elem.textContent = elemUrl
+        elem.textContent = elemUrl;
       }
   },
 

--- a/floorp/browser/components/preferences/dialogs/customURLs.js
+++ b/floorp/browser/components/preferences/dialogs/customURLs.js
@@ -6,26 +6,52 @@
 const { ContextualIdentityService } = ChromeUtils.import(
     "resource://gre/modules/ContextualIdentityService.jsm"
   );
-
-function onSiteDelete() {
-    let URLBoxs = document.getElementsByClassName("URLBox");
-    for (let i = 0; i < URLBoxs.length; i++) {
-        URLBoxs[i].value = "";
-    }
+function setTitle(){
+let params = window.arguments[0] || {};
+let winElem = document.documentElement;
+  if (params.new) {
+    document.l10n.setAttributes(winElem, "bsb-add-title");
+  } else {
+    document.l10n.setAttributes(winElem, "bsb-setting-title");
+  }
 }
 
+setTitle();
+var bsbObject = {}
+var panelId = ""
+var newPanel = false
+var urlList = [
+"floorp//bmt",
+"floorp//bookmarks",
+"floorp//history",
+"floorp//downloads",
+"floorp//tst"
+]
+
 function onLoad() {
-    let elem = document.getElementsByClassName("BrowserSidebarSettingBox");
-    for (let i = 0; i < elem.length; i++) {
-        var num = i;
-        var url = Services.prefs.getStringPref(`floorp.browser.sidebar2.customurl${num}`, undefined);
-        elem[i].querySelector(".URLBox").value = url;
+bsbObject = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
+let params = window.arguments[0] || {};
+newPanel = params.new
+panelId = params.id
+let panelUserAgent = newPanel ? false : bsbObject.data[panelId].userAgent ?? false
+let panelWidth = newPanel ? 0 : bsbObject.data[panelId].width ?? 0
+
+document.addEventListener("dialogaccept", setPref);
+
+let panelUserContext = newPanel ? -1 : bsbObject.data[panelId].usercontext
+        var url = newPanel ? "" : ( bsbObject.data[params.id].url)
+let urlN = urlList.indexOf(url) + 1
+document.querySelector("#pageSelect").value = urlN
+setTimeout(setBox,1000)
+if(urlN == 0)        document.querySelector(".URLBox").value = url;
+        document.querySelector("#userAgentCheck").checked = panelUserAgent;
+        document.querySelector("#widthBox").value = panelWidth;
 
         let container_label = -1
-
-        let container_list = elem[i].querySelector("menupopup")
-
+        let container_list = document.querySelector("#userContextPopup")
+        let container_list_base = document.querySelector("#userContext")
         let menuitem = document.createXULElement("menuitem");
+        container_list_base.value = 0
         menuitem.value = 0
         menuitem.setAttribute("flex", 1);
         let containerName = document.getElementById("browserBundle").getString("userContextNone.label");
@@ -36,56 +62,70 @@ function onLoad() {
             menuitem = document.createXULElement("menuitem");
             menuitem.value = elem.userContextId
             menuitem.setAttribute("flex", 1);
-            containerName = ContextualIdentityService.getUserContextLabel(elem.userContextId);
-	    if (Services.prefs.getIntPref(`floorp.browser.sidebar2.customurl${num}.usercontext`, -1) == elem.userContextId) container_label = ContextualIdentityService.getUserContextLabel(elem.userContextId)
+              containerName = ContextualIdentityService.getUserContextLabel(elem.userContextId);
+            if (panelUserContext == elem.userContextId){
+	      container_label = ContextualIdentityService.getUserContextLabel(elem.userContextId)
+              container_list_base.value = elem.userContextId
+            }
             menuitem.setAttribute("label", containerName);
             container_list.appendChild(menuitem);
         }
 	if (container_label === -1) container_label = document.getElementById("browserBundle").getString("userContextNone.label")
         container_list.parentElement.setAttribute("label", container_label)
-    }
+    
 }
 
-function onunload() {
-    let box = document.getElementsByClassName("URLBox");
+function encodeObjectURL(text) {
     var remove_whitespace = /^\s+/
     var match_https = /^https?:\/\//
     var match_extension = /^moz-extension?:\/\//
-    for (let i = 0; i < box.length; i++) {
-        var box_value = box[i].value
-        box_value = box_value.replace(remove_whitespace, ""); /* Removing whitespace from the beginning of a line */
+        var box_value = text
+        box_value = box_value.replace(remove_whitespace, ""); / * Removing whitespace from the beginning of a line * /
         if (box_value == "") {
 
         }
-        else if (!box_value.match(match_https)) { /* Checks if url in the sidebar contains https in the beginning of a line */
-            if (!box_value.match(match_extension)) { /* Checks if given URL is an extension */
+        else if (!box_value.match(match_https)) { / * Checks if url in the sidebar contains https in the beginning of a line * /
+            if (!box_value.match(match_extension)) { / * Checks if given URL is an extension * /
                 box_value = `https://${box_value}`;
             }
         }
-        var num = i;
-        Services.prefs.setStringPref(`floorp.browser.sidebar2.customurl${num}`, box_value);
-    }
+return box_value
 }
 
-Preferences.addAll([
-    { id: "floorp.browser.sidebar2.customurl0.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl1.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl2.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl3.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl4.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl5.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl6.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl7.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl8.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl9.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl10.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl11.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl12.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl13.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl14.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl15.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl16.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl17.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl18.usercontext", type : "int"},
-    { id: "floorp.browser.sidebar2.customurl19.usercontext", type : "int"},
-]);
+function setPref(){
+console.log(document.querySelector("#pageSelect").value)
+console.log(document.querySelector(".URLBox").value)
+console.log(document.querySelector("#userContext").value)
+console.log(document.querySelector("#userAgentCheck").checked)
+console.log(document.querySelector("#widthBox").value)
+let page = Number(document.querySelector("#pageSelect").value)
+let url = document.querySelector(".URLBox").value
+let container = Number(document.querySelector("#userContext").value)
+let userAgent = document.querySelector("#userAgentCheck").checked
+let width = Number(document.querySelector("#widthBox").value)
+
+  let dataObject = {}
+  if(page < 6 && page > 0){
+    dataObject.url = urlList[page - 1]
+  }else{
+    dataObject.url = encodeObjectURL(url)
+    if(container != 0) dataObject.usercontext = container
+    if(userAgent != 0) dataObject.userAgent = userAgent
+  }
+  if(width != 0) dataObject.width = width
+
+  bsbObject.data[panelId] = dataObject
+  if(newPanel) bsbObject.index.push(panelId)
+
+  Services.prefs.setStringPref("floorp.browser.sidebar2.data",JSON.stringify(bsbObject))
+}
+
+function setBox(){
+let style = document.querySelector("#pageSelect").value == 0 ? "" : "hidden"
+let elems = document.querySelectorAll(".invisible")
+for(let elem of elems){
+elem.style.visibility = style
+}
+}
+
+function onunload(){}

--- a/floorp/browser/components/preferences/dialogs/customURLs.js
+++ b/floorp/browser/components/preferences/dialogs/customURLs.js
@@ -93,11 +93,6 @@ return box_value
 }
 
 function setPref(){
-console.log(document.querySelector("#pageSelect").value)
-console.log(document.querySelector(".URLBox").value)
-console.log(document.querySelector("#userContext").value)
-console.log(document.querySelector("#userAgentCheck").checked)
-console.log(document.querySelector("#widthBox").value)
 let page = Number(document.querySelector("#pageSelect").value)
 let url = document.querySelector(".URLBox").value
 let container = Number(document.querySelector("#userContext").value)

--- a/floorp/browser/components/preferences/dialogs/customURLs.xhtml
+++ b/floorp/browser/components/preferences/dialogs/customURLs.xhtml
@@ -17,7 +17,7 @@
 <stringbundle id="browserBundle"
                 src="chrome://browser/locale/browser.properties"/>
   <dialog
-        buttons="accept"
+        buttons="accept,cancel"
         data-l10n-id="permission-dialog"
         data-l10n-attrs="buttonlabelaccept">
 
@@ -36,176 +36,39 @@
   <vbox class="contentPane">
     <description id="permissionsText" control="url"/>
     <separator class="thin"/>
-    <label id="urlLabel" control="url" data-l10n-id="permissions-address"/>
-    <vbox>
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL0" class="URLBox" type="text" value="" placeholder="https://freasearch.org/"/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl0.usercontext" flex="1">
+<label id="pageLabel" data-l10n-id="bsb-page"/>
+      <hbox>
+        <menulist class="useDocumentColors" flex="1" oncommand="setBox()" id="pageSelect">
          <menupopup>
+<menuitem value="0" flex="1" data-l10n-id="bsb-website" />
+<menuitem value="1" flex="1" data-l10n-id="bsb-browser-manager-sidebar" />
+<menuitem value="2" flex="1" data-l10n-id="bsb-bookmark-sidebar" />
+<menuitem value="3" flex="1" data-l10n-id="bsb-history-sidebar" />
+<menuitem value="4" flex="1" data-l10n-id="bsb-download-sidebar" />
+<menuitem value="5" flex="1" data-l10n-id="bsb-TST-sidebar" />
          </menupopup>
         </menulist>
       </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL1" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl1.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL2" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl2.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-      
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL3" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl3.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL4" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl4.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL5" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl5.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL6" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl6.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL7" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl7.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-      
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL8" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl8.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL9" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl9.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL10" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl10.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL11" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl11.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL12" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl12.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL13" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl13.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL14" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl14.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL15" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl15.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL16" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl16.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL17" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl17.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL18" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl18.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-      <hbox class="BrowserSidebarSettingBox">
-        <html:input id="customURL19" class="URLBox" type="text" value=""/>
-        <menulist class="useDocumentColors" preference="floorp.browser.sidebar2.customurl19.usercontext" flex="1">
-         <menupopup>
-         </menupopup>
-        </menulist>
-      </hbox>
-
-
+    <label id="urlLabel" control="url" data-l10n-id="permissions-address" class="invisible"/>
+    <vbox class="invisible">
+      <html:input id="customURL" class="URLBox" type="text" value="" placeholder="https://freasearch.org/"/>
     </vbox>
+    <label id="usercontextLabel" data-l10n-id="bsb-context" class="invisible"/>
+      <hbox class="invisible">
+        <menulist class="useDocumentColors" flex="1" id="userContext">
+         <menupopup id="userContextPopup">
+         </menupopup>
+        </menulist>
+      </hbox>
+      <hbox class="invisible">
+        <checkbox id="userAgentCheck"
+                  data-l10n-id="bsb-userAgent-label"/>
+      </hbox>
+    <vbox><hbox>
+    <label id="widthLabel" data-l10n-id="bsb-width"/>
+      <html:input id="widthBox" type="number" min="0" value="0" style="min-width:200px;" onchange="bsbGlobalWidthSet()"/>
+    </hbox></vbox>
     <separator class="thin"/>
   </vbox>
-
-  <hbox class="actionButtons">
-    <button id="removeAllPermissions"
-            data-l10n-id="permissions-remove-all"
-            oncommand="onSiteDelete();"/>
-  </hbox>
   </dialog>
 </window>

--- a/floorp/browser/components/preferences/floorp-main.js
+++ b/floorp/browser/components/preferences/floorp-main.js
@@ -36,9 +36,9 @@ Preferences.addAll([
     { id: "floorp.browser.restore.sidebar.panel", type : "bool"},
   ]);
 
+function floorpMain(){
 
-
- window.setTimeout(function(){
+if(document.getElementById("translateoption") != null){
     const needreboot = document.getElementsByClassName("needeboot");
         for(let i = 0; i < needreboot.length; i++) {
           needreboot[i].addEventListener("click",
@@ -68,7 +68,7 @@ Preferences.addAll([
     }
     let el = document.getElementById("translateoption");
     el.addEventListener("click", opentranslateroption, false);
-  
+
     async function opentreestyletaboption(){
       const addon = await AddonManager.getAddonByID("treestyletab@piro.sakura.ne.jp");
       await window.open(addon.optionsURL, '_blank');
@@ -76,14 +76,28 @@ Preferences.addAll([
     el = document.getElementById("treestyletaboption");
     el.addEventListener("click", opentreestyletaboption, false);
 
+document.getElementById("GlobalWidth").value = Services.prefs.getIntPref("floorp.browser.sidebar2.global.webpanel.width", undefined);
+document.getElementById("GlobalWidth").addEventListener('change', bsbGlobalWidthSet, false);
+Services.prefs.addObserver("floorp.browser.sidebar2.global.webpanel.width", function(){document.getElementById("GlobalWidth").value = Services.prefs.getIntPref("floorp.browser.sidebar2.global.webpanel.width", undefined);})
+
     document.getElementById("leptonButton").addEventListener("click", function(){
       window.location.href = "about:preferences#lepton";
     }, false);
-  
     document.getElementById("SetCustomURL").addEventListener("click", function(){
-      gSubDialog.open(
-        "chrome://browser/content/preferences/dialogs/customURLs.xhtml",
-        { features: "resizable=true" }
-      );
+      window.location.href = "about:preferences#bSB";
     }, false);
+}else{
+
+ window.setTimeout(function(){
+floorpMain()
   }, 1000);
+
+}
+
+}
+
+floorpMain()
+
+function bsbGlobalWidthSet(){
+Services.prefs.setIntPref("floorp.browser.sidebar2.global.webpanel.width", Number(document.getElementById("GlobalWidth").value));
+}

--- a/floorp/browser/components/preferences/jar.mn
+++ b/floorp/browser/components/preferences/jar.mn
@@ -5,6 +5,7 @@
 browser.jar:
    content/browser/preferences/floorp-main.js
    content/browser/preferences/lepton.js
+   content/browser/preferences/bsb.js
 
 browser.jar:
 % skin browser classic/1.0 %skin/classic/browser/

--- a/floorp/browser/components/preferences/lepton.js
+++ b/floorp/browser/components/preferences/lepton.js
@@ -63,6 +63,16 @@ var gLeptonPane = {
   // called when the document is first parsed
   init() {
     this._pane = document.getElementById("paneLepton");
+
+document.getElementById("backtogeneral").addEventListener("command", function(){gotoPref("general");});
+  document.getElementById("lepton-design-mode").addEventListener("click", setLeptonUI, false);
+  document.getElementById("photon-design-mode").addEventListener("click", setPhotonUI, false);
+  let targets = document.getElementsByClassName("photonCheckbox");
+  for(let i = 0; i < targets.length; i++){
+    targets[i].addEventListener("click",() => {
+      Services.obs.notifyObservers({}, "update-photon-pref");
+    }, false);
+  }
   },
 };
 
@@ -93,15 +103,3 @@ function setLeptonUI() {
   Services.prefs.setBoolPref("userChrome.tab.static_separator", false);
   Services.obs.notifyObservers({}, "update-photon-pref");
 }
-
-window.setTimeout(function(){
-  document.getElementById("lepton-design-mode").addEventListener("click", setLeptonUI, false);
-  document.getElementById("photon-design-mode").addEventListener("click", setPhotonUI, false);
-  let targets = document.getElementsByClassName("photonCheckbox");
-  for(let i = 0; i < targets.length; i++){
-    targets[i].addEventListener("click",() => {
-      Services.obs.notifyObservers({}, "update-photon-pref");
-    }, false);
-  }
-  document.getElementById("backtogeneral").addEventListener("command", function(){gotoPref("general");});
-}, 1000);

--- a/floorp/browser/components/preferences/preferences-floorp.css
+++ b/floorp/browser/components/preferences/preferences-floorp.css
@@ -568,4 +568,25 @@
     .category[selected]::before {
       border-color: var(--in-content-accent-color) !important;
     }
-  
+
+
+
+BSB-header-links {
+  font-size: 1.25rem;
+  margin-block-end: 15px;
+}
+
+#BSBView {
+  background: transparent;
+  margin-block-end: 8px;
+}
+
+#BSBView richlistitem {
+min-height:60px;
+  padding-block: 4px;
+  border-block-end: 1px solid var(--in-content-border-color);
+}
+
+#BSBView richlistitem > .container-buttons {
+  margin-inline-end: 4px;
+}

--- a/floorp/browser/extensions/webextensions/webpanel-ua/APIs/webRequestExt.js
+++ b/floorp/browser/extensions/webextensions/webpanel-ua/APIs/webRequestExt.js
@@ -26,9 +26,9 @@ this.webRequestExt = class extends ExtensionAPI {
             function listener(e) {
               if (typeof e.browserElement !== "undefined" &&
                   e.browserElement.id.startsWith("webpanel")) {
-                const webpanelid = e.browserElement.id;
-                const uaPref = `floorp.enable.useragent.override.${webpanelid}`;
-                if (Services.prefs.getBoolPref(uaPref, false)) {
+                const webpanelid = e.browserElement.id.replace("webpanel", "");
+  let sidebars = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
+                if (sidebars.data[webpanelid].userAgent) {
                   return fire.async(e.requestId);
                 }
               }

--- a/floorp/browser/extensions/webextensions/webpanel-ua/APIs/webRequestExt.js
+++ b/floorp/browser/extensions/webextensions/webpanel-ua/APIs/webRequestExt.js
@@ -26,9 +26,7 @@ this.webRequestExt = class extends ExtensionAPI {
             function listener(e) {
               if (typeof e.browserElement !== "undefined" &&
                   e.browserElement.id.startsWith("webpanel")) {
-                const webpanelid = e.browserElement.id.replace("webpanel", "");
-  let sidebars = JSON.parse(Services.prefs.getStringPref(`floorp.browser.sidebar2.data`, undefined))
-                if (sidebars.data[webpanelid].userAgent) {
+                if (e.browserElement.getAttribute("changeuseragent") == "true") {
                   return fire.async(e.requestId);
                 }
               }

--- a/floorp/browser/locales/en-US/floorp.ftl
+++ b/floorp/browser/locales/en-US/floorp.ftl
@@ -227,7 +227,7 @@ bsb-header = Browser Manager Sidebar
 bsb-context = Select Container Tabs
 bsb-userAgent-label = 
   .label = Change User Agent to Mobile version
-bsb-width = Width (If this is empty, use global values)
+bsb-width = Width (If this is 0, use global values)
 bsb-page = Page to open
 
 bsb-add = Add webpanel on Browser Manager Sidebar

--- a/floorp/browser/locales/en-US/floorp.ftl
+++ b/floorp/browser/locales/en-US/floorp.ftl
@@ -232,7 +232,7 @@ bsb-page = Page to open
 
 bsb-add = Add webpanel on Browser Manager Sidebar
 
-bsb-setting = Browser Manager Sidebar Setting
+bsb-setting = Webpanel Setting
 
 bsb-add-title = 
  .title = { bsb-add }

--- a/floorp/browser/locales/en-US/floorp.ftl
+++ b/floorp/browser/locales/en-US/floorp.ftl
@@ -223,17 +223,48 @@ custom-URL-option = Set Webpanel URLs
 set-custom-URL-button = 
     .label = Set Custom URLs...
     .accesskey = S
+bsb-header = Browser Manager Sidebar
+bsb-context = Select Container Tabs
+bsb-userAgent-label = 
+  .label = Change User Agent to Mobile version
+bsb-width = Width (If this is empty, use global values)
+bsb-page = Page to open
 
-no-container = 
-    .label = No Container -Default-
-container-1 = 
-    .label = Container 1 -Personal-
-container-2 = 
-    .label = Container 2 -Work-
-container-3 =
-    .label = Container 3 -Bank-
-container-4 =
-    .label = Container 4 -Shopping-
+bsb-add = Add webpanel on Browser Manager Sidebar
+
+bsb-setting = Browser Manager Sidebar Setting
+
+bsb-add-title = 
+ .title = { bsb-add }
+
+bsb-setting-title = 
+ .title = { bsb-setting }
+
+bsb-browser-manager-sidebar =
+  .label = { sidebar2-browser-manager-sidebar }
+
+bsb-bookmark-sidebar =
+  .label = { sidebar2-bookmark-sidebar }
+
+bsb-history-sidebar =
+  .label = { sidebar2-history-sidebar }
+
+bsb-download-sidebar =
+  .label = { sidebar2-download-sidebar }
+
+bsb-TST-sidebar =
+  .label = { sidebar2-TST-sidebar }
+
+bsb-website = 
+  .label = Website
+
+sidebar2-pref-delete =
+ .label = Delete
+
+sidebar2-pref-setting =
+ .label = Setting
+
+sidebar2-global-widht = Global value of webpanel's width
 
 memory-and-performance = Memory Performance Settings
 
@@ -381,20 +412,31 @@ sidebar-reload-button =
 sidebar-muteAndUnmute-button =
   .tooltiptext = Mute/Unmute sidebar
 
+sidebar2-browser-manager-sidebar = Browser Manager
+
 show-browser-manager-sidebar =
-  .tooltiptext = Show Browser Manager Sidebar
+  .tooltiptext = Show { sidebar2-browser-manager-sidebar } Sidebar
+
+sidebar2-bookmark-sidebar = Bookmarks
 
 show-bookmark-sidebar =
-  .tooltiptext = Show Bookmarks Sidebar
+  .tooltiptext = Show { sidebar2-bookmark-sidebar } Sidebar
+
+sidebar2-history-sidebar = History
 
 show-history-sidebar =
-  .tooltiptext = Show History Sidebar
+  .tooltiptext = Show { sidebar2-history-sidebar } Sidebar
+
+sidebar2-download-sidebar = Download
 
 show-download-sidebar =
-  .tooltiptext = Show Download Sidebar
+  .tooltiptext = Show { sidebar2-download-sidebar } Sidebar
+
+sidebar2-TST-sidebar = Tree Style Tab
 
 show-TST-sidebar =
-  .tooltiptext = Show Tree Style Tab Sidebar
+  .tooltiptext = Show { sidebar2-TST-sidebar } Sidebar
+
 
 show-CustomURL-sidebar =
  .label = Show Custom URL Sidebar


### PR DESCRIPTION
- 大量にあったPrefを一つにまとめてObject化
- ついでに無限に登録できるように
- ブラウザ内蔵のページも登録したり削除したりできるように
- それに合わせ設定画面を変更
- ウェブパネルの幅のグローバル値を設定から変更可能に
ざっとこんな感じですかね(何やったか全てはおぼえてないかも)  
<br>
あと、Prefのアップデートは`floorp/browser/base/content/browser-manager-sidebar.js`の6行目にあると思います  
今は`floorp.browser.sidebar2.customurl2`(3つめのウェブパネル)に何かしらのURLが登録されているとき、Objectが初期値ならObjectに変換してPrefを削除、そうでなければなにもせずPrefを削除って感じになってます  
要改善な気がします  
<br>
最後に、設定画面いじる時に若干他のところにも手を出しちゃいました
馬鹿です。どうも。