### PR TITLE
[FB] Bootstrap | Fix urlopen SSL context for Python 3.13+

### DIFF
--- a/python/mozboot/mozboot/bootstrap.py
+++ b/python/mozboot/mozboot/bootstrap.py
@@ -6,6 +6,7 @@ import os
 import platform
 import re
 import shutil
+import ssl
 import stat
 import subprocess
 import sys
@@ -851,10 +852,9 @@ def update_git_tools(git: Optional[Path], root_state_dir: Path):
         cinnabar_url = "https://github.com/glandium/git-cinnabar/"
         download_py = cinnabar_dir / "download.py"
         with open(download_py, "wb") as fh:
+            ssl_context = ssl.create_default_context(cafile=certifi.where())
             shutil.copyfileobj(
-                urlopen(
-                    f"{cinnabar_url}/raw/master/download.py", cafile=certifi.where()
-                ),
+                urlopen(f"{cinnabar_url}/raw/master/download.py", context=ssl_context),
                 fh,
             )
 

--- a/python/mozboot/mozboot/osx.py
+++ b/python/mozboot/mozboot/osx.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import platform
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -274,8 +275,9 @@ class OSXBootstrapper(OSXAndroidBootstrapper, BaseBootstrapper):
 
     def install_homebrew(self):
         print(BREW_INSTALL)
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
         bootstrap = urlopen(
-            url=HOMEBREW_BOOTSTRAP, cafile=certifi.where(), timeout=20
+            url=HOMEBREW_BOOTSTRAP, context=ssl_context, timeout=20
         ).read()
         with tempfile.NamedTemporaryFile() as tf:
             tf.write(bootstrap)


### PR DESCRIPTION
### Check list
- [ ] Referenced all related issues
- [x] Have tested the modifications

---

<!-- Please enter details on below this line -->
### Summary
This patch updates the urlopen calls in bootstrap.py and osx.py to use an SSLContext instead of the deprecated cafile argument (as already done in many other places in the code).

### Reason

- Python 3.13 removed support for the cafile parameter in urllib.request.urlopen.
- Without this change, ./mach bootstrap fails on systems running Python 3.13+ (triggered when git-cinnabar is missing or needs reinstall. Same for Homebrew).
