### PR TITLE
[FB] Cope with deleting TST

### DIFF
--- a/floorp/browser/components/BrowserManagerSidebar.jsm
+++ b/floorp/browser/components/BrowserManagerSidebar.jsm
@@ -63,6 +63,18 @@ let BrowserManagerSidebar = {
             defaultPref.index.push(`w${elem}`)
         }
         Services.prefs.getDefaultBranch(null).setStringPref("floorp.browser.sidebar2.data", JSON.stringify( defaultPref))
+
+        if(Services.prefs.prefHasUserValue("floorp.browser.sidebar2.data") && Services.prefs.getStringPref("floorp.browser.sidebar2.data").includes("floorp//tst")){
+          let prefTemp = JSON.parse( Services.prefs.getStringPref("floorp.browser.sidebar2.data"))
+          let setPref = {data:{},index:[]}
+          for(let elem of prefTemp.index){
+            if(prefTemp.data[elem].url != "floorp//tst"){
+              setPref.data[elem] = prefTemp.data[elem]
+              setPref.index.push(elem)
+            }
+          }
+          Services.prefs.setStringPref("floorp.browser.sidebar2.data", JSON.stringify( setPref))
+        }
         
     },
     getFavicon:function(sbar_url,elem){

--- a/floorp/browser/extensions/webextensions/floorp-actions/background.js
+++ b/floorp/browser/extensions/webextensions/floorp-actions/background.js
@@ -1,9 +1,15 @@
 async function handle_actions(action, options) {
     console.log(action);
     switch (action) {
+        case "open-tree-style-tab":
         case "open-extension-sidebar":
-            if (!options.extensionId) throw '"extensionId" must be specified.';
-            var widgetId = await browser.floorpActions.getExtensionWidgetId(options.extensionId);
+            let widgetId = ""
+            if(action == "open-tree-style-tab"){
+                widgetId = await browser.floorpActions.getExtensionWidgetId("treestyletab@piro.sakura.ne.jp");
+            }else{
+                if (!options.extensionId) throw '"extensionId" must be specified.';
+                widgetId = await browser.floorpActions.getExtensionWidgetId(options.extensionId);
+            }
             await browser.floorpActions.openInSidebar(`${widgetId}-sidebar-action`);
             break;
         case "open-bookmarks-sidebar":
@@ -39,3 +45,22 @@ async function handle_actions(action, options) {
     }
 }
 
+function handleMessage(message, sender) {
+    if (sender.id === "{506e023c-7f2b-40a3-8066-bc5deb40aebe}") {
+        const example_obj = {
+            "action": "tree-style-tab-open"
+        }
+        let message_obj =
+            typeof message === "string" ?
+                JSON.parse(message) :
+                message
+        handle_actions(
+            message_obj["action"],
+            message_obj["options"] ?
+                message_obj["options"] :
+                {}
+        );
+    }
+}
+
+browser.runtime.onMessageExternal.addListener(handleMessage);

--- a/floorp/browser/extensions/webextensions/floorp-system/shared/gesturefy/gesturefy.js
+++ b/floorp/browser/extensions/webextensions/floorp-system/shared/gesturefy/gesturefy.js
@@ -177,6 +177,11 @@ if (browser_.runtime.id == "{506e023c-7f2b-40a3-8066-bc5deb40aebe}") {
     observerFunction: function () {
       let valueJSON = JSON.parse(document.querySelector("#gesturePopupCommandSelect").getAttribute("value") ?? `{"settings":{"extensionId":""}}`)
       if(document.querySelector("#gesturePopup").getAttribute("open") === "" && valueJSON.settings != undefined &&  valueJSON.settings.extensionId == "floorp-actions@floorp.ablaze.one"){
+        if(JSON.parse(valueJSON.settings.message).action == "open-tree-style-tab"){
+          document.querySelector("#gesturePopupCommandSelect").setAttribute("value", `{"name":"SendMessageToOtherAddon","settings":{"extensionId":"floorp-actions@floorp.ablaze.one","message":"{\\"action\\": \\"open-extension-sidebar\\",\\"options\\":{\\"extensionId\\":\\"treestyletab@piro.sakura.ne.jp\\"}}"}}`)
+          valueJSON = JSON.parse(document.querySelector("#gesturePopupCommandSelect").getAttribute("value"))
+          if(document.querySelector("#gesturePopupLabelInput").value.startsWith("[Floorp]")) document.querySelector("#gesturePopupLabelInput").value = gesturefyController.l10n["gf-floorp-open-extension-sidebar-name"]
+        }
         this.popupCommandSet(JSON.parse(valueJSON.settings.message).action,JSON.parse(valueJSON.settings.message).options)
         if(this.l10n["gf-floorp-" + JSON.parse(valueJSON.settings.message).action + "-name"] == document.querySelector("#gesturePopupLabelInput").value){
           document.querySelector("#gesturePopupLabelInput").style.color = "gray"


### PR DESCRIPTION
- BMSのTSTは、強制削除にしておきました(BMSに拡張機能のサイドバーを使えるような設定をつくったらそっちに移行するかも)
- Gesturefyは、TSTが導入されたらすぐ動くように、機能だけは残しときました
- 「ツリー型タブを開く」Gesturefyのコマンドは、そのジェスチャーの設定を開いた時点で「サイドバーで選択したアドオンを開く」に置き換えられるようにしました