### PR TITLE
 [FB] Verticaltab | Fix background color

### DIFF
--- a/floorp/browser/base/content/browser-verticaltabs.css
+++ b/floorp/browser/base/content/browser-verticaltabs.css
@@ -16,6 +16,9 @@
      min-width: -moz-available !important;
      max-width: -moz-available !important;
      height: 100% !important;
+   }
+
+   #toolbar-items-verticaltabs:-moz-lwtheme {
      background-color: var(--lwt-accent-color);
      background-image: var(--lwt-additional-images);
      background-repeat: no-repeat, no-repeat, no-repeat;


### PR DESCRIPTION
### Check list
- [ ] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->

`--lwt-accent-color` has changed correctly when it is lw-theme, so it has been changed.
(There is a problem when the system defalt theme)

Before:
![image](https://github.com/black7375/Floorp/assets/25581533/3ab5c3ae-306d-4f24-8d7c-b62c816bde33)

After:
![image](https://github.com/black7375/Floorp/assets/25581533/9629e6d1-a588-440e-8379-9e72cc74f4a9)

This is tested with linux.