### PR TITLE
fix: keep split-view tabs visible in Lepton when non-selected

### DIFF
--- a/browser-features/chrome/common/split-view/patches/active-pane-tracker.ts
+++ b/browser-features/chrome/common/split-view/patches/active-pane-tracker.ts
@@ -9,7 +9,6 @@ import {
   type SplitViewGBrowser,
   type SplitViewTab,
 } from "../data/types.js";
-import { logTabpanelsSplitDiagnostics } from "./split-view-diagnostics.js";
 import { ensureSplitPaneTabBrowsersAreWarmed } from "./activate-split-pane-browsers.js";
 import { hasLiveSplitPanelsState } from "../utils/live-split-ui.js";
 
@@ -276,13 +275,11 @@ export function refreshActiveSplitPaneIndicator(): void {
       "[refreshIndicator] selectedTab not in split tab list → skip split selection sync",
     );
     clearActivePaneIndicator();
-    logTabpanelsSplitDiagnostics("refreshIndicator:activeIndex=-1");
     return;
   }
 
   clearActivePaneIndicator();
   syncSplitViewDeckSelectedClass(gBrowser);
-  logTabpanelsSplitDiagnostics("refreshIndicator:afterSync");
 }
 
 /**
@@ -302,14 +299,12 @@ export function initActivePaneTracker(
         ensureSplitPanelsActiveClassFromState();
       }
       refreshActiveSplitPaneIndicator();
-      logTabpanelsSplitDiagnostics("TabSelect+rAF1");
       requestAnimationFrame(() => {
         const gb2 = getGBrowser();
         if (gb2 && isMultiPaneSplitUiActive(gb2)) {
           syncSplitViewDeckSelectedClass(gb2);
           ensureSplitPaneTabBrowsersAreWarmed(log);
         }
-        logTabpanelsSplitDiagnostics("TabSelect+rAF2-deckResync");
       });
     });
   };
@@ -324,14 +319,12 @@ export function initActivePaneTracker(
       if (gb) {
         syncSplitViewDeckSelectedClass(gb);
       }
-      logTabpanelsSplitDiagnostics("TabSplitViewActivate+rAF");
     });
   };
 
   const onDeactivate = (): void => {
     clearActivePaneIndicator();
     log.debug("[TabSplitViewDeactivate] cleared stale split pane attrs");
-    logTabpanelsSplitDiagnostics("TabSplitViewDeactivate");
   };
 
   tabContainer.addEventListener("TabSelect", scheduleAfterTabSelect);

--- a/browser-features/chrome/common/split-view/patches/split-view-diagnostics.ts
+++ b/browser-features/chrome/common/split-view/patches/split-view-diagnostics.ts
@@ -17,6 +17,36 @@ const diag = console.createInstance({
   prefix: "nora@split-view:diag",
 });
 
+function emitDiag(message: string): void {
+  diag.debug(message);
+  try {
+    Services.console.logStringMessage(`nora@split-view:diag ${message}`);
+  } catch {
+    // ignore in environments without Services.console
+  }
+}
+
+function safeComputedStyle(
+  el: Element | null | undefined,
+): CSSStyleDeclaration | null {
+  if (!el) {
+    return null;
+  }
+  try {
+    return getComputedStyle(el);
+  } catch {
+    return null;
+  }
+}
+
+function cssValue(style: CSSStyleDeclaration | null, prop: string): string {
+  if (!style) {
+    return "n/a";
+  }
+  const v = style.getPropertyValue(prop).trim();
+  return v || "n/a";
+}
+
 function deepDiagEnabled(): boolean {
   return Boolean(
     (globalThis as { __floorpSplitViewDeepDiag?: boolean })
@@ -32,7 +62,7 @@ export function logTabpanelsSplitDeepInvestigation(phase: string): void {
   const gb = getGBrowser();
   const tp = document?.getElementById("tabbrowser-tabpanels");
   if (!tp) {
-    diag.debug(`[deep ${phase}] no #tabbrowser-tabpanels`);
+    emitDiag(`[deep ${phase}] no #tabbrowser-tabpanels`);
     return;
   }
   const sel = gb?.selectedTab as { linkedPanel?: string } | undefined;
@@ -42,7 +72,7 @@ export function logTabpanelsSplitDeepInvestigation(phase: string): void {
   } catch {
     panelsCsv = "(read splitViewPanels threw)";
   }
-  diag.debug(
+  emitDiag(
     `[deep ${phase}] selected.linkedPanel=${sel?.linkedPanel ?? "null"} ` +
       `splitViewPanels=[${panelsCsv}]`,
   );
@@ -58,25 +88,28 @@ export function logTabpanelsSplitDeepInvestigation(phase: string): void {
     if (bc) {
       const bcEl = bc as HTMLElement;
       const br = bcEl.getBoundingClientRect();
-      const cs = getComputedStyle(bc);
+      const cs = safeComputedStyle(bc);
       bcSnippet =
         `browserContainer ${Math.round(br.width)}x${Math.round(br.height)} ` +
-        `disp=${cs.display} op=${cs.opacity} vis=${cs.visibility} ` +
-        `mozSub=${cs.getPropertyValue("-moz-subtree-hidden-only-visually")}`;
+        `disp=${cssValue(cs, "display")} op=${cssValue(cs, "opacity")} vis=${cssValue(cs, "visibility")} ` +
+        `mozSub=${cssValue(cs, "-moz-subtree-hidden-only-visually")}`;
     }
     const browsers = child.querySelectorAll("browser");
     const bits: string[] = [];
-    browsers.forEach((b, i) => {
-      const cs = getComputedStyle(b);
+    const browserElements = Array.from(
+      browsers as NodeListOf<Element>,
+    ) as Element[];
+    browserElements.forEach((b, i) => {
+      const cs = safeComputedStyle(b);
       const br = (b as HTMLElement).getBoundingClientRect();
       const remote = (b as XULElement).getAttribute?.("remote") ?? "";
       bits.push(
         `#${i} ${Math.round(br.width)}x${Math.round(br.height)} ` +
-          `op=${cs.opacity} fil=${cs.filter} cv=${cs.contentVisibility} ` +
-          `pe=${cs.pointerEvents} remote=${remote}`,
+          `op=${cssValue(cs, "opacity")} fil=${cssValue(cs, "filter")} cv=${cssValue(cs, "content-visibility")} ` +
+          `pe=${cssValue(cs, "pointer-events")} remote=${remote}`,
       );
     });
-    diag.debug(
+    emitDiag(
       `[deep ${phase}] panel=${child.id} rect=${Math.round(r.width)}x${Math.round(r.height)} ` +
         `| ${bcSnippet} | browser count=${browsers.length} ${bits.join(" || ")}`,
     );
@@ -86,37 +119,148 @@ export function logTabpanelsSplitDeepInvestigation(phase: string): void {
 export function logTabpanelsSplitDiagnostics(phase: string): void {
   const tp = document?.getElementById("tabbrowser-tabpanels");
   if (!tp) {
-    diag.debug(`[${phase}] no #tabbrowser-tabpanels`);
+    emitDiag(`[${phase}] no #tabbrowser-tabpanels`);
     return;
   }
-  const tpStyle = getComputedStyle(tp);
-  diag.debug(
+  const tpStyle = safeComputedStyle(tp);
+  emitDiag(
     `[${phase}] tabpanels attrs: splitview=${tp.hasAttribute("splitview")} ` +
       `data-floorp-split=${tp.getAttribute("data-floorp-split") ?? "null"} ` +
       `split-view-layout=${tp.getAttribute("split-view-layout") ?? "null"} ` +
-      `display=${tpStyle.display}`,
+      `display=${cssValue(tpStyle, "display")}`,
   );
 
   for (const child of tp.children) {
     if (!child.classList.contains("split-view-panel")) {
       continue;
     }
-    const st = getComputedStyle(child);
+    const st = safeComputedStyle(child);
     const browser = child.querySelector("browser");
     let browserSnippet = "no <browser>";
     if (browser) {
-      const bs = getComputedStyle(browser);
-      browserSnippet =
-        `<browser> opacity=${bs.opacity} vis=${bs.visibility} mozSub=${bs.getPropertyValue("-moz-subtree-hidden-only-visually")}`;
+      const bs = safeComputedStyle(browser);
+      browserSnippet = `<browser> opacity=${cssValue(bs, "opacity")} vis=${cssValue(bs, "visibility")} mozSub=${cssValue(bs, "-moz-subtree-hidden-only-visually")}`;
     }
-    diag.debug(
+    emitDiag(
       `[${phase}] panel id=${child.id} column=${child.getAttribute("column") ?? "—"} ` +
         `floorpActive=${child.hasAttribute("data-floorp-active-pane")} ` +
-        `classes=[${[...child.classList].filter((c) => c.includes("split") || c === "deck-selected").join(", ") || "—"}] ` +
+        `classes=[${[...child.classList].filter((c) => !!c && (c.includes("split") || c === "deck-selected")).join(", ") || "—"}] ` +
         `paneActive=${child.classList.contains("split-view-panel-active")} ` +
         `deck-selected=${child.classList.contains("deck-selected")} ` +
-        `mozSub=${st.getPropertyValue("-moz-subtree-hidden-only-visually")} ` +
-        `vis=${st.visibility} op=${st.opacity} | ${browserSnippet}`,
+        `mozSub=${cssValue(st, "-moz-subtree-hidden-only-visually")} ` +
+        `vis=${cssValue(st, "visibility")} op=${cssValue(st, "opacity")} | ${browserSnippet}`,
+    );
+  }
+
+  // Tab strip diagnostics for Lepton collision cases.
+  const tabsToolbar = document?.getElementById("TabsToolbar");
+  const arrowscrollbox = document?.getElementById("tabbrowser-arrowscrollbox");
+  const pinnedContainer = document?.getElementById("pinned-tabs-container");
+  const tabbrowserTabs = document?.getElementById("tabbrowser-tabs");
+
+  const splitGroupTabs: HTMLElement[] = document
+    ? Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "#tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId], #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]",
+        ),
+      )
+    : [];
+  const splitMarkerTabs: HTMLElement[] = document
+    ? Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]",
+        ),
+      )
+    : [];
+  const allTabs: HTMLElement[] = document
+    ? Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "#tabbrowser-tabs .tabbrowser-tab",
+        ),
+      )
+    : [];
+
+  let splitviewPropTabs = 0;
+  for (const tab of allTabs) {
+    const maybeSplit = (tab as unknown as { splitview?: unknown }).splitview;
+    if (maybeSplit) {
+      splitviewPropTabs++;
+    }
+  }
+
+  const selectedTab = getGBrowser()?.selectedTab as
+    | { linkedPanel?: string; label?: string; splitview?: unknown }
+    | undefined;
+
+  emitDiag(
+    `[${phase}] strip attrs: toolbar.multibar=${tabsToolbar?.getAttribute("multibar") ?? "null"} ` +
+      `toolbar.splitview-multibar=${tabsToolbar?.getAttribute("splitview-multibar") ?? "null"} ` +
+      `tabpanels.splitview=${tp.getAttribute("splitview") ?? "null"} ` +
+      `tabpanels.data-floorp-split=${tp.getAttribute("data-floorp-split") ?? "null"} ` +
+      `groupTabs=${splitGroupTabs.length} markerTabs=${splitMarkerTabs.length} splitviewPropTabs=${splitviewPropTabs} ` +
+      `selected.linkedPanel=${selectedTab?.linkedPanel ?? "null"} selected.hasSplit=${!!selectedTab?.splitview}`,
+  );
+
+  if (arrowscrollbox) {
+    const s = safeComputedStyle(arrowscrollbox);
+    emitDiag(
+      `[${phase}] arrowscrollbox: overflowing=${arrowscrollbox.getAttribute("overflowing") ?? "null"} ` +
+        `maxHeight=${cssValue(s, "max-height")} height=${cssValue(s, "height")} display=${cssValue(s, "display")} vis=${cssValue(s, "visibility")}`,
+    );
+  }
+  if (pinnedContainer) {
+    const s = safeComputedStyle(pinnedContainer);
+    emitDiag(
+      `[${phase}] pinned-tabs-container: overflowing=${pinnedContainer.getAttribute("overflowing") ?? "null"} ` +
+        `maxHeight=${cssValue(s, "max-height")} height=${cssValue(s, "height")} display=${cssValue(s, "display")} vis=${cssValue(s, "visibility")}`,
+    );
+  }
+  if (tabbrowserTabs) {
+    const s = safeComputedStyle(tabbrowserTabs);
+    emitDiag(
+      `[${phase}] tabbrowser-tabs: orient=${tabbrowserTabs.getAttribute("orient") ?? "null"} ` +
+        `overflow=${tabbrowserTabs.getAttribute("overflow") ?? "null"} ` +
+        `maxHeight=${cssValue(s, "max-height")} height=${cssValue(s, "height")}`,
+    );
+  }
+
+  // Per-tab strip style snapshots (focus on split tabs, incl. non-selected).
+  const splitTabsDetailed: HTMLElement[] = allTabs.filter(
+    (tab: HTMLElement) => {
+      const hasGroupAttr =
+        tab.hasAttribute("floorpSplitViewGroupId") ||
+        tab.hasAttribute("floorpsplitviewgroupid");
+      const hasMarkerAttr = tab.hasAttribute("data-floorp-split-tab");
+      const hasSplitProp = Boolean(
+        (tab as unknown as { splitview?: unknown }).splitview,
+      );
+      return hasGroupAttr || hasMarkerAttr || hasSplitProp;
+    },
+  );
+
+  for (const [idx, tabEl] of splitTabsDetailed.entries()) {
+    if (idx >= 6) {
+      break;
+    }
+
+    const tabStyle = safeComputedStyle(tabEl);
+    const stack = tabEl.querySelector(".tab-stack") as HTMLElement | null;
+    const content = tabEl.querySelector(".tab-content") as HTMLElement | null;
+    const stackStyle = safeComputedStyle(stack);
+    const contentStyle = safeComputedStyle(content);
+
+    emitDiag(
+      `[${phase}] splitTab#${idx} id=${tabEl.id || "(no-id)"} ` +
+        `label=${tabEl.getAttribute("label") ?? ""} ` +
+        `selected=${tabEl.hasAttribute("selected")} ` +
+        `visuallyselected=${tabEl.hasAttribute("visuallyselected")} ` +
+        `multiselected=${tabEl.hasAttribute("multiselected")} ` +
+        `pinned=${tabEl.hasAttribute("pinned")} ` +
+        `group=${tabEl.getAttribute("floorpSplitViewGroupId") ?? tabEl.getAttribute("floorpsplitviewgroupid") ?? "null"} ` +
+        `marker=${tabEl.getAttribute("data-floorp-split-tab") ?? "null"} ` +
+        `tab[maxH=${cssValue(tabStyle, "max-height")} h=${cssValue(tabStyle, "height")}] ` +
+        `stack[maxH=${cssValue(stackStyle, "max-height")} h=${cssValue(stackStyle, "height")}] ` +
+        `content[maxH=${cssValue(contentStyle, "max-height")} h=${cssValue(contentStyle, "height")}]`,
     );
   }
 

--- a/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
+++ b/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
@@ -5,9 +5,7 @@
 
 import type { SplitViewLayout, SplitViewTab } from "../data/types.js";
 import { getGBrowser } from "../data/types.js";
-import {
-  clearSplitHandles,
-} from "../components/split-view-splitters.js";
+import { clearSplitHandles } from "../components/split-view-splitters.js";
 import { clearGridStyles } from "../layout.js";
 import type { PatchState } from "./patch-state.js";
 import {
@@ -18,7 +16,6 @@ import {
   ensureSplitPanelsActiveClassFromState,
   refreshActiveSplitPaneIndicator,
 } from "./active-pane-tracker.js";
-import { logTabpanelsSplitDiagnostics } from "./split-view-diagnostics.js";
 import { resetSplitPanelPresentationState } from "../utils/reset-split-panel-presentation.js";
 import {
   ensureSplitPaneTabBrowsersAreWarmed,
@@ -42,21 +39,40 @@ export function patchTabpanels(
 ): TabpanelsPatchResult | null {
   const gBrowser = getGBrowser();
   if (!gBrowser?.tabpanels) {
-    logger.warn(
-      "[patch] gBrowser.tabpanels not available, skipping patch",
-    );
+    logger.warn("[patch] gBrowser.tabpanels not available, skipping patch");
     return null;
   }
 
   const tabpanels = gBrowser.tabpanels;
   const proto = Object.getPrototypeOf(tabpanels);
 
+  const syncSplitTabMarkerAttrs = (): number => {
+    const tabs = document?.querySelectorAll<HTMLElement>(
+      "#tabbrowser-tabs .tabbrowser-tab",
+    );
+    if (!tabs) {
+      return 0;
+    }
+
+    let splitTabCount = 0;
+    for (const tab of tabs) {
+      const hasSplit = Boolean(
+        (tab as unknown as { splitview?: unknown }).splitview,
+      );
+      if (hasSplit) {
+        splitTabCount++;
+        tab.setAttribute("data-floorp-split-tab", "true");
+      } else {
+        tab.removeAttribute("data-floorp-split-tab");
+      }
+    }
+    return splitTabCount;
+  };
+
   // --- Track originals for unpatch ---
   let patchedSplitViewPanels = false;
   let patchedIsSplitViewActive = false;
-  let origShowSplitViewPanels:
-    | ((tabs: SplitViewTab[]) => void)
-    | null = null;
+  let origShowSplitViewPanels: ((tabs: SplitViewTab[]) => void) | null = null;
 
   // --- Patch splitViewPanels setter ---
   const origPanelsDesc = Object.getOwnPropertyDescriptor(
@@ -81,6 +97,8 @@ export function patchTabpanels(
           );
         }
 
+        const splitTabCount = syncSplitTabMarkerAttrs();
+
         // Grid cell placement follows `column="0"`…`"3"`. After tab reorder,
         // keep attributes aligned with splitViewPanels order.
         if (
@@ -104,9 +122,7 @@ export function patchTabpanels(
         for (const child of tabpanelsEl.children) {
           const childId = child.id;
           if (currentPanelSet.has(childId)) {
-            if (
-              !child.classList.contains("split-view-panel-active")
-            ) {
+            if (!child.classList.contains("split-view-panel-active")) {
               child.classList.add("split-view-panel-active");
             }
           } else {
@@ -117,9 +133,7 @@ export function patchTabpanels(
                 `[patch:splitViewPanels.set] cleaned stale .split-view-panel from ${childId}`,
               );
             }
-            if (
-              child.classList.contains("split-view-panel-active")
-            ) {
+            if (child.classList.contains("split-view-panel-active")) {
               child.classList.remove("split-view-panel-active");
             }
           }
@@ -152,8 +166,7 @@ export function patchTabpanels(
         if (newPanels.length >= 2) {
           this.setAttribute("data-floorp-split", "true");
           // Ensure multibar is set for Lepton theme compatibility
-          const tabsToolbar =
-            document?.getElementById("TabsToolbar");
+          const tabsToolbar = document?.getElementById("TabsToolbar");
           if (tabsToolbar) {
             if (!tabsToolbar.hasAttribute("multibar")) {
               tabsToolbar.setAttribute("multibar", "true");
@@ -165,13 +178,21 @@ export function patchTabpanels(
           onPanelsChanged(newPanels, layout);
         } else {
           // Split view panels cleared — clean up splitview-multibar
-          const tabsToolbar =
-            document?.getElementById("TabsToolbar");
+          const tabsToolbar = document?.getElementById("TabsToolbar");
           if (tabsToolbar) {
-            tabsToolbar.removeAttribute("splitview-multibar");
-            if (state.multibarSetBySplitView) {
-              tabsToolbar.removeAttribute("multibar");
-              state.multibarSetBySplitView = false;
+            const hasSplitTabs = splitTabCount > 0;
+            if (hasSplitTabs) {
+              if (!tabsToolbar.hasAttribute("multibar")) {
+                tabsToolbar.setAttribute("multibar", "true");
+                state.multibarSetBySplitView = true;
+              }
+              tabsToolbar.setAttribute("splitview-multibar", "true");
+            } else {
+              tabsToolbar.removeAttribute("splitview-multibar");
+              if (state.multibarSetBySplitView) {
+                tabsToolbar.removeAttribute("multibar");
+                state.multibarSetBySplitView = false;
+              }
             }
           }
         }
@@ -184,9 +205,7 @@ export function patchTabpanels(
     });
     logger.debug("[patch] splitViewPanels setter/getter patched");
   } else {
-    logger.warn(
-      "[patch] splitViewPanels descriptor not found on prototype",
-    );
+    logger.warn("[patch] splitViewPanels descriptor not found on prototype");
   }
 
   // --- Patch setSplitViewActive method ---
@@ -199,10 +218,11 @@ export function patchTabpanels(
   if (typeof origSetSplitViewActive === "function") {
     patchedIsSplitViewActive = true;
 
-    tabpanels.setSplitViewActive = function (
-      this: HTMLElement,
-      updatedValue: boolean,
-    ) {
+    (
+      tabpanels as unknown as {
+        setSplitViewActive: (updatedValue: boolean) => void;
+      }
+    ).setSplitViewActive = function (this: HTMLElement, updatedValue: boolean) {
       // Reproduce the native logic: isActive is true only when the
       // selected tab actually belongs to a split view AND the caller
       // requested activation.
@@ -218,10 +238,10 @@ export function patchTabpanels(
       try {
         origSetSplitViewActive.call(this, updatedValue);
       } catch (e) {
-        logger.error(
-          `[patch:setSplitViewActive] original threw: ${e}`,
-        );
+        logger.error(`[patch:setSplitViewActive] original threw: ${e}`);
       }
+
+      const splitTabCount = syncSplitTabMarkerAttrs();
 
       const tabsToolbar = document?.getElementById("TabsToolbar");
 
@@ -265,7 +285,14 @@ export function patchTabpanels(
         const panels = (this as unknown as { splitViewPanels?: string[] })
           .splitViewPanels;
         const hasPanels = panels && panels.length >= 2;
-        if (!hasPanels && tabsToolbar) {
+        const hasSplitTabs = splitTabCount > 0;
+        if (hasSplitTabs && tabsToolbar) {
+          if (!tabsToolbar.hasAttribute("multibar")) {
+            tabsToolbar.setAttribute("multibar", "true");
+            state.multibarSetBySplitView = true;
+          }
+          tabsToolbar.setAttribute("splitview-multibar", "true");
+        } else if (!hasPanels && tabsToolbar) {
           tabsToolbar.removeAttribute("splitview-multibar");
           if (state.multibarSetBySplitView) {
             tabsToolbar.removeAttribute("multibar");
@@ -276,15 +303,12 @@ export function patchTabpanels(
     };
     logger.debug("[patch] setSplitViewActive method patched");
   } else {
-    logger.warn(
-      "[patch] setSplitViewActive method not found on prototype",
-    );
+    logger.warn("[patch] setSplitViewActive method not found on prototype");
   }
 
   // --- Patch showSplitViewPanels ---
   if (typeof gBrowser.showSplitViewPanels === "function") {
-    origShowSplitViewPanels =
-      gBrowser.showSplitViewPanels.bind(gBrowser);
+    origShowSplitViewPanels = gBrowser.showSplitViewPanels.bind(gBrowser);
     gBrowser.showSplitViewPanels = (tabs: SplitViewTab[]) => {
       if (state.inShowSplitViewPanels) {
         logger.warn(
@@ -306,11 +330,7 @@ export function patchTabpanels(
         if (domTabs.length === tabs.length && domTabs.length >= 2) {
           const passedSet = new Set(tabs);
           if (domTabs.every((t: SplitViewTab) => passedSet.has(t))) {
-            if (
-              domTabs.some(
-                (t: SplitViewTab, i: number) => t !== tabs[i],
-              )
-            ) {
+            if (domTabs.some((t: SplitViewTab, i: number) => t !== tabs[i])) {
               logger.debug(
                 `[patch:showSplitViewPanels] corrected stale tab order to DOM order: ` +
                   `passed=[${tabs.map((t) => t.linkedPanel).join(", ")}] ` +
@@ -332,7 +352,10 @@ export function patchTabpanels(
         );
       }
       const inputDetail = tabs
-        .map((t, i) => `[${i}]=${t?.linkedPanel ?? "null"}:${t?.label?.slice(0, 24) ?? ""}`)
+        .map(
+          (t, i) =>
+            `[${i}]=${t?.linkedPanel ?? "null"}:${t?.label?.slice(0, 24) ?? ""}`,
+        )
         .join(" ");
       logger.debug(
         `[patch:showSplitViewPanels] validTabs=${validTabs.length}/${tabs.length} input: ${inputDetail}`,
@@ -350,9 +373,22 @@ export function patchTabpanels(
         return;
       }
 
+      // Ensure tabbar attributes are present whenever split view panels are
+      // shown. This prevents theme CSS races where Lepton's not([multibar])
+      // height clamps can re-apply and hide non-selected split tabs.
+      const tabsToolbar = document?.getElementById("TabsToolbar");
+      if (tabsToolbar) {
+        if (!tabsToolbar.hasAttribute("multibar")) {
+          tabsToolbar.setAttribute("multibar", "true");
+          state.multibarSetBySplitView = true;
+        }
+        tabsToolbar.setAttribute("splitview-multibar", "true");
+      }
+
       state.inShowSplitViewPanels = true;
       try {
         origShowSplitViewPanels!(validTabs);
+        syncSplitTabMarkerAttrs();
         applySplitViewSessionMarkersForTabs(
           logger,
           validTabs,
@@ -368,23 +404,19 @@ export function patchTabpanels(
             `[patch:showSplitViewPanels:afterNative] could not read splitViewPanels: ${readErr}`,
           );
         }
-        logTabpanelsSplitDiagnostics("showSplitViewPanels:afterNative");
         scheduleSplitPaneWarmRetries(logger);
-        const bumpSplitViewUi = (phase: string): void => {
+        const bumpSplitViewUi = (): void => {
           ensureSplitPaneTabBrowsersAreWarmed(logger);
           ensureSplitPanelsActiveClassFromState();
           refreshActiveSplitPaneIndicator();
-          logTabpanelsSplitDiagnostics(`showSplitViewPanels:bump:${phase}`);
         };
-        bumpSplitViewUi("sync");
+        bumpSplitViewUi();
         requestAnimationFrame(() => {
-          bumpSplitViewUi("rAF1");
-          requestAnimationFrame(() => bumpSplitViewUi("rAF2"));
+          bumpSplitViewUi();
+          requestAnimationFrame(() => bumpSplitViewUi());
         });
       } catch (e) {
-        logger.error(
-          `[patch:showSplitViewPanels] original threw: ${e}`,
-        );
+        logger.error(`[patch:showSplitViewPanels] original threw: ${e}`);
       } finally {
         state.inShowSplitViewPanels = false;
       }
@@ -404,15 +436,13 @@ export function patchTabpanels(
       const tabpanels = gBrowser.tabpanels;
 
       if (patchedSplitViewPanels) {
-        delete (
-          tabpanels as unknown as Record<string, unknown>
-        ).splitViewPanels;
+        delete (tabpanels as unknown as Record<string, unknown>)
+          .splitViewPanels;
       }
       if (patchedIsSplitViewActive) {
         // Restore the original prototype method by removing the instance override
-        delete (
-          tabpanels as unknown as Record<string, unknown>
-        ).setSplitViewActive;
+        delete (tabpanels as unknown as Record<string, unknown>)
+          .setSplitViewActive;
       }
       if (origShowSplitViewPanels) {
         gBrowser.showSplitViewPanels = origShowSplitViewPanels;
@@ -423,6 +453,14 @@ export function patchTabpanels(
       const tabsToolbar = document?.getElementById("TabsToolbar");
       if (tabsToolbar) {
         tabsToolbar.removeAttribute("splitview-multibar");
+      }
+      const splitMarkerTabs = document?.querySelectorAll<HTMLElement>(
+        "#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]",
+      );
+      if (splitMarkerTabs) {
+        for (const tab of splitMarkerTabs) {
+          tab.removeAttribute("data-floorp-split-tab");
+        }
       }
       logger.debug("[unpatch] MozTabpanels restored");
     },

--- a/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
+++ b/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
@@ -46,15 +46,15 @@ export function patchTabpanels(
   const tabpanels = gBrowser.tabpanels;
   const proto = Object.getPrototypeOf(tabpanels);
 
+  let lastMarkerFingerprint = "";
+
   const syncSplitTabMarkerAttrs = (): number => {
     const tabs = document?.querySelectorAll<HTMLElement>(
       "#tabbrowser-tabs .tabbrowser-tab",
     );
-    if (!tabs) {
-      return 0;
-    }
 
     let splitTabCount = 0;
+    const ids: string[] = [];
     for (const tab of tabs) {
       const hasSplit = Boolean(
         (tab as unknown as { splitview?: unknown }).splitview,
@@ -62,10 +62,19 @@ export function patchTabpanels(
       if (hasSplit) {
         splitTabCount++;
         tab.setAttribute("data-floorp-split-tab", "true");
+        ids.push(tab.id);
       } else {
         tab.removeAttribute("data-floorp-split-tab");
       }
     }
+
+    // Early return if the split-tab set has not changed
+    const fp = `${splitTabCount}:${ids.join(",")}`;
+    if (fp === lastMarkerFingerprint) {
+      return splitTabCount;
+    }
+    lastMarkerFingerprint = fp;
+
     return splitTabCount;
   };
 

--- a/browser-features/chrome/common/split-view/styles/split-view.css
+++ b/browser-features/chrome/common/split-view/styles/split-view.css
@@ -476,162 +476,71 @@
   height: unset !important;
 }
 
-/* Fallback for cases where Lepton's not([multibar]) rules re-apply.
- * Use both active split-view panel state and persisted split-tab markers so
- * this still works when a split tab is not currently selected.
+/* Fallback for cases where Lepton's not([multibar]) rules re-apply during
+ * split-view state transitions. Covers both active split-view panels and
+ * persisted split-tab markers so this works even when a non-split tab is selected.
  */
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+:root:is(
+    :has(
+      #tabbrowser-tabpanels[data-floorp-split],
+      #tabbrowser-tabpanels[splitview],
+      #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+      #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+    ),
+    :has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
   )
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container,
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  :is(
+    #TabsToolbar:not([multibar]) #pinned-tabs-container,
+    #TabsToolbar:not([multibar]) #tabbrowser-arrowscrollbox,
+    #TabsToolbar:not([multibar])
+      #pinned-tabs-container[overflowing="true"]
+      > .tabbrowser-tab[pinned="true"],
+    #TabsToolbar:not([multibar])
+      #pinned-tabs-container[overflowing="true"]
+      > .tabbrowser-tab[pinned="true"]
+      .tab-stack,
+    #TabsToolbar:not([multibar])
+      #pinned-tabs-container[overflowing="true"]
+      > .tabbrowser-tab[pinned="true"]
+      .tab-content,
+    #TabsToolbar:not([multibar])
+      #tabbrowser-arrowscrollbox[overflowing="true"]
+      > .tabbrowser-tab[pinned="true"],
+    #TabsToolbar:not([multibar])
+      #tabbrowser-arrowscrollbox[overflowing="true"]
+      > .tabbrowser-tab[pinned="true"]
+      .tab-stack,
+    #TabsToolbar:not([multibar])
+      #tabbrowser-arrowscrollbox[overflowing="true"]
+      > .tabbrowser-tab[pinned="true"]
+      .tab-content
+  ),
+:root:not([uidensity="compact"]):is(
+    :has(
+      #tabbrowser-tabpanels[data-floorp-split],
+      #tabbrowser-tabpanels[splitview],
+      #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+      #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+    ),
+    :has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
   )
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox,
-:root:not([uidensity="compact"]):has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container,
-:root:not([uidensity="compact"]):has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox,
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"],
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-stack,
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-content,
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"],
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-stack,
-:root:has(
-    #tabbrowser-tabpanels[data-floorp-split],
-    #tabbrowser-tabpanels[splitview],
-    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
-    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
-  )
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-content {
+  :is(
+    #TabsToolbar:not([multibar]) #pinned-tabs-container,
+    #TabsToolbar:not([multibar]) #tabbrowser-arrowscrollbox
+  ) {
   max-height: unset !important;
   height: unset !important;
 }
 
-/* Marker-only fallback: when split tabs exist but split-view panel attributes
- * are temporarily absent (e.g. selected tab is outside the split group), keep
- * Lepton's not([multibar]) max-height clamps disabled.
- */
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container,
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox,
-:root:not([uidensity="compact"]):has(
-    #tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]
-  )
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container,
-:root:not([uidensity="compact"]):has(
-    #tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]
-  )
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox,
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"],
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-stack,
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #pinned-tabs-container[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-content,
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"],
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-stack,
-:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
-  #TabsToolbar:not([multibar])
-  #tabbrowser-arrowscrollbox[overflowing="true"]
-  > .tabbrowser-tab[pinned="true"]
-  .tab-content {
-  max-height: unset !important;
-  height: unset !important;
-}
-
-/* When split view is active, remove Floorp's custom tab min-width override
- * so that Firefox's native tab sizing can shrink tabs to fit in the strip.
+/* When split tabs exist, remove Floorp's custom tab min-width override so that
+ * Firefox's native tab sizing can shrink tabs to fit in the strip.
  * Without this, large tabMinWidth values (e.g. 200px) cause tabs to overlap.
- * The splitview-multibar attribute is set only while split view is active
- * and removed on deactivation, so user's tab width preference is restored. */
-#TabsToolbar[splitview-multibar] .tabbrowser-tab:not([pinned]) {
+ * The splitview-multibar attribute persists while any split tab remains (even
+ * when a non-split tab is selected), so the override stays active until all
+ * split tabs are gone. Scoped to horizontal tab strips only. */
+#TabsToolbar[splitview-multibar]
+  #tabbrowser-tabs:not([orient="vertical"])
+  .tabbrowser-tab:not([pinned]) {
   min-width: unset !important;
 }
 

--- a/browser-features/chrome/common/split-view/styles/split-view.css
+++ b/browser-features/chrome/common/split-view/styles/split-view.css
@@ -65,7 +65,10 @@
  * Explicitly collapse them so only .split-view-panel and our handles
  * participate in the layout.
  */
-#tabbrowser-tabpanels[data-floorp-split] > :not(.split-view-panel):not(.split-view-splitter):not(.floorp-split-handle):not(.floorp-grid-handle) {
+#tabbrowser-tabpanels[data-floorp-split]
+  > :not(.split-view-panel):not(.split-view-splitter):not(
+    .floorp-split-handle
+  ):not(.floorp-grid-handle) {
   display: none !important;
 }
 
@@ -234,8 +237,10 @@
   flex-direction: column;
 }
 
-#tabbrowser-tabpanels[splitview][split-view-layout="vertical"] > .split-view-panel,
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="vertical"] > .split-view-panel {
+#tabbrowser-tabpanels[splitview][split-view-layout="vertical"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="vertical"]
+  > .split-view-panel {
   --panel-min-height: 100px;
   min-height: var(--panel-min-height);
   max-height: calc(100% - var(--panel-min-height));
@@ -263,61 +268,83 @@
 }
 
 /* Collapse non-split-view children so they don't participate in grid layout */
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"] > :not(.split-view-panel):not(.floorp-grid-handle),
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"] > :not(.split-view-panel):not(.floorp-grid-handle),
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"] > :not(.split-view-panel):not(.floorp-grid-handle),
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"] > :not(.split-view-panel):not(.floorp-grid-handle) {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle) {
   display: none !important;
 }
 
 /* Explicitly place split-view panels into grid cells using the column attribute */
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"] > .split-view-panel[column="0"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"] > .split-view-panel[column="0"] {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="0"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="0"] {
   grid-row: 1;
   grid-column: 1;
 }
 
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"] > .split-view-panel[column="1"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"] > .split-view-panel[column="1"] {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="1"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="1"] {
   grid-row: 1;
   grid-column: 2;
 }
 
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"] > .split-view-panel[column="2"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"] > .split-view-panel[column="2"] {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="2"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="2"] {
   grid-row: 2;
   grid-column: 1;
 }
 
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"] > .split-view-panel[column="3"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"] > .split-view-panel[column="3"] {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="3"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
+  > .split-view-panel[column="3"] {
   grid-row: 2;
   grid-column: 2;
 }
 
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"] > .split-view-panel[column="0"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"] > .split-view-panel[column="0"] {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel[column="0"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel[column="0"] {
   grid-row: 1 / span 2;
   grid-column: 1;
 }
 
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"] > .split-view-panel[column="1"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"] > .split-view-panel[column="1"] {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel[column="1"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel[column="1"] {
   grid-row: 1;
   grid-column: 2;
 }
 
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"] > .split-view-panel[column="2"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"] > .split-view-panel[column="2"] {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel[column="2"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel[column="2"] {
   grid-row: 2;
   grid-column: 2;
 }
 
 /* Remove flex-specific constraints that break grid cell sizing */
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"] > .split-view-panel,
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"] > .split-view-panel,
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"] > .split-view-panel,
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"] > .split-view-panel {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel {
   max-width: unset !important;
   min-width: unset !important;
   max-height: unset !important;
@@ -329,10 +356,18 @@
 }
 
 /* Ensure the browserContainer fills the grid cell */
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"] > .split-view-panel > .browserContainer,
-#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"] > .split-view-panel > .browserContainer,
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"] > .split-view-panel > .browserContainer,
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"] > .split-view-panel > .browserContainer {
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel
+  > .browserContainer {
   min-height: 0;
   min-width: 0;
 }
@@ -401,6 +436,203 @@
  */
 #TabsToolbar[splitview-multibar] #tabbrowser-tabs:not([orient="vertical"]) {
   max-height: unset !important;
+  height: unset !important;
+}
+
+/* Lepton can clamp pinned/arrowscrollbox descendants to one tab height.
+ * Clear those clamps while split view is active so all split tabs are visible.
+ */
+#TabsToolbar[splitview-multibar] #pinned-tabs-container,
+#TabsToolbar[splitview-multibar] #tabbrowser-arrowscrollbox,
+:root:not([uidensity="compact"])
+  #TabsToolbar[splitview-multibar]
+  #pinned-tabs-container,
+:root:not([uidensity="compact"])
+  #TabsToolbar[splitview-multibar]
+  #tabbrowser-arrowscrollbox,
+#TabsToolbar[splitview-multibar]
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"],
+#TabsToolbar[splitview-multibar]
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-stack,
+#TabsToolbar[splitview-multibar]
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-content,
+#TabsToolbar[splitview-multibar]
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"],
+#TabsToolbar[splitview-multibar]
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-stack,
+#TabsToolbar[splitview-multibar]
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-content {
+  max-height: unset !important;
+  height: unset !important;
+}
+
+/* Fallback for cases where Lepton's not([multibar]) rules re-apply.
+ * Use both active split-view panel state and persisted split-tab markers so
+ * this still works when a split tab is not currently selected.
+ */
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container,
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox,
+:root:not([uidensity="compact"]):has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container,
+:root:not([uidensity="compact"]):has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox,
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"],
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-stack,
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-content,
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"],
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-stack,
+:root:has(
+    #tabbrowser-tabpanels[data-floorp-split],
+    #tabbrowser-tabpanels[splitview],
+    #tabbrowser-tabs .tabbrowser-tab[floorpSplitViewGroupId],
+    #tabbrowser-tabs .tabbrowser-tab[floorpsplitviewgroupid]
+  )
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-content {
+  max-height: unset !important;
+  height: unset !important;
+}
+
+/* Marker-only fallback: when split tabs exist but split-view panel attributes
+ * are temporarily absent (e.g. selected tab is outside the split group), keep
+ * Lepton's not([multibar]) max-height clamps disabled.
+ */
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container,
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox,
+:root:not([uidensity="compact"]):has(
+    #tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]
+  )
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container,
+:root:not([uidensity="compact"]):has(
+    #tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]
+  )
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox,
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"],
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-stack,
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #pinned-tabs-container[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-content,
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"],
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-stack,
+:root:has(#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab])
+  #TabsToolbar:not([multibar])
+  #tabbrowser-arrowscrollbox[overflowing="true"]
+  > .tabbrowser-tab[pinned="true"]
+  .tab-content {
+  max-height: unset !important;
+  height: unset !important;
+}
+
+/* When split view is active, remove Floorp's custom tab min-width override
+ * so that Firefox's native tab sizing can shrink tabs to fit in the strip.
+ * Without this, large tabMinWidth values (e.g. 200px) cause tabs to overlap.
+ * The splitview-multibar attribute is set only while split view is active
+ * and removed on deactivation, so user's tab width preference is restored. */
+#TabsToolbar[splitview-multibar] .tabbrowser-tab:not([pinned]) {
+  min-width: unset !important;
 }
 
 /* When split view is active, remove Floorp's custom tab min-width override
@@ -459,7 +691,8 @@
     box-shadow 150ms ease,
     background-color 150ms ease;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--focus-outline-color) 24%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--focus-outline-color) 24%, transparent);
   background: color-mix(in srgb, var(--toolbar-bgcolor) 90%, transparent);
   box-shadow: 0 1px 3px color-mix(in srgb, black 12%, transparent);
   display: flex;
@@ -468,7 +701,9 @@
   box-sizing: border-box;
 }
 
-#tabbrowser-tabpanels[data-floorp-split] > .split-view-panel:hover > .floorp-pane-drag-grip {
+#tabbrowser-tabpanels[data-floorp-split]
+  > .split-view-panel:hover
+  > .floorp-pane-drag-grip {
   opacity: 1;
   transform: translateX(-50%) translateY(1px);
   background: color-mix(in srgb, var(--toolbar-bgcolor) 96%, transparent);
@@ -489,7 +724,11 @@
   display: block;
   width: 24px;
   height: 6px;
-  background-image: radial-gradient(circle, var(--toolbar-field-focus-color) 1.5px, transparent 1.5px);
+  background-image: radial-gradient(
+    circle,
+    var(--toolbar-field-focus-color) 1.5px,
+    transparent 1.5px
+  );
   background-size: 8px 4px;
   background-repeat: repeat-x;
   background-position: center;
@@ -499,21 +738,30 @@
   background: color-mix(in srgb, var(--toolbar-bgcolor) 10%, transparent);
 }
 
-#tabbrowser-tabpanels[data-floorp-dragging="pane-reorder"] > .split-view-panel > .floorp-pane-drag-grip {
+#tabbrowser-tabpanels[data-floorp-dragging="pane-reorder"]
+  > .split-view-panel
+  > .floorp-pane-drag-grip {
   opacity: 0.35;
 }
 
-#tabbrowser-tabpanels[data-floorp-split] > .split-view-panel[data-floorp-drag-source] {
+#tabbrowser-tabpanels[data-floorp-split]
+  > .split-view-panel[data-floorp-drag-source] {
   opacity: 0.78;
   box-shadow: inset 0 0 0 2px var(--focus-outline-color) !important;
 }
 
-#tabbrowser-tabpanels[data-floorp-split] > .split-view-panel[data-floorp-drop-target] {
+#tabbrowser-tabpanels[data-floorp-split]
+  > .split-view-panel[data-floorp-drop-target] {
   background: color-mix(in srgb, var(--focus-outline-color) 10%, transparent);
-  box-shadow: inset 0 0 0 3px color-mix(in srgb, var(--focus-outline-color) 72%, transparent) !important;
+  box-shadow: inset 0 0 0 3px
+    color-mix(in srgb, var(--focus-outline-color) 72%, transparent) !important;
 }
 
-#tabbrowser-tabpanels[data-floorp-split] > .split-view-panel[data-floorp-drop-target] > .floorp-pane-drag-grip,
-#tabbrowser-tabpanels[data-floorp-split] > .split-view-panel[data-floorp-drag-source] > .floorp-pane-drag-grip {
+#tabbrowser-tabpanels[data-floorp-split]
+  > .split-view-panel[data-floorp-drop-target]
+  > .floorp-pane-drag-grip,
+#tabbrowser-tabpanels[data-floorp-split]
+  > .split-view-panel[data-floorp-drag-source]
+  > .floorp-pane-drag-grip {
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- keep split-view Lepton compatibility attrs active while split tabs still exist, even when a non-split tab is selected
- add persistent split-tab marker synchronization for stable CSS fallback triggering
- add marker-only CSS fallback to neutralize Lepton height clamps in inactive split-view state
- remove runtime calls that emitted verbose split-view diagnostics logs

## Validation
- reproduced split-view creation then switched to non-split tab via dev-tool
- confirmed TypeScript/CSS diagnostics: no errors in modified files

## Notes
- Lepton theme source file was not modified; fixes are implemented only in split-view patch/CSS layers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-view tab display and toolbar behavior for Lepton theme (height/width and pinned-tab clamping fixes).
  * More reliable split-view state/marker synchronization and cleanup when panels or selections change.

* **Style**
  * CSS tweaks to lift height/min-width constraints during split-view so tabs and pinned tabs size correctly across transitions.

* **Refactor**
  * Reduced noisy internal diagnostics and made internal style sampling more resilient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->