### PR TITLE
Error with `config.py` for any `./mach` operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,4 +214,5 @@ tools/esmify/package-lock.json
 docs/mots/index.rst
 
 # Ignore .venv or venv directories if somebody uses virtualenv
-[.]venv/
+[Vv]env/
+.[Vv]env/

--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ tools/esmify/package-lock.json
 
 # Ignore automatically generated mots documentation
 docs/mots/index.rst
+
+# Ignore .venv or venv directories if somebody uses virtualenv
+[.]venv/

--- a/python/mach/mach/config.py
+++ b/python/mach/mach/config.py
@@ -309,7 +309,7 @@ class ConfigSettings(collections.abc.Mapping):
         """Load config data by reading file objects."""
 
         for fp in fps:
-            self._config.readfp(fp)
+            self._config.read(fp)
 
     def write(self, fh):
         """Write the config to a file object."""

--- a/python/mach/mach/config.py
+++ b/python/mach/mach/config.py
@@ -309,7 +309,7 @@ class ConfigSettings(collections.abc.Mapping):
         """Load config data by reading file objects."""
 
         for fp in fps:
-            self._config.read(fp)
+            self._config.read_file(fp)
 
     def write(self, fh):
         """Write the config to a file object."""


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---
Basically the `RawConfigParser` might've changed. 

I was cleaning my env for my features for Floorp and when I started from scratch this was the result:
![image](https://github.com/Floorp-Projects/Floorp/assets/47304430/823cdb6a-78f8-4ac2-8176-72a235ac0e48)

~It was an easy fix, just changing what python suggested.~

I fixed it to follow mozilla's upstream, now everything works.
![image](https://github.com/Floorp-Projects/Floorp/assets/47304430/5a35006e-00b7-49d3-91f1-e50d3dca4323)

