### PR TITLE
README - updated AUR link to point to floorp-bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Winget repository provided by [@Hibi_10000](https://github.com/Hibi-10000)
 
 3. tarball (All Linux Distributions)    "https://GitHub.com/Floorp-Projects/Floorp/releases/latest"
 
-4. AUR (Arch-based distributions)        "https://aur.archlinux.org/packages/floorp/" **Unofficial**
+4. AUR (Arch-based distributions)        "https://aur.archlinux.org/packages/floorp-bin/" **Unofficial**
 
 5. Nix (NixOS / Anywhere Nix runs)      "https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/browsers/floorp/default.nix" **Unofficial**
 ```


### PR DESCRIPTION
### Check list
- [ /] Referenced all related issues
- [ /] Have tested the modifications

---

<!-- Please enter details on below this line -->

As per pinned comment https://aur.archlinux.org/packages/floorp#comment-952359 floorp-bin should now be used.