### PR TITLE
feat(mouse-gesture): add configurable actions to rocker gestures

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/config.ts
+++ b/browser-features/chrome/common/mouse-gesture/config.ts
@@ -47,6 +47,12 @@ const ContextMenuCodec = t.type({
   preventionTimeout: t.number,
 });
 
+const RockerActionsCodec = t.type({
+  leftRight: t.string,
+  rightLeft: t.string,
+});
+export type RockerActions = t.TypeOf<typeof RockerActionsCodec>;
+
 const MouseGestureConfigRequired = t.type({
   rockerGesturesEnabled: t.boolean,
   wheelGesturesEnabled: t.boolean,
@@ -57,6 +63,7 @@ const MouseGestureConfigRequired = t.type({
   trailWidth: t.number,
   contextMenu: ContextMenuCodec,
   actions: t.array(GestureActionCodec),
+  rockerActions: RockerActionsCodec,
 });
 
 const MouseGestureConfigOptional = t.partial({
@@ -98,6 +105,10 @@ const BASE_DEFAULT_CONFIG: MouseGestureConfig = {
     { pattern: ["left", "down"], action: "gecko-scroll-up" },
     { pattern: ["right", "down"], action: "gecko-scroll-down" },
   ],
+  rockerActions: {
+    leftRight: "gecko-forward",
+    rightLeft: "gecko-back",
+  },
 };
 
 const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig => {
@@ -119,6 +130,11 @@ const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig =>
     ),
   };
 
+  const rockerActions = {
+    ...BASE_DEFAULT_CONFIG.rockerActions,
+    ...(config?.rockerActions as Record<string, unknown> | undefined),
+  };
+
   return {
     ...BASE_DEFAULT_CONFIG,
     ...config,
@@ -127,6 +143,7 @@ const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig =>
     actions: Array.isArray(config?.actions)
       ? (config.actions as GestureAction[])
       : BASE_DEFAULT_CONFIG.actions,
+    rockerActions,
   } as MouseGestureConfig;
 };
 

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -206,13 +206,13 @@ export class MouseGestureController {
       const RIGHT = 2;
       let action: string | null = null;
 
-      // Right button held, then left button pressed -> back
+      // Right button held, then left button pressed -> use configured action
       if (this.isGestureActive && event.button === LEFT) {
-        action = "gecko-back";
+        action = config.rockerActions.rightLeft;
       }
-      // Left button held, then right button pressed -> forward
+      // Left button held, then right button pressed -> use configured action
       else if (this.pressedButtons.has(LEFT) && event.button === RIGHT) {
-        action = "gecko-forward";
+        action = config.rockerActions.leftRight;
       }
 
       if (action) {

--- a/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
+++ b/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
@@ -9,6 +9,7 @@ import { Settings } from "lucide-react";
 import { Switch } from "@/components/common/switch.tsx";
 import { Seekbar } from "@/components/common/seekbar.tsx";
 import type { MouseGestureConfig } from "@/types/pref.ts";
+import { useAvailableActions } from "../useAvailableActions.ts";
 import {
   Card,
   CardContent,
@@ -21,14 +22,20 @@ interface GeneralSettingsProps {
   config: MouseGestureConfig;
   toggleEnabled: () => Promise<boolean>;
   updateConfig: (config: Partial<MouseGestureConfig>) => Promise<boolean>;
+  updateRockerAction: (
+    rockerType: "leftRight" | "rightLeft",
+    action: string,
+  ) => Promise<boolean>;
 }
 
 export function GeneralSettings({
   config,
   toggleEnabled,
   updateConfig,
+  updateRockerAction,
 }: GeneralSettingsProps) {
   const { t } = useTranslation();
+  const availableActions = useAvailableActions();
 
   const toggleShowTrail = async () => {
     await updateConfig({ showTrail: !config.showTrail });
@@ -136,6 +143,59 @@ export function GeneralSettings({
                 disabled={!config.enabled}
               />
             </div>
+
+            {/* Rocker Actions - only show when enabled */}
+            {config.rockerGesturesEnabled && (
+              <>
+                <div className="flex items-center justify-between py-2 pl-4">
+                  <div className="flex-1">
+                    <span className="text-base-content/90 font-medium">
+                      {t("mouseGesture.rockerLeftRight")}
+                    </span>
+                    <p className="text-sm text-base-content/60">
+                      {t("mouseGesture.rockerLeftRightDescription")}
+                    </p>
+                  </div>
+                  <select
+                    className="select select-bordered w-64 max-w-xs text-sm"
+                    value={config.rockerActions.leftRight}
+                    onChange={(e) =>
+                      updateRockerAction("leftRight", e.target.value)}
+                    disabled={!config.enabled}
+                  >
+                    {availableActions.map((action) => (
+                      <option key={action.id} value={action.id}>
+                        {action.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="flex items-center justify-between py-2 pl-4">
+                  <div className="flex-1">
+                    <span className="text-base-content/90 font-medium">
+                      {t("mouseGesture.rockerRightLeft")}
+                    </span>
+                    <p className="text-sm text-base-content/60">
+                      {t("mouseGesture.rockerRightLeftDescription")}
+                    </p>
+                  </div>
+                  <select
+                    className="select select-bordered w-64 max-w-xs text-sm"
+                    value={config.rockerActions.rightLeft}
+                    onChange={(e) =>
+                      updateRockerAction("rightLeft", e.target.value)}
+                    disabled={!config.enabled}
+                  >
+                    {availableActions.map((action) => (
+                      <option key={action.id} value={action.id}>
+                        {action.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </>
+            )}
 
             <div className="flex items-center justify-between py-2">
               <span className="text-base-content/90 font-medium">

--- a/browser-features/pages-settings/src/app/gesture/dataManager.ts
+++ b/browser-features/pages-settings/src/app/gesture/dataManager.ts
@@ -49,6 +49,10 @@ export const useMouseGestureConfig = () => {
             preventionTimeout: 200,
           },
           actions: [],
+          rockerActions: {
+            leftRight: "gecko-forward",
+            rightLeft: "gecko-back",
+          },
         };
 
         try {
@@ -125,6 +129,15 @@ export const useMouseGestureConfig = () => {
     return updateConfig({ actions: newActions });
   };
 
+  const updateRockerAction = (rockerType: "leftRight" | "rightLeft", action: string) => {
+    return updateConfig({
+      rockerActions: {
+        ...config.rockerActions,
+        [rockerType]: action,
+      },
+    });
+  };
+
   return {
     config,
     loading,
@@ -134,6 +147,7 @@ export const useMouseGestureConfig = () => {
     addAction,
     updateAction,
     deleteAction,
+    updateRockerAction,
   };
 };
 

--- a/browser-features/pages-settings/src/app/gesture/page.tsx
+++ b/browser-features/pages-settings/src/app/gesture/page.tsx
@@ -18,6 +18,7 @@ export default function Page() {
         addAction,
         updateAction,
         deleteAction,
+        updateRockerAction,
     } = useMouseGestureConfig();
 
     if (loading) {
@@ -40,6 +41,7 @@ export default function Page() {
                     config={config}
                     toggleEnabled={toggleEnabled}
                     updateConfig={updateConfig}
+                    updateRockerAction={updateRockerAction}
                 />
 
                 <ActionsSettings

--- a/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
@@ -526,6 +526,10 @@
         "actionDescription": "Description of the gesture",
         "rockerGesturesEnabled": "Enable rocker gestures",
         "rockerGesturesDescription": "Right-click and move left to go back, right-click and move right to go forward. (Experimental)",
+        "rockerLeftRight": "Left → Right",
+        "rockerLeftRightDescription": "Hold left button, then click right button",
+        "rockerRightLeft": "Right → Left",
+        "rockerRightLeftDescription": "Hold right button, then click left button",
         "wheelGesturesEnabled": "Enable wheel gestures",
         "actions": {
             "gecko-back": "Go Back",

--- a/browser-features/pages-settings/src/lib/i18n/locales/pl-PL.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/pl-PL.json
@@ -526,6 +526,10 @@
         "actionDescription": "Description of the gesture",
         "rockerGesturesEnabled": "Enable rocker gestures",
         "rockerGesturesDescription": "Right-click and move left to go back, right-click and move right to go forward. (Experimental)",
+        "rockerLeftRight": "Lewy → Prawy",
+        "rockerLeftRightDescription": "Przytrzymaj lewy przycisk, następnie kliknij prawym",
+        "rockerRightLeft": "Prawy → Lewy",
+        "rockerRightLeftDescription": "Przytrzymaj prawy przycisk, następnie kliknij lewym",
         "wheelGesturesEnabled": "Enable wheel gestures",
         "actions": {
             "gecko-back": "Go Back",

--- a/browser-features/pages-settings/src/types/pref.ts
+++ b/browser-features/pages-settings/src/types/pref.ts
@@ -177,6 +177,11 @@ export const zMouseGestureContextMenu = t.type({
   preventionTimeout: t.number,
 });
 
+export const zRockerActions = t.type({
+  leftRight: t.string,
+  rightLeft: t.string,
+});
+
 export const zMouseGestureConfig = t.type({
   enabled: t.boolean,
   rockerGesturesEnabled: t.boolean,
@@ -188,6 +193,7 @@ export const zMouseGestureConfig = t.type({
   trailWidth: t.number,
   contextMenu: zMouseGestureContextMenu,
   actions: t.array(zGestureAction),
+  rockerActions: zRockerActions,
 });
 
 export type GestureAction = t.TypeOf<typeof zGestureAction>;


### PR DESCRIPTION
  ## Summary

  - Add `RockerActionsCodec` and `zRockerActions` type definitions for type safety
  - Extend mouse gesture config to include `rockerActions` with `leftRight` and `rightLeft` mappings
  - Update controller to use configured actions instead of hardcoded "gecko-back"/"gecko-forward"
  - Add UI dropdowns in settings to configure rocker actions (only visible when rocker gestures enabled)
  - Add `updateRockerAction()` function to data manager for persisting rocker action changes
  - Add English and Polish translations for new UI labels
  - Add English placeholder translations to all 29 locale files
  - Set sensible defaults matching previous hardcoded behavior (left→right=forward, right→left=back)

  ## Known Issues

  None

  ## Test plan

  - [ ] Verify rocker gestures work with default actions (left→right=forward, right→left=back)
  - [ ] Verify settings page shows rocker action dropdowns when rocker gestures are enabled
  - [ ] Verify settings page hides rocker action dropdowns when rocker gestures are disabled
  - [ ] Verify changing rocker action in settings persists across browser restarts
  - [ ] Verify all available actions appear in the rocker action dropdowns
  - [ ] Verify rocker gestures trigger the newly configured actions
  - [ ] Verify Polish translations display correctly when locale is set to pl-PL
  - [ ] Verify other locales fall back to English until bot translates
  - [ ] Verify TypeScript compilation succeeds with no type errors
  - [ ] Verify existing mouse gesture functionality is not affected