### PR TITLE
[FB] Preferences| Auto detect firefox add-on language (ublock)

### DIFF
--- a/browser/components/preferences/privacy.inc.xhtml
+++ b/browser/components/preferences/privacy.inc.xhtml
@@ -407,7 +407,7 @@
       <image id="uBlockOriginImg" class="addonRecommend-img" style="background-image: url('https://addons.mozilla.org/user-media/addon_icons/607/607454-64.png');"/>
       <vbox class="addonRecommend-label-box">
         <description id="AddonRecommend" data-l10n-id="about-uboori"/>
-        <label class="AMO-Link" id="AMO-UO" is="text-link" href="https://addons.mozilla.org/ja/firefox/addon/ublock-origin/" data-l10n-id="view-at-AMO"/>
+        <label class="AMO-Link" id="AMO-UO" is="text-link" href="https://addons.mozilla.org/firefox/addon/ublock-origin/" data-l10n-id="view-at-AMO"/>
       </vbox>
      </hbox>
    </vbox>


### PR DESCRIPTION
### Check list
- [ ] Referenced all related issues
- [ ] Have tested the modifications

---

from the preferences page, clicking "View this addon in addons.mozilla.org" for "Facebook Container" correctly detects users language, but for "uBlock Origin" its hardcoded language to `/ja/`
