### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Please note that while some of the software listed below is not included in Floo
 
 - [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/)
 - [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/)
-- Authers: [Mozilla & Contributors](https://www.mozilla.org/credits/)
+- Authors: [Mozilla & Contributors](https://www.mozilla.org/credits/)
 
 ### 💧 Waterfox
 


### PR DESCRIPTION
Correct "Authers" to "Authors"

### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->
The word authers has been corrected to authors