### PR TITLE
Expand JPEG XL support

### DIFF
--- a/floorp/browser/app/profile/000-floorp.js
+++ b/floorp/browser/app/profile/000-floorp.js
@@ -67,7 +67,7 @@ pref("browser.newtabpage.activity-stream.improvesearch.handoffToAwesomebar", fal
 //新しいタブの背景の設定
 pref("browser.newtabpage.activity-stream.floorp.background.type", 1);
 pref("browser.newtabpage.activity-stream.floorp.background.images.folder", "");
-pref("browser.newtabpage.activity-stream.floorp.background.images.extensions", "png,jpg,jpeg,webp,gif,svg,tiff,tif,bmp,avif");
+pref("browser.newtabpage.activity-stream.floorp.background.images.extensions", "png,jpg,jpeg,webp,gif,svg,tiff,tif,bmp,avif,jxl");
 pref("browser.newtabpage.activity-stream.floorp.newtab.backdrop.blur.disable",false);
 
 pref("floorp.multitab.bottommode", false);
@@ -186,9 +186,10 @@ pref("app.normandy.enabled", true);
 //backdropfilterを既定で有効化します。
 pref("layout.css.backdrop-filter.enabled", true);
 
-//SVG avif 画像ファイルをの互換性向上または、既定で開けるように
+//SVG avif jxl 画像ファイルをの互換性向上または、既定で開けるように
 pref("svg.context-properties.content.enabled", true, locked);
 pref("image.avif.enabled", true, locked);
+pref("image.jxl.enabled", true, locked);
 
 // Add-On のブラックリストをFloorpが参照する際の情報漏洩削減
 pref("extensions.blocklist.url", "https://blocklist.addons.mozilla.org/blocklist/3/%APP_ID%/%APP_VERSION%/");

--- a/image/DecoderFactory.cpp
+++ b/image/DecoderFactory.cpp
@@ -234,8 +234,15 @@ nsresult DecoderFactory::CreateAnimationDecoder(
     return NS_ERROR_INVALID_ARG;
   }
 
-  MOZ_ASSERT(aType == DecoderType::GIF || aType == DecoderType::PNG ||
-                 aType == DecoderType::WEBP || aType == DecoderType::AVIF,
+  bool validDecoderType = (aType == DecoderType::GIF ||
+                           aType == DecoderType::PNG ||
+                           aType == DecoderType::WEBP ||
+                           aType == DecoderType::AVIF);
+#ifdef MOZ_JXL
+  validDecoderType = validDecoderType || aType == DecoderType::JXL;
+#endif
+
+  MOZ_ASSERT(validDecoderType,
              "Calling CreateAnimationDecoder for non-animating DecoderType");
 
   // Create an anonymous decoder. Interaction with the SurfaceCache and the
@@ -289,8 +296,15 @@ already_AddRefed<Decoder> DecoderFactory::CloneAnimationDecoder(
   // get scheduled yet, or it has only decoded the first frame and has yet to
   // rediscover it is animated).
   DecoderType type = aDecoder->GetType();
-  MOZ_ASSERT(type == DecoderType::GIF || type == DecoderType::PNG ||
-                 type == DecoderType::WEBP || type == DecoderType::AVIF,
+  bool validDecoderType = (type == DecoderType::GIF ||
+                           type == DecoderType::PNG ||
+                           type == DecoderType::WEBP ||
+                           type == DecoderType::AVIF);
+#ifdef MOZ_JXL
+  validDecoderType = validDecoderType || type == DecoderType::JXL;
+#endif
+
+  MOZ_ASSERT(validDecoderType,
              "Calling CloneAnimationDecoder for non-animating DecoderType");
 
   RefPtr<Decoder> decoder = GetDecoder(type, nullptr, /* aIsRedecode = */ true);

--- a/image/decoders/nsJXLDecoder.h
+++ b/image/decoders/nsJXLDecoder.h
@@ -47,7 +47,12 @@ class nsJXLDecoder final : public Decoder {
   JxlThreadParallelRunnerPtr mParallelRunner;
   Vector<uint8_t> mBuffer;
   Vector<uint8_t> mOutBuffer;
-  JxlBasicInfo mInfo{};
+  JxlBasicInfo mInfo;
+  JxlPixelFormat mFormat;
+
+  bool mUsePipeTransform;
+  uint8_t mChannels;
+  uint8_t* mCMSLine;
 };
 
 }  // namespace mozilla::image

--- a/image/decoders/nsJXLDecoder.h
+++ b/image/decoders/nsJXLDecoder.h
@@ -49,10 +49,16 @@ class nsJXLDecoder final : public Decoder {
   Vector<uint8_t> mOutBuffer;
   JxlBasicInfo mInfo;
   JxlPixelFormat mFormat;
+  JxlFrameHeader mFrameHeader;
 
   bool mUsePipeTransform;
   uint8_t mChannels;
   uint8_t* mCMSLine;
+
+  uint32_t mNumFrames;
+  FrameTimeout mTimeout;
+  gfx::SurfaceFormat mSurfaceFormat;
+  bool mContinue;
 };
 
 }  // namespace mozilla::image

--- a/image/decoders/nsJXLDecoder.h
+++ b/image/decoders/nsJXLDecoder.h
@@ -58,6 +58,7 @@ class nsJXLDecoder final : public Decoder {
   uint32_t mNumFrames;
   FrameTimeout mTimeout;
   gfx::SurfaceFormat mSurfaceFormat;
+  SurfacePipe mPipe;
   bool mContinue;
 };
 

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -7201,7 +7201,11 @@
 # Whether we attempt to decode JXL images or not.
 - name: image.jxl.enabled
   type: RelaxedAtomicBool
+#if defined(MOZ_JXL)
+  value: true
+#else
   value: false
+#endif
   mirror: always
 
 #---------------------------------------------------------------------------

--- a/toolkit/moz.configure
+++ b/toolkit/moz.configure
@@ -721,9 +721,9 @@ set_define("MOZ_AV1", av1)
 option("--disable-jxl", help="Disable jxl image support")
 
 
-@depends("--disable-jxl", milestone.is_nightly)
-def jxl(value, is_nightly):
-    if is_nightly and value:
+@depends("--disable-jxl")
+def jxl(value):
+    if value:
         return True
 
 

--- a/uriloader/exthandler/nsExternalHelperAppService.cpp
+++ b/uriloader/exthandler/nsExternalHelperAppService.cpp
@@ -533,7 +533,6 @@ static const nsExtraMimeTypeEntry extraMimeEntries[] = {
     {IMAGE_SVG_XML, "svg", "Scalable Vector Graphics"},
     {IMAGE_WEBP, "webp", "WebP Image"},
     {IMAGE_AVIF, "avif", "AV1 Image File"},
-    {IMAGE_JXL, "jxl", "JPEG XL Image File"},
 
     {MESSAGE_RFC822, "eml", "RFC-822 data"},
     {TEXT_PLAIN, "txt,text", "Text File"},

--- a/uriloader/exthandler/nsExternalHelperAppService.cpp
+++ b/uriloader/exthandler/nsExternalHelperAppService.cpp
@@ -422,6 +422,9 @@ static const nsDefaultMimeTypeEntry defaultMimeEntries[] = {
     {TEXT_CSS, "css"},
     {IMAGE_JPEG, "jpeg"},
     {IMAGE_JPEG, "jpg"},
+#ifdef MOZ_JXL
+    {IMAGE_JXL, "jxl"},
+#endif
     {IMAGE_SVG_XML, "svg"},
     {TEXT_HTML, "html"},
     {TEXT_HTML, "htm"},
@@ -520,6 +523,9 @@ static const nsExtraMimeTypeEntry extraMimeEntries[] = {
     {IMAGE_GIF, "gif", "GIF Image"},
     {IMAGE_ICO, "ico,cur", "ICO Image"},
     {IMAGE_JPEG, "jpg,jpeg,jfif,pjpeg,pjp", "JPEG Image"},
+#ifdef MOZ_JXL
+    {IMAGE_JXL, "jxl", "JPEG-XL Image"},
+#endif
     {IMAGE_PNG, "png", "PNG Image"},
     {IMAGE_APNG, "apng", "APNG Image"},
     {IMAGE_TIFF, "tiff,tif", "TIFF Image"},


### PR DESCRIPTION
Testcases:
https://jpegxl.info/test-page/ (main test, with animations, transparency, and ICC)
https://google.github.io/attention-center/ (progressive decoding test)

Based on the following patches:
* [D119700](https://phabricator.services.mozilla.com/D119700), intended for [bug 1709814](https://bugzilla.mozilla.org/show_bug.cgi?id=1709814)
* [D122158](https://phabricator.services.mozilla.com/D122158), intended for bugs [1709818](https://bugzilla.mozilla.org/show_bug.cgi?id=1709818) and [1709816](https://bugzilla.mozilla.org/show_bug.cgi?id=1709816)
* [D122159](https://phabricator.services.mozilla.com/D122159), intended for [bug 1709815](https://bugzilla.mozilla.org/show_bug.cgi?id=1709815)
* Unified XUL Platform (a fork of mozilla-esr52) commit [d14c78b29d5a44679b08682ee5430f494b8e5ce3](https://repo.palemoon.org/MoonchildProductions/UXP/commit/d14c78b29d5a44679b08682ee5430f494b8e5ce3)

This pull request disables the nightly check that prevents JPEG XL support from being enabled in build-time, expands the JPEG XL support (which is currently barebones in Firefox Nightly) with pending patches from Mozilla Phabricator, adding alpha transparency, animations, progressive decoding, and ICC, and enables JPEG XL support by default.