### PR TITLE
fix(ISSUE_TEMPLATE): update old info and URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,7 @@ body:
 
         ## Disclaimer
         > [!NOTE]
+        > Floorp 12 is our current focus. Floorp 11 receives security fixes only. [Details](https://github.com/Floorp-Projects/Floorp/issues/1735)
         > Windows 7, 8, 8.1, and earlier versions are not supported due to maintenance costs.
         > DRM is not supported, esp. on Netflix.
         > In addition, kindly refer to the [Issue Tracker](https://docs.floorp.app/docs/issue-tracker/).
@@ -39,7 +40,7 @@ body:
         - label: I have checked with a new profile and the issue still occurs.
         - label: I have provided detailed step-by-step instructions on how to reproduce the issue.
         - label: I have included relevant screenshots or console outputs.
-        - label: I have checked that this problem is not occurring in the latest version of Firefox ESR.
+        - label: I have checked that this problem is not occurring in the latest version of Firefox.
         - label: This issue is specific to this browser and does not occur in other browsers.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/Floorp-Projects/Floorp/discussions/new?category=feature-request
     about: Suggest an idea for Floorp.
   - name: User Support
-    url: https://support.ablaze.one/articles/floorp/
+    url: https://docs.floorp.app
     about: Support for end-user.


### PR DESCRIPTION
### Check list
- [ ] Referenced all related issues
- [ ] Have tested the modifications

---

<!-- Please enter details on below this line -->
- Floorp 11 がメンテナンスモードであることを追記
- "最新の Firefox ESR で同じ問題が発生していないか確認する項目" は、もはや実態に則していないため更新
- ユーザーサポートの URL を Floorp Docs に置き換え
  - ただし、元の Ablaze さんのリンクも Floorp Docs にリダイレクトさせてくれます
