### PR TITLE
fix(os-api): comprehensive bug fixes for WebScraper and OS API server

### DIFF
--- a/browser-features/modules/actors/webscraper/DOMReadOperations.ts
+++ b/browser-features/modules/actors/webscraper/DOMReadOperations.ts
@@ -108,6 +108,19 @@ export class DOMReadOperations {
       const doc = this.document;
       if (!doc?.body) return null;
 
+      // Check root element first (TreeWalker skips the root node)
+      const bodyText = doc.body.textContent;
+      if (bodyText && bodyText.includes(textContent)) {
+        this.deps.highlightManager.runAsyncInspection(
+          doc.body,
+          "inspectGetElementByText",
+          {
+            text: this.deps.translationHelper.truncate(textContent, 30),
+          },
+        );
+        return String(doc.body.outerHTML);
+      }
+
       const walker = doc.createTreeWalker(
         doc.body,
         NodeFilter.SHOW_ELEMENT,

--- a/browser-features/modules/actors/webscraper/DOMReadOperations.ts
+++ b/browser-features/modules/actors/webscraper/DOMReadOperations.ts
@@ -105,12 +105,17 @@ export class DOMReadOperations {
 
   getElementByText(textContent: string): string | null {
     try {
-      const nodeList = this.document?.querySelectorAll("*") as
-        | NodeListOf<Element>
-        | undefined;
-      if (!nodeList) return null;
-      const elArray = Array.from(nodeList as NodeListOf<Element>) as Element[];
-      for (const el of elArray) {
+      const doc = this.document;
+      if (!doc?.body) return null;
+
+      const walker = doc.createTreeWalker(
+        doc.body,
+        NodeFilter.SHOW_ELEMENT,
+      );
+
+      let node: Node | null;
+      while ((node = walker.nextNode())) {
+        const el = node as Element;
         const txt = el.textContent;
         if (txt && txt.includes(textContent)) {
           this.deps.highlightManager.runAsyncInspection(
@@ -359,7 +364,9 @@ export class DOMReadOperations {
    * Extracts text from Shadow DOM trees.
    * Uses TreeWalker for efficient traversal of large DOMs.
    */
-  private getTextFromShadowDOM(root: Element): string {
+  private getTextFromShadowDOM(root: Element, depth = 0): string {
+    const MAX_SHADOW_DEPTH = 5;
+    if (depth >= MAX_SHADOW_DEPTH) return "";
     let text = "";
 
     try {
@@ -393,7 +400,7 @@ export class DOMReadOperations {
           }
 
           // Recursively handle nested shadow roots
-          text += this.getTextFromShadowDOM(shadowRoot as Element);
+          text += this.getTextFromShadowDOM(shadowRoot as Element, depth + 1);
         }
       }
     } catch (e) {

--- a/browser-features/modules/actors/webscraper/DOMReadOperations.ts
+++ b/browser-features/modules/actors/webscraper/DOMReadOperations.ts
@@ -108,17 +108,24 @@ export class DOMReadOperations {
       const doc = this.document;
       if (!doc?.body) return null;
 
-      // Check root element first (TreeWalker skips the root node)
+      // Check root element first (TreeWalker skips the root node).
+      // Only match body itself if the text is in body's direct text nodes,
+      // not inherited from child elements — avoids returning the entire page HTML.
       const bodyText = doc.body.textContent;
       if (bodyText && bodyText.includes(textContent)) {
-        this.deps.highlightManager.runAsyncInspection(
-          doc.body,
-          "inspectGetElementByText",
-          {
-            text: this.deps.translationHelper.truncate(textContent, 30),
-          },
-        );
-        return String(doc.body.outerHTML);
+        const childText = Array.from(doc.body.children)
+          .map((c) => c.textContent ?? "")
+          .join("");
+        if (!childText.includes(textContent)) {
+          this.deps.highlightManager.runAsyncInspection(
+            doc.body,
+            "inspectGetElementByText",
+            {
+              text: this.deps.translationHelper.truncate(textContent, 30),
+            },
+          );
+          return String(doc.body.outerHTML);
+        }
       }
 
       const walker = doc.createTreeWalker(

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -153,7 +153,8 @@ class TabManager {
     Services.obs.addObserver(
       {
         observe: (subject: nsISupports) => {
-          const win = subject.QueryInterface(Ci.nsIDOMWindow) as Window;
+          // deno-lint-ignore no-explicit-any
+          const win = (subject as any).QueryInterface(Ci.nsIDOMWindow) as Window;
           win.addEventListener(
             "load",
             () => {
@@ -174,7 +175,8 @@ class TabManager {
     Services.obs.addObserver(
       {
         observe: (subject: nsISupports) => {
-          const win = subject.QueryInterface(Ci.nsIDOMWindow) as Window;
+          // deno-lint-ignore no-explicit-any
+          const win = (subject as any).QueryInterface(Ci.nsIDOMWindow) as Window;
           this._listenedWindows.delete(win);
         },
       },

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -37,6 +37,7 @@ interface BrowserTab {
 interface GBrowser {
   tabs: BrowserTab[];
   selectedTab: BrowserTab;
+  tabContainer: EventTarget & { addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void };
   addTab(
     url: string,
     options: {
@@ -203,7 +204,7 @@ class TabManager {
    * Prevents zombie entries when tabs are closed manually by the user.
    */
   private _onTabClose = (event: Event) => {
-    const tab = event.target as BrowserTab;
+    const tab = event.target as unknown as BrowserTab;
     for (const [instanceId, entry] of this._browserInstances.entries()) {
       if (entry.tab === tab) {
         // Clean up GlobalHTTPTracker for this tab's browsing context

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -7,6 +7,8 @@
  */
 
 import type { WaitForElementState } from "../../os-server/shared/types.ts";
+import { GlobalHTTPTracker } from "./shared/GlobalHTTPTracker.sys.mts";
+import { PROGRESS_LISTENERS } from "./shared/ProgressListeners.sys.mts";
 
 const { E10SUtils } = ChromeUtils.importESModule(
   "resource://gre/modules/E10SUtils.sys.mjs",
@@ -15,59 +17,6 @@ const { setTimeout, clearTimeout } = ChromeUtils.importESModule(
   "resource://gre/modules/Timer.sys.mjs",
 );
 
-/**
- * Global HTTP request tracker to accurately monitor network idle state.
- * This tracker lives for the lifetime of the module and monitors all instances.
- */
-const GlobalHTTPTracker = {
-  activeRequests: new Map<number, Set<nsIRequest>>(),
-
-  init() {
-    try {
-      Services.obs.addObserver(this, "http-on-opening-request");
-      Services.obs.addObserver(this, "http-on-stop-request");
-    } catch (e) {
-      console.error("TabManager: GlobalHTTPTracker init failed:", e);
-    }
-  },
-
-  observe(subject: nsISupports, topic: string, _data: string | null) {
-    try {
-      // deno-lint-ignore no-explicit-any
-      const channel = (subject as any).QueryInterface(Ci.nsIHttpChannel);
-      const bcid = channel.loadInfo?.browsingContextID;
-      if (!bcid) return;
-
-      if (topic === "http-on-opening-request") {
-        const url = channel.URI.spec;
-        if (url.startsWith("http") || url.startsWith("https")) {
-          let requests = this.activeRequests.get(bcid);
-          if (!requests) {
-            requests = new Set();
-            this.activeRequests.set(bcid, requests);
-          }
-          requests.add(channel);
-        }
-      } else if (topic === "http-on-stop-request") {
-        const requests = this.activeRequests.get(bcid);
-        if (requests) {
-          requests.delete(channel);
-          if (requests.size === 0) {
-            this.activeRequests.delete(bcid);
-          }
-        }
-      }
-    } catch {
-      // Ignore
-    }
-  },
-
-  getActiveCount(bcid: number): number {
-    return this.activeRequests.get(bcid)?.size || 0;
-  },
-};
-
-GlobalHTTPTracker.init();
 // Actor interface for WebScraper communication
 interface WebScraperActor {
   sendQuery(name: string, data?: object): Promise<unknown>;
@@ -125,7 +74,6 @@ interface TabInstanceInfo {
 
 // Global sets to prevent garbage collection of active components
 const TAB_MANAGER_ACTOR_SETS: Set<XULBrowserElement> = new Set();
-const PROGRESS_LISTENERS = new Set();
 
 /**
  * A utility function to get the most recent browser window.
@@ -220,6 +168,17 @@ class TabManager {
         },
       },
       "domwindowopened",
+    );
+
+    // Clean up _listenedWindows when windows are closed
+    Services.obs.addObserver(
+      {
+        observe: (subject: nsISupports) => {
+          const win = subject.QueryInterface(Ci.nsIDOMWindow) as Window;
+          this._listenedWindows.delete(win);
+        },
+      },
+      "domwindowclosed",
     );
   }
 
@@ -422,7 +381,7 @@ class TabManager {
             "NRWebScraper",
           ) as WebScraperActor | undefined;
           if (!actor) {
-            for (let i = 0; i < 150; i++) {
+            for (let i = 0; i < 50; i++) {
               await new Promise((r) => setTimeout(r, 100));
               actor = browser.browsingContext?.currentWindowGlobal?.getActor(
                 "NRWebScraper",
@@ -433,18 +392,18 @@ class TabManager {
           if (actor) {
             // Prefer readiness wait; fallback to element waits for heavy SPAs (X.com等)
             let ok = await actor
-              .sendQuery("WebScraper:WaitForReady", { timeout: 20000 })
+              .sendQuery("WebScraper:WaitForReady", { timeout: 5000 })
               .catch(() => false);
-            const tryWait = async (sel: string, to = 20000) =>
+            const tryWait = async (sel: string, to = 5000) =>
               await actor!.sendQuery("WebScraper:WaitForElement", {
                 selector: sel,
                 timeout: to,
               });
             if (!ok)
-              ok = (await tryWait("body", 20000).catch(() => false)) as boolean;
+              ok = (await tryWait("body", 5000).catch(() => false)) as boolean;
             if (!ok)
-              ok = (await tryWait("html", 8000).catch(() => false)) as boolean;
-            if (!ok) await tryWait("main", 8000).catch(() => false);
+              ok = (await tryWait("html", 3000).catch(() => false)) as boolean;
+            if (!ok) await tryWait("main", 3000).catch(() => false);
           }
         } catch {
           // ignore
@@ -564,6 +523,13 @@ class TabManager {
     await this._waitForLoad(browser, url);
     await this._delayForUser();
 
+    // Check tab is still alive (user may have closed it during load)
+    const currentBrowser = tab.linkedBrowser;
+    if (!currentBrowser?.ownerGlobal ||
+      (currentBrowser.ownerGlobal as Window).closed) {
+      throw new Error("Tab was closed during load");
+    }
+
     const instanceId = crypto.randomUUID();
     this._browserInstances.set(instanceId, { tab, browser });
     TAB_MANAGER_ACTOR_SETS.add(browser);
@@ -648,7 +614,10 @@ class TabManager {
     const { tab, browser } = this._getInstance(instanceId);
     const win = (browser.ownerGlobal as Window & { gBrowser: GBrowser })
       ?? (getBrowserWindow() as Window & { gBrowser: GBrowser });
-    const gBrowser = win.gBrowser;
+    const gBrowser = win?.gBrowser;
+    if (!gBrowser) {
+      return null;
+    }
 
     const [html, screenshot] = await Promise.all([
       this.getHTML(instanceId),
@@ -769,7 +738,11 @@ class TabManager {
       // Throw an error if loadURI is not available
       throw new Error("browser.loadURI is not defined");
     }
-    await this._waitForLoad(browser, url);
+
+    // Refresh browser reference after loadURI (process swap may occur on cross-origin nav)
+    const freshEntry = this._getEntry(instanceId);
+    const loadBrowser = freshEntry?.browser ?? browser;
+    await this._waitForLoad(loadBrowser, url);
     await this._delayForUser();
 
     // Re-show control overlay after navigation (new document, new actor)

--- a/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
@@ -161,66 +161,47 @@ class webScraper {
    * @returns Promise<void> - Resolves when the page has finished loading
    * @throws Error - If the browser instance is not found
    */
-  public navigate(instanceId: string, url: string): Promise<void> {
+  public async navigate(instanceId: string, url: string): Promise<void> {
     const browser = this._browserInstances.get(instanceId);
     if (!browser) {
       throw new Error(`Browser not found for instance ${instanceId}`);
     }
 
     const principal = Services.scriptSecurityManager.getSystemPrincipal();
-    return new Promise((resolve) => {
+    const oa = E10SUtils.predictOriginAttributes({
+      browser,
+    });
+    const loadURIOptions = {
+      triggeringPrincipal: principal,
+      remoteType: E10SUtils.getRemoteTypeForURI(
+        url,
+        true,
+        false,
+        E10SUtils.DEFAULT_REMOTE_TYPE,
+        null,
+        oa,
+      ),
+    };
+
+    const uri = Services.io.newURI(url);
+
+    await this._delayForUser();
+    if (typeof browser.loadURI === "function") {
+      browser.loadURI(uri, loadURIOptions);
+    } else {
+      throw new Error("browser.loadURI is not defined");
+    }
+
+    // Wait for page load via progress listener
+    await new Promise<void>((resolve) => {
       let resolved = false;
-      const complete = async () => {
+      const complete = () => {
         if (resolved) return;
         resolved = true;
-        try {
-          const actor = await this._getActorForBrowser(browser, 150, 100); // up to ~15s
-          if (actor) {
-            // Prefer explicit readiness wait in the child actor
-            const ok = await actor
-              .sendQuery("WebScraper:WaitForReady", { timeout: 15000 })
-              .catch(() => false);
-            if (!ok) {
-              await actor
-                .sendQuery("WebScraper:WaitForElement", {
-                  selector: "body",
-                  timeout: 15000,
-                })
-                .catch(() => null);
-            }
-          }
-        } catch (_) {
-          // ignore
-        }
-        await this._delayForUser();
         resolve();
       };
-      const oa = E10SUtils.predictOriginAttributes({
-        browser,
-      });
-      const loadURIOptions = {
-        triggeringPrincipal: principal,
-        remoteType: E10SUtils.getRemoteTypeForURI(
-          url,
-          true,
-          false,
-          E10SUtils.DEFAULT_REMOTE_TYPE,
-          null,
-          oa,
-        ),
-      };
-
-      const uri = Services.io.newURI(url);
 
       const { webProgress } = browser;
-
-      // Delay before navigation
-      await this._delayForUser();
-      if (typeof browser.loadURI === "function") {
-        browser.loadURI(uri, loadURIOptions);
-      } else {
-        throw new Error("browser.loadURI is not defined");
-      }
 
       /**
        * Progress listener to monitor page load completion
@@ -288,6 +269,27 @@ class webScraper {
           (Ci.nsIWebProgress.NOTIFY_STATE_DOCUMENT ?? 0),
       );
     });
+
+    // Wait for content actor readiness
+    try {
+      const actor = await this._getActorForBrowser(browser, 150, 100);
+      if (actor) {
+        const ok = await actor
+          .sendQuery("WebScraper:WaitForReady", { timeout: 15000 })
+          .catch(() => false);
+        if (!ok) {
+          await actor
+            .sendQuery("WebScraper:WaitForElement", {
+              selector: "body",
+              timeout: 15000,
+            })
+            .catch(() => null);
+        }
+      }
+    } catch {
+      // ignore
+    }
+    await this._delayForUser();
   }
 
   public getURI(instanceId: string): Promise<string | null> {

--- a/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
@@ -13,6 +13,8 @@
  */
 
 import type { WaitForElementState } from "../../os-server/shared/types.ts";
+import { GlobalHTTPTracker } from "./shared/GlobalHTTPTracker.sys.mts";
+import { PROGRESS_LISTENERS } from "./shared/ProgressListeners.sys.mts";
 
 const { E10SUtils } = ChromeUtils.importESModule(
   "resource://gre/modules/E10SUtils.sys.mjs",
@@ -31,62 +33,7 @@ interface WebScraperActor {
 
 // Global sets to prevent garbage collection of active components
 const SCRAPER_ACTOR_SETS: Set<XULBrowserElement> = new Set();
-const PROGRESS_LISTENERS = new Set();
 const FRAME = new HiddenFrame();
-
-/**
- * Global HTTP request tracker to accurately monitor network idle state.
- * This tracker lives for the lifetime of the module and monitors all instances.
- */
-const GlobalHTTPTracker = {
-  activeRequests: new Map<number, Set<nsIRequest>>(),
-
-  init() {
-    try {
-      Services.obs.addObserver(this, "http-on-opening-request");
-      Services.obs.addObserver(this, "http-on-stop-request");
-    } catch (e) {
-      console.error("WebScraper: GlobalHTTPTracker init failed:", e);
-    }
-  },
-
-  observe(subject: nsISupports, topic: string, _data: string | null) {
-    try {
-      // deno-lint-ignore no-explicit-any
-      const channel = (subject as any).QueryInterface(Ci.nsIHttpChannel);
-      const bcid = channel.loadInfo?.browsingContextID;
-      if (!bcid) return;
-
-      if (topic === "http-on-opening-request") {
-        const url = channel.URI.spec;
-        if (url.startsWith("http") || url.startsWith("https")) {
-          let requests = this.activeRequests.get(bcid);
-          if (!requests) {
-            requests = new Set();
-            this.activeRequests.set(bcid, requests);
-          }
-          requests.add(channel);
-        }
-      } else if (topic === "http-on-stop-request") {
-        const requests = this.activeRequests.get(bcid);
-        if (requests) {
-          requests.delete(channel);
-          if (requests.size === 0) {
-            this.activeRequests.delete(bcid);
-          }
-        }
-      }
-    } catch {
-      // Ignore
-    }
-  },
-
-  getActiveCount(bcid: number): number {
-    return this.activeRequests.get(bcid)?.size || 0;
-  },
-};
-
-GlobalHTTPTracker.init();
 
 /**
  * WebScraper class that manages headless browser instances for web scraping
@@ -268,13 +215,12 @@ class webScraper {
       const { webProgress } = browser;
 
       // Delay before navigation
-      this._delayForUser().then(() => {
-        if (typeof browser.loadURI === "function") {
-          browser.loadURI(uri, loadURIOptions);
-        } else {
-          throw new Error("browser.loadURI is not defined");
-        }
-      });
+      await this._delayForUser();
+      if (typeof browser.loadURI === "function") {
+        browser.loadURI(uri, loadURIOptions);
+      } else {
+        throw new Error("browser.loadURI is not defined");
+      }
 
       /**
        * Progress listener to monitor page load completion

--- a/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
@@ -9,8 +9,11 @@
  */
 const GlobalHTTPTracker = {
   activeRequests: new Map<number, Set<nsIRequest>>(),
+  _initialized: false,
 
   init() {
+    if (this._initialized) return;
+    this._initialized = true;
     try {
       Services.obs.addObserver(this, "http-on-opening-request");
       Services.obs.addObserver(this, "http-on-stop-request");

--- a/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Global HTTP request tracker to accurately monitor network idle state.
+ * This tracker lives for the lifetime of the module and monitors all instances.
+ * Shared between TabManagerServices and WebScraperServices.
+ */
+const GlobalHTTPTracker = {
+  activeRequests: new Map<number, Set<nsIRequest>>(),
+
+  init() {
+    try {
+      Services.obs.addObserver(this, "http-on-opening-request");
+      Services.obs.addObserver(this, "http-on-stop-request");
+    } catch (e) {
+      console.error("GlobalHTTPTracker: init failed:", e);
+    }
+  },
+
+  observe(subject: nsISupports, topic: string, _data: string | null) {
+    try {
+      // deno-lint-ignore no-explicit-any
+      const channel = (subject as any).QueryInterface(Ci.nsIHttpChannel);
+      const bcid = channel.loadInfo?.browsingContextID;
+      if (!bcid) return;
+
+      if (topic === "http-on-opening-request") {
+        const url = channel.URI.spec;
+        if (url.startsWith("http") || url.startsWith("https")) {
+          let requests = this.activeRequests.get(bcid);
+          if (!requests) {
+            requests = new Set();
+            this.activeRequests.set(bcid, requests);
+          }
+          requests.add(channel);
+        }
+      } else if (topic === "http-on-stop-request") {
+        const requests = this.activeRequests.get(bcid);
+        if (requests) {
+          requests.delete(channel);
+          if (requests.size === 0) {
+            this.activeRequests.delete(bcid);
+          }
+        }
+      }
+    } catch {
+      // Ignore
+    }
+  },
+
+  getActiveCount(bcid: number): number {
+    return this.activeRequests.get(bcid)?.size || 0;
+  },
+};
+
+GlobalHTTPTracker.init();
+
+export { GlobalHTTPTracker };

--- a/browser-features/modules/modules/os-apis/web/shared/ProgressListeners.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/ProgressListeners.sys.mts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Global set to prevent garbage collection of active progress listeners.
+ * Shared between TabManagerServices and WebScraperServices.
+ */
+const PROGRESS_LISTENERS = new Set();
+
+export { PROGRESS_LISTENERS };

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -408,7 +408,7 @@ class LocalHttpServer implements nsIServerSocketListener {
           "\r\n";
         writeUtf8(output, headers);
 
-        // Callback to clean up
+        // Callback to clean up — stream callbacks own the stream lifecycle
         streamResult.onConnect(
           (data) => {
             try {
@@ -428,6 +428,9 @@ class LocalHttpServer implements nsIServerSocketListener {
             }
           },
         );
+        // Prevent onSocketAccepted's finally from double-closing stream-owned handles
+        input = null;
+        output = null;
         return;
       }
 

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -228,9 +228,11 @@ class LocalHttpServer implements nsIServerSocketListener {
   // nsIServerSocketListener
   onSocketAccepted(_serv: nsIServerSocket, transport: nsISocketTransport) {
     const handle = async () => {
+      let input: nsIAsyncInputStream | null = null;
+      let output: nsIAsyncOutputStream | null = null;
       try {
-        const input = transport.openInputStream(0, 0, 0);
-        const output = transport.openOutputStream(0, 0, 0);
+        input = transport.openInputStream(0, 0, 0);
+        output = transport.openOutputStream(0, 0, 0);
         const sis = Cc["@mozilla.org/scriptableinputstream;1"].createInstance(
           Ci.nsIScriptableInputStream,
         );
@@ -248,10 +250,7 @@ class LocalHttpServer implements nsIServerSocketListener {
             if (head.includes("\r\n\r\n")) break;
           } else {
             if (Date.now() > headDeadline) {
-              const res = requestTimeout();
-              writeUtf8(output, res);
-              output.close();
-              input.close();
+              writeUtf8(output, requestTimeout());
               return;
             }
             await new Promise<void>((resolve) =>
@@ -263,29 +262,18 @@ class LocalHttpServer implements nsIServerSocketListener {
         const headStr = split >= 0 ? head.slice(0, split) : head;
         const req = parseRequestHead(headStr);
         if (!req) {
-          {
-            const res = jsonResponse(400, { error: "malformed request" });
-            writeUtf8(output, res);
-          }
-          output.close();
-          input.close();
+          writeUtf8(output, jsonResponse(400, { error: "malformed request" }));
           return;
         }
         // Determine body length
         const contentLength =
           Number.parseInt(req.headers["content-length"] || "0", 10) || 0;
         if (contentLength < 0) {
-          const res = badRequest("invalid content-length");
-          writeUtf8(output, res);
-          output.close();
-          input.close();
+          writeUtf8(output, badRequest("invalid content-length"));
           return;
         }
         if (contentLength > LocalHttpServer.MAX_BODY_BYTES) {
-          const res = payloadTooLarge();
-          writeUtf8(output, res);
-          output.close();
-          input.close();
+          writeUtf8(output, payloadTooLarge());
           return;
         }
         const leftover = split >= 0 ? head.slice(split + 4) : "";
@@ -298,10 +286,7 @@ class LocalHttpServer implements nsIServerSocketListener {
             bodyBytes.push(...binaryStringToByteArray(piece));
           } else {
             if (Date.now() > bodyDeadline) {
-              const res = badRequest("incomplete body");
-              writeUtf8(output, res);
-              output.close();
-              input.close();
+              writeUtf8(output, badRequest("incomplete body"));
               return;
             }
             await new Promise<void>((resolve) =>
@@ -316,29 +301,28 @@ class LocalHttpServer implements nsIServerSocketListener {
           const auth = req.headers["authorization"] || "";
           const expect = `Bearer ${this._token}`;
           if (auth !== expect) {
-            {
-              const res = unauthorized();
-              writeUtf8(output, res);
-            }
-            output.close();
-            input.close();
+            writeUtf8(output, unauthorized());
             return;
           }
         }
 
-        // Route (async)
+        // Route (async) — route handler is responsible for writing and closing streams
         await this.routeAsync(req, output, input);
+        // Prevent finally from double-closing
+        input = null;
+        output = null;
       } catch (e) {
         try {
-          // Only try to send error if stream is still writable
-          const output = transport.openOutputStream(0, 0, 0);
-          const res = serverError(String(e));
-          writeUtf8(output, res);
-          output.close();
+          if (output) {
+            writeUtf8(output, serverError(String(e)));
+          }
         } catch {
-          // ignore
+          // ignore write failure on already-closed stream
         }
         err("socket error: ", e);
+      } finally {
+        try { output?.close(); } catch { /* ignore */ }
+        try { input?.close(); } catch { /* ignore */ }
       }
     };
     // Fire and forget

--- a/browser-features/modules/modules/os-server/shared/routes.sys.mts
+++ b/browser-features/modules/modules/os-server/shared/routes.sys.mts
@@ -75,7 +75,7 @@ export function registerCommonAutomationRoutes(
       const sel = ctx.searchParams.get("selector") ?? "";
       const service = getService();
       if (!service.getElement) {
-        return { status: 200, body: {} };
+        return { status: 200, body: { element: null } };
       }
       const element = await service.getElement(ctx.params.id, sel);
       return { status: 200, body: { element } };

--- a/browser-features/modules/modules/os-server/shared/routes.sys.mts
+++ b/browser-features/modules/modules/os-server/shared/routes.sys.mts
@@ -59,14 +59,14 @@ export function registerCommonAutomationRoutes(
   ns.get("/instances/:id/html", async (ctx: RouterContext) => {
     const service = getService();
     const html = await service.getHTML(ctx.params.id);
-    return { status: 200, body: html != null ? { html } : {} };
+    return { status: 200, body: { html } };
   });
 
   // Get visible text content (as Markdown)
   ns.get("/instances/:id/text", async (ctx: RouterContext) => {
     const service = getService();
     const text = await service.getText(ctx.params.id);
-    return { status: 200, body: text != null ? { text } : {} };
+    return { status: 200, body: { text } };
   });
 
   // Get element by selector (optional - only Tab exposes this)
@@ -78,7 +78,7 @@ export function registerCommonAutomationRoutes(
         return { status: 200, body: {} };
       }
       const element = await service.getElement(ctx.params.id, sel);
-      return { status: 200, body: element != null ? { element } : {} };
+      return { status: 200, body: { element } };
     });
   }
 
@@ -87,7 +87,7 @@ export function registerCommonAutomationRoutes(
     const sel = ctx.searchParams.get("selector") ?? "";
     const service = getService();
     const text = await service.getElementText(ctx.params.id, sel);
-    return { status: 200, body: text != null ? { text } : {} };
+    return { status: 200, body: { text } };
   });
 
   // Get all matching elements (outerHTML array)
@@ -111,7 +111,7 @@ export function registerCommonAutomationRoutes(
     const sel = ctx.searchParams.get("selector") ?? "";
     const service = getService();
     const text = await service.getElementTextContent(ctx.params.id, sel);
-    return { status: 200, body: text != null ? { text } : {} };
+    return { status: 200, body: { text } };
   });
 
   // Click element
@@ -142,7 +142,7 @@ export function registerCommonAutomationRoutes(
   ns.get("/instances/:id/screenshot", async (ctx: RouterContext) => {
     const service = getService();
     const image = await service.takeScreenshot(ctx.params.id);
-    return { status: 200, body: image != null ? { image } : {} };
+    return { status: 200, body: { image } };
   });
 
   // Take element screenshot
@@ -150,14 +150,14 @@ export function registerCommonAutomationRoutes(
     const sel = ctx.searchParams.get("selector") ?? "";
     const service = getService();
     const image = await service.takeElementScreenshot(ctx.params.id, sel);
-    return { status: 200, body: image != null ? { image } : {} };
+    return { status: 200, body: { image } };
   });
 
   // Take full page screenshot
   ns.get("/instances/:id/fullPageScreenshot", async (ctx: RouterContext) => {
     const service = getService();
     const image = await service.takeFullPageScreenshot(ctx.params.id);
-    return { status: 200, body: image != null ? { image } : {} };
+    return { status: 200, body: { image } };
   });
 
   // Take region screenshot
@@ -165,7 +165,7 @@ export function registerCommonAutomationRoutes(
     const json = ctx.json() as { rect?: ScreenshotRect } | null;
     const service = getService();
     const image = await service.takeRegionScreenshot(ctx.params.id, json?.rect);
-    return { status: 200, body: image != null ? { image } : {} };
+    return { status: 200, body: { image } };
   });
 
   // Fill form fields
@@ -189,7 +189,7 @@ export function registerCommonAutomationRoutes(
     const sel = ctx.searchParams.get("selector") ?? "";
     const service = getService();
     const value = await service.getValue(ctx.params.id, sel);
-    return { status: 200, body: value != null ? { value } : {} };
+    return { status: 200, body: { value } };
   });
 
   // Submit form

--- a/browser-features/modules/modules/os-server/shared/types.ts
+++ b/browser-features/modules/modules/os-server/shared/types.ts
@@ -22,6 +22,20 @@ export type ScreenshotRect = {
 };
 
 /**
+ * Cookie data type for get/set cookie operations
+ */
+export interface CookieData {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: "Strict" | "Lax" | "None";
+  expirationDate?: number;
+}
+
+/**
  * Common browser automation service interface
  * Implemented by both WebScraper and TabManager services
  */
@@ -56,29 +70,29 @@ export interface BrowserAutomationService {
   isEnabled(instanceId: string, selector: string): Promise<boolean>;
 
   // Element interactions
-  clickElement(instanceId: string, selector: string): Promise<boolean>;
-  doubleClick?(instanceId: string, selector: string): Promise<boolean>;
-  rightClick?(instanceId: string, selector: string): Promise<boolean>;
-  hoverElement(instanceId: string, selector: string): Promise<boolean>;
-  scrollToElement(instanceId: string, selector: string): Promise<boolean>;
-  focusElement?(instanceId: string, selector: string): Promise<boolean>;
+  clickElement(instanceId: string, selector: string): Promise<boolean | null>;
+  doubleClick?(instanceId: string, selector: string): Promise<boolean | null>;
+  rightClick?(instanceId: string, selector: string): Promise<boolean | null>;
+  hoverElement(instanceId: string, selector: string): Promise<boolean | null>;
+  scrollToElement(instanceId: string, selector: string): Promise<boolean | null>;
+  focusElement?(instanceId: string, selector: string): Promise<boolean | null>;
 
   // Form operations
   fillForm(
     instanceId: string,
     formData: Record<string, string>,
     options?: { typingMode?: boolean; typingDelayMs?: number },
-  ): Promise<boolean>;
+  ): Promise<boolean | null>;
   inputElement?(
     instanceId: string,
     selector: string,
     value: string,
     options?: { typingMode?: boolean; typingDelayMs?: number },
-  ): Promise<boolean>;
-  clearInput(instanceId: string, selector: string): Promise<boolean>;
-  submit(instanceId: string, selector: string): Promise<boolean>;
-  selectOption(instanceId: string, selector: string, value: string): Promise<boolean>;
-  setChecked(instanceId: string, selector: string, checked: boolean): Promise<boolean>;
+  ): Promise<boolean | null>;
+  clearInput(instanceId: string, selector: string): Promise<boolean | null>;
+  submit(instanceId: string, selector: string): Promise<boolean | null>;
+  selectOption(instanceId: string, selector: string, value: string): Promise<boolean | null>;
+  setChecked(instanceId: string, selector: string, checked: boolean): Promise<boolean | null>;
 
   // Waiting
   waitForElement(
@@ -86,8 +100,8 @@ export interface BrowserAutomationService {
     selector: string,
     timeout?: number,
     state?: WaitForElementState,
-  ): Promise<boolean>;
-  waitForReady(instanceId: string, timeout?: number): Promise<boolean>;
+  ): Promise<boolean | null>;
+  waitForReady(instanceId: string, timeout?: number): Promise<boolean | null>;
   waitForNetworkIdle?(instanceId: string, timeout?: number): Promise<boolean>;
 
   // Screenshots
@@ -97,26 +111,26 @@ export interface BrowserAutomationService {
   takeRegionScreenshot(instanceId: string, rect?: ScreenshotRect): Promise<string | null>;
 
   // Cookie management
-  getCookies(instanceId: string): Promise<unknown[]>;
-  setCookie(instanceId: string, cookie: unknown): Promise<boolean>;
+  getCookies(instanceId: string): Promise<CookieData[]>;
+  setCookie(instanceId: string, cookie: CookieData): Promise<boolean | null>;
 
   // Advanced operations
-  setInnerHTML(instanceId: string, selector: string, html: string): Promise<boolean>;
-  setTextContent(instanceId: string, selector: string, text: string): Promise<boolean>;
+  setInnerHTML(instanceId: string, selector: string, html: string): Promise<boolean | null>;
+  setTextContent(instanceId: string, selector: string, text: string): Promise<boolean | null>;
   dispatchEvent(
     instanceId: string,
     selector: string,
     eventType: string,
     options?: { bubbles?: boolean; cancelable?: boolean },
-  ): Promise<boolean>;
-  pressKey?(instanceId: string, key: string): Promise<boolean>;
-  uploadFile?(instanceId: string, selector: string, filePath: string): Promise<boolean>;
-  dispatchTextInput(instanceId: string, selector: string, text: string): Promise<boolean>;
+  ): Promise<boolean | null>;
+  pressKey?(instanceId: string, key: string): Promise<boolean | null>;
+  uploadFile?(instanceId: string, selector: string, filePath: string): Promise<boolean | null>;
+  dispatchTextInput(instanceId: string, selector: string, text: string): Promise<boolean | null>;
 
   // Dialogs
-  acceptAlert?(instanceId: string): Promise<boolean>;
-  dismissAlert?(instanceId: string): Promise<boolean>;
+  acceptAlert?(instanceId: string): Promise<boolean | null>;
+  dismissAlert?(instanceId: string): Promise<boolean | null>;
 
   // Drag and drop
-  dragAndDrop(instanceId: string, sourceSelector: string, targetSelector: string): Promise<boolean>;
+  dragAndDrop(instanceId: string, sourceSelector: string, targetSelector: string): Promise<boolean | null>;
 }

--- a/browser-features/modules/modules/os-server/shared/types.ts
+++ b/browser-features/modules/modules/os-server/shared/types.ts
@@ -102,7 +102,7 @@ export interface BrowserAutomationService {
     state?: WaitForElementState,
   ): Promise<boolean | null>;
   waitForReady(instanceId: string, timeout?: number): Promise<boolean | null>;
-  waitForNetworkIdle?(instanceId: string, timeout?: number): Promise<boolean>;
+  waitForNetworkIdle?(instanceId: string, timeout?: number): Promise<boolean | null>;
 
   // Screenshots
   takeScreenshot(instanceId: string): Promise<string | null>;


### PR DESCRIPTION
## Summary

Comprehensive bug fixes for the WebScraper and OS API server implementation (12 fixes across 8 files).

### High Priority
- **Fix ＃4**: Stream resource leak in `server.sys.mts` — `onSocketAccepted` catch block opened a new stream instead of reusing the original, leaking the original streams. Fixed by moving stream declarations outside `try` and adding `finally` for guaranteed cleanup.
- **Fix ＃10**: Unhandled promise rejection in `WebScraperServices.navigate()` — `_delayForUser().then()` callback threw inside `.then()`, causing silent failures. Changed to `await`.

### Medium Priority
- **Fix ＃1**: Eliminated duplicate `GlobalHTTPTracker` and `PROGRESS_LISTENERS` between TabManagerServices and WebScraperServices by extracting shared modules.
- **Fix ＃6**: `navigate()` passed stale `browser` reference to `_waitForLoad()` after cross-origin process swap. Now refreshes browser reference via `_getEntry()` after `loadURI()`.
- **Fix ＃5**: Updated `BrowserAutomationService` interface to match actual return types (`Promise<boolean | null>`) and added `CookieData` interface replacing `unknown` types.

### Low Priority
- **Fix ＃9**: Reduced cumulative timeout in `_waitForLoad` from ~101s to ~25s by shortening actor readiness waits.
- **Fix ＃13**: Added `domwindowclosed` observer to clean up `_listenedWindows` Set, preventing memory leak.
- **Fix ＃19**: Added `gBrowser` null check in `getInstanceInfo()`.
- **Fix ＃20**: Standardized null responses in shared routes from `{}` to `{ key: null }` for consistency.
- **Fix ＃14**: Added tab alive check in `createInstance()` to prevent registering zombie instances when tab is closed during load.
- **Fix ＃17**: Replaced `querySelectorAll("*")` with `TreeWalker` in `getElementByText()` for better performance on large DOMs.
- **Fix ＃18**: Added depth limit (max 5) to `getTextFromShadowDOM()` recursion to prevent infinite recursion.

### Files Changed
| File | Change |
|------|--------|
| `server.sys.mts` | Stream leak fix |
| `WebScraperServices.sys.mts` | Unhandled rejection + dedup |
| `TabManagerServices.sys.mts` | Dedup + ＃6, ＃9, ＃13, ＃14, ＃19 |
| `shared/GlobalHTTPTracker.sys.mts` | **New** — shared module |
| `shared/ProgressListeners.sys.mts` | **New** — shared module |
| `shared/types.ts` | Type accuracy |
| `shared/routes.sys.mts` | Response consistency |
| `DOMReadOperations.ts` | TreeWalker + depth limit |

## Test Plan
- [ ] Build and verify no compilation errors
- [ ] Test `/scraper/instances` + `navigate` — no unhandled rejections (Fix ＃10)
- [ ] Test cross-origin navigation in `/tabs/instances` — fresh browser ref works (Fix ＃6)
- [ ] Test `_waitForLoad` timeout on slow/buggy pages — should resolve within ~25s (Fix ＃9)
- [ ] Close tab manually during `createInstance` — no zombie entry (Fix ＃14)
- [ ] Test `getElementByText` on large DOM pages — should complete promptly (Fix ＃17)
- [ ] Verify GlobalHTTPTracker observers only registered once (Fix ＃1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)