### PR TITLE
fix: prevent split-view tab overlap when minimum tab width is increased

### DIFF
--- a/browser-features/chrome/common/split-view/styles/split-view.css
+++ b/browser-features/chrome/common/split-view/styles/split-view.css
@@ -407,8 +407,9 @@
  * so that Firefox's native tab sizing can shrink tabs to fit in the strip.
  * Without this, large tabMinWidth values (e.g. 200px) cause tabs to overlap.
  * The splitview-multibar attribute is set only while split view is active
- * and removed on deactivation, so user's tab width preference is restored. */
-#TabsToolbar[splitview-multibar] .tabbrowser-tab:not([pinned]) {
+ * and removed on deactivation, so user's tab width preference is restored.
+ * Scoped to horizontal tab strips only — vertical tabs have their own layout. */
+#TabsToolbar[splitview-multibar] #tabbrowser-tabs:not([orient="vertical"]) .tabbrowser-tab:not([pinned]) {
   min-width: unset !important;
 }
 

--- a/browser-features/chrome/common/split-view/styles/split-view.css
+++ b/browser-features/chrome/common/split-view/styles/split-view.css
@@ -403,6 +403,15 @@
   max-height: unset !important;
 }
 
+/* When split view is active, remove Floorp's custom tab min-width override
+ * so that Firefox's native tab sizing can shrink tabs to fit in the strip.
+ * Without this, large tabMinWidth values (e.g. 200px) cause tabs to overlap.
+ * The splitview-multibar attribute is set only while split view is active
+ * and removed on deactivation, so user's tab width preference is restored. */
+#TabsToolbar[splitview-multibar] .tabbrowser-tab:not([pinned]) {
+  min-width: unset !important;
+}
+
 /* Prevent user text selection during splitter drag */
 #tabbrowser-tabpanels[data-floorp-dragging] {
   user-select: none !important;


### PR DESCRIPTION
## Summary

Fixes #2360

When the user sets a large minimum tab width (e.g. 200px) via `browser.tabs.tabMinWidth`, tabs in the tab strip overlap during split view because Floorp's `min-width` override (`var(--floorp-tab-min-width) !important`) prevents them from shrinking below the configured value.

## Root Cause

`browser-features/chrome/common/tab/sizeSpecification/style.css` applies `min-width: var(--floorp-tab-min-width) !important` to all `.tabbrowser-tab:not([pinned])` elements. During split view, multiple tabs are displayed in the tab strip simultaneously, and if the user's minimum tab width is large, the tabs cannot shrink to fit — causing them to overlap.

## Fix

Added a CSS override in `split-view.css` that removes Floorp's custom tab `min-width` while split view is active. The override uses the existing `splitview-multibar` attribute on `#TabsToolbar`, which is set when split view is activated and removed on deactivation.

```css
#TabsToolbar[splitview-multibar] .tabbrowser-tab:not([pinned]) {
  min-width: unset !important;
}
```

This allows Firefox's native tab sizing to handle split-view tabs properly (same behavior as Firefox 149), while the user's tab width preference is automatically restored when split view is deactivated.

## Testing

1. Set minimum tab width to 200px in `about:hub#/features/design` → Tabs
2. Activate split view
3. Verify tabs no longer overlap in the tab strip
4. Deactivate split view and confirm tabs return to the configured 200px minimum width

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab sizing behavior in split-view mode by allowing unpinned tabs to adapt more flexibly to available space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->