### PR TITLE
feat(tools): add dev-tool CLI for browser debugging via Marionette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/node_modules/
 **/.turbo
 **/.vite/
+*.timestamp-*
 
 *.tar.zst
 *.tar.xz

--- a/deno.json
+++ b/deno.json
@@ -35,7 +35,8 @@
   ],
   "tasks": {
     "feles-build": "deno run -A tools/feles-build.ts",
-    "act": "deno run -A tools/act/run-package-workflow.ts"
+    "act": "deno run -A tools/act/run-package-workflow.ts",
+    "dev-tool": "deno run -A tools/dev-tool.ts"
   },
   "nodeModulesDir": "manual"
 }

--- a/docs/llm/development-notes.md
+++ b/docs/llm/development-notes.md
@@ -471,21 +471,46 @@ deno task dev --measure-startup
 
 ## デバッグとトラブルシューティング
 
-### 1. ブラウザコンソール
+### 1. dev-tool（CLI デバッグツール）
+
+`tools/dev-tool.ts` は、ブラウザの起動・停止・デバッグを CLI から行うためのツールです。Marionette プロトコル経由で chrome コンテキスト（XUL DOM）にアクセスできます。
+
+```bash
+# プロセス管理
+deno task dev-tool start       # ブラウザをバックグラウンドで起動
+deno task dev-tool stop        # 全プロセスを停止（通常版 Floorp は kill しない）
+deno task dev-tool restart     # 再起動（stop + start）
+deno task dev-tool rebuild     # アセットだけリビルド（ブラウザ継続、HMR 対象外のモジュール用）
+
+# ブラウザ操作
+deno task dev-tool status                      # 接続確認 + タブ情報
+deno task dev-tool screenshot                  # XUL UI 含むフルウィンドウ スクリーンショット
+deno task dev-tool screenshot -c content       # コンテンツエリアのみ
+deno task dev-tool eval "gBrowser.tabs.length" # chrome コンテキストで JS 実行
+deno task dev-tool eval "document.title" -c content  # content コンテキストで JS 実行
+deno task dev-tool console --level error       # ブラウザコンソールのエラーログ取得
+deno task dev-tool console --filter noraneko   # テキストフィルタ
+deno task dev-tool dom "#nav-bar"              # XUL DOM 要素の検査
+deno task dev-tool navigate "about:config" -c content  # URL に遷移
+deno task dev-tool title                       # ページタイトル取得
+```
+
+**アーキテクチャ**:
+- `tools/src/browser_connector.ts` — Marionette TCP クライアント（バイトベースのプロトコルパーサー）
+- `tools/src/browser_launcher.ts` — `--marionette --remote-allow-system-access` フラグ付きで起動
+- ブラウザプロファイルに `remote.active-protocols: 0`、`marionette.enabled: true` を設定
+
+**注意事項**:
+- `rebuild` コマンドは `bridge/loader-features` のビルドを除外しています（Vite dev servers の HMR に任せる）。`loader-features` をフルリビルドするとシンボリンク経由で chrome コンテンツが上書きされ、Marionette セッションが壊れます
+- `stop` は dev プロファイル (`_dist/profile/test`) を使用するプロセスのみ kill します。通常版 Floorp には影響しません
+- スクリーンショットは `_dist/screenshot.png` に保存されます
+
+### 2. ブラウザコンソール（手動）
 
 Firefox の開発者ツールを活用：
 
 - `Ctrl+Shift+J` (Windows/Linux) または `Cmd+Option+J` (macOS): ブラウザコンソール
 - `Ctrl+Shift+I` (Windows/Linux) または `Cmd+Option+I` (macOS): ページコンソール
-
-### 2. リモートデバッグ
-
-```bash
-# Firefox をデバッグモードで起動
-deno task dev -- --remote-debugging-port=9222
-```
-
-その後、Chrome で `chrome://inspect` を開いて接続。
 
 ### 3. ログ出力
 

--- a/tools/dev-tool.ts
+++ b/tools/dev-tool.ts
@@ -51,12 +51,19 @@ const args = parseArgs(Deno.args, {
 });
 
 const command = args._[0] as string | undefined;
-const context = args.context as "chrome" | "content";
 
 if (!command || args.help) {
   console.log(HELP);
   Deno.exit(0);
 }
+
+// Validate --context
+const VALID_CONTEXTS = ["chrome", "content"] as const;
+if (!VALID_CONTEXTS.includes(args.context as typeof VALID_CONTEXTS[number])) {
+  console.error(`Invalid --context "${args.context}". Allowed: chrome, content`);
+  Deno.exit(1);
+}
+const context = args.context as "chrome" | "content";
 
 async function main() {
   switch (command) {
@@ -224,9 +231,20 @@ async function cmdStop() {
       await runSilent("taskkill", ["/PID", p, "/F"]);
     }
     if (browserPids.length === 0 && pid) {
-      // Fallback: kill floorp child processes of the saved PID tree
-      // (CommandLine might not be available for all processes)
-      await runSilent("taskkill", ["/IM", "floorp.exe", "/F"]);
+      // Fallback: find floorp by parent PID (never kill by image name alone)
+      const findChild = new Deno.Command("powershell", {
+        args: [
+          "-NoProfile", "-Command",
+          `Get-WmiObject Win32_Process | Where-Object { $_.Name -eq 'floorp.exe' -and $_.ParentProcessId -eq ${pid} } | ForEach-Object { $_.ProcessId }`,
+        ],
+        stdout: "piped",
+        stderr: "null",
+      });
+      const childOut = await findChild.output();
+      const childPids = new TextDecoder().decode(childOut.stdout).trim().split(/\r?\n/).filter(Boolean);
+      for (const p of childPids) {
+        await runSilent("taskkill", ["/PID", p, "/F"]);
+      }
     }
 
     // 4. Wait for cleanup
@@ -392,7 +410,20 @@ async function cmdScreenshot() {
 
   await withBrowser(async (client) => {
     await client.setContext(context);
-    const data = await client.takeScreenshot({ full: true });
+
+    let data: Uint8Array;
+    if (args.selector) {
+      // Find element by selector, then screenshot it
+      const elements = await client.findElements(String(args.selector));
+      if (elements.length === 0) {
+        console.error(`Element not found: ${args.selector}`);
+        Deno.exit(1);
+      }
+      data = await client.takeScreenshot({ element: elements[0] });
+    } else {
+      data = await client.takeScreenshot({ full: true });
+    }
+
     Deno.writeFileSync(outputPath, data);
     console.log(`Screenshot saved to ${outputPath} (${data.length} bytes)`);
   });

--- a/tools/dev-tool.ts
+++ b/tools/dev-tool.ts
@@ -1,0 +1,480 @@
+#!/usr/bin/env -S deno run -A
+// SPDX-License-Identifier: MPL-2.0
+
+import * as path from "@std/path";
+import { parseArgs } from "@std/cli/parse-args";
+import { withBrowser } from "./src/browser_connector.ts";
+import { PLATFORM, PROJECT_ROOT } from "./src/defines.ts";
+// Lazy imports for rebuild — avoids type-checking injector.ts at dev-tool level
+async function loadBuildModules() {
+  const Builder = await import("./src/builder.ts");
+  const Injector = await import("./src/injector.ts");
+  const Update = await import("./src/update.ts");
+  return { Builder, Injector, Update };
+}
+
+const PID_FILE = path.join(PROJECT_ROOT, "_dist", "dev-server.pid");
+
+const HELP = `
+Usage: deno run -A tools/dev-tool.ts <command> [options]
+
+Process management:
+  start                     Start feles-build dev (background)
+  stop                      Stop all dev processes cleanly
+  restart                   Restart dev processes
+  rebuild                   Rebuild assets without restarting browser
+
+Browser commands:
+  status                    Check browser connection
+  screenshot [options]      Take a screenshot
+  eval <script>             Evaluate JavaScript in browser
+  console [options]         Get browser console messages
+  navigate <url>            Navigate to a URL
+  dom <selector>            Inspect DOM elements
+  title                     Get page title
+
+Options:
+  --context, -c <ctx>       Context: "chrome" or "content" (default: chrome)
+  --selector, -s <sel>      Screenshot: capture a specific element
+  --output, -o <path>       Screenshot: output file path (default: _dist/screenshot.png)
+  --limit, -l <n>           Console: max messages (default: 50)
+  --filter, -f <pattern>    Console: filter by text pattern
+  --level <level>           Console: filter by level (error/warn/info/debug/all, default: all)
+  --help, -h                Show this help
+`.trim();
+
+const args = parseArgs(Deno.args, {
+  string: ["context", "selector", "output", "limit", "filter", "level"],
+  alias: { c: "context", s: "selector", o: "output", h: "help", l: "limit", f: "filter" },
+  boolean: ["help"],
+  default: { context: "chrome" },
+});
+
+const command = args._[0] as string | undefined;
+const context = args.context as "chrome" | "content";
+
+if (!command || args.help) {
+  console.log(HELP);
+  Deno.exit(0);
+}
+
+async function main() {
+  switch (command) {
+    case "start":
+      await cmdStart();
+      break;
+    case "stop":
+      await cmdStop();
+      break;
+    case "restart":
+      await cmdStop();
+      await cmdStart();
+      break;
+    case "rebuild":
+      await cmdRebuild();
+      break;
+    case "status":
+      await cmdStatus();
+      break;
+    case "screenshot":
+      await cmdScreenshot();
+      break;
+    case "eval":
+      await cmdEval();
+      break;
+    case "console":
+      await cmdConsole();
+      break;
+    case "navigate":
+      await cmdNavigate();
+      break;
+    case "dom":
+      await cmdDom();
+      break;
+    case "title":
+      await cmdTitle();
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.log(HELP);
+      Deno.exit(1);
+  }
+}
+
+async function cmdStart() {
+  // Check if already running
+  try {
+    const existingPid = Deno.readTextFileSync(PID_FILE).trim();
+    // Verify process is actually alive
+    const check = new Deno.Command(
+      PLATFORM === "windows" ? "tasklist" : "ps",
+      PLATFORM === "windows"
+        ? { args: ["/FI", `PID eq ${existingPid}`, "/NH"], stdout: "piped", stderr: "null" }
+        : { args: ["-p", existingPid], stdout: "piped", stderr: "null" },
+    );
+    const out = await check.output();
+    const text = new TextDecoder().decode(out.stdout);
+    if (text.includes(existingPid)) {
+      console.log(`Dev server already running (PID ${existingPid}).`);
+      console.log("Use 'dev-tool stop' to stop it first, or 'dev-tool restart'.");
+      return;
+    }
+  } catch {
+    // No PID file or process not found — proceed
+  }
+
+  console.log("Starting feles-build dev...");
+
+  const logFile = path.join(PROJECT_ROOT, "_dist", "dev-server.log");
+  const marionetteFile = path.join(PROJECT_ROOT, "_dist", "marionette-port.txt");
+
+  // Remove stale state files
+  for (const f of [marionetteFile, PID_FILE]) {
+    try { Deno.removeSync(f); } catch { /* ignore */ }
+  }
+
+  // Spawn a fully detached process that survives parent exit
+  const denoPath = Deno.execPath();
+
+  // Use bash to spawn a background process (works on all platforms with bash)
+  const setsid = PLATFORM !== "windows" ? "setsid " : "";
+  const cmd = new Deno.Command("bash", {
+    args: [
+      "-c",
+      `${setsid}"${denoPath}" task feles-build dev > "${logFile}" 2>&1 & echo $!`,
+    ],
+    cwd: PROJECT_ROOT,
+    stdout: "piped",
+    stderr: "null",
+  });
+  const out = await cmd.output();
+  const pid = new TextDecoder().decode(out.stdout).trim();
+
+  if (!pid || isNaN(Number(pid))) {
+    console.error("Failed to start. Check log:", logFile);
+    Deno.exit(1);
+  }
+  Deno.writeTextFileSync(PID_FILE, pid);
+  console.log(`Started (PID ${pid}). Waiting for Marionette...`);
+
+  // Poll for marionette-port.txt
+  const maxWait = 120; // seconds
+  for (let i = 0; i < maxWait; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    try {
+      const port = Deno.readTextFileSync(marionetteFile).trim();
+      if (port) {
+        console.log(`Browser ready! Marionette on port ${port}.`);
+        console.log(`Log: ${logFile}`);
+        return;
+      }
+    } catch {
+      // not yet
+    }
+  }
+
+  console.error(`Timed out after ${maxWait}s. Check ${logFile} for errors.`);
+  Deno.exit(1);
+}
+
+async function cmdStop() {
+  let pid: string | null = null;
+  try {
+    pid = Deno.readTextFileSync(PID_FILE).trim();
+  } catch {
+    // no PID file
+  }
+
+  console.log("Stopping dev processes...");
+
+  if (PLATFORM === "windows") {
+    // 1. Kill saved PID tree
+    if (pid) {
+      await runSilent("taskkill", ["/PID", pid, "/T", "/F"]);
+    }
+
+    // 2. Kill all feles-build related deno processes
+    //    (bash & spawns outside the process tree, so /T may miss children)
+    const findCmd = new Deno.Command("powershell", {
+      args: [
+        "-NoProfile", "-Command",
+        `Get-WmiObject Win32_Process | Where-Object { $_.Name -eq 'deno.exe' -and $_.CommandLine -like '*feles-build*' } | ForEach-Object { $_.ProcessId }`,
+      ],
+      stdout: "piped",
+      stderr: "null",
+    });
+    const findOut = await findCmd.output();
+    const pids = new TextDecoder().decode(findOut.stdout).trim().split(/\r?\n/).filter(Boolean);
+    for (const p of pids) {
+      await runSilent("taskkill", ["/PID", p, "/T", "/F"]);
+    }
+
+    // 3. Kill only dev floorp.exe (uses test profile, not the user's regular browser)
+    const findBrowser = new Deno.Command("powershell", {
+      args: [
+        "-NoProfile", "-Command",
+        `Get-WmiObject Win32_Process | Where-Object { $_.Name -eq 'floorp.exe' -and $_.CommandLine -like '*_dist*profile*test*' } | ForEach-Object { $_.ProcessId }`,
+      ],
+      stdout: "piped",
+      stderr: "null",
+    });
+    const browserOut = await findBrowser.output();
+    const browserPids = new TextDecoder().decode(browserOut.stdout).trim().split(/\r?\n/).filter(Boolean);
+    for (const p of browserPids) {
+      await runSilent("taskkill", ["/PID", p, "/F"]);
+    }
+    if (browserPids.length === 0 && pid) {
+      // Fallback: kill floorp child processes of the saved PID tree
+      // (CommandLine might not be available for all processes)
+      await runSilent("taskkill", ["/IM", "floorp.exe", "/F"]);
+    }
+
+    // 4. Wait for cleanup
+    await new Promise((r) => setTimeout(r, 1000));
+  } else {
+    if (pid) {
+      await runSilent("kill", ["-TERM", `-${pid}`]);
+      await new Promise((r) => setTimeout(r, 1000));
+      await runSilent("kill", ["-9", `-${pid}`]);
+    }
+  }
+
+  // Clean up state files
+  for (const f of [PID_FILE, path.join(PROJECT_ROOT, "_dist", "marionette-port.txt")]) {
+    try { Deno.removeSync(f); } catch { /* ignore */ }
+  }
+
+  console.log("Stopped.");
+}
+
+async function runSilent(cmd: string, args: string[]): Promise<void> {
+  try {
+    await new Deno.Command(cmd, { args, stdout: "null", stderr: "null" }).output();
+  } catch { /* ignore */ }
+}
+
+async function cmdRebuild() {
+  // In dev mode, Vite dev servers handle HMR for loader-features.
+  // Only rebuild startup + loader-modules + inject XHTML.
+  // (Rebuilding loader-features overwrites symlinked files and crashes Marionette)
+  console.log("Rebuilding assets (startup + modules + inject)...");
+  const { Injector, Update } = await loadBuildModules();
+  const { packageVersion, runInParallel } = await import("./src/builder.ts");
+  const { writeBuildid2 } = await import("./src/update.ts");
+
+  const buildid2 = Update.generateUuidV7();
+  const buildid2Path = path.join(PROJECT_ROOT, "_dist", "buildid2");
+  writeBuildid2(buildid2Path, buildid2);
+
+  const denoPath = Deno.execPath();
+  const version = packageVersion();
+
+  await runInParallel([
+    [
+      [denoPath, "task", "build", "--env.MODE=dev"],
+      path.join(PROJECT_ROOT, "bridge/startup"),
+    ],
+    [
+      [denoPath, "task", "build", `--env.__BUILDID2__=${buildid2}`, `--env.__VERSION2__=${version}`],
+      path.join(PROJECT_ROOT, "bridge/loader-modules"),
+    ],
+  ]);
+
+  Injector.run("dev");
+  await Injector.injectXhtmlFromTs(true);
+  console.log("Rebuild complete. (loader-features is handled by HMR)");
+}
+
+async function cmdConsole() {
+  const limit = parseInt(args.limit ?? "50", 10);
+  const filter = args.filter ?? "";
+  const level = args.level ?? "all";
+
+  await withBrowser(async (client) => {
+    await client.setContext("chrome");
+    const raw = await client.executeScript(`
+      const messages = Services.console.getMessageArray();
+      return JSON.stringify(messages.slice(-${limit * 3}).map(m => {
+        if (m instanceof Ci.nsIScriptError) {
+          return {
+            level: m.flags & 0x1 ? 'error' : m.flags & 0x2 ? 'warn' : 'info',
+            message: m.errorMessage,
+            source: m.sourceName,
+            line: m.lineNumber,
+            category: m.category,
+            time: m.timeStamp,
+          };
+        }
+        return {
+          level: 'info',
+          message: m.message || String(m),
+          source: '',
+          line: 0,
+          category: '',
+          time: 0,
+        };
+      }));
+    `);
+
+    let messages: Array<{
+      level: string;
+      message: string;
+      source: string;
+      line: number;
+      category: string;
+      time: number;
+    }> = JSON.parse(raw);
+
+    // Filter by level
+    if (level !== "all") {
+      messages = messages.filter((m) => m.level === level);
+    }
+
+    // Filter by text
+    if (filter) {
+      const pat = filter.toLowerCase();
+      messages = messages.filter(
+        (m) =>
+          m.message.toLowerCase().includes(pat) ||
+          m.source.toLowerCase().includes(pat),
+      );
+    }
+
+    // Limit
+    messages = messages.slice(-limit);
+
+    if (messages.length === 0) {
+      console.log("No matching console messages.");
+      return;
+    }
+
+    for (const m of messages) {
+      const src = m.source ? ` (${m.source}${m.line ? ":" + m.line : ""})` : "";
+      const tag = m.level.toUpperCase().padEnd(5);
+      console.log(`[${tag}] ${m.message}${src}`);
+    }
+
+    console.log(`\n${messages.length} message(s) shown.`);
+  });
+}
+
+async function cmdStatus() {
+  await withBrowser(async (client) => {
+    await client.setContext("chrome");
+    const info = await client.executeScript(`
+      return JSON.stringify({
+        title: document.title,
+        url: document.documentURI,
+        tabCount: typeof gBrowser !== 'undefined' ? gBrowser.tabs.length : 'N/A',
+        activeTab: typeof gBrowser !== 'undefined' ? gBrowser.selectedTab.getAttribute('label') : 'N/A',
+      })
+    `);
+    const data = JSON.parse(info);
+    console.log("Connected to browser.");
+    console.log(`  Title: ${data.title}`);
+    console.log(`  URL: ${data.url}`);
+    console.log(`  Tabs: ${data.tabCount}`);
+    console.log(`  Active tab: ${data.activeTab}`);
+  });
+}
+
+async function cmdTitle() {
+  await withBrowser(async (client) => {
+    await client.setContext(context);
+    const title = await client.getTitle();
+    console.log(title);
+  });
+}
+
+async function cmdScreenshot() {
+  const outputPath = args.output ??
+    path.join(PROJECT_ROOT, "_dist", "screenshot.png");
+
+  await withBrowser(async (client) => {
+    await client.setContext(context);
+    const data = await client.takeScreenshot({ full: true });
+    Deno.writeFileSync(outputPath, data);
+    console.log(`Screenshot saved to ${outputPath} (${data.length} bytes)`);
+  });
+}
+
+async function cmdEval() {
+  const script = args._.slice(1).join(" ");
+  if (!script) {
+    console.error("Usage: dev-tool eval <script>");
+    Deno.exit(1);
+  }
+
+  await withBrowser(async (client) => {
+    await client.setContext(context);
+    const result = await client.executeScript(`return (${script})`);
+    if (typeof result === "string") {
+      console.log(result);
+    } else {
+      console.log(JSON.stringify(result, null, 2));
+    }
+  });
+}
+
+async function cmdNavigate() {
+  const url = args._[1] as string | undefined;
+  if (!url) {
+    console.error("Usage: dev-tool navigate <url>");
+    Deno.exit(1);
+  }
+
+  await withBrowser(async (client) => {
+    await client.setContext(context);
+    await client.navigate(String(url));
+    const title = await client.getTitle();
+    console.log(`Navigated to ${url}`);
+    console.log(`Title: ${title}`);
+  });
+}
+
+async function cmdDom() {
+  const selector = args._[1] as string | undefined;
+  if (!selector) {
+    console.error("Usage: dev-tool dom <selector>");
+    Deno.exit(1);
+  }
+
+  await withBrowser(async (client) => {
+    await client.setContext(context);
+
+    const elementIds = await client.findElements(String(selector));
+    if (elementIds.length === 0) {
+      console.log(`No elements found for: ${selector}`);
+      return;
+    }
+
+    console.log(`Found ${elementIds.length} element(s):\n`);
+
+    for (const [i, id] of elementIds.entries()) {
+      const info = await client.executeScript(
+        `
+        const el = arguments[0];
+        return JSON.stringify({
+          tagName: el.tagName?.toLowerCase(),
+          id: el.id || undefined,
+          className: el.className || undefined,
+          textContent: el.textContent?.slice(0, 200),
+          childCount: el.children?.length,
+          attributes: Object.fromEntries(
+            Array.from(el.attributes ?? []).map(a => [a.name, a.value])
+          ),
+        });
+      `,
+        [{ "element-6066-11e4-a52e-4f735466cecf": id }],
+      );
+      console.log(`[${i}]`, JSON.parse(info));
+    }
+  });
+}
+
+main()
+  .then(() => Deno.exit(0))
+  .catch((err) => {
+    console.error(`Error: ${err.message}`);
+    Deno.exit(1);
+  });

--- a/tools/src/browser_connector.ts
+++ b/tools/src/browser_connector.ts
@@ -103,8 +103,13 @@ export class MarionetteClient {
   ): Promise<any> {
     const id = this.#msgId++;
     const msg = JSON.stringify([0, id, command, params]);
-    const packet = `${msg.length}:${msg}`;
-    await this.#conn.write(this.#encoder.encode(packet));
+    // Marionette uses byte-length prefix, not character-length
+    const msgBytes = this.#encoder.encode(msg);
+    const prefixBytes = this.#encoder.encode(`${msgBytes.length}:`);
+    const packet = new Uint8Array(prefixBytes.length + msgBytes.length);
+    packet.set(prefixBytes, 0);
+    packet.set(msgBytes, prefixBytes.length);
+    await this.#conn.write(packet);
 
     const resp = await this.#readPacketWithTimeout(timeoutMs);
     // Response: [1, msgId, error, result]
@@ -259,7 +264,7 @@ function readPort(): number {
   } catch {
     throw new Error(
       `Marionette port not found at ${MARIONETTE_STATE_FILE}\n` +
-        `Is the browser running? Start it with: deno task feles-build dev`,
+        `Is the browser running? Start it with: deno task dev-tool start`,
     );
   }
 }

--- a/tools/src/browser_connector.ts
+++ b/tools/src/browser_connector.ts
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import * as path from "@std/path";
+import { PROJECT_ROOT } from "./defines.ts";
+
+const MARIONETTE_STATE_FILE = path.join(
+  PROJECT_ROOT,
+  "_dist",
+  "marionette-port.txt",
+);
+
+const SESSION_TIMEOUT_MS = 15_000;
+const CONNECT_RETRY_DELAY_MS = 2_000;
+const CONNECT_MAX_RETRIES = 3;
+
+/**
+ * Minimal Marionette protocol client for Firefox/Floorp.
+ *
+ * Protocol: length-prefixed JSON over TCP.
+ *   Send:    [0, msgId, command, params]
+ *   Receive: [1, msgId, error, result]
+ */
+export class MarionetteClient {
+  #conn!: Deno.TcpConn;
+  #msgId = 0;
+  #byteBuffer = new Uint8Array(0);
+  #encoder = new TextEncoder();
+  #decoder = new TextDecoder();
+  #sessionId: string | null = null;
+
+  private constructor() {}
+
+  static async connect(port?: number): Promise<MarionetteClient> {
+    const actualPort = port ?? readPort();
+
+    for (let attempt = 1; attempt <= CONNECT_MAX_RETRIES; attempt++) {
+      try {
+        return await MarionetteClient.#tryConnect(actualPort);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (attempt < CONNECT_MAX_RETRIES) {
+          console.error(
+            `[marionette] Attempt ${attempt} failed: ${msg}. Retrying in ${CONNECT_RETRY_DELAY_MS}ms...`,
+          );
+          await new Promise((r) => setTimeout(r, CONNECT_RETRY_DELAY_MS));
+        } else {
+          throw new Error(
+            `Failed to connect to Marionette after ${CONNECT_MAX_RETRIES} attempts: ${msg}`,
+          );
+        }
+      }
+    }
+    throw new Error("Unreachable");
+  }
+
+  static async #tryConnect(port: number): Promise<MarionetteClient> {
+    const client = new MarionetteClient();
+
+    console.error(`[marionette] Connecting to port ${port}`);
+    client.#conn = await Deno.connect({
+      hostname: "127.0.0.1",
+      port,
+    });
+
+    // Read handshake
+    const handshake = await client.#readPacketWithTimeout(SESSION_TIMEOUT_MS);
+    if (handshake?.marionetteProtocol !== 3) {
+      client.#conn.close();
+      throw new Error(
+        `Unexpected Marionette protocol: ${JSON.stringify(handshake)}`,
+      );
+    }
+    console.error("[marionette] Connected (protocol v3)");
+
+    // Create session with timeout
+    try {
+      const session = await client.sendWithTimeout(
+        "WebDriver:NewSession",
+        {},
+        SESSION_TIMEOUT_MS,
+      );
+      client.#sessionId = session?.sessionId;
+      console.error(`[marionette] Session: ${client.#sessionId}`);
+    } catch {
+      client.#conn.close();
+      throw new Error("NewSession timed out — browser may be busy or BiDi conflict");
+    }
+
+    return client;
+  }
+
+  async send(
+    command: string,
+    params: Record<string, unknown> = {},
+  ): Promise<any> {
+    return this.sendWithTimeout(command, params, 30_000);
+  }
+
+  async sendWithTimeout(
+    command: string,
+    params: Record<string, unknown>,
+    timeoutMs: number,
+  ): Promise<any> {
+    const id = this.#msgId++;
+    const msg = JSON.stringify([0, id, command, params]);
+    const packet = `${msg.length}:${msg}`;
+    await this.#conn.write(this.#encoder.encode(packet));
+
+    const resp = await this.#readPacketWithTimeout(timeoutMs);
+    // Response: [1, msgId, error, result]
+    if (!Array.isArray(resp) || resp[0] !== 1) {
+      throw new Error(`Invalid response: ${JSON.stringify(resp)}`);
+    }
+    if (resp[2]) {
+      const err = resp[2];
+      throw new Error(
+        `Marionette error (${err.error}): ${err.message ?? JSON.stringify(err)}`,
+      );
+    }
+    return resp[3];
+  }
+
+  async setContext(context: "chrome" | "content"): Promise<void> {
+    await this.send("Marionette:SetContext", { value: context });
+  }
+
+  async executeScript(script: string, args: unknown[] = []): Promise<any> {
+    const result = await this.send("WebDriver:ExecuteScript", {
+      script,
+      args,
+    });
+    return result?.value;
+  }
+
+  async takeScreenshot(opts?: {
+    full?: boolean;
+    element?: string;
+  }): Promise<Uint8Array> {
+    const params: Record<string, unknown> = {
+      full: opts?.full ?? true,
+      hash: false,
+    };
+    if (opts?.element) {
+      params.id = opts.element;
+    }
+    const result = await this.send("WebDriver:TakeScreenshot", params);
+    const b64 = result?.value;
+    if (!b64) throw new Error("No screenshot data returned");
+    return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  }
+
+  async findElements(
+    selector: string,
+    strategy = "css selector",
+  ): Promise<string[]> {
+    const result = await this.send("WebDriver:FindElements", {
+      using: strategy,
+      value: selector,
+    });
+    return (result ?? []).map(
+      (el: Record<string, string>) =>
+        el["element-6066-11e4-a52e-4f735466cecf"] ?? el.ELEMENT,
+    );
+  }
+
+  async getElementAttribute(
+    elementId: string,
+    name: string,
+  ): Promise<string | null> {
+    const result = await this.send("WebDriver:GetElementAttribute", {
+      id: elementId,
+      name,
+    });
+    return result?.value ?? null;
+  }
+
+  async getElementText(elementId: string): Promise<string> {
+    const result = await this.send("WebDriver:GetElementText", {
+      id: elementId,
+    });
+    return result?.value ?? "";
+  }
+
+  async navigate(url: string): Promise<void> {
+    await this.send("WebDriver:Navigate", { url });
+  }
+
+  async getTitle(): Promise<string> {
+    const result = await this.send("WebDriver:GetTitle", {});
+    return result?.value ?? "";
+  }
+
+  async getUrl(): Promise<string> {
+    const result = await this.send("WebDriver:GetCurrentUrl", {});
+    return result?.value ?? "";
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.sendWithTimeout("WebDriver:DeleteSession", {}, 5_000);
+    } catch {
+      // ignore
+    }
+    try {
+      this.#conn.close();
+    } catch {
+      // ignore
+    }
+  }
+
+  async #readPacketWithTimeout(timeoutMs: number): Promise<any> {
+    const result = await Promise.race([
+      this.#readPacket(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`Read timeout (${timeoutMs}ms)`)), timeoutMs)
+      ),
+    ]);
+    return result;
+  }
+
+  async #readPacket(): Promise<any> {
+    // Marionette protocol: length-prefixed by BYTE count, not character count.
+    while (true) {
+      const colonIdx = this.#byteBuffer.indexOf(0x3a); // ':'
+      if (colonIdx > 0) {
+        const lenStr = this.#decoder.decode(
+          this.#byteBuffer.subarray(0, colonIdx),
+        );
+        const len = parseInt(lenStr, 10);
+        const jsonStart = colonIdx + 1;
+        if (!isNaN(len) && this.#byteBuffer.length >= jsonStart + len) {
+          const jsonBytes = this.#byteBuffer.subarray(
+            jsonStart,
+            jsonStart + len,
+          );
+          const jsonStr = this.#decoder.decode(jsonBytes);
+          this.#byteBuffer = this.#byteBuffer.slice(jsonStart + len);
+          return JSON.parse(jsonStr);
+        }
+      }
+
+      const buf = new Uint8Array(65536);
+      const n = await this.#conn.read(buf);
+      if (!n) throw new Error("Marionette connection closed");
+      const newBuf = new Uint8Array(this.#byteBuffer.length + n);
+      newBuf.set(this.#byteBuffer);
+      newBuf.set(buf.subarray(0, n), this.#byteBuffer.length);
+      this.#byteBuffer = newBuf;
+    }
+  }
+}
+
+function readPort(): number {
+  try {
+    const content = Deno.readTextFileSync(MARIONETTE_STATE_FILE).trim();
+    const port = parseInt(content, 10);
+    if (isNaN(port)) throw new Error("Invalid port");
+    return port;
+  } catch {
+    throw new Error(
+      `Marionette port not found at ${MARIONETTE_STATE_FILE}\n` +
+        `Is the browser running? Start it with: deno task feles-build dev`,
+    );
+  }
+}
+
+export async function withBrowser<T>(
+  fn: (client: MarionetteClient) => Promise<T>,
+): Promise<T> {
+  const client = await MarionetteClient.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.close();
+  }
+}

--- a/tools/src/browser_launcher.ts
+++ b/tools/src/browser_launcher.ts
@@ -4,7 +4,6 @@ import * as path from "@std/path";
 import { BIN_PATH_EXE, PATHS, PROJECT_ROOT } from "./defines.ts";
 import { ProcessUtils } from "./utils.ts";
 
-export const MARIONETTE_PORT = 2828;
 export const MARIONETTE_STATE_FILE = path.join(PROJECT_ROOT, "_dist", "marionette-port.txt");
 
 /**

--- a/tools/src/browser_launcher.ts
+++ b/tools/src/browser_launcher.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import { BIN_PATH_EXE, PATHS } from "./defines.ts";
+import * as path from "@std/path";
+import { BIN_PATH_EXE, PATHS, PROJECT_ROOT } from "./defines.ts";
 import { ProcessUtils } from "./utils.ts";
+
+export const MARIONETTE_PORT = 2828;
+export const MARIONETTE_STATE_FILE = path.join(PROJECT_ROOT, "_dist", "marionette-port.txt");
 
 /**
  * Minimal port of tools/lib/browser_launcher.rb
@@ -28,6 +32,8 @@ export async function browserCommand(port: number): Promise<string[]> {
     BIN_PATH_EXE,
     "--profile",
     PATHS.profile_test,
+    "--marionette",
+    "--remote-allow-system-access",
   ];
 }
 
@@ -39,15 +45,20 @@ export async function run(port = 5180): Promise<void> {
   await ProcessUtils.runCommandWithLogging(
     cmd,
     (stream: "stdout" | "stderr", line: string) => {
-      if (stream === "stderr") {
-        const m = line.match(/^WebDriver BiDi listening on (ws:\/\/.*)/);
-        if (m) {
-          console.log("nora-{bbd11c51-3be9-4676-b912-ca4c0bdcab94}-webdriver");
-        }
+      const m = line.match(/Marionette\tINFO\tListening on port (\d+)/);
+      if (m) {
+        console.log("nora-{bbd11c51-3be9-4676-b912-ca4c0bdcab94}-webdriver");
+        Deno.writeTextFileSync(MARIONETTE_STATE_FILE, m[1]);
+        console.log(`[launcher] Marionette port saved to ${MARIONETTE_STATE_FILE}`);
       }
       printFirefoxLog(line.trim());
     },
   );
 
+  try {
+    Deno.removeSync(MARIONETTE_STATE_FILE);
+  } catch {
+    // ignore if already removed
+  }
   console.log("[launcher] Browser Closed");
 }

--- a/tools/src/initializer.ts
+++ b/tools/src/initializer.ts
@@ -179,7 +179,10 @@ export function savePrefsForProfile(): void {
 user_pref("devtools.debugger.prompt-connection", false);
 user_pref("security.disallow_privileged_https_script_loads", false);
 user_pref("security.allow_parent_unrestricted_js_loads", true);
-user_pref("remote.active-protocols", 1);
+user_pref("remote.active-protocols", 0);
+user_pref("marionette.enabled", true);
+user_pref("marionette.port", 2828);
+user_pref("devtools.chrome.enabled", true);
 user_pref("browser.newtabpage.enabled", true);
 `;
 

--- a/tools/src/injector.ts
+++ b/tools/src/injector.ts
@@ -49,9 +49,9 @@ export async function injectXhtmlFromTs(
             break;
           }
         }
-      } catch (e) {
+      } catch (e: unknown) {
         logger.warn(
-          `Could not read dist directory ${distDir} for macOS .app bundle search: ${e.message}`,
+          `Could not read dist directory ${distDir} for macOS .app bundle search: ${e instanceof Error ? e.message : e}`,
         );
       }
       if (!appBundleFound) {


### PR DESCRIPTION
## Summary

- Marionette プロトコル経由でブラウザの chrome/content コンテキストにアクセスする CLI ツールを追加
- プロセス管理（start/stop/restart/rebuild）とブラウザ操作（screenshot/eval/console/dom）をサポート
- XUL DOM の検査、フルウィンドウスクリーンショット、コンソールログ取得が可能

## Commands

| Command | Description |
|---------|-------------|
| `deno task dev-tool start` | ブラウザをバックグラウンドで起動 |
| `deno task dev-tool stop` | 全プロセスを停止（通常版 Floorp は kill しない） |
| `deno task dev-tool restart` | 再起動 |
| `deno task dev-tool rebuild` | アセットだけリビルド（ブラウザ継続） |
| `deno task dev-tool status` | 接続確認 + タブ情報 |
| `deno task dev-tool screenshot` | XUL UI 含むフルウィンドウ スクリーンショット |
| `deno task dev-tool eval <script>` | chrome/content で JS 実行 |
| `deno task dev-tool console` | ブラウザコンソールログ取得 |
| `deno task dev-tool dom <selector>` | XUL DOM 要素の検査 |
| `deno task dev-tool navigate <url>` | URL に遷移 |

## Changed files

- `tools/dev-tool.ts` — CLI entry point (new)
- `tools/src/browser_connector.ts` — Marionette TCP client (new)
- `tools/src/browser_launcher.ts` — `--marionette --remote-allow-system-access` フラグ追加
- `tools/src/initializer.ts` — BiDi 無効化、Marionette prefs 追加
- `tools/src/injector.ts` — TypeScript error fix (`unknown` catch type)
- `.gitignore` — Vite timestamp files を除外
- `docs/llm/development-notes.md` — dev-tool の使い方をドキュメント化

## Test plan

- [x] `start` → ブラウザ起動、Marionette 接続確認
- [x] `status` → タブ情報取得
- [x] `screenshot` → フルウィンドウキャプチャ
- [x] `eval` → chrome/content 両コンテキストで JS 実行
- [x] `console` → エラーログ取得、フィルタ動作
- [x] `dom` → XUL 要素の属性取得
- [x] `rebuild` → ブラウザを停止せずにアセットリビルド
- [x] `stop` → プロセスツリー完全停止、ゾンビなし、通常版 Floorp に影響なし