### PR TITLE
[FB] Vertical Tab | Fix transparent vertical tab bar background color on Linux

### DIFF
--- a/browser/themes/linux/browser.css
+++ b/browser/themes/linux/browser.css
@@ -138,6 +138,7 @@ menuitem.bookmark-item {
 
 #TabsToolbar {
   min-height: 0;
+  background-color: ActiveCaption !important;
 }
 
 #titlebar {


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->
Updated System theme to show background color for vertical tab bar on Linux

Before:
![image](https://github.com/Floorp-Projects/Floorp/assets/84299080/82e82c31-f2aa-4683-947a-8edf33cfc994)

After:
![image](https://github.com/Floorp-Projects/Floorp/assets/84299080/5217b466-f8bd-4fb0-88ed-a8aaa36f4ade)
