### PR TITLE
Fixed paddings for right section of about dialog.

### DIFF
--- a/tools/patches/browser-chrome-browser-content-browser-aboutDialog.patch
+++ b/tools/patches/browser-chrome-browser-content-browser-aboutDialog.patch
@@ -1,0 +1,24 @@
+diff --git a/browser/chrome/browser/content/browser/aboutDialog.css b/browser/chrome/browser/content/browser/aboutDialog.css
+index bca264f..6860af7 100755
+--- ./browser/chrome/browser/content/browser/aboutDialog.css
++++ ./browser/chrome/browser/content/browser/aboutDialog.css
+@@ -17,7 +17,10 @@
+ }
+ 
+ #leftBox {
+-  background-image: image-set(url("chrome://branding/content/about-logo.png"), url("chrome://branding/content/about-logo@2x.png") 2x);
++  background-image: image-set(
++    url("chrome://branding/content/about-logo.png"),
++    url("chrome://branding/content/about-logo@2x.png") 2x
++  );
+   background-repeat: no-repeat;
+   background-size: 192px auto;
+   background-position: center 40px;
+@@ -33,6 +36,7 @@
+   background-image: url("chrome://branding/content/about-wordmark.svg");
+   background-repeat: no-repeat;
+   background-size: 288px auto;
++  padding-top: 75px;
+   /* move wordmark down a bit so it doesnt bump up too closely to top of dialog */
+   margin-top: 20px;
+   /* We don't want this box to contribute arbitrarily to the intrinsic size of


### PR DESCRIPTION
Fixed cosmetic issue with about window which described here: 
https://github.com/Floorp-Projects/Floorp/issues/2297

<img width="842" height="497" alt="Screenshot 2026-02-28 at 3 13 24 PM" src="https://github.com/user-attachments/assets/676bc712-d05c-4f16-bcc8-76b03c8db926" />
<img width="842" height="530" alt="Screenshot 2026-02-28 at 3 13 37 PM" src="https://github.com/user-attachments/assets/f34bf3d6-1535-4072-bc6f-438173eee3b4" />
