### PR TITLE
[FB] Preferences | Add "close window with last tab" preference

### DIFF
--- a/browser/components/preferences/main.inc.xhtml
+++ b/browser/components/preferences/main.inc.xhtml
@@ -88,6 +88,9 @@
     <checkbox id="warnCloseMultiple" data-l10n-id="confirm-on-close-multiple-tabs"
               preference="browser.tabs.warnOnClose"/>
 
+    <checkbox id="closeWindowWithLastTab" data-l10n-id="close-window-with-last-tab"
+              preference="browser.tabs.closeWindowWithLastTab"/>
+
 #ifndef XP_WIN
     <checkbox id="warnOnQuitKey" preference="browser.warnOnQuitShortcut"/>
 #endif

--- a/browser/components/preferences/main.js
+++ b/browser/components/preferences/main.js
@@ -62,6 +62,9 @@ Preferences.addAll([
   browser.tabs.warnOnClose
   - true if when closing a window with multiple tabs the user is warned and
     allowed to cancel the action, false to just close the window
+  browser.tabs.closeWindowWithLastTab
+  - true if the window should be closed when the last tab is closed, false
+    to create a new tab instead
   browser.tabs.warnOnOpen
   - true if the user should be warned if he attempts to open a lot of tabs at
     once (e.g. a large folder of bookmarks), false otherwise
@@ -74,6 +77,7 @@ Preferences.addAll([
   { id: "browser.link.open_newwindow", type: "int" },
   { id: "browser.tabs.loadInBackground", type: "bool", inverted: true },
   { id: "browser.tabs.warnOnClose", type: "bool" },
+  { id: "browser.tabs.closeWindowWithLastTab", type: "bool" },
   { id: "browser.warnOnQuitShortcut", type: "bool" },
   { id: "browser.tabs.warnOnOpen", type: "bool" },
   { id: "browser.ctrlTab.sortByRecentlyUsed", type: "bool" },
@@ -1634,6 +1638,9 @@ var gMainPane = {
    * browser.tabs.warnOnClose - bool
    *   True - If when closing a window with multiple tabs the user is warned and
    *          allowed to cancel the action, false to just close the window.
+   * browser.tabs.closeWindowWithLastTab - bool
+   *   True - If the last tab in a window is closed, the window should be closed.
+   *   False - If the last tab in a window is closed, create a new tab instead.
    * browser.warnOnQuitShortcut - bool
    *   True - If the keyboard shortcut (Ctrl/Cmd+Q) is pressed, the user should
    *          be warned, false to just quit without prompting.

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -169,6 +169,10 @@ confirm-on-close-multiple-tabs =
     .label = Confirm before closing multiple tabs
     .accesskey = m
 
+close-window-with-last-tab =
+    .label = Close window with last tab
+    .accessKey = l
+
 # This string is used for the confirm before quitting preference.
 # Variables:
 #   $quitKey (string) - the quit keyboard shortcut, and formatted

--- a/third_party/rust/fluent-testing/src/scenarios/preferences.rs
+++ b/third_party/rust/fluent-testing/src/scenarios/preferences.rs
@@ -74,6 +74,7 @@ pub fn get_scenario() -> Scenario {
             ("ctrl-tab-recently-used-order", L10nMessage::new(None, Some(vec![L10nAttribute::new("label", "Ctrl+Tab cycles through tabs in recently used order"), L10nAttribute::new("accesskey", "T")]))),
             ("open-new-link-as-tabs", L10nMessage::new(None, Some(vec![L10nAttribute::new("label", "Open links in tabs instead of new windows"), L10nAttribute::new("accesskey", "w")]))),
             ("warn-on-close-multiple-tabs", L10nMessage::new(None, Some(vec![L10nAttribute::new("label", "Warn you when closing multiple tabs"), L10nAttribute::new("accesskey", "m")]))),
+            ("close-window-with-last-tab", L10nMessage::new(None, Some(vec![L10nAttribute::new("label", "Close window with last tab"), L10nAttribute::new("accesskey", "l")]))),
             ("warn-on-open-many-tabs", L10nMessage::new(None, Some(vec![L10nAttribute::new("label", "Warn you when opening multiple tabs might slow down Nightly"), L10nAttribute::new("accesskey", "d")]))),
             ("switch-links-to-new-tabs", L10nMessage::new(None, Some(vec![L10nAttribute::new("label", "When you open a link in a new tab, switch to it immediately"), L10nAttribute::new("accesskey", "h")]))),
             ("disable-extension", L10nMessage::new(None, Some(vec![L10nAttribute::new("label", "Disable Extension")]))),


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

This adds the existing Firefox preference `browser.tabs.closeWindowWithLastTab` to the Floorp Preferences > General >Tabs section, as discussed [here](https://github.com/Floorp-Projects/Floorp/discussions/1198).
