### PR TITLE
Fix License Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For more detailed information and guidance, check out our [Floorp Documentation 
 
 - Floorp Browser is based on Mozilla Firefox. Floorp Browser is not affiliated with Mozilla & Mozilla Firefox.
 
-- Floorp uses Mozilla Firefox's source code and other open-source projects. See [Floorp License Notices](#📄-Floorp-License-Notices-📄)
+- Floorp uses Mozilla Firefox's source code and other open-source projects. See [Floorp License Notices](https://github.com/floorp-Projects/floorp/?tab=License-1-ov-file#readme)
 
 ### 📧 Contact
 


### PR DESCRIPTION
### Check list
- Referenced all related issues: Yes; no relevant issues exist for search terms "readme" or "license" mentioning the link changed in this request.
- Have tested the modifications: Yes; the link will open the "License" tab of the Floorp (main, not my fork) when clicked. As this change was made from the fork, it may not give "focus" to the link until committed to the parent repository. Once the link is in the same repository it should also scroll to the correct part of the page.

---

<!-- Please enter details on below this line -->
The old link didn't point to the License tab on the bottom of the page when clicked in Chrome or Firefox, when clicking on this link the page stayed the same (the main project page with README tab). The changed link contains the entire URL and when clicked will go to the correct location.