### PR TITLE
feat: add new split view layouts

### DIFF
--- a/browser-features/chrome/common/split-view/components/split-view-layout-picker.tsx
+++ b/browser-features/chrome/common/split-view/components/split-view-layout-picker.tsx
@@ -5,7 +5,7 @@
 
 import i18next from "i18next";
 import { applyLayout } from "../layout.js";
-import { splitViewConfig, setSplitViewConfig } from "../data/config.js";
+import { setSplitViewConfig, splitViewConfig } from "../data/config.js";
 import type { SplitViewLayout, SplitViewTab } from "../data/types.js";
 import { getGBrowser } from "../data/types.js";
 import {
@@ -16,8 +16,7 @@ import {
 
 const log = console.createInstance({ prefix: "nora@split-view-picker" });
 
-const t = (key: string): string =>
-  (i18next.t as (k: string) => string)(key);
+const t = (key: string): string => (i18next.t as (k: string) => string)(key);
 
 interface LayoutOption {
   layout: SplitViewLayout;
@@ -27,15 +26,45 @@ interface LayoutOption {
 }
 
 const LAYOUT_OPTIONS: LayoutOption[] = [
-  { layout: "horizontal", i18nKey: "splitView.layoutPicker.horizontal", minPanes: 2 },
-  { layout: "vertical", i18nKey: "splitView.layoutPicker.vertical", minPanes: 2 },
+  {
+    layout: "horizontal",
+    i18nKey: "splitView.layoutPicker.horizontal",
+    minPanes: 2,
+  },
+  {
+    layout: "vertical",
+    i18nKey: "splitView.layoutPicker.vertical",
+    minPanes: 2,
+  },
   {
     layout: "grid-3pane-left-main",
     i18nKey: "splitView.layoutPicker.grid3paneLeftMain",
     minPanes: 3,
     maxPanes: 3,
   },
-  { layout: "grid-2x2", i18nKey: "splitView.layoutPicker.grid2x2", minPanes: 4 },
+  {
+    layout: "grid-3pane-right-main",
+    i18nKey: "splitView.layoutPicker.grid3paneRightMain",
+    minPanes: 3,
+    maxPanes: 3,
+  },
+  {
+    layout: "grid-3pane-top-main",
+    i18nKey: "splitView.layoutPicker.grid3paneTopMain",
+    minPanes: 3,
+    maxPanes: 3,
+  },
+  {
+    layout: "grid-3pane-bottom-main",
+    i18nKey: "splitView.layoutPicker.grid3paneBottomMain",
+    minPanes: 3,
+    maxPanes: 3,
+  },
+  {
+    layout: "grid-2x2",
+    i18nKey: "splitView.layoutPicker.grid2x2",
+    minPanes: 4,
+  },
 ];
 
 export function initLayoutPicker(): void {
@@ -87,7 +116,9 @@ function onPopupShowing(): void {
     ? resolveLayoutForSplitTabs(activeSplitView.tabs)
     : splitViewConfig().layout;
 
-  log.debug(`[popupShowing] panes=${currentPaneCount}, currentLayout=${currentLayout}, activeSplitView=${!!activeSplitView}`);
+  log.debug(
+    `[popupShowing] panes=${currentPaneCount}, currentLayout=${currentLayout}, activeSplitView=${!!activeSplitView}`,
+  );
 
   for (const opt of LAYOUT_OPTIONS) {
     if (currentPaneCount < opt.minPanes) continue;
@@ -101,7 +132,12 @@ function onPopupShowing(): void {
     item.className = "floorp-split-view-menu-item";
     item.setAttribute("label", t(opt.i18nKey));
     item.setAttribute("type", "radio");
-    item.setAttribute("checked", String(currentLayout === opt.layout));
+
+    if (opt.layout === currentLayout) {
+      item.setAttribute("checked", "true");
+    } else {
+      item.removeAttribute("checked");
+    }
 
     item.addEventListener("command", () => {
       log.debug(`[command] switching layout to ${opt.layout}`);
@@ -168,7 +204,10 @@ function addPaneToActiveSplitView(): void {
   // of gBrowser.selectedTab, so it correctly replaces the opentabs pane
   // even in N-pane split view.
   const newTab = gBrowser.addTrustedTab("about:opentabs");
-  log.debug(`[addPane] created new tab: linkedBrowser=${!!newTab.linkedBrowser}, linkedPanel=${newTab.linkedPanel}`);
+  log.debug(
+    `[addPane] created new tab: linkedBrowser=${!!newTab
+      .linkedBrowser}, linkedPanel=${newTab.linkedPanel}`,
+  );
   activeSplitView.addTabs([newTab]);
   log.debug(`[addPane] after addTabs: tabs=${activeSplitView.tabs.length}`);
 }
@@ -178,13 +217,18 @@ function removePaneFromActiveSplitView(): void {
   if (!gBrowser) return;
   const activeSplitView = gBrowser.activeSplitView;
   if (!activeSplitView || activeSplitView.tabs.length <= 2) {
-    log.warn(`[removePane] cannot remove: tabs=${activeSplitView?.tabs?.length ?? 0}`);
+    log.warn(
+      `[removePane] cannot remove: tabs=${activeSplitView?.tabs?.length ?? 0}`,
+    );
     return;
   }
 
   const tabs = activeSplitView.tabs;
   const lastTab = tabs[tabs.length - 1];
-  log.debug(`[removePane] removing tab: linkedPanel=${lastTab.linkedPanel}, linkedBrowser=${!!lastTab.linkedBrowser}`);
+  log.debug(
+    `[removePane] removing tab: linkedPanel=${lastTab.linkedPanel}, linkedBrowser=${!!lastTab
+      .linkedBrowser}`,
+  );
 
   gBrowser.moveTabToSplitView(lastTab, null);
 

--- a/browser-features/chrome/common/split-view/components/split-view-splitters.tsx
+++ b/browser-features/chrome/common/split-view/components/split-view-splitters.tsx
@@ -97,13 +97,17 @@ export function insertFlexHandles(
   const orderedIds = orderFlexPanelIdsToLayout(tabpanels, panelIds);
   if (orderedIds.join(",") !== upstreamIds.join(",")) {
     log.debug(
-      `[insertFlexHandles] reordered for DOM/visual layout: upstream=[${upstreamIds.join(", ")}] ` +
+      `[insertFlexHandles] reordered for DOM/visual layout: upstream=[${
+        upstreamIds.join(", ")
+      }] ` +
         `ordered=[${orderedIds.join(", ")}]`,
     );
   }
 
   log.debug(
-    `[insertFlexHandles] orientation=${orientation}, panels=${orderedIds.length}, ids=[${orderedIds.join(", ")}]`,
+    `[insertFlexHandles] orientation=${orientation}, panels=${orderedIds.length}, ids=[${
+      orderedIds.join(", ")
+    }]`,
   );
 
   const sizes = resolvePaneSizesForPanelIds(upstreamIds);
@@ -113,7 +117,9 @@ export function insertFlexHandles(
     orderedIds.length,
   );
   log.debug(
-    `[insertFlexHandles] ratios=[${ratios.map((r) => r.toFixed(3)).join(", ")}]`,
+    `[insertFlexHandles] ratios=[${
+      ratios.map((r) => r.toFixed(3)).join(", ")
+    }]`,
   );
 
   for (let i = 0; i < orderedIds.length; i++) {
@@ -274,12 +280,17 @@ export function updateHandles(
   layout: SplitViewLayout,
 ): void {
   log.debug(
-    `[updateHandles] layout=${layout}, panels=${panelIds.length}, ids=[${panelIds.join(", ")}]`,
+    `[updateHandles] layout=${layout}, panels=${panelIds.length}, ids=[${
+      panelIds.join(", ")
+    }]`,
   );
   if (layout === "grid-2x2" && panelIds.length === 4) {
     insertGridHandles(panelIds);
   } else if (
-    layout === "grid-3pane-left-main" &&
+    (layout === "grid-3pane-left-main" ||
+      layout === "grid-3pane-right-main" ||
+      layout === "grid-3pane-top-main" ||
+      layout === "grid-3pane-bottom-main") &&
     panelIds.length === 3
   ) {
     insertThreePaneGridHandles(panelIds);

--- a/browser-features/chrome/common/split-view/data/config.ts
+++ b/browser-features/chrome/common/split-view/data/config.ts
@@ -29,6 +29,9 @@ const VALID_LAYOUTS = new Set([
   "vertical",
   "grid-2x2",
   "grid-3pane-left-main",
+  "grid-3pane-right-main",
+  "grid-3pane-top-main",
+  "grid-3pane-bottom-main",
 ]);
 
 function clampRatio(n: unknown): number {
@@ -129,9 +132,7 @@ function createSplitViewPaneSizes(): [
   });
 
   const observer = () => {
-    setPaneSizes(
-      parsePaneSizesPref(PREF_SPLIT_VIEW_PANE_SIZES),
-    );
+    setPaneSizes(parsePaneSizesPref(PREF_SPLIT_VIEW_PANE_SIZES));
   };
 
   Services.prefs.addObserver(PREF_SPLIT_VIEW_PANE_SIZES, observer);

--- a/browser-features/chrome/common/split-view/data/types.ts
+++ b/browser-features/chrome/common/split-view/data/types.ts
@@ -7,7 +7,10 @@ export type SplitViewLayout =
   | "horizontal"
   | "vertical"
   | "grid-2x2"
-  | "grid-3pane-left-main";
+  | "grid-3pane-left-main"
+  | "grid-3pane-right-main"
+  | "grid-3pane-top-main"
+  | "grid-3pane-bottom-main";
 
 // ===== Firefox/Gecko API types for split-view =====
 
@@ -45,10 +48,7 @@ export interface SplitViewGBrowser {
   activeSplitView: SplitViewWrapper | null;
   showSplitViewPanels(tabs: SplitViewTab[]): void;
   moveTabBefore(tab: SplitViewTab, beforeTab: SplitViewTab | null): void;
-  moveTabToSplitView(
-    tab: SplitViewTab,
-    wrapper: SplitViewWrapper | null,
-  ): void;
+  moveTabToSplitView(tab: SplitViewTab, wrapper: SplitViewWrapper | null): void;
   addTrustedTab(url: string): SplitViewTab;
   /** Create a split view wrapper, move tabs into it, and activate. */
   addTabSplitView(

--- a/browser-features/chrome/common/split-view/layout.spec.ts
+++ b/browser-features/chrome/common/split-view/layout.spec.ts
@@ -19,4 +19,30 @@ assert.equal(
 assert.equal(getEffectiveSplitViewLayout("grid-2x2", 4), "grid-2x2");
 assert.equal(getEffectiveSplitViewLayout("grid-2x2", 3), "horizontal");
 
+// New 3-pane grid layouts: should match when paneCount=3, fallback otherwise
+assert.equal(
+  getEffectiveSplitViewLayout("grid-3pane-right-main", 3),
+  "grid-3pane-right-main",
+);
+assert.equal(
+  getEffectiveSplitViewLayout("grid-3pane-right-main", 4),
+  "horizontal",
+);
+assert.equal(
+  getEffectiveSplitViewLayout("grid-3pane-top-main", 3),
+  "grid-3pane-top-main",
+);
+assert.equal(
+  getEffectiveSplitViewLayout("grid-3pane-top-main", 2),
+  "horizontal",
+);
+assert.equal(
+  getEffectiveSplitViewLayout("grid-3pane-bottom-main", 3),
+  "grid-3pane-bottom-main",
+);
+assert.equal(
+  getEffectiveSplitViewLayout("grid-3pane-bottom-main", 4),
+  "horizontal",
+);
+
 console.log("layout.spec: ok");

--- a/browser-features/chrome/common/split-view/styles/split-view.css
+++ b/browser-features/chrome/common/split-view/styles/split-view.css
@@ -66,9 +66,7 @@
  * participate in the layout.
  */
 #tabbrowser-tabpanels[data-floorp-split]
-  > :not(.split-view-panel):not(.split-view-splitter):not(
-    .floorp-split-handle
-  ):not(.floorp-grid-handle) {
+  > :not(.split-view-panel, .split-view-splitter, .floorp-split-handle, .floorp-grid-handle) {
   display: none !important;
 }
 
@@ -334,25 +332,25 @@
 
 /* Collapse non-split-view children so they don't participate in grid layout */
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle),
+  > :not(.split-view-panel, .floorp-grid-handle),
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
-  > :not(.split-view-panel):not(.floorp-grid-handle) {
+  > :not(.split-view-panel, .floorp-grid-handle) {
   display: none !important;
 }
 

--- a/browser-features/chrome/common/split-view/styles/split-view.css
+++ b/browser-features/chrome/common/split-view/styles/split-view.css
@@ -198,7 +198,7 @@
   width: 4px;
 }
 
-/* 3-pane grid horizontal handle (only within the right stack) */
+/* 3-pane grid horizontal handle (only within the right stack - left-main layout) */
 .floorp-grid-handle[data-orientation="grid-3pane-row"] {
   left: calc(var(--floorp-grid-col-ratio, 50%) + 4px);
   right: 0;
@@ -213,6 +213,65 @@
   transform: translateX(-50%);
   width: 40px;
   height: 4px;
+}
+
+/* 3-pane grid handles for right-main layout */
+#tabbrowser-tabpanels[split-view-layout="grid-3pane-right-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-row"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-row"] {
+  left: 0;
+  right: calc(100% - var(--floorp-grid-col-ratio, 50%) + 4px);
+}
+
+/* 3-pane grid handles for top-main layout */
+#tabbrowser-tabpanels[split-view-layout="grid-3pane-top-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-col"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-col"] {
+  top: calc(var(--floorp-grid-row-ratio, 50%) + 4px);
+  bottom: 0;
+  left: calc(var(--floorp-grid-col-ratio, 50%) - 4px);
+  width: 8px;
+  height: auto;
+  cursor: col-resize;
+}
+
+#tabbrowser-tabpanels[split-view-layout="grid-3pane-top-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-row"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-row"] {
+  left: 0;
+  right: 0;
+  top: calc(var(--floorp-grid-row-ratio, 50%) - 4px);
+  height: 8px;
+  width: auto;
+  cursor: row-resize;
+}
+
+/* 3-pane grid handles for bottom-main layout */
+#tabbrowser-tabpanels[split-view-layout="grid-3pane-bottom-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-col"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-col"] {
+  top: 0;
+  bottom: calc(100% - var(--floorp-grid-row-ratio, 50%) + 4px);
+  left: calc(var(--floorp-grid-col-ratio, 50%) - 4px);
+  width: 8px;
+  height: auto;
+  cursor: col-resize;
+}
+
+#tabbrowser-tabpanels[split-view-layout="grid-3pane-bottom-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-row"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
+  .floorp-grid-handle[data-orientation="grid-3pane-row"] {
+  left: 0;
+  right: 0;
+  top: calc(var(--floorp-grid-row-ratio, 50%) - 4px);
+  height: 8px;
+  width: auto;
+  cursor: row-resize;
 }
 
 /* Center intersection handle */
@@ -259,8 +318,14 @@
  */
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"],
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"],
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"],
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"],
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"],
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"],
-#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"] {
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"] {
   display: grid !important;
   position: relative;
   grid-template-columns: 1fr 1fr;
@@ -272,9 +337,21 @@
   > :not(.split-view-panel):not(.floorp-grid-handle),
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
   > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
   > :not(.split-view-panel):not(.floorp-grid-handle),
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  > :not(.split-view-panel):not(.floorp-grid-handle),
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
   > :not(.split-view-panel):not(.floorp-grid-handle) {
   display: none !important;
 }
@@ -336,14 +413,125 @@
   grid-column: 2;
 }
 
+/* ===== Grid 3-pane right main (large right pane) ===== */
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"] {
+  display: grid !important;
+  position: relative;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel[column="0"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel[column="0"] {
+  grid-row: 1;
+  grid-column: 1;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel[column="1"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel[column="1"] {
+  grid-row: 2;
+  grid-column: 1;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel[column="2"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel[column="2"] {
+  grid-row: 1 / span 2;
+  grid-column: 2;
+}
+
+/* ===== Grid 3-pane top main (large top pane) ===== */
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"] {
+  display: grid !important;
+  position: relative;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel[column="0"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel[column="0"] {
+  grid-row: 1;
+  grid-column: 1 / span 2;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel[column="1"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel[column="1"] {
+  grid-row: 2;
+  grid-column: 1;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel[column="2"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel[column="2"] {
+  grid-row: 2;
+  grid-column: 2;
+}
+
+/* ===== Grid 3-pane bottom main (large bottom pane) ===== */
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"] {
+  display: grid !important;
+  position: relative;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel[column="0"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel[column="0"] {
+  grid-row: 1;
+  grid-column: 1;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel[column="1"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel[column="1"] {
+  grid-row: 1;
+  grid-column: 2;
+}
+
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel[column="2"],
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel[column="2"] {
+  grid-row: 2;
+  grid-column: 1 / span 2;
+}
+
 /* Remove flex-specific constraints that break grid cell sizing */
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-2x2"]
   > .split-view-panel,
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
   > .split-view-panel,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel,
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
   > .split-view-panel,
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
   > .split-view-panel {
   max-width: unset !important;
   min-width: unset !important;
@@ -362,10 +550,28 @@
 #tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-left-main"]
   > .split-view-panel
   > .browserContainer,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[splitview][split-view-layout="grid-3pane-bottom-main"]
+  > .split-view-panel
+  > .browserContainer,
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-2x2"]
   > .split-view-panel
   > .browserContainer,
 #tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-left-main"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-right-main"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-top-main"]
+  > .split-view-panel
+  > .browserContainer,
+#tabbrowser-tabpanels[data-floorp-split][split-view-layout="grid-3pane-bottom-main"]
   > .split-view-panel
   > .browserContainer {
   min-height: 0;

--- a/browser-features/chrome/common/split-view/utils/effective-layout.ts
+++ b/browser-features/chrome/common/split-view/utils/effective-layout.ts
@@ -12,7 +12,13 @@ export function getEffectiveSplitViewLayout(
   if (layout === "grid-2x2" && paneCount !== 4) {
     return "horizontal";
   }
-  if (layout === "grid-3pane-left-main" && paneCount !== 3) {
+  if (
+    (layout === "grid-3pane-left-main" ||
+      layout === "grid-3pane-right-main" ||
+      layout === "grid-3pane-top-main" ||
+      layout === "grid-3pane-bottom-main") &&
+    paneCount !== 3
+  ) {
     return "horizontal";
   }
   return layout;

--- a/browser-features/chrome/common/split-view/utils/group-layout-store.spec.ts
+++ b/browser-features/chrome/common/split-view/utils/group-layout-store.spec.ts
@@ -55,6 +55,32 @@ import {
   assert.equal(getGroupLayoutFromStore(next, "beta"), "grid-3pane-left-main");
 }
 
+// Verify new 3-pane layouts survive round-trip through parseGroupLayoutStore
+{
+  for (const layout of [
+    "grid-3pane-right-main",
+    "grid-3pane-top-main",
+    "grid-3pane-bottom-main",
+  ] as const) {
+    const raw = JSON.stringify({
+      groups: [{ groupId: "g", layout }],
+    });
+    const store = parseGroupLayoutStore(raw);
+    assert.equal(getGroupLayoutFromStore(store, "g"), layout);
+  }
+}
+
+// Verify upsert works for new 3-pane layouts
+{
+  const start = parseGroupLayoutStore(
+    JSON.stringify({
+      groups: [{ groupId: "a", layout: "horizontal" }],
+    }),
+  );
+  const next = upsertGroupLayoutInStore(start, "a", "grid-3pane-right-main");
+  assert.equal(getGroupLayoutFromStore(next, "a"), "grid-3pane-right-main");
+}
+
 {
   const start = parseGroupLayoutStore(
     JSON.stringify({

--- a/browser-features/chrome/common/split-view/utils/group-layout-store.ts
+++ b/browser-features/chrome/common/split-view/utils/group-layout-store.ts
@@ -23,6 +23,9 @@ const VALID_LAYOUTS = new Set<SplitViewLayout>([
   "vertical",
   "grid-2x2",
   "grid-3pane-left-main",
+  "grid-3pane-right-main",
+  "grid-3pane-top-main",
+  "grid-3pane-bottom-main",
 ]);
 
 function isValidPaneSizes(

--- a/i18n/en-US/browser-chrome.json
+++ b/i18n/en-US/browser-chrome.json
@@ -384,6 +384,9 @@
       "horizontal": "Horizontal Split",
       "vertical": "Vertical Split",
       "grid3paneLeftMain": "Grid (Large Left)",
+      "grid3paneRightMain": "Grid (Large Right)",
+      "grid3paneTopMain": "Grid (Large Top)",
+      "grid3paneBottomMain": "Grid (Large Bottom)",
       "grid2x2": "Grid (2×2)",
       "addPane": "Add Pane",
       "removePane": "Remove Last Pane"

--- a/i18n/ja-JP-mac/browser-chrome.json
+++ b/i18n/ja-JP-mac/browser-chrome.json
@@ -384,6 +384,9 @@
       "horizontal": "左右に分割",
       "vertical": "上下に分割",
       "grid3paneLeftMain": "グリッド (左側を広く)",
+      "grid3paneRightMain": "グリッド (右側を広く)",
+      "grid3paneTopMain": "グリッド (上側を広く)",
+      "grid3paneBottomMain": "グリッド (下側を広く)",
       "grid2x2": "グリッド (2×2)",
       "addPane": "区分けを追加",
       "removePane": "最後の区分けを削除"

--- a/i18n/ja-JP/browser-chrome.json
+++ b/i18n/ja-JP/browser-chrome.json
@@ -384,6 +384,9 @@
       "horizontal": "左右に分割",
       "vertical": "上下に分割",
       "grid3paneLeftMain": "グリッド (左側を広く)",
+      "grid3paneRightMain": "グリッド (右側を広く)",
+      "grid3paneTopMain": "グリッド (上側を広く)",
+      "grid3paneBottomMain": "グリッド (下側を広く)",
       "grid2x2": "グリッド (2×2)",
       "addPane": "区分けを追加",
       "removePane": "最後の区分けを削除"


### PR DESCRIPTION
Add three layouts to Spilt view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new 3‑pane split‑view grid layouts: Large Right, Large Top, and Large Bottom; layout picker now exposes more 3‑pane options.
  * Layout handling and panel positioning updated so those new layouts render and behave correctly.

* **Localization**
  * Added English and Japanese labels for the new layout options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->