### PR TITLE
fix: Fix hiding sidebar when fullscreen

### DIFF
--- a/src/apps/main/core/common/panel-sidebar/components/style.css
+++ b/src/apps/main/core/common/panel-sidebar/components/style.css
@@ -198,7 +198,7 @@
     *|*:root[chromehidden~="toolbar"],
     :root[invisibleBMS]
   )
-  #sidebar-select-box {
+  #panel-sidebar-select-box {
   display: none;
 }
 


### PR DESCRIPTION
### Check list
- [x] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->

The sidebar is not hidden when fullscreen since the css rule uses the wrong id: #sidebar-select-box instead should be #panel-sidebar-select-box

https://github.com/Floorp-Projects/Floorp/blob/90692e3857f3eea0a2732bf3a629ad472b14df70/src/apps/main/core/common/panel-sidebar/components/style.css#L201