### PR TITLE
Consistent Pocket New Tab section styling

### DIFF
--- a/browser/components/newtab/css/activity-stream-linux.css
+++ b/browser/components/newtab/css/activity-stream-linux.css
@@ -3583,7 +3583,6 @@ main.has-snippet {
 .ds-card .ds-card-link:focus {
   border: 0;
   outline: 0;
-  box-shadow: 0 0 0 3px var(--newtab-primary-action-background-dimmed), 0 0 0 1px var(--newtab-primary-action-background);
   transition: none;
 }
 .ds-card .meta {

--- a/browser/components/newtab/css/activity-stream-linux.css
+++ b/browser/components/newtab/css/activity-stream-linux.css
@@ -2688,7 +2688,7 @@ main.has-snippet {
 
 .ds-header,
 .ds-layout .section-title span {
-  color: var(--newtab-text-primary-color);
+  color: rgb(255, 255, 255);
   font-size: 17px;
   font-weight: 600;
   line-height: 20px;
@@ -2702,7 +2702,7 @@ main.has-snippet {
   margin: auto;
 }
 .collapsible-section.ds-layout .section-top-bar .learn-more-link a {
-  color: var(--newtab-primary-action-background);
+  color: #ffffff8e;
   font-weight: 500;
 }
 .collapsible-section.ds-layout .section-top-bar .learn-more-link a:is(:focus, :hover) {
@@ -2711,17 +2711,23 @@ main.has-snippet {
 
 .ds-onboarding-container,
 .ds-card-grid .ds-card {
-  background: #FFF;
+  background-color: color-mix(in srgb, var(--newtab-background-color) 50%, transparent);
+  border: 1px solid rgba(170, 170, 170, 0.6);
   border-radius: 4px;
+}
+.ds-card-grid .ds-card:is(.active, :focus, :hover) {
+  background: var(--newtab-element-hover-color);
 }
 [lwt-newtab-brighttext] .ds-onboarding-container,
 [lwt-newtab-brighttext] .ds-card-grid .ds-card {
   background: none;
 }
+.floorp-backdrop-blur-enable .ds-card-grid .ds-card {
+  backdrop-filter: blur(12px);
+}
 .ds-onboarding-container:not(.placeholder),
 .ds-card-grid .ds-card:not(.placeholder) {
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 [lwt-newtab-brighttext] .ds-onboarding-container:not(.placeholder),
 [lwt-newtab-brighttext] .ds-card-grid .ds-card:not(.placeholder) {
@@ -3574,20 +3580,11 @@ main.has-snippet {
   flex-direction: column;
   text-decoration: none;
 }
-.ds-card .ds-card-link:hover header {
-  color: var(--newtab-primary-action-background);
-}
 .ds-card .ds-card-link:focus {
   border: 0;
   outline: 0;
   box-shadow: 0 0 0 3px var(--newtab-primary-action-background-dimmed), 0 0 0 1px var(--newtab-primary-action-background);
   transition: none;
-}
-.ds-card .ds-card-link:focus header {
-  color: var(--newtab-primary-action-background);
-}
-.ds-card .ds-card-link:active header {
-  color: var(--newtab-primary-element-active-color);
 }
 .ds-card .meta {
   display: flex;

--- a/browser/components/newtab/css/activity-stream-mac.css
+++ b/browser/components/newtab/css/activity-stream-mac.css
@@ -2692,7 +2692,7 @@ main.has-snippet {
 
 .ds-header,
 .ds-layout .section-title span {
-  color: var(--newtab-text-primary-color);
+  color: rgb(255, 255, 255);
   font-size: 17px;
   font-weight: 600;
   line-height: 20px;
@@ -2706,7 +2706,7 @@ main.has-snippet {
   margin: auto;
 }
 .collapsible-section.ds-layout .section-top-bar .learn-more-link a {
-  color: var(--newtab-primary-action-background);
+  color: #ffffff8e;
   font-weight: 500;
 }
 .collapsible-section.ds-layout .section-top-bar .learn-more-link a:is(:focus, :hover) {
@@ -2715,21 +2715,19 @@ main.has-snippet {
 
 .ds-onboarding-container,
 .ds-card-grid .ds-card {
-  background: #FFF;
+  background-color: color-mix(in srgb, var(--newtab-background-color) 50%, transparent);
+  border: 1px solid rgba(170, 170, 170, 0.6);
   border-radius: 4px;
 }
-[lwt-newtab-brighttext] .ds-onboarding-container,
-[lwt-newtab-brighttext] .ds-card-grid .ds-card {
-  background: none;
+.ds-card-grid .ds-card:is(.active, :focus, :hover) {
+  background: var(--newtab-element-hover-color);
+}
+.floorp-backdrop-blur-enable .ds-card-grid .ds-card {
+  backdrop-filter: blur(12px);
 }
 .ds-onboarding-container:not(.placeholder),
 .ds-card-grid .ds-card:not(.placeholder) {
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-}
-[lwt-newtab-brighttext] .ds-onboarding-container:not(.placeholder),
-[lwt-newtab-brighttext] .ds-card-grid .ds-card:not(.placeholder) {
-  background: var(--newtab-background-color-secondary);
 }
 .ds-onboarding-container:not(.placeholder) .img-wrapper .img img,
 .ds-onboarding-container:not(.placeholder) .img-wrapper .img .placeholder-image,
@@ -3578,20 +3576,10 @@ main.has-snippet {
   flex-direction: column;
   text-decoration: none;
 }
-.ds-card .ds-card-link:hover header {
-  color: var(--newtab-primary-action-background);
-}
 .ds-card .ds-card-link:focus {
   border: 0;
   outline: 0;
-  box-shadow: 0 0 0 3px var(--newtab-primary-action-background-dimmed), 0 0 0 1px var(--newtab-primary-action-background);
   transition: none;
-}
-.ds-card .ds-card-link:focus header {
-  color: var(--newtab-primary-action-background);
-}
-.ds-card .ds-card-link:active header {
-  color: var(--newtab-primary-element-active-color);
 }
 .ds-card .meta {
   display: flex;

--- a/browser/components/newtab/css/activity-stream-windows.css
+++ b/browser/components/newtab/css/activity-stream-windows.css
@@ -2688,7 +2688,7 @@ main.has-snippet {
 
 .ds-header,
 .ds-layout .section-title span {
-  color: var(--newtab-text-primary-color);
+  color: rgb(255, 255, 255);
   font-size: 17px;
   font-weight: 600;
   line-height: 20px;
@@ -2702,7 +2702,7 @@ main.has-snippet {
   margin: auto;
 }
 .collapsible-section.ds-layout .section-top-bar .learn-more-link a {
-  color: var(--newtab-primary-action-background);
+  color: #ffffff8e;
   font-weight: 500;
 }
 .collapsible-section.ds-layout .section-top-bar .learn-more-link a:is(:focus, :hover) {
@@ -2711,21 +2711,19 @@ main.has-snippet {
 
 .ds-onboarding-container,
 .ds-card-grid .ds-card {
-  background: #FFF;
+  background-color: color-mix(in srgb, var(--newtab-background-color) 50%, transparent);
+  border: 1px solid rgba(170, 170, 170, 0.6);
   border-radius: 4px;
 }
-[lwt-newtab-brighttext] .ds-onboarding-container,
-[lwt-newtab-brighttext] .ds-card-grid .ds-card {
-  background: none;
+.ds-card-grid .ds-card:is(.active, :focus, :hover) {
+  background: var(--newtab-element-hover-color);
+}
+.floorp-backdrop-blur-enable .ds-card-grid .ds-card {
+  backdrop-filter: blur(12px);
 }
 .ds-onboarding-container:not(.placeholder),
 .ds-card-grid .ds-card:not(.placeholder) {
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-}
-[lwt-newtab-brighttext] .ds-onboarding-container:not(.placeholder),
-[lwt-newtab-brighttext] .ds-card-grid .ds-card:not(.placeholder) {
-  background: var(--newtab-background-color-secondary);
 }
 .ds-onboarding-container:not(.placeholder) .img-wrapper .img img,
 .ds-onboarding-container:not(.placeholder) .img-wrapper .img .placeholder-image,
@@ -3574,20 +3572,10 @@ main.has-snippet {
   flex-direction: column;
   text-decoration: none;
 }
-.ds-card .ds-card-link:hover header {
-  color: var(--newtab-primary-action-background);
-}
 .ds-card .ds-card-link:focus {
   border: 0;
   outline: 0;
-  box-shadow: 0 0 0 3px var(--newtab-primary-action-background-dimmed), 0 0 0 1px var(--newtab-primary-action-background);
   transition: none;
-}
-.ds-card .ds-card-link:focus header {
-  color: var(--newtab-primary-action-background);
-}
-.ds-card .ds-card-link:active header {
-  color: var(--newtab-primary-element-active-color);
 }
 .ds-card .meta {
   display: flex;

--- a/floorp/browser/themes/designs/lepton/leptonContent.css
+++ b/floorp/browser/themes/designs/lepton/leptonContent.css
@@ -355,12 +355,14 @@
       }
       /* Background */
       .top-site-outer,
+      .ds-card-grid .ds-card,
       #searchSubmit,
       button.icon,
       button.close-button {
         transition: background 1.5s var(--animation-easing-function);
       }
       .top-site-outer:hover,
+      .ds-card-grid .ds-card:hover,
       #searchSubmit:hover,
       button.icon:hover,
       button.close-button:hover {


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->
FIXES #375
This pull request adds consistent styling for the Pocket section of the New Tab page of Floorp, fixing the inconsistent, and unfitting, upstream Firefox styling of the section.

BEFORE:
![Screenshot_20230822_160300](https://github.com/Floorp-Projects/Floorp/assets/11057934/c30362f4-ca0b-452b-99d8-0cbb9a5ee30d)

AFTER:
![Screenshot_20230822_160327](https://github.com/Floorp-Projects/Floorp/assets/11057934/e0c0dde9-8cab-47db-99b1-f63a87997574)

