### PR TITLE
feat(zen-mode): implement distraction-free browsing mode

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -326,4 +326,13 @@ export const actions: GestureActionRegistration[] = [
     name: "gecko-workspace-previous",
     fn: (win) => win.workspacesFuncs.changeWorkspaceToPrevious(),
   },
+  {
+    name: "floorp-toggle-zen-mode",
+    fn: (_win) => {
+      Services.prefs.setBoolPref(
+        "floorp.zenmode.enabled",
+        !Services.prefs.getBoolPref("floorp.zenmode.enabled", false),
+      );
+    },
+  },
 ];

--- a/browser-features/chrome/common/zen-mode/icon.css
+++ b/browser-features/chrome/common/zen-mode/icon.css
@@ -1,0 +1,8 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#zen-mode-button {
+  list-style-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='context-fill' fill-opacity='context-fill-opacity'%3E%3Cpath d='M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm1.5.5v9h9v-9h-9z'/%3E%3Cpath d='M5.5 6.5a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm5 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm-5.25 3a.75.75 0 0 0 0 1.5h5.5a.75.75 0 0 0 0-1.5h-5.5z'/%3E%3C/svg%3E");
+}

--- a/browser-features/chrome/common/zen-mode/index.ts
+++ b/browser-features/chrome/common/zen-mode/index.ts
@@ -1,0 +1,144 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render } from "@nora/solid-xul";
+import { createRootHMR } from "@nora/solid-xul";
+import { createSignal, onCleanup } from "solid-js";
+import { noraComponent, NoraComponentBase } from "#features-chrome/utils/base";
+import { BrowserActionUtils } from "../../utils/browser-action.tsx";
+import {
+  ZenModeMenuElement,
+  setZenModeEnabled,
+  initZenModeState,
+} from "./zen-mode.tsx";
+import { StyleElement } from "./styleElem.tsx";
+import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
+import i18next from "i18next";
+
+const { CustomizableUI } = ChromeUtils.importESModule(
+  "moz-src:///browser/components/customizableui/CustomizableUI.sys.mjs",
+);
+
+@noraComponent(import.meta.hot)
+export default class ZenMode extends NoraComponentBase {
+  init() {
+    this.logger.info("Initializing Zen Mode");
+
+    if (typeof document === "undefined") {
+      this.logger.warn(
+        "Document is unavailable; skip initializing Zen Mode.",
+      );
+      return;
+    }
+
+    // Initialize state management and hover detection
+    initZenModeState();
+
+    const tryInit = () => {
+      this.injectMenu();
+      this.createToolbarButton();
+      this.registerKeyboardShortcut();
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", tryInit, { once: true });
+    } else {
+      tryInit();
+    }
+  }
+
+  private injectMenu() {
+    const menuPopup = document.getElementById("menu_ToolsPopup");
+    if (!menuPopup) {
+      this.logger.warn(
+        "Failed to locate #menu_ToolsPopup; Zen Mode menu item will not be injected.",
+      );
+      return;
+    }
+
+    const marker = document.getElementById("menu_openFirefoxView");
+
+    try {
+      render(ZenModeMenuElement, menuPopup, {
+        marker: marker?.parentElement === menuPopup ? marker : undefined,
+        hotCtx: import.meta.hot,
+      });
+      this.logger.info("Zen Mode menu item rendered successfully.");
+    } catch (error) {
+      const reason = error instanceof Error ? error : new Error(String(error));
+      this.logger.error("Failed to render Zen Mode menu item", reason);
+    }
+  }
+
+  private createToolbarButton() {
+    BrowserActionUtils.createToolbarClickActionButton(
+      "zen-mode-button",
+      null,
+      () => setZenModeEnabled((prev) => !prev),
+      StyleElement(),
+      CustomizableUI.AREA_NAVBAR,
+      null,
+      (aNode: XULElement) => {
+        const tooltip = document?.createXULElement("tooltip") as XULElement;
+        tooltip.id = "zen-mode-button-tooltip";
+        tooltip.setAttribute("hasbeenopened", "false");
+        document?.getElementById("mainPopupSet")?.appendChild(tooltip);
+        aNode.setAttribute("tooltip", "zen-mode-button-tooltip");
+
+        createRootHMR(
+          () => {
+            const [texts, setTexts] = createSignal({
+              buttonLabel: "Zen Mode",
+              tooltipText: "Toggle Zen Mode",
+            });
+
+            aNode.setAttribute("label", texts().buttonLabel);
+            tooltip.setAttribute("label", texts().tooltipText);
+
+            addI18nObserver(() => {
+              setTexts({
+                buttonLabel: i18next.t("zen-mode.label", {
+                  defaultValue: "Zen Mode",
+                }),
+                tooltipText: i18next.t("zen-mode.tooltiptext", {
+                  defaultValue: "Toggle Zen Mode",
+                }),
+              });
+              aNode.setAttribute("label", texts().buttonLabel);
+              tooltip.setAttribute("label", texts().tooltipText);
+            });
+          },
+          import.meta.hot,
+        );
+      },
+    );
+  }
+
+  private registerKeyboardShortcut() {
+    const isMac =
+      navigator.platform?.toUpperCase().includes("MAC") ?? false;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const accelKey = isMac ? event.metaKey : event.ctrlKey;
+      if (
+        accelKey &&
+        event.shiftKey &&
+        event.key.toUpperCase() === "Z" &&
+        !event.altKey
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        setZenModeEnabled((prev) => !prev);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    onCleanup(() => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+    });
+
+    this.logger.info("Zen Mode keyboard shortcut registered (Ctrl+Shift+Z).");
+  }
+}

--- a/browser-features/chrome/common/zen-mode/styleElem.tsx
+++ b/browser-features/chrome/common/zen-mode/styleElem.tsx
@@ -1,0 +1,10 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import iconStyle from "./icon.css?inline";
+
+export const StyleElement = () => {
+  return <style>{iconStyle}</style>;
+};

--- a/browser-features/chrome/common/zen-mode/zen-mode.css
+++ b/browser-features/chrome/common/zen-mode/zen-mode.css
@@ -1,0 +1,96 @@
+/*-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* ===== Zen Mode: Hide all browser chrome ===== */
+
+/* Navigator toolbox (tab bar + navigation bar) — slide up via negative margin */
+:root[zenmode] #navigator-toolbox {
+  margin-top: calc(-1 * var(--zenmode-toolbox-height, 80px)) !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transition: margin-top 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.25s ease !important;
+  position: relative !important;
+  z-index: 1 !important;
+}
+
+/* Firefox sidebar */
+:root[zenmode] #sidebar-box,
+:root[zenmode] #sidebar-select-box,
+:root[zenmode] #sidebar-splitter2 {
+  display: none !important;
+}
+
+/* Floorp panel sidebar — slide out via negative margin */
+:root[zenmode] #panel-sidebar-box {
+  margin-inline-start: calc(-1 * var(--zenmode-sidebar-width, 250px)) !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transition: margin-inline-start 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.25s ease !important;
+}
+
+:root[zenmode] #panel-sidebar-select-box {
+  margin-inline-start: calc(-1 * var(--zenmode-selectbox-width, 40px)) !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transition: margin-inline-start 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.25s ease !important;
+}
+
+/* Status bar — slide down via negative margin */
+:root[zenmode] #nora-statusbar {
+  margin-bottom: calc(-1 * var(--zenmode-statusbar-height, 30px)) !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transition: margin-bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.25s ease !important;
+}
+
+/* ===== Window drag region ===== */
+/* Transparent draggable area at top so the window can still be moved */
+:root[zenmode] #browser {
+  position: relative !important;
+}
+
+:root[zenmode] #browser::before {
+  content: "" !important;
+  display: block !important;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  height: 8px !important;
+  -moz-window-dragging: drag !important;
+  z-index: 100 !important;
+}
+
+/* ===== Hover Reveal ===== */
+
+/* Reveal top chrome on hover — slide back in */
+:root[zenmode][zenmode-reveal-top] #navigator-toolbox {
+  margin-top: 0 !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+}
+
+/* Reveal panel sidebar on edge hover — slide back in */
+:root[zenmode][zenmode-reveal-side] #panel-sidebar-box {
+  margin-inline-start: 0 !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+}
+
+:root[zenmode][zenmode-reveal-side] #panel-sidebar-select-box {
+  margin-inline-start: 0 !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+}
+
+/* Reveal status bar on hover — slide back in */
+:root[zenmode][zenmode-reveal-bottom] #nora-statusbar {
+  margin-bottom: 0 !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+}

--- a/browser-features/chrome/common/zen-mode/zen-mode.tsx
+++ b/browser-features/chrome/common/zen-mode/zen-mode.tsx
@@ -1,0 +1,247 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createSignal, createEffect, onCleanup } from "solid-js";
+import { Show } from "solid-js";
+import { createRootHMR } from "@nora/solid-xul";
+import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
+import i18next from "i18next";
+import zenModeStyle from "./zen-mode.css?inline";
+
+const ZENMODE_PREF = "floorp.zenmode.enabled";
+
+const EDGE_THRESHOLD = 10;
+const HIDE_DELAY_MS = 500;
+
+export const [zenModeEnabled, setZenModeEnabled] = createRootHMR(
+  () =>
+    createSignal(
+      typeof Services !== "undefined"
+        ? Services.prefs.getBoolPref(ZENMODE_PREF, false)
+        : false,
+    ),
+  import.meta.hot,
+);
+
+function measureAndSetCSSVariables() {
+  const root = document.documentElement;
+
+  const toolbox = document.getElementById("navigator-toolbox");
+  if (toolbox) {
+    root.style.setProperty(
+      "--zenmode-toolbox-height",
+      `${toolbox.getBoundingClientRect().height}px`,
+    );
+  }
+
+  const sidebar = document.getElementById("panel-sidebar-box");
+  if (sidebar) {
+    root.style.setProperty(
+      "--zenmode-sidebar-width",
+      `${sidebar.getBoundingClientRect().width}px`,
+    );
+  }
+
+  const selectBox = document.getElementById("panel-sidebar-select-box");
+  if (selectBox) {
+    root.style.setProperty(
+      "--zenmode-selectbox-width",
+      `${selectBox.getBoundingClientRect().width}px`,
+    );
+  }
+
+  const statusbar = document.getElementById("nora-statusbar");
+  if (statusbar) {
+    root.style.setProperty(
+      "--zenmode-statusbar-height",
+      `${statusbar.getBoundingClientRect().height}px`,
+    );
+  }
+}
+
+function setupPrefSync() {
+  createEffect(() => {
+    const enabled = zenModeEnabled();
+    Services.prefs.setBoolPref(ZENMODE_PREF, enabled);
+
+    if (enabled) {
+      // Measure element sizes before hiding so animations have correct distances
+      measureAndSetCSSVariables();
+      document.documentElement.setAttribute("zenmode", "");
+    } else {
+      document.documentElement.removeAttribute("zenmode");
+      document.documentElement.removeAttribute("zenmode-reveal-top");
+      document.documentElement.removeAttribute("zenmode-reveal-bottom");
+      document.documentElement.removeAttribute("zenmode-reveal-side");
+    }
+  });
+
+  const observer = () => {
+    const prefValue = Services.prefs.getBoolPref(ZENMODE_PREF, false);
+    if (prefValue !== zenModeEnabled()) {
+      setZenModeEnabled(prefValue);
+    }
+  };
+  Services.prefs.addObserver(ZENMODE_PREF, observer);
+  onCleanup(() => {
+    Services.prefs.removeObserver(ZENMODE_PREF, observer);
+  });
+}
+
+function setupHoverReveal() {
+  let topHideTimer: ReturnType<typeof setTimeout> | null = null;
+  let bottomHideTimer: ReturnType<typeof setTimeout> | null = null;
+  let sideHideTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTopTimer = () => {
+    if (topHideTimer !== null) {
+      clearTimeout(topHideTimer);
+      topHideTimer = null;
+    }
+  };
+
+  const clearBottomTimer = () => {
+    if (bottomHideTimer !== null) {
+      clearTimeout(bottomHideTimer);
+      bottomHideTimer = null;
+    }
+  };
+
+  const clearSideTimer = () => {
+    if (sideHideTimer !== null) {
+      clearTimeout(sideHideTimer);
+      sideHideTimer = null;
+    }
+  };
+
+  const handleMouseMove = (event: MouseEvent) => {
+    if (!zenModeEnabled()) return;
+
+    const { clientX, clientY } = event;
+    const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
+
+    // Top edge detection
+    if (clientY <= EDGE_THRESHOLD) {
+      clearTopTimer();
+      document.documentElement.setAttribute("zenmode-reveal-top", "");
+    } else if (
+      document.documentElement.hasAttribute("zenmode-reveal-top")
+    ) {
+      const navigatorToolbox = document.getElementById("navigator-toolbox");
+      if (navigatorToolbox) {
+        const rect = navigatorToolbox.getBoundingClientRect();
+        if (clientY > rect.bottom) {
+          clearTopTimer();
+          topHideTimer = setTimeout(() => {
+            document.documentElement.removeAttribute("zenmode-reveal-top");
+            topHideTimer = null;
+          }, HIDE_DELAY_MS);
+        } else {
+          clearTopTimer();
+        }
+      }
+    }
+
+    // Bottom edge detection
+    if (clientY >= windowHeight - EDGE_THRESHOLD) {
+      clearBottomTimer();
+      document.documentElement.setAttribute("zenmode-reveal-bottom", "");
+    } else if (
+      document.documentElement.hasAttribute("zenmode-reveal-bottom")
+    ) {
+      const statusbar = document.getElementById("nora-statusbar");
+      if (statusbar) {
+        const rect = statusbar.getBoundingClientRect();
+        if (clientY < rect.top) {
+          clearBottomTimer();
+          bottomHideTimer = setTimeout(() => {
+            document.documentElement.removeAttribute("zenmode-reveal-bottom");
+            bottomHideTimer = null;
+          }, HIDE_DELAY_MS);
+        } else {
+          clearBottomTimer();
+        }
+      }
+    }
+
+    // Left/right edge detection for panel sidebar
+    if (clientX <= EDGE_THRESHOLD || clientX >= windowWidth - EDGE_THRESHOLD) {
+      clearSideTimer();
+      document.documentElement.setAttribute("zenmode-reveal-side", "");
+    } else if (
+      document.documentElement.hasAttribute("zenmode-reveal-side")
+    ) {
+      const panelSidebar = document.getElementById("panel-sidebar-box");
+      const panelSelectBox = document.getElementById(
+        "panel-sidebar-select-box",
+      );
+      const insideSidebar =
+        (panelSidebar &&
+          clientX >= panelSidebar.getBoundingClientRect().left &&
+          clientX <= panelSidebar.getBoundingClientRect().right) ||
+        (panelSelectBox &&
+          clientX >= panelSelectBox.getBoundingClientRect().left &&
+          clientX <= panelSelectBox.getBoundingClientRect().right);
+
+      if (!insideSidebar) {
+        clearSideTimer();
+        sideHideTimer = setTimeout(() => {
+          document.documentElement.removeAttribute("zenmode-reveal-side");
+          sideHideTimer = null;
+        }, HIDE_DELAY_MS);
+      } else {
+        clearSideTimer();
+      }
+    }
+  };
+
+  window.addEventListener("mousemove", handleMouseMove);
+
+  onCleanup(() => {
+    window.removeEventListener("mousemove", handleMouseMove);
+    clearTopTimer();
+    clearBottomTimer();
+    clearSideTimer();
+    document.documentElement.removeAttribute("zenmode");
+    document.documentElement.removeAttribute("zenmode-reveal-top");
+    document.documentElement.removeAttribute("zenmode-reveal-bottom");
+    document.documentElement.removeAttribute("zenmode-reveal-side");
+  });
+}
+
+export function initZenModeState() {
+  setupPrefSync();
+  setupHoverReveal();
+}
+
+export function ZenModeMenuElement() {
+  const [label, setLabel] = createSignal(
+    i18next.t("zen-mode.menu-label", { defaultValue: "Toggle Zen Mode" }),
+  );
+
+  addI18nObserver(() => {
+    setLabel(
+      i18next.t("zen-mode.menu-label", { defaultValue: "Toggle Zen Mode" }),
+    );
+  });
+
+  return (
+    <>
+      <xul:menuitem
+        label={label()}
+        type="checkbox"
+        id="toggle_zenmode"
+        checked={zenModeEnabled()}
+        onCommand={() => setZenModeEnabled((prev) => !prev)}
+        accesskey="Z"
+      />
+
+      <Show when={zenModeEnabled()}>
+        <style>{zenModeStyle}</style>
+      </Show>
+    </>
+  );
+}

--- a/i18n/en-US/browser-chrome.json
+++ b/i18n/en-US/browser-chrome.json
@@ -200,7 +200,8 @@
       "gecko-scroll-to-top": "Scroll to Top",
       "gecko-scroll-to-bottom": "Scroll to Bottom",
       "gecko-workspace-next": "Switch to Next Workspace",
-      "gecko-workspace-previous": "Switch to Previous Workspace"
+      "gecko-workspace-previous": "Switch to Previous Workspace",
+      "floorp-toggle-zen-mode": "Toggle Zen Mode"
     },
     "descriptions": {
       "gecko-back": "Navigate back to the previous page",
@@ -210,7 +211,8 @@
       "gecko-open-new-tab": "Open a new tab",
       "gecko-duplicate-tab": "Duplicate the current tab",
       "gecko-reload-all-tabs": "Reload all tabs",
-      "gecko-restore-last-tab": "Reopen the last closed tab"
+      "gecko-restore-last-tab": "Reopen the last closed tab",
+      "floorp-toggle-zen-mode": "Toggle Zen Mode to hide all UI elements for distraction-free browsing"
     }
   },
   "qrCode": {
@@ -370,5 +372,10 @@
     "menu": {
       "title": "Floorp Hub"
     }
+  },
+  "zen-mode": {
+    "label": "Zen Mode",
+    "tooltiptext": "Toggle Zen Mode",
+    "menu-label": "Toggle Zen Mode"
   }
 }

--- a/i18n/ja-JP/browser-chrome.json
+++ b/i18n/ja-JP/browser-chrome.json
@@ -200,7 +200,8 @@
       "gecko-scroll-to-top": "最上部までスクロール",
       "gecko-scroll-to-bottom": "最下部までスクロール",
       "gecko-workspace-next": "次のワークスペースに切り替える",
-      "gecko-workspace-previous": "前のワークスペースに切り替える"
+      "gecko-workspace-previous": "前のワークスペースに切り替える",
+      "floorp-toggle-zen-mode": "Zen モードの切り替え"
     },
     "descriptions": {
       "gecko-back": "前のページに戻る",
@@ -210,7 +211,8 @@
       "gecko-open-new-tab": "新しいタブを開く",
       "gecko-duplicate-tab": "現在のタブを複製",
       "gecko-reload-all-tabs": "すべてのタブを再読み込み",
-      "gecko-restore-last-tab": "最後に閉じたタブを開きなおす"
+      "gecko-restore-last-tab": "最後に閉じたタブを開きなおす",
+      "floorp-toggle-zen-mode": "Zen モードを切り替えて、集中できるブラウジング環境にする"
     }
   },
   "qrCode": {
@@ -370,5 +372,10 @@
     "menu": {
       "title": "Floorp Hub"
     }
+  },
+  "zen-mode": {
+    "label": "Zen モード",
+    "tooltiptext": "Zen モードの切り替え",
+    "menu-label": "Zen モードの切り替え"
   }
 }


### PR DESCRIPTION
## Summary

- Zen モード（集中ブラウジングモード）を新規実装
- 全 UI 要素（タブバー、ナビゲーションバー、サイドバー、ステータスバー）を非表示にし、コンテンツのみ表示
- マウスホバーで画面端に近づくと、非表示の UI が滑らかにスライドインで一時表示

## Features

- **トグル方法**: ツールバーボタン / キーボードショートカット (Ctrl+Shift+Z) / ツールメニュー / マウスジェスチャー
- **ホバーリビール**: 上端→ツールバー、下端→ステータスバー、左右端→パネルサイドバー
- **スムーズアニメーション**: margin ベース + cubic-bezier イージングで滑らかなスライド
- **状態永続化**: `floorp.zenmode.enabled` pref に保存、再起動後も維持
- **ウィンドウ移動**: 上部 8px にドラッグ領域を確保
- **i18n**: en-US / ja-JP 対応

## New files

- `browser-features/chrome/common/zen-mode/index.ts` — エントリーポイント
- `browser-features/chrome/common/zen-mode/zen-mode.tsx` — 状態管理・ホバー検出
- `browser-features/chrome/common/zen-mode/zen-mode.css` — CSS ルール・アニメーション
- `browser-features/chrome/common/zen-mode/icon.css` — ツールバーボタンアイコン
- `browser-features/chrome/common/zen-mode/styleElem.tsx` — スタイルラッパー

## Modified files

- `browser-features/chrome/common/mouse-gesture/utils/actions.ts` — アクション追加
- `i18n/en-US/browser-chrome.json` / `i18n/ja-JP/browser-chrome.json` — 翻訳キー追加

## Test plan

- [ ] ブラウザ起動後、ツールバーに Zen Mode ボタンが表示される
- [ ] ボタンクリックで全 UI が滑らかに非表示になる
- [ ] 画面上端にマウス移動 → ツールバーがスライドインする
- [ ] 画面下端にマウス移動 → ステータスバーがスライドインする
- [ ] 画面左右端にマウス移動 → パネルサイドバーがスライドインする
- [ ] Ctrl+Shift+Z でトグルできる
- [ ] ツールメニューにトグル項目が表示される
- [ ] ブラウザ再起動後に状態が保持される
- [ ] Zen モード中もウィンドウのドラッグ移動ができる

🤖 Generated with [Claude Code](https://claude.com/claude-code)