### PR TITLE
fix: Mouse gesture trail hide on toggle

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/components/GestureDisplay.tsx
+++ b/browser-features/chrome/common/mouse-gesture/components/GestureDisplay.tsx
@@ -165,12 +165,14 @@ export class GestureDisplay {
   }
 
   private draw(): void {
-    const showTrail = getConfig().showTrail;
+    const config = getConfig();
     if (!this.canvasEl || !this.ctx) return;
     const dpr = this.targetWindow.devicePixelRatio || 1;
     const w = this.canvasEl.width / dpr;
     const h = this.canvasEl.height / dpr;
     this.ctx.clearRect(0, 0, w, h);
+
+    if (!config.showTrail) return;
 
     const trail = this.trail || [];
     if (trail.length < 2) return;
@@ -179,10 +181,8 @@ export class GestureDisplay {
     this.ctx.lineJoin = "round";
     this.ctx.lineCap = "round";
     this.ctx.globalAlpha = 0.9;
-    this.ctx.strokeStyle = getConfig().trailColor || "#37ff00";
-    if(!showTrail)
-      this.ctx.strokeStyle = "transparent";
-    this.ctx.lineWidth = getConfig().trailWidth || 6;
+    this.ctx.strokeStyle = config.trailColor || "#37ff00";
+    this.ctx.lineWidth = config.trailWidth || 6;
     this.ctx.beginPath();
     this.ctx.moveTo(trail[0].x, trail[0].y);
     for (let i = 1; i < trail.length; i++) {


### PR DESCRIPTION
## Fix: Mouse Gesture Trail Visibility when Toggled Off

### Related Issue
Closes #2283 

### Description
This PR fixes an issue where the **Mouse Gesture Trail** remained visible even when the **"Show gesture trail"** option was toggled off.

Previously, disabling the setting did not hide the gesture trail, causing it to still appear during mouse gestures. The visibility logic has now been corrected so that the trail strictly follows the state of the toggle.

### Changes Made
- Introduced a configuration state check using:
  ```js
  const config = getConfig();
- When ```config.showTrail``` is ```false```, the ```draw``` function is set to return before drawing, preventing the gesture trail from being rendered.
- When ```showTrail``` is ```true```, the gesture trail behaves as usual.
- Ensures the "Show gesture trail" toggle correctly controls the visibility of the mouse gesture trail.

### Reproduction Steps
- Open about:hub
- Navigate to Mouse Gestures
- Enable Mouse Gestures
- Disable Mouse Gesture Trail

### Expected Behavior
- When **Show gesture trail = ON** → Gesture trail is visible.
- When **Show gesture trail = OFF** → Gesture trail is hidden.

### Testing
- Enabled the gesture trail and confirmed it appears during mouse gestures.
- Disabled the gesture trail and verified that no trail is rendered.
- Repeated toggle cycles to confirm consistent behavior.

### Type of Change
- 🐛 Bug fix

### Screenshots / GIF (Optional)

#### When Show gesture trail is ON
<img width="1919" height="1037" alt="Screenshot from 2026-03-06 09-21-56" src="https://github.com/user-attachments/assets/04c8f359-6b8a-4c9e-a33d-d29c170f83b7" />

#### When Show gesture trail is OFF
<img width="1919" height="1037" alt="Screenshot from 2026-03-06 09-22-21" src="https://github.com/user-attachments/assets/cc6dee25-5f95-402d-9472-ca3cc8faebaf" />

