### PR TITLE
Refactor: Centralize PWA taskbar experiment logic

### DIFF
--- a/browser-features/chrome/common/pwa/ssbManager.ts
+++ b/browser-features/chrome/common/pwa/ssbManager.ts
@@ -11,34 +11,9 @@ import { SsbRunner } from "./ssbRunner.ts";
 const { AppConstants } = ChromeUtils.importESModule(
   "resource://gre/modules/AppConstants.sys.mjs",
 );
-
-const LINUX_TASKBAR_EXPERIMENT = "pwa_taskbar_integration_linux";
-
-// Check if Linux-only PWA taskbar integration experiment is enabled
-// Simply checks if the user is assigned to the experiment (rollout-based)
-const isTaskbarIntegrationEnabled = (): boolean => {
-  if (AppConstants.platform !== "linux") {
-    return true;
-  }
-
-  try {
-    const { Experiments } = ChromeUtils.importESModule(
-      "resource://noraneko/modules/experiments/Experiments.sys.mjs",
-    );
-    const variant = Experiments.getVariant(LINUX_TASKBAR_EXPERIMENT);
-
-    // If variant is assigned (not null), the feature is enabled
-    // Rollout percentage controls what portion of users get the feature
-    return variant !== null;
-  } catch (error) {
-    console.error(
-      "Failed to check pwa_taskbar_integration_linux experiment:",
-      error,
-    );
-    // If experiments system fails, default to disabled for safety
-    return false;
-  }
-};
+const { TaskbarExperiment } = ChromeUtils.importESModule(
+  "resource://noraneko/modules/pwa/TaskbarExperiment.sys.mjs",
+);
 
 let SupportClass: any | null = null;
 if (AppConstants.platform === "win") {
@@ -185,61 +160,61 @@ export class SiteSpecificBrowserManager {
     return await this.manifestProcesser.getManifestFromBrowser(browser, true);
   }
 
-  private async createFromBrowser(
-    browser: Browser,
-    options: { useWebManifest: boolean },
-  ): Promise<Manifest | null> {
-    return await this.manifestProcesser.getManifestFromBrowser(
-      browser,
-      options.useWebManifest,
-    );
-  }
-
-  private async install(manifest: Manifest) {
-    if (SupportClass) {
-      if (AppConstants.platform === "win") {
-        // Windows install (taskbar integration) is controlled by A/B test
-        if (isTaskbarIntegrationEnabled()) {
-          const windowsSupport = new SupportClass(this);
-          await windowsSupport.install(manifest);
-        } else {
-          console.debug(
-            "[SiteSpecificBrowserManager] PWA taskbar integration disabled by A/B test, skipping Windows install",
-          );
-        }
-      } else if (AppConstants.platform === "linux") {
-        // Linux install (.desktop file generation) is NOT controlled by A/B test
-        // This is excluded from A/B test as per requirements
-        const linuxSupport = new SupportClass(this);
-        await linuxSupport.install(manifest);
-      }
+    private async createFromBrowser(
+      browser: Browser,
+      options: { useWebManifest: boolean },
+    ): Promise<Manifest | null> {
+      return await this.manifestProcesser.getManifestFromBrowser(
+        browser,
+        options.useWebManifest,
+      );
     }
 
-    await this.dataManager.saveSsbData(manifest);
-  }
-
-  private async uninstall(manifest: Manifest) {
-    if (SupportClass) {
-      if (AppConstants.platform === "win") {
-        // Windows uninstall (taskbar integration) is controlled by A/B test
-        if (isTaskbarIntegrationEnabled()) {
-          const windowsSupport = new SupportClass(this);
-          await windowsSupport.uninstall(manifest);
-        } else {
-          console.debug(
-            "[SiteSpecificBrowserManager] PWA taskbar integration disabled by A/B test, skipping Windows uninstall",
-          );
+    private async install(manifest: Manifest) {
+      if (SupportClass) {
+        if (AppConstants.platform === "win") {
+          // Windows install (taskbar integration) is controlled by A/B test
+          if (TaskbarExperiment.isEnabledForCurrentPlatform()) {
+            const windowsSupport = new SupportClass(this);
+            await windowsSupport.install(manifest);
+          } else {
+            console.debug(
+              "[SiteSpecificBrowserManager] PWA taskbar integration disabled by A/B test, skipping Windows install",
+            );
+          }
+        } else if (AppConstants.platform === "linux") {
+          // Linux install (.desktop file generation) is NOT controlled by A/B test
+          // This is excluded from A/B test as per requirements
+          const linuxSupport = new SupportClass(this);
+          await linuxSupport.install(manifest);
         }
-      } else if (AppConstants.platform === "linux") {
-        // Linux uninstall (.desktop file removal) is NOT controlled by A/B test
-        // This is excluded from A/B test as per requirements
-        const linuxSupport = new SupportClass(this);
-        await linuxSupport.uninstall(manifest);
       }
+
+      await this.dataManager.saveSsbData(manifest);
     }
 
-    await this.dataManager.removeSsbData(manifest.start_url);
-  }
+    private async uninstall(manifest: Manifest) {
+      if (SupportClass) {
+        if (AppConstants.platform === "win") {
+          // Windows uninstall (taskbar integration) is controlled by A/B test
+          if (TaskbarExperiment.isEnabledForCurrentPlatform()) {
+            const windowsSupport = new SupportClass(this);
+            await windowsSupport.uninstall(manifest);
+          } else {
+            console.debug(
+              "[SiteSpecificBrowserManager] PWA taskbar integration disabled by A/B test, skipping Windows uninstall",
+            );
+          }
+        } else if (AppConstants.platform === "linux") {
+          // Linux uninstall (.desktop file removal) is NOT controlled by A/B test
+          // This is excluded from A/B test as per requirements
+          const linuxSupport = new SupportClass(this);
+          await linuxSupport.uninstall(manifest);
+        }
+      }
+
+      await this.dataManager.removeSsbData(manifest.start_url);
+    }
 
   public async uninstallById(id: string) {
     const ssbObj = await this.getSsbObj(id);

--- a/browser-features/modules/modules/pwa/SsbCommandLineHandler.sys.mts
+++ b/browser-features/modules/modules/pwa/SsbCommandLineHandler.sys.mts
@@ -12,34 +12,9 @@ const { AppConstants } = ChromeUtils.importESModule(
 const { SessionStore } = ChromeUtils.importESModule(
   "resource:///modules/sessionstore/SessionStore.sys.mjs",
 );
-
-const LINUX_TASKBAR_EXPERIMENT = "pwa_taskbar_integration_linux";
-
-// Check if Linux-only PWA taskbar integration experiment is enabled
-// Simply checks if the user is assigned to the experiment (rollout-based)
-const isTaskbarIntegrationEnabled = (): boolean => {
-  if (AppConstants.platform !== "linux") {
-    return true;
-  }
-
-  try {
-    const { Experiments } = ChromeUtils.importESModule(
-      "resource://noraneko/modules/experiments/Experiments.sys.mjs",
-    );
-    const variant = Experiments.getVariant(LINUX_TASKBAR_EXPERIMENT);
-
-    // If variant is assigned (not null), the feature is enabled
-    // Rollout percentage controls what portion of users get the feature
-    return variant !== null;
-  } catch (error) {
-    console.error(
-      "Failed to check pwa_taskbar_integration_linux experiment:",
-      error,
-    );
-    // If experiments system fails, default to disabled for safety
-    return false;
-  }
-};
+const { TaskbarExperiment } = ChromeUtils.importESModule(
+  "resource://noraneko/modules/pwa/TaskbarExperiment.sys.mjs",
+);
 
 export const PWA_WINDOW_NAME = "FloorpPWAWindow";
 const SSB_WINDOW_FEATURES =
@@ -48,64 +23,64 @@ const SSB_WINDOW_FEATURES =
 type TQueryInterface = <T extends nsIID>(aIID: T) => nsQIResult<T>;
 
 export class SsbRunnerUtils {
-  static async openSsbWindow(ssb: Manifest, initialLaunch: boolean = false) {
-    let initialLaunchWin: nsIDOMWindow | null = null;
-    if (initialLaunch) {
-      initialLaunchWin = Services.ww.openWindow(
+    static async openSsbWindow(ssb: Manifest, initialLaunch: boolean = false) {
+      let initialLaunchWin: nsIDOMWindow | null = null;
+      if (initialLaunch) {
+        initialLaunchWin = Services.ww.openWindow(
+          null as unknown as mozIDOMWindowProxy,
+          AppConstants.BROWSER_CHROME_URL,
+          "_blank",
+          "",
+          {},
+        ) as nsIDOMWindow;
+      }
+
+      const args = this.createWindowArgs(ssb.start_url);
+      const uniqueWindowName = this.generateWindowName(ssb.id);
+
+      const win = Services.ww.openWindow(
         null as unknown as mozIDOMWindowProxy,
         AppConstants.BROWSER_CHROME_URL,
-        "_blank",
-        "",
-        {},
+        uniqueWindowName,
+        SSB_WINDOW_FEATURES,
+        args,
       ) as nsIDOMWindow;
+
+      win.focus();
+      SessionStore.promiseAllWindowsRestored.then(() => {
+        initialLaunchWin?.close();
+      });
+
+      await this.waitForWindowLoaded(win);
+      return win;
     }
 
-    const args = this.createWindowArgs(ssb.start_url);
-    const uniqueWindowName = this.generateWindowName(ssb.id);
+    static async applyOSIntegration(ssb: Manifest, win: Window) {
+      // Check A/B test before applying taskbar integration
+      if (!TaskbarExperiment.isEnabledForCurrentPlatform()) {
+        console.debug(
+          "[SsbRunnerUtils] PWA taskbar integration disabled by A/B test, skipping OS integration",
+        );
+        return;
+      }
 
-    const win = Services.ww.openWindow(
-      null as unknown as mozIDOMWindowProxy,
-      AppConstants.BROWSER_CHROME_URL,
-      uniqueWindowName,
-      SSB_WINDOW_FEATURES,
-      args,
-    ) as nsIDOMWindow;
+      if (AppConstants.platform === "win") {
+        const { WindowsSupport } = ChromeUtils.importESModule(
+          "resource://noraneko/modules/pwa/supports/Windows.sys.mjs",
+        );
+        const windowsSupport = new WindowsSupport();
+        await windowsSupport.applyOSIntegration(ssb, win);
+        return;
+      }
 
-    win.focus();
-    SessionStore.promiseAllWindowsRestored.then(() => {
-      initialLaunchWin?.close();
-    });
-
-    await this.waitForWindowLoaded(win);
-    return win;
-  }
-
-  static async applyOSIntegration(ssb: Manifest, win: Window) {
-    // Check A/B test before applying taskbar integration
-    if (!isTaskbarIntegrationEnabled()) {
-      console.debug(
-        "[SsbRunnerUtils] PWA taskbar integration disabled by A/B test, skipping OS integration",
-      );
-      return;
+      if (AppConstants.platform === "linux") {
+        const { LinuxSupport } = ChromeUtils.importESModule(
+          "resource://noraneko/modules/pwa/supports/Linux.sys.mjs",
+        );
+        const linuxSupport = new LinuxSupport();
+        await linuxSupport.applyOSIntegration(ssb, win);
+      }
     }
-
-    if (AppConstants.platform === "win") {
-      const { WindowsSupport } = ChromeUtils.importESModule(
-        "resource://noraneko/modules/pwa/supports/Windows.sys.mjs",
-      );
-      const windowsSupport = new WindowsSupport();
-      await windowsSupport.applyOSIntegration(ssb, win);
-      return;
-    }
-
-    if (AppConstants.platform === "linux") {
-      const { LinuxSupport } = ChromeUtils.importESModule(
-        "resource://noraneko/modules/pwa/supports/Linux.sys.mjs",
-      );
-      const linuxSupport = new LinuxSupport();
-      await linuxSupport.applyOSIntegration(ssb, win);
-    }
-  }
 
   private static createWindowArgs(startUrl: string) {
     const args = Cc["@mozilla.org/supports-string;1"].createInstance(

--- a/browser-features/modules/modules/pwa/TaskbarExperiment.sys.mts
+++ b/browser-features/modules/modules/pwa/TaskbarExperiment.sys.mts
@@ -1,0 +1,43 @@
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs",
+);
+
+const LINUX_TASKBAR_EXPERIMENT = "pwa_taskbar_integration_linux";
+
+const readLinuxExperimentAssignment = (): boolean => {
+  try {
+    const { Experiments } = ChromeUtils.importESModule(
+      "resource://noraneko/modules/experiments/Experiments.sys.mjs",
+    );
+    const variant = Experiments.getVariant(LINUX_TASKBAR_EXPERIMENT);
+    return variant !== null;
+  } catch (error) {
+    console.error(
+      "[TaskbarExperiment] Failed to check pwa_taskbar_integration_linux experiment:",
+      error,
+    );
+    // If experiments system fails, default to disabled for safety
+    return false;
+  }
+};
+
+export const TaskbarExperiment = {
+  /**
+   * Returns true when taskbar integration should run on Linux.
+   * This ignores the current platform and only checks the experiment state.
+   */
+  isEnabledForLinux(): boolean {
+    return readLinuxExperimentAssignment();
+  },
+
+  /**
+   * Returns true when taskbar integration should run on the current platform.
+   * Linux is guarded by the experiment rollout, other platforms always allow it.
+   */
+  isEnabledForCurrentPlatform(): boolean {
+    if (AppConstants.platform !== "linux") {
+      return true;
+    }
+    return readLinuxExperimentAssignment();
+  },
+} as const;


### PR DESCRIPTION
Moves experiment checking to a dedicated module and simplifies usage.