### PR TITLE
feat: add AI Community Moderator workflow 

### DIFF
--- a/.github/workflows/moderate.yml
+++ b/.github/workflows/moderate.yml
@@ -1,0 +1,31 @@
+name: AI Community Moderator
+
+on:
+    issues:
+        types: [opened, edited]
+    pull_request:
+        types: [opened, edited]
+    issue_comment:
+        types: [created, edited]
+    pull_request_review_comment:
+        types: [created, edited]
+    discussion:
+        types: [created, edited]
+    discussion_comment:
+        types: [created, edited]
+
+jobs:
+    moderate:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+            pull-requests: write
+            discussions: write
+            models: read
+        steps:
+            - uses: benbalter/ai-community-moderator@v1
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  severity-threshold: 5
+                  model: "microsoft/Phi-4-reasoning"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate moderation of community interactions using AI. The workflow is triggered by various events related to issues, pull requests, comments, and discussions, and leverages the `benbalter/ai-community-moderator` action to help maintain a positive environment.

**Automated moderation workflow:**

* Added `.github/workflows/moderate.yml` to set up the "AI Community Moderator" workflow, which runs on `ubuntu-latest` and responds to creation and edits of issues, pull requests, comments, and discussions.
* Configured permissions for the workflow to allow reading contents and models, and writing to issues, pull requests, and discussions.
* Integrated the `benbalter/ai-community-moderator@v1` action, specifying the use of the `microsoft/Phi-4-reasoning` model and a severity threshold of 5 for moderation actions.