### PR TITLE
perf(os-api): optimize actor polling, tab lookup, HTTP server, and error handling

### DIFF
--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -9,6 +9,7 @@
 import type { WaitForElementState } from "../../os-server/shared/types.ts";
 import { GlobalHTTPTracker } from "./shared/GlobalHTTPTracker.sys.mts";
 import { PROGRESS_LISTENERS } from "./shared/ProgressListeners.sys.mts";
+import { waitForActor } from "./shared/waitForActor.sys.mts";
 
 const { E10SUtils } = ChromeUtils.importESModule(
   "resource://gre/modules/E10SUtils.sys.mjs",
@@ -394,13 +395,11 @@ class TabManager {
             "NRWebScraper",
           ) as WebScraperActor | undefined;
           if (!actor) {
-            for (let i = 0; i < 50; i++) {
-              await new Promise((r) => setTimeout(r, 100));
-              actor = browser.browsingContext?.currentWindowGlobal?.getActor(
-                "NRWebScraper",
-              ) as WebScraperActor | undefined;
-              if (actor) break;
-            }
+            actor = (await waitForActor<WebScraperActor>(
+              () => browser,
+              "NRWebScraper",
+              { maxMs: 5000 },
+            )) ?? undefined;
           }
           if (actor) {
             // Prefer readiness wait; fallback to element waits for heavy SPAs (X.com等)
@@ -508,19 +507,14 @@ class TabManager {
         "NRWebScraper",
       ) as WebScraperActor | undefined;
 
-      // Retry a few times after navigation for actor readiness
-      // Bug #5: refresh browser reference in case of process swap during retry
+      // Retry with exponential backoff after navigation for actor readiness
+      // Bug #5: getBrowser callback refreshes browser reference for process swaps
       if (!actor) {
-        for (let i = 0; i < 150; i++) {
-          await new Promise((r) => setTimeout(r, 100));
-          const freshEntry = this._getEntry(instanceId);
-          if (!freshEntry) break;
-          actor =
-            freshEntry.browser.browsingContext?.currentWindowGlobal?.getActor(
-              "NRWebScraper",
-            ) as WebScraperActor | undefined;
-          if (actor) break;
-        }
+        actor = (await waitForActor<WebScraperActor>(
+          () => this._getEntry(instanceId)?.browser,
+          "NRWebScraper",
+          { maxMs: 15000 },
+        )) ?? undefined;
       }
 
       if (!actor) {

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -150,6 +150,9 @@ class TabManager {
     { tab: BrowserTab; browser: XULBrowserElement }
   > = new Map();
 
+  // Reverse index: tab → instanceId for O(1) lookup in listTabs()
+  private _tabToInstanceId: Map<BrowserTab, string> = new Map();
+
   // Set of instance IDs currently being destroyed (TOCTOU guard)
   private _destroying: Set<string> = new Set();
 
@@ -237,6 +240,7 @@ class TabManager {
           GlobalHTTPTracker.clearForContext(bcid);
         }
         this._browserInstances.delete(instanceId);
+        this._tabToInstanceId.delete(tab);
         TAB_MANAGER_ACTOR_SETS.delete(entry.browser);
         this._destroying.delete(instanceId);
         if (tab.removeAttribute) {
@@ -279,6 +283,7 @@ class TabManager {
         if (targetTab) {
           entry = { tab: targetTab, browser: targetTab.linkedBrowser };
           this._browserInstances.set(instanceId, entry);
+          this._tabToInstanceId.set(targetTab, instanceId);
           TAB_MANAGER_ACTOR_SETS.add(entry.browser);
           if (targetTab.setAttribute) {
             targetTab.setAttribute("data-floorp-os-automated", "true");
@@ -294,6 +299,7 @@ class TabManager {
       const browser = entry.tab.linkedBrowser;
       if (!browser || !browser.ownerGlobal || browser.ownerGlobal.closed) {
         this._browserInstances.delete(instanceId);
+        this._tabToInstanceId.delete(entry.tab);
         TAB_MANAGER_ACTOR_SETS.delete(entry.browser);
         return null;
       }
@@ -560,6 +566,7 @@ class TabManager {
 
     const instanceId = crypto.randomUUID();
     this._browserInstances.set(instanceId, { tab, browser });
+    this._tabToInstanceId.set(tab, instanceId);
     TAB_MANAGER_ACTOR_SETS.add(browser);
 
     // Mark tab as automated
@@ -598,6 +605,7 @@ class TabManager {
     const browser = targetTab.linkedBrowser;
     const instanceId = crypto.randomUUID();
     this._browserInstances.set(instanceId, { tab: targetTab, browser });
+    this._tabToInstanceId.set(targetTab, instanceId);
     TAB_MANAGER_ACTOR_SETS.add(browser);
 
     // Mark tab as automated
@@ -619,14 +627,8 @@ class TabManager {
       const wid = getWindowId(win);
       for (const tab of gBrowser.tabs) {
         const browserId = tab.linkedBrowser.browserId.toString();
-        // Find if this tab is already an instance
-        let instanceId: string | undefined;
-        for (const [id, entry] of this._browserInstances.entries()) {
-          if (entry.tab === tab) {
-            instanceId = id;
-            break;
-          }
-        }
+        // O(1) reverse index lookup instead of linear scan
+        const instanceId = this._tabToInstanceId.get(tab);
 
         results.push({
           browserId,
@@ -703,6 +705,7 @@ class TabManager {
         tab.removeAttribute("data-floorp-os-instance-id");
       }
       this._browserInstances.delete(instanceId);
+      if (tab) this._tabToInstanceId.delete(tab);
       TAB_MANAGER_ACTOR_SETS.delete(browser);
     } finally {
       this._destroying.delete(instanceId);
@@ -735,6 +738,7 @@ class TabManager {
 
       // Remove from tracking
       this._browserInstances.delete(instanceId);
+      if (tab) this._tabToInstanceId.delete(tab);
       TAB_MANAGER_ACTOR_SETS.delete(browser);
 
       // Remove automated attributes

--- a/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
@@ -16,6 +16,7 @@ import type { WaitForElementState } from "../../os-server/shared/types.ts";
 import { GlobalHTTPTracker } from "./shared/GlobalHTTPTracker.sys.mts";
 import { AutomationConstants } from "../../os-server/shared/http-tracker.sys.mts";
 import { PROGRESS_LISTENERS } from "./shared/ProgressListeners.sys.mts";
+import { waitForActor } from "./shared/waitForActor.sys.mts";
 
 const { E10SUtils } = ChromeUtils.importESModule(
   "resource://gre/modules/E10SUtils.sys.mjs",
@@ -61,16 +62,13 @@ class webScraper {
     tries = 100,
     delayMs = 100,
   ): Promise<WebScraperActor | null> {
-    let actor = browser.browsingContext?.currentWindowGlobal?.getActor(
+    // Use exponential backoff. Preserve total timeout budget from original
+    // fixed-interval polling: tries * delayMs.
+    return waitForActor<WebScraperActor>(
+      () => browser,
       "NRWebScraper",
-    ) as WebScraperActor | undefined;
-    for (let i = 0; !actor && i < tries; i++) {
-      await new Promise((r) => setTimeout(r, delayMs));
-      actor = browser.browsingContext?.currentWindowGlobal?.getActor(
-        "NRWebScraper",
-      ) as WebScraperActor | undefined;
-    }
-    return actor ?? null;
+      { maxMs: tries * delayMs },
+    );
   }
 
   /**

--- a/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
@@ -17,7 +17,7 @@ const GlobalHTTPTracker = {
     try {
       Services.obs.addObserver(this, "http-on-opening-request");
       Services.obs.addObserver(this, "http-on-stop-request");
-      Services.obs.addObserver(this, "browsing-context-discarded");
+      Services.obs.addObserver(this, "browsing-context-detached");
     } catch (e) {
       console.error("GlobalHTTPTracker: init failed:", e);
     }
@@ -25,10 +25,11 @@ const GlobalHTTPTracker = {
 
   observe(subject: nsISupports, topic: string, _data: string | null) {
     // Auto-cleanup when a browsing context is destroyed (tab closed, process crash)
-    if (topic === "browsing-context-discarded") {
+    if (topic === "browsing-context-detached") {
       try {
-        const bc = subject.QueryInterface(Ci.nsIBrowsingContext);
-        this.clearForContext(bc.id);
+        // BrowsingContext is a WebIDL object, not XPCOM — no QueryInterface needed
+        const bc = subject as { id?: number };
+        if (bc.id != null) this.clearForContext(bc.id);
       } catch {
         // ignore
       }

--- a/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/GlobalHTTPTracker.sys.mts
@@ -17,12 +17,24 @@ const GlobalHTTPTracker = {
     try {
       Services.obs.addObserver(this, "http-on-opening-request");
       Services.obs.addObserver(this, "http-on-stop-request");
+      Services.obs.addObserver(this, "browsing-context-discarded");
     } catch (e) {
       console.error("GlobalHTTPTracker: init failed:", e);
     }
   },
 
   observe(subject: nsISupports, topic: string, _data: string | null) {
+    // Auto-cleanup when a browsing context is destroyed (tab closed, process crash)
+    if (topic === "browsing-context-discarded") {
+      try {
+        const bc = subject.QueryInterface(Ci.nsIBrowsingContext);
+        this.clearForContext(bc.id);
+      } catch {
+        // ignore
+      }
+      return;
+    }
+
     try {
       // deno-lint-ignore no-explicit-any
       const channel = (subject as any).QueryInterface(Ci.nsIHttpChannel);

--- a/browser-features/modules/modules/os-apis/web/shared/waitForActor.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/waitForActor.sys.mts
@@ -1,0 +1,73 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared polling utility for waiting on JSWindowActor readiness
+ * with exponential backoff.
+ */
+
+interface WaitForActorOptions {
+  /** Maximum total wait time in milliseconds (default: 15000) */
+  maxMs?: number;
+  /** Initial delay between polls in milliseconds (default: 10) */
+  initialMs?: number;
+  /** Maximum per-poll delay cap in milliseconds (default: 500) */
+  capMs?: number;
+  /** Multiplicative backoff factor (default: 1.5) */
+  factor?: number;
+}
+
+/**
+ * Polls for a JSWindowActor on a browser element using exponential backoff.
+ *
+ * The backoff sequence starts at `initialMs` and multiplies by `factor` each
+ * iteration, capped at `capMs`: 10, 15, 22, 33, 50, 75, 112, 168, 252, 378, 500, ...
+ *
+ * This provides fast response when the actor is immediately available (~10ms)
+ * while avoiding CPU waste during slow page loads.
+ *
+ * @param getBrowser Callback returning the current browser element. Called each
+ *                   iteration to handle process swaps (remoteness changes).
+ *                   Return null/undefined to abort the wait.
+ * @param actorName  The actor name (e.g. "NRWebScraper").
+ * @param opts       Backoff configuration.
+ * @returns The actor instance, or null if the timeout expires or getBrowser
+ *          returns null.
+ */
+export async function waitForActor<T = unknown>(
+  getBrowser: () => { browsingContext?: { currentWindowGlobal?: { getActor(name: string): unknown } | null } | null } | null | undefined,
+  actorName: string,
+  opts?: WaitForActorOptions,
+): Promise<T | null> {
+  const {
+    maxMs = 15000,
+    initialMs = 10,
+    capMs = 500,
+    factor = 1.5,
+  } = opts ?? {};
+
+  // First attempt without any delay
+  const browser = getBrowser();
+  if (browser) {
+    const actor = browser.browsingContext?.currentWindowGlobal?.getActor(actorName);
+    if (actor) return actor as T;
+  }
+
+  let delay = initialMs;
+  const deadline = Date.now() + maxMs;
+
+  while (Date.now() < deadline) {
+    await new Promise<void>((r) => setTimeout(r, delay));
+    delay = Math.min(delay * factor, capMs);
+
+    const b = getBrowser();
+    if (!b) return null;
+
+    const actor = b.browsingContext?.currentWindowGlobal?.getActor(actorName);
+    if (actor) return actor as T;
+  }
+
+  return null;
+}

--- a/browser-features/modules/modules/os-server/http/utils.sys.mts
+++ b/browser-features/modules/modules/os-server/http/utils.sys.mts
@@ -8,6 +8,9 @@
 
 import type { HeadersMap, HttpRequest } from "./types.ts";
 
+// Shared TextEncoder singleton (stateless, safe to reuse)
+const TEXT_ENCODER = new TextEncoder();
+
 // -- Logging utilities --------------------------------------------------------
 
 export function log(...args: unknown[]) {
@@ -125,8 +128,7 @@ export function jsonResponse(
   extraHeaders: HeadersMap = {},
 ): string {
   const body = JSON.stringify(bodyObj);
-  const enc = new TextEncoder();
-  const bytes = enc.encode(body);
+  const bytes = TEXT_ENCODER.encode(body);
   const headers: HeadersMap = {
     "Content-Type": "application/json; charset=utf-8",
     "Content-Length": String(bytes.length),
@@ -147,8 +149,7 @@ export function jsonResponse(
 
 // Write UTF-8 bytes to an nsIOutputStream safely
 export function writeUtf8(out: nsIOutputStream, text: string) {
-  const enc = new TextEncoder();
-  const bytes = enc.encode(text);
+  const bytes = TEXT_ENCODER.encode(text);
   const bos = Cc["@mozilla.org/binaryoutputstream;1"].createInstance(
     Ci.nsIBinaryOutputStream,
   );

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -241,14 +241,14 @@ class LocalHttpServer implements nsIServerSocketListener {
         sis.init(input);
 
         // Read until we hit CRLF CRLF for headers
-        const chunks: string[] = [];
+        // Use string concatenation (rope-based O(1) amortized in SpiderMonkey)
+        // instead of chunks.join("") per read which copies the entire string each time.
         let head = "";
         const headDeadline = Date.now() + LocalHttpServer.READ_HEAD_TIMEOUT_MS;
         while (true) {
           const avail = sis.available();
           if (avail > 0) {
-            chunks.push(sis.read(avail));
-            head = chunks.join("");
+            head += sis.read(avail);
             if (head.includes("\r\n\r\n")) break;
           } else {
             if (Date.now() > headDeadline) {
@@ -279,13 +279,17 @@ class LocalHttpServer implements nsIServerSocketListener {
           return;
         }
         const leftover = split >= 0 ? head.slice(split + 4) : "";
-        const bodyBytes: number[] = binaryStringToByteArray(leftover);
+        // Accumulate binary strings and convert once at end,
+        // instead of push(...bytes) per chunk which is O(n²).
+        const bodyParts: string[] = [leftover];
+        let bodyLen = leftover.length;
         const bodyDeadline = Date.now() + LocalHttpServer.READ_BODY_TIMEOUT_MS;
-        while (bodyBytes.length < contentLength) {
+        while (bodyLen < contentLength) {
           const avail = sis.available();
           if (avail > 0) {
             const piece = sis.read(avail);
-            bodyBytes.push(...binaryStringToByteArray(piece));
+            bodyParts.push(piece);
+            bodyLen += piece.length;
           } else {
             if (Date.now() > bodyDeadline) {
               writeUtf8(output, badRequest("incomplete body"));
@@ -296,7 +300,10 @@ class LocalHttpServer implements nsIServerSocketListener {
             );
           }
         }
-        req.body = new Uint8Array(bodyBytes.slice(0, contentLength));
+        const fullBody = bodyParts.join("");
+        req.body = new Uint8Array(
+          binaryStringToByteArray(fullBody).slice(0, contentLength),
+        );
 
         // Auth (optional)
         if (this._token) {

--- a/browser-features/modules/modules/os-server/shared/routes.sys.mts
+++ b/browser-features/modules/modules/os-server/shared/routes.sys.mts
@@ -46,7 +46,7 @@ function clampTimeout(value: number | undefined, fallback: number): number {
  * Wraps a route handler with try/catch to prevent service exceptions
  * from propagating as unhandled rejections.
  */
-function safeRoute<F extends (...args: never[]) => Promise<unknown>>(handler: F): F {
+export function safeRoute<F extends (...args: never[]) => Promise<unknown>>(handler: F): F {
   return (async (...args: unknown[]) => {
     try {
       return await handler(...(args as Parameters<F>));

--- a/browser-features/modules/modules/os-server/tabs/routes.sys.mts
+++ b/browser-features/modules/modules/os-server/tabs/routes.sys.mts
@@ -16,7 +16,7 @@ import type {
 import type { ErrorResponse } from "../_os-plugin/api-spec/types.ts";
 import type { TabManagerAPI } from "./types.ts";
 import type { ActionResponse } from "../shared/types.ts";
-import { registerCommonAutomationRoutes } from "../shared/routes.sys.mts";
+import { registerCommonAutomationRoutes, safeRoute } from "../shared/routes.sys.mts";
 
 // Lazy import of TabManager module
 const TabManagerModule = () =>
@@ -92,34 +92,18 @@ export function registerTabRoutes(api: NamespaceBuilder): void {
     });
 
     // Destroy instance (async cleanup, does not close the tab)
-    t.delete<unknown, ActionResponse>("/instances/:id", async (ctx: RouterContext) => {
+    t.delete<unknown, ActionResponse>("/instances/:id", safeRoute(async (ctx: RouterContext) => {
       const { TabManagerServices } = TabManagerModule();
-      try {
-        await TabManagerServices.destroyInstance(ctx.params.id);
-        return { status: 200, body: { ok: true } };
-      } catch (e) {
-        const msg = (e as Error)?.message ?? String(e);
-        if (msg.includes("not found")) {
-          return { status: 404, body: { error: msg } };
-        }
-        return { status: 500, body: { error: msg } };
-      }
-    });
+      await TabManagerServices.destroyInstance(ctx.params.id);
+      return { status: 200, body: { ok: true } };
+    }));
 
     // Close tab (destroys instance AND closes the actual browser tab)
-    t.post<unknown, ActionResponse>("/instances/:id/close", async (ctx: RouterContext) => {
+    t.post<unknown, ActionResponse>("/instances/:id/close", safeRoute(async (ctx: RouterContext) => {
       const { TabManagerServices } = TabManagerModule();
-      try {
-        await TabManagerServices.closeTab(ctx.params.id);
-        return { status: 200, body: { ok: true } };
-      } catch (e) {
-        const msg = (e as Error)?.message ?? String(e);
-        if (msg.includes("not found")) {
-          return { status: 404, body: { error: msg } };
-        }
-        return { status: 500, body: { error: msg } };
-      }
-    });
+      await TabManagerServices.closeTab(ctx.params.id);
+      return { status: 200, body: { ok: true } };
+    }));
 
     // -- Common automation routes --
     registerCommonAutomationRoutes(

--- a/browser-features/modules/modules/os-server/workspaces/routes.sys.mts
+++ b/browser-features/modules/modules/os-server/workspaces/routes.sys.mts
@@ -19,6 +19,7 @@ import type {
 } from "../router.sys.mts";
 import type { WorkspacesApiModule } from "./types.ts";
 import type { ErrorResponse } from "../_os-plugin/api-spec/types.ts";
+import { safeRoute } from "../shared/routes.sys.mts";
 
 // Lazy import of WorkspacesApiService module
 const WorkspacesApiModule = () =>
@@ -31,7 +32,7 @@ const WorkspacesApiModule = () =>
 export function registerWorkspaceRoutes(api: NamespaceBuilder): void {
   api.namespace("/workspaces", (w: NamespaceBuilder) => {
     // List all workspaces
-    w.get("/", () => {
+    w.get("/", safeRoute(async () => {
       const { WorkspacesApiService } = WorkspacesApiModule();
       const workspaces = WorkspacesApiService.listWorkspaces();
       const currentId = WorkspacesApiService.getCurrentWorkspaceId();
@@ -42,23 +43,23 @@ export function registerWorkspaceRoutes(api: NamespaceBuilder): void {
           currentId,
         },
       };
-    });
+    }));
 
     // Get current workspace ID
-    w.get("/current", () => {
+    w.get("/current", safeRoute(async () => {
       const { WorkspacesApiService } = WorkspacesApiModule();
       const currentId = WorkspacesApiService.getCurrentWorkspaceId();
       return {
         status: 200,
         body: { workspaceId: currentId },
       };
-    });
+    }));
 
     // Switch to next workspace
     w.post<
       undefined,
       { success: boolean; workspaceId: string | null } | ErrorResponse
-    >("/next", () => {
+    >("/next", safeRoute(async () => {
       const { WorkspacesApiService } = WorkspacesApiModule();
       const success = WorkspacesApiService.switchToNext();
       if (!success) {
@@ -72,13 +73,13 @@ export function registerWorkspaceRoutes(api: NamespaceBuilder): void {
         status: 200,
         body: { success: true, workspaceId: currentId },
       };
-    });
+    }));
 
     // Switch to previous workspace
     w.post<
       undefined,
       { success: boolean; workspaceId: string | null } | ErrorResponse
-    >("/previous", () => {
+    >("/previous", safeRoute(async () => {
       const { WorkspacesApiService } = WorkspacesApiModule();
       const success = WorkspacesApiService.switchToPrevious();
       if (!success) {
@@ -92,13 +93,13 @@ export function registerWorkspaceRoutes(api: NamespaceBuilder): void {
         status: 200,
         body: { success: true, workspaceId: currentId },
       };
-    });
+    }));
 
     // Switch to specific workspace by ID
     w.post<
       undefined,
       { success: boolean; workspaceId: string | null } | ErrorResponse
-    >("/:id/switch", (ctx: RouterContext) => {
+    >("/:id/switch", safeRoute(async (ctx: RouterContext) => {
       const { id } = ctx.params;
       if (!id) {
         return {
@@ -119,6 +120,6 @@ export function registerWorkspaceRoutes(api: NamespaceBuilder): void {
         status: 200,
         body: { success: true, workspaceId: id },
       };
-    });
+    }));
   });
 }


### PR DESCRIPTION
## Summary

OS API 全体のパフォーマンス改善と品質向上。5つの独立した改善を1つの PR にまとめています。

## Changes

### 1. Actor ポーリングの指数バックオフ化 (`800e84e`)
- 固定 100ms 間隔 → 指数バックオフ（10ms→500ms cap, factor 1.5）
- Actor が即座に利用可能な場合: 100ms → ~10ms に短縮
- 新規 `shared/waitForActor.sys.mts` に共通ユーティリティを抽出
- TabManagerServices (2箇所) + WebScraperServices (1箇所) を置換

### 2. タブ逆引きインデックス (`0a03b9`)
- `listTabs()` の計算量: O(W×T×M) → O(W×T)
- `_tabToInstanceId: Map<BrowserTab, string>` を追加
- 全 mutation ポイント（create/attach/destroy/close/onTabClose/recovery）で同期

### 3. HTTP サーバー最適化 (`24084a`)
- ヘッダー読み込み: `chunks.join("")` 毎回 → 文字列結合（O(n²) → O(n)）
- ボディ読み込み: `push(...bytes)` 毎チャンク → 文字列蓄積＋最後に1回変換
- TextEncoder: 毎回生成 → モジュールレベルシングルトン

### 4. エラーハンドリング統一 (`5910ba`)
- `safeRoute()` を export 化
- tabs/routes: 2ルートのインライン try-catch を `safeRoute()` に統一
- workspaces/routes: エラーハンドリングなしの5ルートを `safeRoute()` でラップ

### 5. GlobalHTTPTracker 自動クリーンアップ (`dcbb3d`)
- `browsing-context-discarded` オブザーバーを追加
- タブ閉じやプロセスクラッシュ時に `activeRequests` を自動クリーンアップ
- API 経由でないタブ閉じでのメモリリークを防止

## Test plan

- [ ] `deno task feles-build stage` でブラウザ起動
- [ ] Gmail で全 API エンドポイント動作確認
- [ ] `/tabs/list` のレスポンス確認
- [ ] workspace API のエラーレスポンス確認（不正 ID で 404/500 が返ること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)