### PR TITLE
uBlock Origin Redirection to English Site

### DIFF
--- a/browser/components/preferences/privacy.inc.xhtml
+++ b/browser/components/preferences/privacy.inc.xhtml
@@ -356,7 +356,7 @@
       <image id="uBlockOriginImg" class="addonRecommend-img" style="background-image: url('https://addons.mozilla.org/user-media/addon_icons/607/607454-64.png');"/>
       <vbox class="addonRecommend-label-box">
         <description id="AddonRecommend" data-l10n-id="about-uboori"/>
-        <label class="AMO-Link" id="AMO-UO" is="text-link" href="https://addons.mozilla.org/ja/firefox/addon/ublock-origin/" data-l10n-id="view-at-AMO"/>
+        <label class="AMO-Link" id="AMO-UO" is="text-link" href="https://addons.mozilla.org/firefox/addon/ublock-origin/" data-l10n-id="view-at-AMO"/>
       </vbox>
      </hbox>
    </vbox>


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [ ] Have tested the modifications

---

<!-- Please enter details on below this line -->
Changed uBlock Origin link from the japanese site to the english site.

When clicking on the "view this addons on addons.mozilla.org", it would open:
Before: https://addons.mozilla.org/ja/firefox/addon/ublock-origin/
After: https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/
