### PR TITLE
fix: Zen Mode menu checkmark always shown when disabled

### DIFF
--- a/browser-features/chrome/common/zen-mode/zen-mode.tsx
+++ b/browser-features/chrome/common/zen-mode/zen-mode.tsx
@@ -341,7 +341,7 @@ export function ZenModeMenuElement() {
         label={label()}
         type="checkbox"
         id="toggle_zenmode"
-        checked={zenModeEnabled()}
+        checked={zenModeEnabled() || undefined}
         onCommand={() => setZenModeEnabled((prev) => !prev)}
         accesskey="Z"
       />


### PR DESCRIPTION
Fixes #2373

## Problem
In Proton/Fluerial themes, the Zen Mode menu checkmark was always displayed regardless of whether Zen Mode was enabled or disabled.

## Root Cause
In XUL, the checked attribute on a menuitem type=checkbox is treated as a boolean attribute - its presence alone indicates a checked state, regardless of the attribute value.

When SolidJS set checked=false (via @nora/solid-xul setProperty), the attribute was still present on the element, causing the checkmark to always display.

## Fix
Changed checked={zenModeEnabled()} to checked={zenModeEnabled() || undefined}.

This ensures:
- Zen Mode ON: true -> setAttribute(checked, true) -> checkmark shown
- Zen Mode OFF: undefined -> removeAttribute(checked) -> checkmark hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zen Mode checkbox to properly display the unchecked state when the feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->