### PR TITLE
fix(zen-mode): disable zen mode during toolbar customization

### DIFF
--- a/browser-features/chrome/common/zen-mode/zen-mode.tsx
+++ b/browser-features/chrome/common/zen-mode/zen-mode.tsx
@@ -245,6 +245,18 @@ function setupHoverReveal() {
 export function initZenModeState() {
   setupPrefSync();
   setupHoverReveal();
+
+  // Disable zen mode when entering toolbar customization
+  const customizeObserver = new MutationObserver(() => {
+    if (document!.documentElement!.hasAttribute("customizing")) {
+      setZenModeEnabled(false);
+    }
+  });
+  customizeObserver.observe(document!.documentElement!, {
+    attributes: true,
+    attributeFilter: ["customizing"],
+  });
+  onCleanup(() => customizeObserver.disconnect());
 }
 
 export function ZenModeMenuElement() {


### PR DESCRIPTION
## Summary

- Automatically disable Zen Mode when entering Firefox's toolbar customization mode (`gCustomizeMode.enter()`)

When the user customizes the toolbar while Zen Mode is active, the navigator-toolbox and statusbar remain hidden, making the customization UI unusable. A `MutationObserver` on the root element's `customizing` attribute now detects when customization starts and disables Zen Mode.

## Test plan

- [ ] Enable Zen Mode
- [ ] Enter toolbar customization (View > Customize Toolbar, or `gCustomizeMode.enter()`)
- [ ] Verify Zen Mode is automatically disabled
- [ ] Exit customization — Zen Mode remains off
- [ ] Re-enable Zen Mode — works normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zen mode now automatically disables when the browser enters customization mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->