### PR TITLE
fix(os-api): make TabManager multi-window aware

### DIFF
--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -104,6 +104,7 @@ interface GBrowser {
 interface TabListEntry {
   browserId: string;
   instanceId?: string;
+  windowId: string;
   title: string;
   url: string;
   selected: boolean;
@@ -164,6 +165,16 @@ function getBrowserWindows(): Array<Window & { gBrowser: GBrowser }> {
     }
   }
   return windows;
+}
+
+/**
+ * Returns a unique identifier for a browser window.
+ */
+function getWindowId(win: Window): string {
+  return String(
+    (win as unknown as { docShell?: { outerWindowID: number } }).docShell
+      ?.outerWindowID ?? 0,
+  );
 }
 
 /**
@@ -525,12 +536,13 @@ class TabManager {
   }
 
   public async attachToTab(browserId: string): Promise<string | null> {
-    const win = getBrowserWindow() as Window & { gBrowser: GBrowser };
-    const gBrowser = win.gBrowser;
-
-    const targetTab = gBrowser.tabs.find(
-      (tab: BrowserTab) => tab.linkedBrowser.browserId.toString() === browserId,
-    );
+    let targetTab: BrowserTab | undefined;
+    for (const win of getBrowserWindows()) {
+      targetTab = win.gBrowser.tabs.find(
+        (tab: BrowserTab) => tab.linkedBrowser.browserId.toString() === browserId,
+      );
+      if (targetTab) break;
+    }
 
     if (!targetTab) {
       return null;
@@ -556,11 +568,11 @@ class TabManager {
   }
 
   public listTabs(): Promise<TabListEntry[]> {
-    const win = getBrowserWindow() as Window & { gBrowser: GBrowser };
-    const gBrowser = win.gBrowser;
-
-    return Promise.resolve(
-      gBrowser.tabs.map((tab: BrowserTab) => {
+    const results: TabListEntry[] = [];
+    for (const win of getBrowserWindows()) {
+      const gBrowser = win.gBrowser;
+      const wid = getWindowId(win);
+      for (const tab of gBrowser.tabs) {
         const browserId = tab.linkedBrowser.browserId.toString();
         // Find if this tab is already an instance
         let instanceId: string | undefined;
@@ -571,23 +583,26 @@ class TabManager {
           }
         }
 
-        return {
+        results.push({
           browserId,
           instanceId,
+          windowId: wid,
           title: tab.label,
           url: tab.linkedBrowser.currentURI.spec,
           selected: tab.selected,
           pinned: tab.pinned,
-        };
-      }),
-    );
+        });
+      }
+    }
+    return Promise.resolve(results);
   }
 
   public async getInstanceInfo(
     instanceId: string,
   ): Promise<TabInstanceInfo | null> {
     const { tab, browser } = this._getInstance(instanceId);
-    const win = getBrowserWindow() as Window & { gBrowser: GBrowser };
+    const win = (browser.ownerGlobal as Window & { gBrowser: GBrowser })
+      ?? (getBrowserWindow() as Window & { gBrowser: GBrowser });
     const gBrowser = win.gBrowser;
 
     const [html, screenshot] = await Promise.all([

--- a/browser-features/modules/modules/os-server/tabs/types.ts
+++ b/browser-features/modules/modules/os-server/tabs/types.ts
@@ -15,6 +15,7 @@ export type { ScreenshotRect };
 
 export interface TabInfo {
   browserId: string;
+  windowId: string;
   title: string;
   url: string;
   selected: boolean;


### PR DESCRIPTION
## Summary

`listTabs()`, `attachToTab()`, `getInstanceInfo()` が `getBrowserWindow()` (最前面ウィンドウのみを返す) を使用していたため、別ウィンドウに切り替えるとタブ操作ができなくなる問題を修正。

### Changes

- **listTabs**: 全ウィンドウのタブを返すように変更。各タブに `windowId` を追加
- **attachToTab**: 全ウィンドウから対象タブを検索するように変更
- **getInstanceInfo**: アクティブウィンドウではなくタブの `ownerGlobal` を使用するように変更
- `getWindowId()` ヘルパー追加 (`docShell.outerWindowID` を使用)

### 既存のマルチウィンドウ対応メソッド (変更不要)

- `_getEntry()` - 4段階フォールバックで全ウィンドウをスキャン済み
- `_queryActor()` / `_focusInstance()` - `_getEntry` 経由で解決済み
- 全自動操作メソッド (navigate, click, getHTML 等)

### Files Changed

- `TabManagerServices.sys.mts`: 3メソッド修正 + ヘルパー追加 + `TabListEntry` に `windowId` 追加
- `tabs/types.ts`: `TabInfo` に `windowId` 追加
- `_os-plugin` submodule: `TabEntry` に `windowId` 追加

## Test plan

- [ ] 2つのFirefoxウィンドウを開く
- [ ] Window A で `POST /tabs/instances` でタブを作成
- [ ] Window B に切り替え
- [ ] `GET /tabs/list` で両ウィンドウのタブが含まれることを確認
- [ ] `POST /tabs/attach` で Window A のタブにアタッチできることを確認
- [ ] インスタンスに対する操作 (getHTML, click 等) が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)