### PR TITLE
ChromeCSS in macOS

### DIFF
--- a/floorp/browser/base/content/browser-userChrome.js
+++ b/floorp/browser/base/content/browser-userChrome.js
@@ -7,8 +7,6 @@ var { AppConstants } = ChromeUtils.import(
     "resource://gre/modules/AppConstants.jsm"
  );
 
-if (AppConstants.platform != "macosx") {
 const ucScript = document.createElement('script');
 ucScript.src = "chrome://userchromejs/content/chromecss.uc.js"; 
 document.head.appendChild(ucScript); 
-}

--- a/floorp/browser/extensions/userChromejs/chromecss.uc.js
+++ b/floorp/browser/extensions/userChromejs/chromecss.uc.js
@@ -83,9 +83,6 @@ window.UCL = {
 			aFolder = Services.dirsvc.get("UChrm", Ci.nsIFile);
 			aFolder.appendRelativePath("CSS");
 		}
-		if (!aFolder.exists() || !aFolder.isDirectory()) {
-			aFolder.create(Ci.nsIFile.DIRECTORY_TYPE, 0664);
-		}
 		delete this.FOLDER;
 		return this.FOLDER = aFolder;
 	},
@@ -591,8 +588,12 @@ CSSTester.prototype = {
 		this.logField.textContent = dateFormat(new Date(), "%H:%M:%S") + ": " + $A(arguments);
 	}
 };
-
+(async () => {
+if (!UCL.FOLDER.exists() || !UCL.FOLDER.isDirectory()) {
+await IOUtils.makeDirectory(OS.Path.join(OS.Path.join(OS.Constants.Path.profileDir, "chrome"), 'CSS'))
+}
 UCL.init();
+})()
 
 function $(id) { return document.getElementById(id); }
 function $A(arr) { return Array.slice(arr); }

--- a/floorp/browser/extensions/userChromejs/chromecss.uc.js
+++ b/floorp/browser/extensions/userChromejs/chromecss.uc.js
@@ -590,7 +590,7 @@ CSSTester.prototype = {
 };
 (async () => {
 if (!UCL.FOLDER.exists() || !UCL.FOLDER.isDirectory()) {
-await IOUtils.makeDirectory(OS.Path.join(OS.Path.join(OS.Constants.Path.profileDir, "chrome"), 'CSS'))
+await IOUtils.makeDirectory(OS.Path.join(OS.Constants.Path.profileDir, "chrome", "CSS"))
 }
 UCL.init();
 })()


### PR DESCRIPTION
macでChromeCSSを使えるようにしてきました
(といっても、逆にMacでできなかったのはアクセス権のあるフォルダ作成のみですが)

あと、mac標準のテキストエディタはなぜか使えません
Firefox標準の方でも使えません
なので、VSCodeでデバッグしてます