### PR TITLE
fix: address Copilot review feedback from PR #2329

### DIFF
--- a/browser-features/pages-settings/src/components/app-sidebar.tsx
+++ b/browser-features/pages-settings/src/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   PanelLeft,
   PencilRuler,
   RefreshCw,
+  Settings,
   UserRoundPen,
 } from "lucide-react";
 import { NavHeader } from "@/components/nav-header.tsx";
@@ -102,6 +103,13 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   ], [isFloorpOSVisible, t]);
 
   const about = [
+    {
+      title: t("sidebar.firefoxSettings"),
+      url: "",
+      icon: Settings,
+      isExternal: true,
+      onClick: () => window.NRAddTab("about:preferences"),
+    },
     { title: t("pages.aboutBrowser"), url: "/about/browser", icon: BadgeInfo },
     { title: t("pages.updates"), url: "/about/updates", icon: RefreshCw },
   ];

--- a/browser-features/pages-settings/src/components/nav-features.tsx
+++ b/browser-features/pages-settings/src/components/nav-features.tsx
@@ -1,23 +1,79 @@
 import type { LucideIcon } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import {
   SidebarGroup,
   SidebarGroupLabel,
   SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
 } from "@/components/common/sidebar.tsx";
 import { Link, useLocation } from "react-router-dom";
+
+// Discriminated union for feature items
+type BaseFeature = {
+  title: string;
+  url: string;
+  icon: LucideIcon;
+};
+
+type ExternalFeature = BaseFeature & {
+  isExternal: true;
+  onClick: (e: React.MouseEvent) => void;
+};
+
+type InternalFeature = BaseFeature & {
+  isExternal?: false;
+  onClick?: never;
+};
+
+type Feature = InternalFeature | ExternalFeature;
+
+// Internal item renderer without SidebarMenuItem wrapper
+function InternalItem({
+  feature,
+  isActive,
+}: {
+  feature: InternalFeature;
+  isActive: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors">
+      <Link
+        to={feature.url}
+        className={`${
+          isActive
+            ? "bg-primary text-primary-content"
+            : "hover:bg-primary/30"
+        } w-full flex items-center rounded-lg p-3 text-left gap-3`}
+      >
+        <feature.icon className="size-4" />
+        <span>{feature.title}</span>
+      </Link>
+    </div>
+  );
+}
+
+// External item renderer without SidebarMenuItem wrapper
+function ExternalItem({ feature }: { feature: ExternalFeature }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors">
+      <button
+        type="button"
+        onClick={feature.onClick}
+        className="hover:bg-primary/30 w-full flex items-center rounded-lg p-3 text-left gap-3"
+      >
+        <feature.icon className="size-4" />
+        <span>{feature.title}</span>
+        <ExternalLink className="size-3 ml-auto opacity-60" />
+      </button>
+    </div>
+  );
+}
 
 export function NavFeatures({
   title,
   features,
 }: {
   title: string;
-  features: {
-    title: string;
-    url: string;
-    icon: LucideIcon;
-  }[];
+  features: Feature[];
 }) {
   const location = useLocation();
   const currentRoute = location.pathname;
@@ -34,22 +90,11 @@ export function NavFeatures({
             ? currentRoute === "/"
             : currentRoute.startsWith(featurePath);
 
-          return (
-            <SidebarMenuItem key={feature.title}>
-              <Link to={feature.url} className="block w-full">
-                <SidebarMenuButton
-                  className={`${
-                    isActive
-                      ? "bg-primary text-primary-content"
-                      : "hover:bg-primary/30"
-                  } w-full flex items-center rounded-lg p-4`}
-                >
-                  <feature.icon className="size-4" />
-                  <span>{feature.title}</span>
-                </SidebarMenuButton>
-              </Link>
-            </SidebarMenuItem>
-          );
+          if (feature.isExternal) {
+            return <ExternalItem key={feature.title} feature={feature} />;
+          }
+
+          return <InternalItem key={feature.title} feature={feature} isActive={isActive} />;
         })}
       </SidebarMenu>
     </SidebarGroup>

--- a/browser-features/pages-settings/src/types/settings_format.d.ts
+++ b/browser-features/pages-settings/src/types/settings_format.d.ts
@@ -56,3 +56,16 @@ export interface TNumberSetting extends TSetting {
   title: string;
   description: string;
 }
+
+// Global type declarations for Floorp native APIs
+declare global {
+  interface Window {
+    /**
+     * Open a new tab in Floorp with the given URL
+     * @param url - The URL to open in the new tab
+     */
+    NRAddTab: (url: string) => void;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

This PR addresses the feedback from GitHub Copilot Pull Request Reviewer on PR #2329 (Add Firefox settings link to sidebar and enhance external link handling).

## Changes

### nav-features.tsx
- **Add discriminated union**: `ExternalFeature` and `InternalFeature` types for type-safe `isExternal`/`onClick` handling
- **Remove nested anchors**: Replace `SidebarMenuItem` with direct `div` wrapper to avoid `<a><a>` nesting
- **Separate renderers**: Create `InternalItem` and `ExternalItem` components for clean rendering

### settings_format.d.ts
- **Add global type declaration**: Add `window.NRAddTab(url: string)` type declaration

## Test plan

- [ ] Test Firefox Settings link opens correctly
- [ ] Verify TypeScript compilation passes
- [ ] Test navigation links still work correctly

## Related

Addresses review comments from #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)