### PR TITLE
Fix undo closed tab with multiple windows

### DIFF
--- a/src/apps/main/core/common/undo-closed-tab/index.ts
+++ b/src/apps/main/core/common/undo-closed-tab/index.ts
@@ -37,8 +37,8 @@ export default class UndoClosedTab extends NoraComponentBase {
     BrowserActionUtils.createToolbarClickActionButton(
       "undo-closed-tab",
       null,
-      () => {
-        (document?.getElementById("toolbar-context-undoCloseTab") as XULElement)
+      (event: XULCommandEvent) => {
+        (event.view?.document?.getElementById("toolbar-context-undoCloseTab") as XULElement)
           ?.doCommand();
       },
       StyleElement(),

--- a/src/apps/main/core/utils/browser-action.tsx
+++ b/src/apps/main/core/utils/browser-action.tsx
@@ -118,7 +118,7 @@ export namespace BrowserActionUtils {
   export function createToolbarClickActionButton(
     widgetId: string,
     l10nId: string | null,
-    onCommandFunc: () => void,
+    onCommandFunc: (event: XULCommandEvent) => void,
     styleElement: JSXElement | null = null,
     area: string = CustomizableUI.AREA_NAVBAR,
     position: number | null = 0,
@@ -143,8 +143,8 @@ export namespace BrowserActionUtils {
         tooltiptext,
         label,
         removable: true,
-        onCommand: () => {
-          onCommandFunc?.();
+        onCommand: (event: XULCommandEvent) => {
+          onCommandFunc?.(event);
         },
         onCreated: (aNode: XULElement) => {
           onCreatedFunc?.(aNode);


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->

When using the undo closed tab widget within a second window, it instead undos the closed tab in the first window.

This fix uses the view provided by the XULCommandEvent to trigger the undo in the specific window the widget was clicked in.