### PR TITLE
[FB] Installer | Fix Display Version

### DIFF
--- a/browser/installer/windows/moz.build
+++ b/browser/installer/windows/moz.build
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-DEFINES["APP_VERSION"] = CONFIG["MOZ_APP_VERSION"]
+DEFINES["APP_VERSION"] = CONFIG["MOZ_APP_VERSION_DISPLAY"]
 
 DEFINES["MOZ_APP_NAME"] = CONFIG["MOZ_APP_NAME"]
 DEFINES["MOZ_APP_DISPLAYNAME"] = CONFIG["MOZ_APP_DISPLAYNAME"]


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

Windowsの設定で表示されるバージョンをFloorpのバージョンに修正しました

Before:
![](https://github.com/Floorp-Projects/Floorp/assets/87810571/bbec9f00-f6a8-4fff-99db-a78294e2f9bb)
After:
![](https://github.com/Floorp-Projects/Floorp/assets/87810571/f13cc7d8-8028-4020-b2d6-9f21a69a7f42)

あと`./mach package`で生成されるファイルの名前もFloorpのバージョンになってます(他にも変わってる所あるかも?)

ESR102の
https://github.com/Floorp-Projects/Floorp/commit/e58357add948f63660c690bf68dcca6b44d8769a
https://github.com/Floorp-Projects/Floorp/commit/2376a412318bfaf6420d8b655a86257a545a42ac
のコミットから取ってきました
