### PR TITLE
[FB] Branding | Replace about:debugging icons

### DIFF
--- a/devtools/client/aboutdebugging/src/actions/runtimes.js
+++ b/devtools/client/aboutdebugging/src/actions/runtimes.js
@@ -59,23 +59,6 @@ const {
 const CONNECTION_TIMING_OUT_DELAY = 3000;
 const CONNECTION_CANCEL_DELAY = 13000;
 
-async function getRuntimeIcon(runtime, channel) {
-  if (runtime.isFenix) {
-    switch (channel) {
-      case "release":
-      case "beta":
-        return "chrome://devtools/skin/images/aboutdebugging-fenix.svg";
-      case "aurora":
-      default:
-        return "chrome://devtools/skin/images/aboutdebugging-fenix-nightly.svg";
-    }
-  }
-
-  return channel === "release" || channel === "beta" || channel === "aurora"
-    ? `chrome://devtools/skin/images/aboutdebugging-firefox-${channel}.svg`
-    : "chrome://devtools/skin/images/aboutdebugging-firefox-nightly.svg";
-}
-
 function onRemoteDevToolsClientClosed() {
   window.AboutDebugging.onNetworkLocationsUpdated();
   window.AboutDebugging.onUSBRuntimesUpdated();
@@ -123,7 +106,7 @@ function connectRuntime(id) {
       const deviceDescription = await clientWrapper.getDeviceDescription();
       const compatibilityReport =
         await clientWrapper.checkVersionCompatibility();
-      const icon = await getRuntimeIcon(runtime, deviceDescription.channel);
+      const icon = "resource:///chrome/browser/content/branding/icon64.png"
 
       const {
         CONNECTION_PROMPT,

--- a/devtools/client/aboutdebugging/src/components/sidebar/Sidebar.js
+++ b/devtools/client/aboutdebugging/src/components/sidebar/Sidebar.js
@@ -42,8 +42,8 @@ const SidebarRuntimeItem = createFactory(
 const RefreshDevicesButton = createFactory(
   require("resource://devtools/client/aboutdebugging/src/components/sidebar/RefreshDevicesButton.js")
 );
-const FIREFOX_ICON =
-  "chrome://devtools/skin/images/aboutdebugging-firefox-logo.svg";
+const FLOORP_ICON =
+  "chrome://browser/skin/floorp-monochrome.svg";
 const CONNECT_ICON = "chrome://devtools/skin/images/settings.svg";
 const GLOBE_ICON =
   "chrome://devtools/skin/images/aboutdebugging-globe-icon.svg";
@@ -223,7 +223,7 @@ class Sidebar extends PureComponent {
         Localized(
           { id: "about-debugging-sidebar-this-firefox", attrs: { name: true } },
           SidebarFixedItem({
-            icon: FIREFOX_ICON,
+            icon: FLOORP_ICON,
             isSelected:
               PAGE_TYPES.RUNTIME === selectedPage &&
               selectedRuntimeId === RUNTIMES.THIS_FIREFOX,


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->
Replace Firefox icons in `about:debugging`
Fixes #1051 