### PR TITLE
【衍字修正(Error correction)】AAArch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Winget repository provided by [@Hibi_10000](https://github.com/Hibi-10000)
 
 - Debian-based distributions (such as Ubuntu and Linux Mint) and Arch-based distributions (such as Manjaro) are supported.
 
-- x86_64 & AAarch64 CPU architecture.
+- x86_64 & AArch64 CPU architecture.
 
 - Floorp Browser Requirements: ["Firefox Linux Requirements"](https://www.mozilla.org/en-US/firefox/115.0beta/system-requirements/#gnulinux)
 

--- a/js/src/jit/arm64/vixl/MozCpu-vixl.cpp
+++ b/js/src/jit/arm64/vixl/MozCpu-vixl.cpp
@@ -112,7 +112,7 @@ void CPU::EnsureIAndDCacheCoherency(void* address, size_t length) {
   sys_icache_invalidate(address, length);
 #elif defined(__aarch64__) && (defined(__linux__) || defined(__android__))
   // Implement the cache synchronisation for all targets where AArch64 is the
-  // host, even if we're building the simulator for an AAarch64 host. This
+  // host, even if we're building the simulator for an AArch64 host. This
   // allows for cases where the user wants to simulate code as well as run it
   // natively.
 

--- a/js/src/jit/arm64/vixl/MozCpu-vixl.cpp
+++ b/js/src/jit/arm64/vixl/MozCpu-vixl.cpp
@@ -112,7 +112,7 @@ void CPU::EnsureIAndDCacheCoherency(void* address, size_t length) {
   sys_icache_invalidate(address, length);
 #elif defined(__aarch64__) && (defined(__linux__) || defined(__android__))
   // Implement the cache synchronisation for all targets where AArch64 is the
-  // host, even if we're building the simulator for an AArch64 host. This
+  // host, even if we're building the simulator for an AAArch64 host. This
   // allows for cases where the user wants to simulate code as well as run it
   // natively.
 


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---
日本語

# 衍字修正
## 内容について
ShinecatのREADMEを作るために確認していたら偶然発見した謎のアーキテクチャ**AAArch64**。  
Googleで検索しても修正したと言われ、Wikipedia(ja)には記事がないし、Wikipedia(en)には歴史にこそ記載されているものの、リンクもなくましてやAArch64の事を触れていた。  
そのため`AAArch64`について、衍字として修正を行った。  
リポジトリ内の修正点は二カ所であった。

## 情報
**READMEおよびビルドに関係のないコメントの編集のため、テストをスキップしています。**

---
English

# Error correction.
## About the content
A mysterious architecture **AAArch64** that I discovered by accident when checking to create a README for Shinecat.  
A Google search showed that it had been modified, Wikipedia (en) has no article on it, and Wikipedia (en), although it is mentioned in the history, has no link to it, much less the content which should originally be "AArch64".  
The `AAArch64` has therefore been corrected as a typographical error.  
There were two corrections in the repository.

## Information.
**Skipped testing due to edits to the README and comments not related to the build. **
