### PR TITLE
Grammar fix for the about string

### DIFF
--- a/browser/branding/official/locales/en-US/brand.ftl
+++ b/browser/branding/official/locales/en-US/brand.ftl
@@ -24,4 +24,4 @@
 # remain unchanged across different versions (Nightly, Beta, etc.).
 -brand-product-name = Floorp
 -vendor-short-name = Ablaze
-trademarkInfo = Floorp and the Floorp logos are trademarks of the Ablaze.
+trademarkInfo = Floorp and the Floorp logos are trademarks of Ablaze.


### PR DESCRIPTION
It sounds way more natural and professional without the 'the'.

### Check list
- [x] Referenced all related issues
- [ ] Have tested the modifications

---

<!-- Please enter details on below this line -->
