### PR TITLE
fix(pages-settings): resolve Invalid Hook Call error in SortableContext

### DIFF
--- a/browser-features/pages-settings/package.json
+++ b/browser-features/pages-settings/package.json
@@ -24,6 +24,9 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@icons-pack/react-simple-icons": "^13.8.0",
     "@tailwindcss/vite": "^4.1.18",
     "birpc": "^4.0.0",

--- a/browser-features/pages-settings/vite.config.ts
+++ b/browser-features/pages-settings/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig(({ command }) => ({
   build: {
     outDir: "_dist",
   },
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
   plugins: [
     tailwindcss(),
     react({

--- a/deno.lock
+++ b/deno.lock
@@ -4821,6 +4821,9 @@
         "packageJson": {
           "dependencies": [
             "npm:@dnd-kit/core@^6.3.1",
+            "npm:@dnd-kit/modifiers@9",
+            "npm:@dnd-kit/sortable@10",
+            "npm:@dnd-kit/utilities@^3.2.2",
             "npm:@icons-pack/react-simple-icons@^13.8.0",
             "npm:@tailwindcss/vite@^4.1.18",
             "npm:@types/react-dom@^19.2.3",


### PR DESCRIPTION
## Summary

- Add missing `@dnd-kit/sortable`, `@dnd-kit/modifiers`, `@dnd-kit/utilities` to `pages-settings/package.json` (these packages were imported in `PanelList.tsx` but not declared as dependencies)
- Add `resolve.dedupe: ["react", "react-dom"]` to `pages-settings/vite.config.ts` to prevent Vite's `optimizeDeps` from creating duplicate React instances during pre-bundling

## Problem

The settings page panel sidebar threw `Invalid hook call` errors from `@dnd-kit/sortable`'s `SortableContext` component. This was caused by two issues:

1. Three `@dnd-kit` packages used in `PanelList.tsx` were not declared in `package.json`, causing Deno to resolve them incorrectly
2. Vite's `optimizeDeps` pre-bundling created separate React instances for the application code vs `@dnd-kit` packages, breaking React's hook dispatcher

## Test plan

- [ ] Open the settings page and navigate to the panel sidebar section
- [ ] Verify no `Invalid hook call` errors in the browser console
- [ ] Test drag-and-drop reordering of panels works correctly
- [ ] Verify adding, editing, and deleting panels still functions

Made with [Cursor](https://cursor.com)