### PR TITLE
"Open in Main Browser" should use Container

### DIFF
--- a/src/apps/main/core/common/panel-sidebar/components/panel-sidebar.tsx
+++ b/src/apps/main/core/common/panel-sidebar/components/panel-sidebar.tsx
@@ -232,9 +232,11 @@ export class CPanelSidebar {
 
   public openInMainWindow(panelId: string) {
     const url = this.getPanelData(panelId)?.url;
+    const userContextId = this.getPanelData(panelId)?.userContextId;
     globalThis.gBrowser.addTab(url, {
       triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
       inBackground: false,
+      userContextId: userContextId
     });
   }
 


### PR DESCRIPTION
My first contribution!! 
Simple problem, simple fix.  Fixes #1924 
Now, the "Open in Main Browser" will open in the good Container.
Tested with container-less and container sidebar. Seems to work perfectly!
Thanks to @nyanrus for the build script spaghetti workaround :)