### PR TITLE
[FB] Workflow | Update action version

### DIFF
--- a/.github/workflows/auto-labeler-to-issues.yml
+++ b/.github/workflows/auto-labeler-to-issues.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label new issue or discussion
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const issueNumber = context.payload.issue.number;

--- a/.github/workflows/daily-build-with-update.yml
+++ b/.github/workflows/daily-build-with-update.yml
@@ -74,11 +74,11 @@ jobs:
     needs: Part1-win-x86_64-build-with-profgen-zstd
     uses: ./.github/workflows/window-generate-profile-data-and-jarlog.yml
     with:
-     browser-artifact-name: floorp-windows-x86_64-build-with-profgen-zstd
-     arch: x86_64
+      browser-artifact-name: floorp-windows-x86_64-build-with-profgen-zstd
+      arch: x86_64
 
   Part3-win-x86_64-build-with-profdata-and-jarlog:
-    needs: [Part2-win-x86_64-gen-profdata-and-jarlog ,get-buildid]
+    needs: [Part2-win-x86_64-gen-profdata-and-jarlog, get-buildid]
     uses: ./.github/workflows/windows-build.yml
     with:
       aarch64: false
@@ -89,7 +89,7 @@ jobs:
       MOZ_BUILD_DATE: ${{needs.get-buildid.outputs.buildids}}
 
   Part4-win-x86_64-gen-update-xml:
-    needs: [get-display-version, get-buildid, get-inside-version,Part3-win-x86_64-build-with-profdata-and-jarlog]
+    needs: [get-display-version, get-buildid, get-inside-version, Part3-win-x86_64-build-with-profdata-and-jarlog]
     runs-on: ubuntu-latest
     steps:
     - name: generate update XML file
@@ -278,7 +278,7 @@ jobs:
 
     - name: Deploy to GitHub Releases 🚀
       id: create_release
-      uses: "softprops/action-gh-release@v1"
+      uses: softprops/action-gh-release@v1
       with:
         files: |
           /home/runner/downloads/artifacts/linux-x64/LINUX-x86_64.mar
@@ -301,7 +301,7 @@ jobs:
         prerelease: true
         token: ${{ github.token }}
       env:
-       GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
 
     - name: Upload update.xml file to Ablaze server 📤
       run: |

--- a/.github/workflows/daily-build-with-update.yml
+++ b/.github/workflows/daily-build-with-update.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       display-version: ${{ steps.get.outputs.display-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: 'browser/config/version_display.txt'
     - name: Get Display Version
@@ -40,7 +40,7 @@ jobs:
     outputs:
       inside-version: ${{ steps.get.outputs.inside-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: 'browser/config/version.txt'
     - name: Get Inside Version
@@ -120,7 +120,7 @@ jobs:
         MAR_SIZE: ${{needs.Part3-win-x86_64-build-with-profdata-and-jarlog.outputs.mar_size}}
 
     - name: Publish 🎁
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: update-xml-floorp-win-x86_64
         path: |
@@ -167,7 +167,7 @@ jobs:
           MAR_NAME: ${{needs.Part1-build-linux-x86_64-PGO.outputs.mar_name}}
           MAR_SIZE: ${{needs.Part1-build-linux-x86_64-PGO.outputs.mar_size}}
       - name: Publish 🎁
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: update-xml-floorp-linux-x86_64
           path: |
@@ -234,31 +234,31 @@ jobs:
         mkdir -p ~/downloads/artifacts/macOS-x64
 
     - name: download Linux x86_64 build artifact 📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: floorp-linux-x64
         path: ~/downloads/artifacts/linux-x64
 
     - name: download Linux x86_64 build artifact 📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: update-xml-floorp-linux-x86_64
         path: ~/downloads/artifacts/linux-x64
 
     - name: download Windows x86_64 build artifact📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: please-use-this-floorp-windows-x86_64-package-build-with-profdata-and-jarlog
         path: ~/downloads/artifacts/windows-x64
 
     - name: download Windows x86_64 update xml📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: update-xml-floorp-win-x86_64
         path: ~/downloads/artifacts/windows-x64
 
     - name: download macOS Universal build artifact📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Universal-Artifact
         path: ~/downloads/artifacts/macOS-x64

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       display-version: ${{ steps.get.outputs.display-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: 'browser/config/version_display.txt'
     - name: Get Display Version
@@ -47,7 +47,7 @@ jobs:
     outputs:
       inside-version: ${{ steps.get.outputs.inside-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: 'browser/config/version.txt'
     - name: Get Inside Version
@@ -217,31 +217,31 @@ jobs:
         mkdir -p ~/downloads/artifacts/macOS-x64
 
     - name: download Linux x86_64 build artifact 📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: floorp-linux-x64
         path: ~/downloads/artifacts/linux-x64
 
     - name: download Linux aarch64 build artifact 📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: floorp-linux-aarch64
         path: ~/downloads/artifacts/linux-aarch64
 
     - name: download Windows x86_64 build artifact📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: please-use-this-floorp-windows-x86_64-package-build-with-profdata-and-jarlog
         path: ~/downloads/artifacts/windows-x64
 
     - name: download Windows x86 build artifact📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: please-use-this-floorp-windows-x86-package-build-with-profdata-and-jarlog
         path: ~/downloads/artifacts/windows-x86
 
     - name: download macOS Universal build artifact📥
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Universal-Artifact
         path: ~/downloads/artifacts/macOS-x64

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -113,7 +113,7 @@ jobs:
     with:
       browser-artifact-name: floorp-windows-x86-build-with-profgen-zstd
       arch: x86
-    
+
   Part3-win-x86-build-with-profdata-and-jarlog:
     needs: [get-buildid, Part2-win-x86-gen-profdata-and-jarlog]
     uses: ./.github/workflows/windows-build.yml
@@ -153,7 +153,7 @@ jobs:
 
 ################################################ ↑ Linux AArch64 Build ################################################
 
- #----------------------------------------- macOS -----------------------------------------#
+#----------------------------------------- macOS -----------------------------------------#
 
   Part1-macOS-Universal-build-with-profgen:
     uses: ./.github/workflows/macOS-Universal.yml
@@ -165,7 +165,7 @@ jobs:
   Part2-macOS-Universal-gen-profdata-and-jarlog:
     needs: Part1-macOS-Universal-build-with-profgen
     uses: ./.github/workflows/macOS-generate-profile-data-and-jarlog.yml
-  
+
   Part3-macOS-Universal-build-with-profdata-and-jarlog:
     uses: ./.github/workflows/macOS-Universal.yml
     needs: [get-buildid,  Part2-macOS-Universal-gen-profdata-and-jarlog]
@@ -256,7 +256,7 @@ jobs:
 
     - name: Deploy to GitHub Releases for Stable Version 🚀
       id: create_release
-      uses: "softprops/action-gh-release@v1"
+      uses: softprops/action-gh-release@v1
       with:
         files: |
           /home/runner/downloads/artifacts/linux-x64/LINUX-x86_64.mar

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         sudo perl -p -i -e 's%(deb(?:-src|)\s+)https?://(?!archive\.canonical\.com|security\.ubuntu\.com)[^\s]+%$1http://archive.ubuntu.com/ubuntu/%' /etc/apt/sources.list
         sudo apt update
-  
+
     - name: Setup Disk & Swap Space 💿
       run: |
         chmod +x .github/workflows/src/disk_swap_for_github_runner.sh
@@ -222,7 +222,7 @@ jobs:
       run: |
         rm -fr ./third_party/rust
         rm -fr ./third_party/libwebrtc
-        
+
     - name: Package 1 - mach 🎁
       run: |
         if [[ -n $GHA_MOZ_BUILD_DATE ]];then
@@ -269,7 +269,7 @@ jobs:
 
           echo "MAR_NAME=LINUX-aarch64.mar" >> $GITHUB_OUTPUT
           echo "MAR_SIZE=$(stat -c "%s" ~/output/LINUX-aarch64.mar)" >> $GITHUB_OUTPUT
-  
+
         else
 
           touch "obj-x86_64-pc-linux-gnu/dist/floorp/precomplete"

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -59,7 +59,7 @@ jobs:
       mar_size: ${{steps.gen-mar.outputs.MAR_SIZE}}
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Clone 🧬
       with:
         submodules: 'recursive'
@@ -92,7 +92,7 @@ jobs:
         GHA_aarch64: ${{inputs.aarch64}}
 
     - name: Configure sccache
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -289,7 +289,7 @@ jobs:
 
     #PUBLISH START
     - name: Publish🎁
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: floorp-linux-${{fromJson('["x64","aarch64"]')[inputs.aarch64]}}
         path: ~/output

--- a/.github/workflows/linux-x64-deb.yml
+++ b/.github/workflows/linux-x64-deb.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Change PPA mirror servers
       run: |
@@ -111,7 +111,7 @@ jobs:
         rm init_script.txt finish_script.txt Floorp_sec.asc
 
     - name: Publish 🎁
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: floorp-debian-amd64
         path: dist.zip

--- a/.github/workflows/macOS-Universal.yml
+++ b/.github/workflows/macOS-Universal.yml
@@ -238,13 +238,12 @@ jobs:
         if [[ -n $GHA_MOZ_BUILD_DATE ]];then
           export MOZ_BUILD_DATE=$GHA_MOZ_BUILD_DATE
         fi
-  
+
         ./mach build
       env:
         GHA_MOZ_BUILD_DATE: ${{inputs.MOZ_BUILD_DATE}}
-  
-    - name: Package 📦
 
+    - name: Package 📦
       run: |
         if [[ -n $GHA_MOZ_BUILD_DATE ]];then
           export MOZ_BUILD_DATE=$GHA_MOZ_BUILD_DATE

--- a/.github/workflows/macOS-Universal.yml
+++ b/.github/workflows/macOS-Universal.yml
@@ -69,7 +69,7 @@ jobs:
         arch: [x86_64, aarch64]
     steps:
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "lts/*"
     - name: Check Argument Compatibility
@@ -91,7 +91,7 @@ jobs:
         sudo apt update
         echo "$GHA_aarch64"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Clone 🧬
       with:
         submodules: 'recursive'
@@ -102,13 +102,13 @@ jobs:
         .github/workflows/src/disk_swap_for_github_runner.sh
 
     - name: Configure sccache
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Download artifact if use profdata📥
       if: inputs.build-with-profdata-and-jarlog
       with:
@@ -288,7 +288,7 @@ jobs:
         GHA_default_name: floorp-mac-${{ matrix.arch }}-${{fromJson('["package","build-with-profgen"]')[inputs.profgen]}}
 
     - name: Publish Package🎁
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.ARTIFACT_NAME}}
         path: ~/output

--- a/.github/workflows/macOS-generate-profile-data-and-jarlog.yml
+++ b/.github/workflows/macOS-generate-profile-data-and-jarlog.yml
@@ -23,7 +23,7 @@ jobs:
           echo "RUNNER_USERDIR=$RUNNER_USERDIR" >> $GITHUB_ENV
           mkdir -p ~/downloads/artifacts
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Clone 🧬
         with:
           submodules: 'recursive'
@@ -41,14 +41,14 @@ jobs:
         env:
           GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download-artifacts-mac-enable-profgen
         name: Download artifact 📥
         with:
           name: floorp-mac-${{ env.ARCH_TYPE }}-build-with-profgen 
           path: ~/downloads/artifacts
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: ${{ env.ARCH_TYPE == 'x86_64' }}
         with:
           python-version: '3.11' 
@@ -78,7 +78,7 @@ jobs:
           GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
 
       - name: Publish 🎁
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: floorp-${{ env.ARCH_TYPE }}-apple-darwin-profdata-and-jarlog
           path: |

--- a/.github/workflows/macOS-generate-profile-data-and-jarlog.yml
+++ b/.github/workflows/macOS-generate-profile-data-and-jarlog.yml
@@ -9,7 +9,7 @@ on:
     workflow_call:
     workflow_dispatch:
 jobs:
-   macOS-Universal-gen-profdata-and-jarlog:
+  macOS-Universal-gen-profdata-and-jarlog:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
@@ -76,7 +76,7 @@ jobs:
           LLVM_PROFDATA=$RUNNER_USERDIR/.mozbuild/clang/bin/llvm-profdata JARLOG_FILE=en-US.log ./mach python build/pgo/profileserver.py --binary ./obj-${ARCH_TYPE}-apple-darwin/dist/floorp/Floorp.app/Contents/MacOS/floorp
         env:
           GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
-      
+
       - name: Publish 🎁
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/macOS-integration.yml
+++ b/.github/workflows/macOS-integration.yml
@@ -87,18 +87,18 @@ jobs:
     runs-on: macos-latest
     steps:
         - name: Clone 📥
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             submodules: 'recursive'
 
         - name: download M1 build artifact 📥
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: ${{ inputs.aarch64_artifact_name }}
             path: ./
 
         - name: download Intel build artifact 📥
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: ${{ inputs.x86_64_artifact_name }}
             path: ./
@@ -111,7 +111,7 @@ jobs:
             tar -xf ./floorp-aarch64-apple-darwin-with-pgo.tar.gz
             tar -xf ./floorp-x86_64-apple-darwin-with-pgo.tar.gz
 
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: '3.11' 
 
@@ -252,7 +252,7 @@ jobs:
             GHA_default_name: Universal-Artifact
 
         - name: Publish 🎁
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: ${{ env.ARTIFACT_NAME }}
             if-no-files-found: ignore

--- a/.github/workflows/macOS-integration.yml
+++ b/.github/workflows/macOS-integration.yml
@@ -83,20 +83,20 @@ on:
         default: ""
 
 jobs:
-   Integration:
+  Integration:
     runs-on: macos-latest
     steps:
         - name: Clone 📥
           uses: actions/checkout@v3
           with:
             submodules: 'recursive'
-    
+
         - name: download M1 build artifact 📥
           uses: actions/download-artifact@v3
           with:
             name: ${{ inputs.aarch64_artifact_name }}
             path: ./
-    
+
         - name: download Intel build artifact 📥
           uses: actions/download-artifact@v3
           with:
@@ -120,7 +120,7 @@ jobs:
           run: |
             ./mach --no-interactive bootstrap --application-choice browser
             echo -e "ac_add_options --enable-bootstrap" >> mozconfig
-      
+
             echo 'mozconfig: **********************'
             cat ./mozconfig
             echo '*********************************'
@@ -136,7 +136,7 @@ jobs:
             echo "folder structure: aarch64-apple-darwin"
             ls -l ./obj-aarch64-apple-darwin/dist/
             echo "****************************************************************************************************"
-            
+
         - name: Integration 🗃
           run: |
             if [ ${{ inputs.beta }} == 'true' ]; then
@@ -150,8 +150,8 @@ jobs:
         - name: import APPLE DEVELOPER ID CERTIFICATE for .app 🔑
           uses: apple-actions/import-codesign-certs@v2
           with:
-           p12-file-base64: ${{ secrets.macOS_CERTIFICATES_P12_For_App_BASE64 }}
-           p12-password: ${{ secrets.macOS_CERTIFICATES_P12_PASSWORD }}
+            p12-file-base64: ${{ secrets.macOS_CERTIFICATES_P12_For_App_BASE64 }}
+            p12-password: ${{ secrets.macOS_CERTIFICATES_P12_PASSWORD }}
 
         - name: Sign to .app 🖋️
           run: |
@@ -200,46 +200,46 @@ jobs:
             fi
 
             codesign -s "${{ secrets.macOS_AppleDeveloperId }}" floorp-macOS-universal.dmg
-      
+
             xcrun notarytool submit "floorp-macOS-universal.dmg" \
                 --apple-id "${{ secrets.macOS_AppleAccountId }}" \
                 --team-id "${{ secrets.macOS_AppleTeamId }}" \
                 --password "${{ secrets.macOS_AppleAccountAppSpecificPassword }}" \
                 --wait
-      
+
             mkdir -p ./output
             mv ./floorp-macOS-universal.dmg ./output/${INSTALLER_NAME}-macOS-universal.dmg
 
         - name: Create MAR artifact 📦
           run: |
-           if [ ${{ inputs.beta }} == true ]; then
-             export APP_NAME="Floorp Daylight.app"
-           else
-             export APP_NAME="Floorp.app"
-           fi
+            if [ ${{ inputs.beta }} == true ]; then
+              export APP_NAME="Floorp Daylight.app"
+            else
+              export APP_NAME="Floorp.app"
+            fi
 
-           brew install tree
-           chmod +x ./floorp/build/bin/mac/mar
-           chmod +x ./tools/update-packaging/make_full_update.sh
-           touch "obj-x86_64-apple-darwin/dist/floorp/precomplete"
-           MAR="floorp/build/bin/mac/mar" MOZ_PRODUCT_VERSION=${{ inputs.display_version }} MAR_CHANNEL_ID=release tools/update-packaging/make_full_update.sh ./output/DARWIN-Universal.mar "obj-x86_64-apple-darwin/dist/floorp/${APP_NAME}"
+            brew install tree
+            chmod +x ./floorp/build/bin/mac/mar
+            chmod +x ./tools/update-packaging/make_full_update.sh
+            touch "obj-x86_64-apple-darwin/dist/floorp/precomplete"
+            MAR="floorp/build/bin/mac/mar" MOZ_PRODUCT_VERSION=${{ inputs.display_version }} MAR_CHANNEL_ID=release tools/update-packaging/make_full_update.sh ./output/DARWIN-Universal.mar "obj-x86_64-apple-darwin/dist/floorp/${APP_NAME}"
 
-           export MACOS_MAR_SIZE=`stat -f%z ./output/DARWIN-Universal.mar`
-           echo "MACOS_MAR_SIZE=$MACOS_MAR_SIZE" >> $GITHUB_ENV
+            export MACOS_MAR_SIZE=`stat -f%z ./output/DARWIN-Universal.mar`
+            echo "MACOS_MAR_SIZE=$MACOS_MAR_SIZE" >> $GITHUB_ENV
           env: 
             GHA_beta: ${{ inputs.beta }}
- 
+
         - name: Create Update XML for "BETA" Build 🚩
           if : ${{ inputs.beta }} == 'true'
           run: |
-           echo '<?xml version="1.0" encoding="UTF-8"?>
-             <updates>
-              <update type="minor" displayVersion="${{ inputs.display_version }}" appVersion="${{ inputs.inside_version }}" platformVersion="${{ inputs.inside_version }}" buildID="${{ inputs.MOZ_BUILD_DATE }}" detailsURL="https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/">
-              <patch type="complete" URL="https://github.com/${{ github.repository }}/releases/download/beta/DARWIN-Universal.mar" size="${{ env.MACOS_MAR_SIZE }}" />
-             </update>
-           </updates>' > DARWIN-Universal.xml
-        
-           cp DARWIN-Universal.xml output/DARWIN-Universal.xml
+            echo '<?xml version="1.0" encoding="UTF-8"?>
+              <updates>
+                <update type="minor" displayVersion="${{ inputs.display_version }}" appVersion="${{ inputs.inside_version }}" platformVersion="${{ inputs.inside_version }}" buildID="${{ inputs.MOZ_BUILD_DATE }}" detailsURL="https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/">
+                <patch type="complete" URL="https://github.com/${{ github.repository }}/releases/download/beta/DARWIN-Universal.mar" size="${{ env.MACOS_MAR_SIZE }}" />
+              </update>
+            </updates>' > DARWIN-Universal.xml
+
+            cp DARWIN-Universal.xml output/DARWIN-Universal.xml
 
         - name: make name of publish archive
           shell: node {0}
@@ -248,8 +248,8 @@ jobs:
             let name = process.env.GHA_out_artifact_name ? process.env.GHA_out_artifact_name : process.env.GHA_default_name
             fs.appendFileSync(process.env.GITHUB_ENV, `ARTIFACT_NAME=${name}`);
           env:
-             GHA_out_artifact_name : ${{inputs.out_artifact_name}}
-             GHA_default_name: Universal-Artifact
+            GHA_out_artifact_name : ${{inputs.out_artifact_name}}
+            GHA_default_name: Universal-Artifact
 
         - name: Publish 🎁
           uses: actions/upload-artifact@v3
@@ -257,4 +257,4 @@ jobs:
             name: ${{ env.ARTIFACT_NAME }}
             if-no-files-found: ignore
             path: |
-             ./output/
+              ./output/

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: "recursive"
 

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-    
+
     - name: Update Submodules
       run: |
         git submodule update --remote

--- a/.github/workflows/window-generate-profile-data-and-jarlog.yml
+++ b/.github/workflows/window-generate-profile-data-and-jarlog.yml
@@ -35,7 +35,7 @@ jobs:
   Generate-Profile-data-and-jarlog:
     runs-on: windows-latest
     steps:
-        - uses: actions/download-artifact@v3
+        - uses: actions/download-artifact@v4
           name: Download artifact 📥
           with:
             name: ${{ inputs.browser-artifact-name }}
@@ -47,7 +47,7 @@ jobs:
             zstd -d floorp-*.tar.zst
             7z x floorp-*.tar
 
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           name: Clone 🧬
           with:
             submodules: 'recursive'    
@@ -70,7 +70,7 @@ jobs:
             C:\mozilla-build\start-shell.bat $workspace_dir\mozilla-build-run.sh
 
         - name: Publish 🎁
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: floorp-windows-${{ inputs.arch }}-profdata-and-jarlog
             path: |

--- a/.github/workflows/window-generate-profile-data-and-jarlog.yml
+++ b/.github/workflows/window-generate-profile-data-and-jarlog.yml
@@ -19,7 +19,7 @@ on:
           default: 'x86_64'
           type: string
     workflow_dispatch:
-     inputs:
+      inputs:
         browser-artifact:
           description: 'Artifact to download'
           required: true
@@ -30,8 +30,9 @@ on:
           required: true
           default: 'x86_64'
           type: string
+
 jobs:
-   Generate-Profile-data-and-jarlog:
+  Generate-Profile-data-and-jarlog:
     runs-on: windows-latest
     steps:
         - uses: actions/download-artifact@v3
@@ -50,7 +51,7 @@ jobs:
           name: Clone 🧬
           with:
             submodules: 'recursive'    
-        
+
         - name: Setup 🪛
           run: |
             (New-Object System.Net.WebClient).DownloadFile("https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-Latest.exe","C:\MozillaBuildSetup-Latest.exe")
@@ -61,7 +62,7 @@ jobs:
             $Env:USE_MINTTY = "0"
 
             $workspace_dir = [regex]::replace($env:GITHUB_WORKSPACE, "^([A-Z]):", { "/" + $args.value.Substring(0, 1).toLower() }) -replace "\\","/"
-      
+
             echo "cd $workspace_dir" '' >> mozilla-build-run.sh
             echo 'export PATH=/c/mozilla-build/msys2/usr/bin:$PATH' '' >> mozilla-build-run.sh
             echo './mach --no-interactive bootstrap --application-choice browser' '' >> mozilla-build-run.sh

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -221,8 +221,8 @@ jobs:
     - name: Change update url if beta
       if: inputs.beta
       run: |
-       sed -i 's|https://@MOZ_APPUPDATE_HOST@/browser/%DISPLAY_VERSION%/%OS%/%ARCH%/update.xml|https://@MOZ_APPUPDATE_HOST@/browser/beta/%OS%/%ARCH%/update.xml |g' ./build/application.ini.in
-  
+        sed -i 's|https://@MOZ_APPUPDATE_HOST@/browser/%DISPLAY_VERSION%/%OS%/%ARCH%/update.xml|https://@MOZ_APPUPDATE_HOST@/browser/beta/%OS%/%ARCH%/update.xml |g' ./build/application.ini.in
+
     #On Package, if not copies, error occur
     - name: Copy l10n files if beta
       if: inputs.beta
@@ -256,7 +256,7 @@ jobs:
         ./mach build
       env:
         GHA_MOZ_BUILD_DATE: ${{inputs.MOZ_BUILD_DATE}}
-        
+
     - name: Retry Build if 1st build is failed 🔨
       if: failure()
       run: |
@@ -269,7 +269,6 @@ jobs:
         GHA_MOZ_BUILD_DATE: ${{inputs.MOZ_BUILD_DATE}}
 
     - name: Package 📦
-
       run: |
         if [[ -n $GHA_MOZ_BUILD_DATE ]];then
           export MOZ_BUILD_DATE=$GHA_MOZ_BUILD_DATE

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -72,7 +72,7 @@ jobs:
       mar_size: ${{steps.gen-mar.outputs.MAR_SIZE}}
     steps:
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "lts/*"
     - name: Check Argument Compatibility
@@ -113,7 +113,7 @@ jobs:
         sudo perl -p -i -e 's%(deb(?:-src|)\s+)https?://(?!archive\.canonical\.com|security\.ubuntu\.com)[^\s]+%$1http://archive.ubuntu.com/ubuntu/%' /etc/apt/sources.list
         sudo apt update
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Clone 🧬
       with:
         submodules: 'recursive'
@@ -124,13 +124,13 @@ jobs:
         .github/workflows/src/disk_swap_for_github_runner.sh
 
     - name: Configure sccache
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Download artifact if use profdata📥
       if: inputs.profdata_jarlog_artifact_name
       with:
@@ -349,7 +349,7 @@ jobs:
         GHA_default_name: floorp-windows-${{fromJson('["x86","aarch"]')[inputs.aarch64]}}${{fromJson('["_64",""]')[inputs.build32bit]}}-${{fromJson('["package","build-with-profgen"]')[inputs.profgen]}}${{fromJson('["","-zstd"]')[inputs.zstd]}}
 
     - name: Publish Package🎁
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.ARTIFACT_NAME}}
         path: ~/output


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [ ] Have tested the modifications

---

node16を使用するactionを使用すると実行時に警告が出るようになったため、使用しているactionのバージョンを更新しました
ついでにインデントが変なところとかを修正したり

テストはしてない(おい)んですが、各actionのchangelogを見た感じは大丈夫そう

softprops/action-gh-release と apple-actions/import-codesign-certs はnode16を使用していますが、
node20を使用するバージョンが出ていないため更新できていません
(softprops/action-gh-release はnode20にするコミットはされているのでコミットSHAを指定して回避することもできますが...)
