### PR TITLE
fix: Do not hide navbar when in fullscreen for macOS

### DIFF
--- a/src/apps/main/core/common/designs/browser.css
+++ b/src/apps/main/core/common/designs/browser.css
@@ -190,6 +190,8 @@ notification-message[message-bar-type="infobar"] {
   --info-bar-text-color: var(--lwt-text-color, #222) !important;
 }
 
-:root[sizemode="fullscreen"]:not([inDOMFullscreen="true"]) #nav-bar {
-  display: none !important;
+@media not (-moz-platform: macos) {
+  :root[sizemode="fullscreen"]:not([inDOMFullscreen="true"]) #nav-bar {
+    display: none !important;
+  }
 }


### PR DESCRIPTION
As of version 12.2.0, Floorp hides the navbar when in full-screen view (i.e. when F11 is pressed). This behavior also applies to macOS, although macOS' fullscreen view is usually more comparable to the maximized view on Windows and Linux in terms of how it's used.

For example, on Firefox:
- When the window is **maximized** on Windows/Linux, the toolbar remains.
- When the window is **full-screened (F11)** on Windows/Linux, the toolbar automatically hides.
- When the window is **full-screened** on macOS, the toolbar remains.

I believe Floorp should also follow this behavior, so I've added a condition to the CSS rule so that the navbar only hides itself when it is on fullscreen on a non-macOS system.