### PR TITLE
fix: address second round of Copilot review feedback from PR #2332

### DIFF
--- a/browser-features/pages-settings/src/components/app-sidebar.tsx
+++ b/browser-features/pages-settings/src/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   PanelLeft,
   PencilRuler,
   RefreshCw,
+  Settings,
   UserRoundPen,
 } from "lucide-react";
 import { NavHeader } from "@/components/nav-header.tsx";
@@ -20,7 +21,7 @@ import {
   SidebarHeader,
   SidebarRail,
 } from "@/components/common/sidebar.tsx";
-import { NavFeatures } from "@/components/nav-features.tsx";
+import { NavFeatures, type Feature } from "@/components/nav-features.tsx";
 import { useEffect, useMemo, useState } from "react";
 import { rpc } from "../lib/rpc/rpc.ts";
 
@@ -101,7 +102,14 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     },
   ], [isFloorpOSVisible, t]);
 
-  const about = [
+  const about: Feature[] = [
+    {
+      title: t("sidebar.firefoxSettings"),
+      url: "",
+      icon: Settings,
+      isExternal: true,
+      onClick: () => window.NRAddTab("about:preferences"),
+    },
     { title: t("pages.aboutBrowser"), url: "/about/browser", icon: BadgeInfo },
     { title: t("pages.updates"), url: "/about/updates", icon: RefreshCw },
   ];

--- a/browser-features/pages-settings/src/components/nav-features.tsx
+++ b/browser-features/pages-settings/src/components/nav-features.tsx
@@ -1,23 +1,80 @@
 import type { LucideIcon } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import {
   SidebarGroup,
   SidebarGroupLabel,
   SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
 } from "@/components/common/sidebar.tsx";
 import { Link, useLocation } from "react-router-dom";
+import type * as React from "react";
+
+// Discriminated union for feature items
+type BaseFeature = {
+  title: string;
+  url: string;
+  icon: LucideIcon;
+};
+
+type ExternalFeature = BaseFeature & {
+  isExternal: true;
+  onClick: (e: React.MouseEvent) => void;
+};
+
+type InternalFeature = BaseFeature & {
+  isExternal?: false;
+  onClick?: never;
+};
+
+export type Feature = InternalFeature | ExternalFeature;
+
+// Internal item renderer without SidebarMenuItem wrapper
+function InternalItem({
+  feature,
+  isActive,
+}: {
+  feature: InternalFeature;
+  isActive: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors">
+      <Link
+        to={feature.url}
+        className={`${
+          isActive
+            ? "bg-primary text-primary-content"
+            : "hover:bg-primary/30"
+        } w-full flex items-center rounded-lg p-3 text-left gap-3`}
+      >
+        <feature.icon className="size-4" />
+        <span>{feature.title}</span>
+      </Link>
+    </div>
+  );
+}
+
+// External item renderer without SidebarMenuItem wrapper
+function ExternalItem({ feature }: { feature: ExternalFeature }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors">
+      <button
+        type="button"
+        onClick={feature.onClick}
+        className="hover:bg-primary/30 w-full flex items-center rounded-lg p-3 text-left gap-3"
+      >
+        <feature.icon className="size-4" />
+        <span>{feature.title}</span>
+        <ExternalLink className="size-3 ml-auto opacity-60" />
+      </button>
+    </div>
+  );
+}
 
 export function NavFeatures({
   title,
   features,
 }: {
   title: string;
-  features: {
-    title: string;
-    url: string;
-    icon: LucideIcon;
-  }[];
+  features: Feature[];
 }) {
   const location = useLocation();
   const currentRoute = location.pathname;
@@ -34,22 +91,11 @@ export function NavFeatures({
             ? currentRoute === "/"
             : currentRoute.startsWith(featurePath);
 
-          return (
-            <SidebarMenuItem key={feature.title}>
-              <Link to={feature.url} className="block w-full">
-                <SidebarMenuButton
-                  className={`${
-                    isActive
-                      ? "bg-primary text-primary-content"
-                      : "hover:bg-primary/30"
-                  } w-full flex items-center rounded-lg p-4`}
-                >
-                  <feature.icon className="size-4" />
-                  <span>{feature.title}</span>
-                </SidebarMenuButton>
-              </Link>
-            </SidebarMenuItem>
-          );
+          if (feature.isExternal) {
+            return <ExternalItem key={feature.title} feature={feature} />;
+          }
+
+          return <InternalItem key={feature.title} feature={feature} isActive={isActive} />;
         })}
       </SidebarMenu>
     </SidebarGroup>

--- a/browser-features/pages-settings/src/types/settings_format.d.ts
+++ b/browser-features/pages-settings/src/types/settings_format.d.ts
@@ -56,3 +56,16 @@ export interface TNumberSetting extends TSetting {
   title: string;
   description: string;
 }
+
+// Global type declarations for Floorp native APIs
+declare global {
+  interface Window {
+    /**
+     * Open a new tab in Floorp with the given URL
+     * @param url - The URL to open in the new tab
+     */
+    NRAddTab: (url: string) => void;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

This PR addresses the second round of feedback from GitHub Copilot Pull Request Reviewer on PR #2332 (fix: address Copilot review feedback from PR #2329).

## Changes

### nav-features.tsx
- **Add React type import**: Add `import type * as React from "react"` for `React.MouseEvent`
- **Export Feature type**: Export `Feature` type for use in other components

### app-sidebar.tsx
- **Add explicit type annotation**: Annotate `about` array with `Feature[]` type to ensure proper type inference

## Test plan

- [ ] Verify TypeScript compilation passes
- [ ] Test Firefox Settings link opens correctly

## Related

Addresses second round of review comments from #2332

🤖 Generated with [Claude Code](https://claude.com/claude-code)