### PR TITLE
fix: Properly remove home page with its entire content when floorp start is enabled

### DIFF
--- a/src/apps/startup/src/about-preferences.ts
+++ b/src/apps/startup/src/about-preferences.ts
@@ -114,16 +114,15 @@ function addFloorpHubCategory(): void {
 }
 
 function hideNewTabPage(): void {
-  const homeCategory = document.querySelector("#category-home");
   const pref = Services.prefs.getStringPref("floorp.design.configs");
   const config = JSON.parse(pref).uiCustomization.disableFloorpStart;
 
-  if (
-    homeCategory && !config
-  ) {
-    homeCategory.remove();
+  if (!config) {
+    document.querySelectorAll('#category-home, [data-category="paneHome"]').forEach((el) => {
+      el.remove();
+    });
   }
 }
 
 addFloorpHubCategory();
-hideNewTabPage();
+Services.obs.addObserver(hideNewTabPage, 'home-pane-loaded');


### PR DESCRIPTION
If the content is not removed as well it can still be found using the search function.

To properly remove the entire panes content it is necessary to wait for the 'home-pane-loaded' event.

<img width="964" height="642" alt="Screenshot_20250830_201536" src="https://github.com/user-attachments/assets/37e56cbd-accd-4eaf-82e9-765561efe48e" />
