### PR TITLE
feat: add command palette (Ctrl+Shift+P)

### DIFF
--- a/browser-features/chrome/common/command-palette/command-registry.ts
+++ b/browser-features/chrome/common/command-palette/command-registry.ts
@@ -7,6 +7,8 @@ import {
 } from "../mouse-gesture/utils/gestures.ts";
 import { fuzzySearch } from "./fuzzy.ts";
 import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
+import { getTabCommands, isTabCommand } from "./tab-provider.ts";
+import { getConfig, shortcutToString } from "../keyboard-shortcut/config.ts";
 
 export interface PaletteCommand {
   id: string;
@@ -142,7 +144,7 @@ const ACTION_KEYWORDS: Record<string, string[]> = {
 
 let cachedCommands: PaletteCommand[] | null = null;
 
-function buildCommands(): PaletteCommand[] {
+function buildGestureCommands(): PaletteCommand[] {
   const gestureActions = getAllGestureActions();
   return gestureActions.map((action) => ({
     id: action.name,
@@ -154,25 +156,42 @@ function buildCommands(): PaletteCommand[] {
   }));
 }
 
-export function getPaletteCommands(): PaletteCommand[] {
+export function getPaletteCommands(win?: Window): PaletteCommand[] {
   if (!cachedCommands) {
-    cachedCommands = buildCommands();
+    cachedCommands = buildGestureCommands();
   }
-  return cachedCommands;
+  const gestureCommands = cachedCommands;
+  const tabCommands = win ? getTabCommands(win) : [];
+  return [...tabCommands, ...gestureCommands];
 }
 
-export function searchCommands(query: string): PaletteCommand[] {
-  const commands = getPaletteCommands();
+export function searchCommands(query: string, win?: Window): PaletteCommand[] {
+  const commands = getPaletteCommands(win);
   if (!query.trim()) return commands;
   return fuzzySearch(query, commands);
 }
 
-export function getCommand(id: string): PaletteCommand | undefined {
-  return getPaletteCommands().find((cmd) => cmd.id === id);
+export function getCommand(id: string, win?: Window): PaletteCommand | undefined {
+  return getPaletteCommands(win).find((cmd) => cmd.id === id);
 }
 
 export function invalidateCache() {
   cachedCommands = null;
+}
+
+export function getShortcutForAction(actionId: string): string | null {
+  if (isTabCommand(actionId)) return null;
+  try {
+    const config = getConfig();
+    for (const shortcut of Object.values(config.shortcuts)) {
+      if (shortcut.action === actionId) {
+        return shortcutToString(shortcut);
+      }
+    }
+  } catch {
+    // keyboard-shortcut module may not be available
+  }
+  return null;
 }
 
 addI18nObserver(() => {

--- a/browser-features/chrome/common/command-palette/command-registry.ts
+++ b/browser-features/chrome/common/command-palette/command-registry.ts
@@ -6,6 +6,7 @@ import {
   getActionDisplayName,
 } from "../mouse-gesture/utils/gestures.ts";
 import { fuzzySearch } from "./fuzzy.ts";
+import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
 
 export interface PaletteCommand {
   id: string;
@@ -173,3 +174,7 @@ export function getCommand(id: string): PaletteCommand | undefined {
 export function invalidateCache() {
   cachedCommands = null;
 }
+
+addI18nObserver(() => {
+  invalidateCache();
+});

--- a/browser-features/chrome/common/command-palette/command-registry.ts
+++ b/browser-features/chrome/common/command-palette/command-registry.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  getAllGestureActions,
+  getActionDescription,
+  getActionDisplayName,
+} from "../mouse-gesture/utils/gestures.ts";
+import { fuzzySearch } from "./fuzzy.ts";
+
+export interface PaletteCommand {
+  id: string;
+  label: string;
+  description: string;
+  category: string;
+  keywords: string[];
+  fn: (win: Window) => void;
+}
+
+const ACTION_CATEGORY_MAP: Record<string, string> = {
+  "gecko-back": "navigation",
+  "gecko-forward": "navigation",
+  "gecko-reload": "navigation",
+  "gecko-force-reload": "navigation",
+  "gecko-stop": "navigation",
+  "gecko-open-home-page": "navigation",
+
+  "gecko-close-tab": "tabs",
+  "gecko-open-new-tab": "tabs",
+  "gecko-duplicate-tab": "tabs",
+  "gecko-reload-all-tabs": "tabs",
+  "gecko-restore-last-tab": "tabs",
+  "gecko-show-next-tab": "tabs",
+  "gecko-show-previous-tab": "tabs",
+  "gecko-show-previously-selected-tab": "tabs",
+  "gecko-show-all-tabs-panel": "tabs",
+  "gecko-mute-current-tab": "tabs",
+
+  "gecko-zoom-in": "zoom",
+  "gecko-zoom-out": "zoom",
+  "gecko-reset-zoom": "zoom",
+
+  "gecko-bookmark-this-page": "bookmarks",
+
+  "gecko-save-page": "page",
+  "gecko-print-page": "page",
+  "gecko-show-source-of-page": "page",
+  "gecko-show-page-info": "page",
+  "gecko-open-screen-capture": "page",
+
+  "gecko-search-in-this-page": "search",
+  "gecko-show-next-search-result": "search",
+  "gecko-show-previous-search-result": "search",
+  "gecko-search-the-web": "search",
+
+  "gecko-show-bookmark-sidebar": "sidebar",
+  "gecko-show-history-sidebar": "sidebar",
+  "gecko-show-synced-tabs-sidebar": "sidebar",
+  "gecko-reverse-sidebar": "sidebar",
+  "gecko-hide-sidebar": "sidebar",
+  "gecko-toggle-sidebar": "sidebar",
+
+  "gecko-scroll-up": "scrolling",
+  "gecko-scroll-down": "scrolling",
+  "gecko-scroll-right": "scrolling",
+  "gecko-scroll-left": "scrolling",
+  "gecko-scroll-to-top": "scrolling",
+  "gecko-scroll-to-bottom": "scrolling",
+
+  "gecko-restore-last-session": "history",
+  "gecko-search-history": "history",
+  "gecko-manage-history": "history",
+  "gecko-forget-history": "history",
+  "gecko-quick-forget-history": "history",
+
+  "gecko-open-new-window": "window",
+  "gecko-open-new-private-window": "window",
+  "gecko-close-window": "window",
+  "gecko-restore-last-window": "window",
+  "gecko-quit-from-application": "window",
+
+  "gecko-open-addons-manager": "tools",
+  "gecko-open-migration-wizard": "tools",
+  "gecko-enter-into-customize-mode": "tools",
+  "gecko-open-task-manager": "tools",
+  "gecko-send-with-mail": "tools",
+  "gecko-enter-into-offline-mode": "tools",
+  "gecko-open-sync-preferences": "tools",
+
+  "gecko-open-downloads": "downloads",
+
+  "gecko-workspace-next": "workspace",
+  "gecko-workspace-previous": "workspace",
+
+  "floorp-rest-mode": "floorp",
+  "floorp-hide-user-interface": "floorp",
+  "floorp-toggle-navigation-panel": "floorp",
+  "floorp-toggle-zen-mode": "floorp",
+
+  "floorp-show-pip": "media",
+};
+
+const ACTION_KEYWORDS: Record<string, string[]> = {
+  "gecko-back": ["back", "previous"],
+  "gecko-forward": ["forward", "next"],
+  "gecko-reload": ["refresh", "reload"],
+  "gecko-force-reload": ["hard refresh", "hard reload", "skip cache"],
+  "gecko-close-tab": ["close", "remove tab"],
+  "gecko-open-new-tab": ["new", "open tab", "create tab"],
+  "gecko-duplicate-tab": ["clone", "copy tab"],
+  "gecko-show-next-tab": ["next tab", "switch right"],
+  "gecko-show-previous-tab": ["previous tab", "switch left"],
+  "gecko-show-all-tabs-panel": ["list tabs", "tab list"],
+  "gecko-mute-current-tab": ["mute", "silence", "audio"],
+  "gecko-bookmark-this-page": ["bookmark", "favorite", "star"],
+  "gecko-save-page": ["save", "download page"],
+  "gecko-print-page": ["print"],
+  "gecko-show-source-of-page": ["source", "view source", "html"],
+  "gecko-show-page-info": ["page info", "info"],
+  "gecko-open-screen-capture": ["screenshot", "capture", "screen"],
+  "gecko-search-in-this-page": ["find", "search page"],
+  "gecko-search-the-web": ["web search", "search"],
+  "gecko-toggle-sidebar": ["sidebar", "panel"],
+  "gecko-scroll-to-top": ["top", "beginning"],
+  "gecko-scroll-to-bottom": ["bottom", "end"],
+  "gecko-open-addons-manager": ["addons", "extensions", "plugins"],
+  "gecko-open-task-manager": ["task manager", "processes"],
+  "gecko-forget-history": ["clear history", "delete history"],
+  "gecko-restore-last-session": ["restore session", "recover"],
+  "gecko-open-downloads": ["downloads"],
+  "gecko-workspace-next": ["next workspace"],
+  "gecko-workspace-previous": ["previous workspace"],
+  "floorp-rest-mode": ["rest", "break"],
+  "floorp-hide-user-interface": ["hide ui", "hide interface"],
+  "floorp-toggle-zen-mode": ["zen", "focus", "distraction free"],
+  "floorp-show-pip": ["pip", "picture in picture", "mini player"],
+  "gecko-enter-into-customize-mode": ["customize", "toolbar"],
+  "gecko-quit-from-application": ["quit", "exit"],
+};
+
+let cachedCommands: PaletteCommand[] | null = null;
+
+function buildCommands(): PaletteCommand[] {
+  const gestureActions = getAllGestureActions();
+  return gestureActions.map((action) => ({
+    id: action.name,
+    label: getActionDisplayName(action.name),
+    description: getActionDescription(action.name),
+    category: ACTION_CATEGORY_MAP[action.name] ?? "tools",
+    keywords: ACTION_KEYWORDS[action.name] ?? [],
+    fn: action.fn,
+  }));
+}
+
+export function getPaletteCommands(): PaletteCommand[] {
+  if (!cachedCommands) {
+    cachedCommands = buildCommands();
+  }
+  return cachedCommands;
+}
+
+export function searchCommands(query: string): PaletteCommand[] {
+  const commands = getPaletteCommands();
+  if (!query.trim()) return commands;
+  return fuzzySearch(query, commands);
+}
+
+export function getCommand(id: string): PaletteCommand | undefined {
+  return getPaletteCommands().find((cmd) => cmd.id === id);
+}
+
+export function invalidateCache() {
+  cachedCommands = null;
+}

--- a/browser-features/chrome/common/command-palette/command-registry.ts
+++ b/browser-features/chrome/common/command-palette/command-registry.ts
@@ -95,6 +95,7 @@ const ACTION_CATEGORY_MAP: Record<string, string> = {
   "floorp-hide-user-interface": "floorp",
   "floorp-toggle-navigation-panel": "floorp",
   "floorp-toggle-zen-mode": "floorp",
+  "floorp-toggle-command-palette": "floorp",
 
   "floorp-show-pip": "media",
 };
@@ -132,6 +133,7 @@ const ACTION_KEYWORDS: Record<string, string[]> = {
   "floorp-rest-mode": ["rest", "break"],
   "floorp-hide-user-interface": ["hide ui", "hide interface"],
   "floorp-toggle-zen-mode": ["zen", "focus", "distraction free"],
+  "floorp-toggle-command-palette": ["command palette", "palette", "command"],
   "floorp-show-pip": ["pip", "picture in picture", "mini player"],
   "gecko-enter-into-customize-mode": ["customize", "toolbar"],
   "gecko-quit-from-application": ["quit", "exit"],

--- a/browser-features/chrome/common/command-palette/components/CategoryHeader.tsx
+++ b/browser-features/chrome/common/command-palette/components/CategoryHeader.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import i18next from "i18next";
+
+interface CategoryHeaderProps {
+  category: string;
+}
+
+export function CategoryHeader(props: CategoryHeaderProps) {
+  const label = () =>
+    i18next.t(`commandPalette.categories.${props.category}`, {
+      defaultValue: props.category,
+    });
+
+  return (
+    <div class="command-palette-category-header">
+      {label()}
+    </div>
+  );
+}

--- a/browser-features/chrome/common/command-palette/components/CommandItem.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandItem.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import type { PaletteCommand } from "../command-registry.ts";
+
+interface CommandItemProps {
+  command: PaletteCommand;
+  isSelected: boolean;
+  onSelect: () => void;
+  onExecute: () => void;
+}
+
+export function CommandItem(props: CommandItemProps) {
+  const handleMouseEnter = () => {
+    props.onSelect();
+  };
+
+  const handleClick = () => {
+    props.onExecute();
+  };
+
+  return (
+    <div
+      class="command-palette-item"
+      data-selected={props.isSelected ? "true" : undefined}
+      onMouseEnter={handleMouseEnter}
+      onClick={handleClick}
+      role="option"
+      aria-selected={props.isSelected}
+    >
+      <div class="command-palette-item-info">
+        <span class="command-palette-item-label">{props.command.label}</span>
+        {props.command.description && (
+          <span class="command-palette-item-description">
+            {props.command.description}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/browser-features/chrome/common/command-palette/components/CommandItem.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandItem.tsx
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+import { Show, For } from "solid-js";
 import type { PaletteCommand } from "../command-registry.ts";
+import { getHighlightSegments, type TextSegment } from "../utils/highlight.ts";
+import { getShortcutForAction } from "../command-registry.ts";
 
 interface CommandItemProps {
   command: PaletteCommand;
   isSelected: boolean;
+  query: string;
   onSelect: () => void;
   onExecute: () => void;
 }
@@ -18,6 +22,12 @@ export function CommandItem(props: CommandItemProps) {
     props.onExecute();
   };
 
+  const segments = (): TextSegment[] =>
+    getHighlightSegments(props.query, props.command.label);
+
+  const shortcut = (): string | null =>
+    getShortcutForAction(props.command.id);
+
   return (
     <div
       class="command-palette-item"
@@ -26,15 +36,29 @@ export function CommandItem(props: CommandItemProps) {
       onClick={handleClick}
       role="option"
       aria-selected={props.isSelected}
+      tabindex={props.isSelected ? 0 : -1}
     >
       <div class="command-palette-item-info">
-        <span class="command-palette-item-label">{props.command.label}</span>
+        <span class="command-palette-item-label">
+          <For each={segments()}>
+            {(seg) =>
+              seg.matched ? (
+                <strong class="command-palette-match">{seg.text}</strong>
+              ) : (
+                seg.text
+              )
+            }
+          </For>
+        </span>
         {props.command.description && (
           <span class="command-palette-item-description">
             {props.command.description}
           </span>
         )}
       </div>
+      <Show when={shortcut()}>
+        {(s) => <kbd class="command-palette-shortcut-badge">{s()}</kbd>}
+      </Show>
     </div>
   );
 }

--- a/browser-features/chrome/common/command-palette/components/CommandList.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandList.tsx
@@ -9,6 +9,7 @@ import { CategoryHeader } from "./CategoryHeader.tsx";
 interface CommandListProps {
   commands: PaletteCommand[];
   selectedIndex: number;
+  query: string;
   onCommandSelect: (index: number) => void;
   onCommandExecute: (command: PaletteCommand) => void;
 }
@@ -17,6 +18,8 @@ interface CategorizedCommands {
   category: string;
   commands: PaletteCommand[];
 }
+
+const HIDDEN_CATEGORIES = new Set(["navigation-suggestion"]);
 
 export function CommandList(props: CommandListProps) {
   const grouped = createMemo(() => {
@@ -53,7 +56,16 @@ export function CommandList(props: CommandListProps) {
       when={props.commands.length > 0}
       fallback={
         <div class="command-palette-empty">
-          {i18next.t("commandPalette.noResults", { defaultValue: "No commands found" })}
+          <div class="command-palette-empty-title">
+            {i18next.t("commandPalette.noResults", {
+              defaultValue: "No commands found",
+            })}
+          </div>
+          <div class="command-palette-empty-hint">
+            {i18next.t("commandPalette.noResultsHint", {
+              defaultValue: "Try a different search term",
+            })}
+          </div>
         </div>
       }
     >
@@ -61,7 +73,9 @@ export function CommandList(props: CommandListProps) {
         <For each={grouped()}>
           {(group, groupIdx) => (
             <>
-              <CategoryHeader category={group.category} />
+              <Show when={!HIDDEN_CATEGORIES.has(group.category)}>
+                <CategoryHeader category={group.category} />
+              </Show>
               <For each={group.commands}>
                 {(cmd, itemIdx) => {
                   const globalIdx = () =>
@@ -70,6 +84,7 @@ export function CommandList(props: CommandListProps) {
                     <CommandItem
                       command={cmd}
                       isSelected={props.selectedIndex === globalIdx()}
+                      query={props.query}
                       onSelect={() => props.onCommandSelect(globalIdx())}
                       onExecute={() => props.onCommandExecute(cmd)}
                     />

--- a/browser-features/chrome/common/command-palette/components/CommandList.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandList.tsx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { createMemo, For, Show } from "solid-js";
+import i18next from "i18next";
+import type { PaletteCommand } from "../command-registry.ts";
+import { CommandItem } from "./CommandItem.tsx";
+import { CategoryHeader } from "./CategoryHeader.tsx";
+
+interface CommandListProps {
+  commands: PaletteCommand[];
+  selectedIndex: number;
+  onCommandSelect: (index: number) => void;
+  onCommandExecute: (command: PaletteCommand) => void;
+}
+
+interface CategorizedCommands {
+  category: string;
+  commands: PaletteCommand[];
+}
+
+export function CommandList(props: CommandListProps) {
+  const grouped = createMemo(() => {
+    const groups: CategorizedCommands[] = [];
+    const categoryMap = new Map<string, PaletteCommand[]>();
+
+    for (const cmd of props.commands) {
+      const list = categoryMap.get(cmd.category);
+      if (list) {
+        list.push(cmd);
+      } else {
+        categoryMap.set(cmd.category, [cmd]);
+      }
+    }
+
+    for (const [category, commands] of categoryMap) {
+      groups.push({ category, commands });
+    }
+
+    return groups;
+  });
+
+  const getGlobalIndex = (groupIdx: number, itemIdx: number): number => {
+    let idx = 0;
+    const groups = grouped();
+    for (let g = 0; g < groupIdx; g++) {
+      idx += groups[g].commands.length;
+    }
+    return idx + itemIdx;
+  };
+
+  return (
+    <Show
+      when={props.commands.length > 0}
+      fallback={
+        <div class="command-palette-empty">
+          {i18next.t("commandPalette.noResults", { defaultValue: "No commands found" })}
+        </div>
+      }
+    >
+      <div class="command-palette-list" role="listbox">
+        <For each={grouped()}>
+          {(group, groupIdx) => (
+            <>
+              <CategoryHeader category={group.category} />
+              <For each={group.commands}>
+                {(cmd, itemIdx) => {
+                  const globalIdx = () =>
+                    getGlobalIndex(groupIdx(), itemIdx());
+                  return (
+                    <CommandItem
+                      command={cmd}
+                      isSelected={props.selectedIndex === globalIdx()}
+                      onSelect={() => props.onCommandSelect(globalIdx())}
+                      onExecute={() => props.onCommandExecute(cmd)}
+                    />
+                  );
+                }}
+              </For>
+            </>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+}

--- a/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
@@ -2,7 +2,6 @@
 
 import { Show, createEffect, on } from "solid-js";
 import { Portal } from "solid-js/web";
-import { state } from "../data/state.ts";
 import { commandPaletteService } from "../service.ts";
 import { SearchInput } from "./SearchInput.tsx";
 import { CommandList } from "./CommandList.tsx";
@@ -13,6 +12,11 @@ function getController() {
 }
 
 export function CommandPaletteUI() {
+  const controller = getController();
+  if (!controller) return;
+
+  const state = controller.state;
+
   const handleBackdropClick = (e: MouseEvent) => {
     if (e.target === e.currentTarget) {
       state.setIsVisible(false);
@@ -21,7 +25,7 @@ export function CommandPaletteUI() {
 
   const handleInput = (value: string) => {
     state.setQuery(value);
-    getController()?.updateSearch(value);
+    controller.updateSearch(value);
   };
 
   const handleCommandSelect = (index: number) => {
@@ -29,7 +33,7 @@ export function CommandPaletteUI() {
   };
 
   const handleCommandExecute = (cmd: PaletteCommand) => {
-    getController()?.executeCommand(cmd);
+    controller.executeCommand(cmd);
   };
 
   // Scroll selected item into view

--- a/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { Show, createEffect, on } from "solid-js";
+import { Portal } from "solid-js/web";
+import { state } from "../data/state.ts";
+import { commandPaletteService } from "../service.ts";
+import { SearchInput } from "./SearchInput.tsx";
+import { CommandList } from "./CommandList.tsx";
+import type { PaletteCommand } from "../command-registry.ts";
+
+function getController() {
+  return commandPaletteService.getController(window);
+}
+
+export function CommandPaletteUI() {
+  const handleBackdropClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      state.setIsVisible(false);
+    }
+  };
+
+  const handleInput = (value: string) => {
+    state.setQuery(value);
+    getController()?.updateSearch(value);
+  };
+
+  const handleCommandSelect = (index: number) => {
+    state.setSelectedIndex(index);
+  };
+
+  const handleCommandExecute = (cmd: PaletteCommand) => {
+    getController()?.executeCommand(cmd);
+  };
+
+  // Scroll selected item into view
+  createEffect(
+    on(state.selectedIndex, () => {
+      if (!state.isVisible()) return;
+      requestAnimationFrame(() => {
+        const selected = document.querySelector(
+          '.command-palette-item[data-selected="true"]',
+        );
+        selected?.scrollIntoView({ block: "nearest" });
+      });
+    }),
+  );
+
+  return (
+    <Portal mount={document.getElementById("main-window")}>
+      <Show when={state.isVisible()}>
+        <div
+          id="command-palette-overlay"
+          onClick={handleBackdropClick}
+        >
+          <div id="command-palette-container">
+            <SearchInput
+              query={state.query()}
+              onInput={handleInput}
+            />
+            <CommandList
+              commands={state.filteredCommands()}
+              selectedIndex={state.selectedIndex()}
+              onCommandSelect={handleCommandSelect}
+              onCommandExecute={handleCommandExecute}
+            />
+          </div>
+        </div>
+      </Show>
+    </Portal>
+  );
+}

--- a/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
@@ -2,6 +2,7 @@
 
 import { Show, createEffect, on } from "solid-js";
 import { Portal } from "solid-js/web";
+import i18next from "i18next";
 import { commandPaletteService } from "../service.ts";
 import { SearchInput } from "./SearchInput.tsx";
 import { CommandList } from "./CommandList.tsx";
@@ -19,7 +20,7 @@ export function CommandPaletteUI() {
 
   const handleBackdropClick = (e: MouseEvent) => {
     if (e.target === e.currentTarget) {
-      state.setIsVisible(false);
+      controller.hidePalette();
     }
   };
 
@@ -34,6 +35,12 @@ export function CommandPaletteUI() {
 
   const handleCommandExecute = (cmd: PaletteCommand) => {
     controller.executeCommand(cmd);
+  };
+
+  const handleTransitionEnd = (e: TransitionEvent) => {
+    if (e.target === e.currentTarget && !state.isVisible()) {
+      state.setIsAnimatingOut(false);
+    }
   };
 
   // Scroll selected item into view
@@ -51,10 +58,17 @@ export function CommandPaletteUI() {
 
   return (
     <Portal mount={document.getElementById("main-window") ?? undefined}>
-      <Show when={state.isVisible()}>
+      <Show when={state.isVisible() || state.isAnimatingOut()}>
         <div
           id="command-palette-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={i18next.t("commandPalette.dialogLabel", {
+            defaultValue: "Command Palette",
+          })}
+          data-visible={state.isVisible() ? "true" : undefined}
           onClick={handleBackdropClick}
+          onTransitionEnd={handleTransitionEnd}
         >
           <div id="command-palette-container">
             <SearchInput
@@ -64,6 +78,7 @@ export function CommandPaletteUI() {
             <CommandList
               commands={state.filteredCommands()}
               selectedIndex={state.selectedIndex()}
+              query={state.query()}
               onCommandSelect={handleCommandSelect}
               onCommandExecute={handleCommandExecute}
             />

--- a/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
+++ b/browser-features/chrome/common/command-palette/components/CommandPalette.tsx
@@ -46,7 +46,7 @@ export function CommandPaletteUI() {
   );
 
   return (
-    <Portal mount={document.getElementById("main-window")}>
+    <Portal mount={document.getElementById("main-window") ?? undefined}>
       <Show when={state.isVisible()}>
         <div
           id="command-palette-overlay"

--- a/browser-features/chrome/common/command-palette/components/SearchInput.tsx
+++ b/browser-features/chrome/common/command-palette/components/SearchInput.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import i18next from "i18next";
+
+interface SearchInputProps {
+  query: string;
+  onInput: (value: string) => void;
+}
+
+export function SearchInput(props: SearchInputProps) {
+  const placeholder = () =>
+    i18next.t("commandPalette.placeholder", {
+      defaultValue: "Type a command...",
+    });
+
+  const handleInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    props.onInput(target.value);
+  };
+
+  return (
+    <input
+      id="command-palette-search"
+      type="text"
+      value={props.query}
+      onInput={handleInput}
+      placeholder={placeholder()}
+      autocomplete="off"
+      spellcheck={false}
+    />
+  );
+}

--- a/browser-features/chrome/common/command-palette/components/SearchInput.tsx
+++ b/browser-features/chrome/common/command-palette/components/SearchInput.tsx
@@ -19,14 +19,22 @@ export function SearchInput(props: SearchInputProps) {
   };
 
   return (
-    <input
-      id="command-palette-search"
-      type="text"
-      value={props.query}
-      onInput={handleInput}
-      placeholder={placeholder()}
-      autocomplete="off"
-      spellcheck={false}
-    />
+    <div class="command-palette-search-wrapper">
+      <img
+        class="command-palette-search-icon"
+        src="chrome://global/skin/icons/search-glass.svg"
+        alt=""
+      />
+      <input
+        id="command-palette-search"
+        type="text"
+        value={props.query}
+        onInput={handleInput}
+        placeholder={placeholder()}
+        aria-label={placeholder()}
+        autocomplete="off"
+        spellcheck={false}
+      />
+    </div>
   );
 }

--- a/browser-features/chrome/common/command-palette/config.ts
+++ b/browser-features/chrome/common/command-palette/config.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  type Accessor,
+  createEffect,
+  createSignal,
+  onCleanup,
+  type Setter,
+} from "solid-js";
+import { createRootHMR } from "@nora/solid-xul";
+
+export const COMMAND_PALETTE_ENABLED_PREF = "floorp.commandPalette.enabled";
+export const COMMAND_PALETTE_RECENT_PREF = "floorp.commandPalette.recentCommands";
+
+export interface CommandPaletteConfig {
+  enabled: boolean;
+  recentCommands: string[];
+  maxRecentCommands: number;
+}
+
+export const defaultConfig: CommandPaletteConfig = {
+  enabled: true,
+  recentCommands: [],
+  maxRecentCommands: 10,
+};
+
+const parseRecentCommands = (jsonStr: string): string[] => {
+  try {
+    const parsed = JSON.parse(jsonStr);
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((el): el is string => typeof el === "string")
+    ) {
+      return parsed;
+    }
+  } catch {
+    // ignore
+  }
+  return [];
+};
+
+function createEnabled(): [Accessor<boolean>, Setter<boolean>] {
+  const [enabled, setEnabled] = createSignal(
+    Services.prefs.getBoolPref(
+      COMMAND_PALETTE_ENABLED_PREF,
+      defaultConfig.enabled,
+    ),
+  );
+
+  createEffect(() => {
+    Services.prefs.setBoolPref(COMMAND_PALETTE_ENABLED_PREF, enabled());
+  });
+
+  const enabledObserver = () => {
+    setEnabled(
+      Services.prefs.getBoolPref(
+        COMMAND_PALETTE_ENABLED_PREF,
+        defaultConfig.enabled,
+      ),
+    );
+  };
+
+  Services.prefs.addObserver(COMMAND_PALETTE_ENABLED_PREF, enabledObserver);
+  onCleanup(() => {
+    Services.prefs.removeObserver(
+      COMMAND_PALETTE_ENABLED_PREF,
+      enabledObserver,
+    );
+  });
+
+  return [enabled, setEnabled];
+}
+
+function createRecentCommands(): [
+  Accessor<string[]>,
+  Setter<string[]>,
+] {
+  const [recent, setRecent] = createSignal(
+    parseRecentCommands(
+      Services.prefs.getStringPref(
+        COMMAND_PALETTE_RECENT_PREF,
+        "[]",
+      ),
+    ),
+  );
+
+  createEffect(() => {
+    Services.prefs.setStringPref(
+      COMMAND_PALETTE_RECENT_PREF,
+      JSON.stringify(recent()),
+    );
+  });
+
+  const recentObserver = () => {
+    setRecent(
+      parseRecentCommands(
+        Services.prefs.getStringPref(
+          COMMAND_PALETTE_RECENT_PREF,
+          "[]",
+        ),
+      ),
+    );
+  };
+
+  Services.prefs.addObserver(COMMAND_PALETTE_RECENT_PREF, recentObserver);
+  onCleanup(() => {
+    Services.prefs.removeObserver(
+      COMMAND_PALETTE_RECENT_PREF,
+      recentObserver,
+    );
+  });
+
+  return [recent, setRecent];
+}
+
+export const [_enabled, _setEnabled] = createRootHMR(
+  createEnabled,
+  import.meta.hot,
+);
+export const [_recentCommands, _setRecentCommands] = createRootHMR(
+  createRecentCommands,
+  import.meta.hot,
+);
+
+export const isEnabled = () => _enabled();
+export const setEnabled = (value: boolean) => _setEnabled(value);
+export const getRecentCommands = () => _recentCommands();
+
+export function addRecentCommand(id: string) {
+  const current = _recentCommands().filter((c) => c !== id);
+  current.unshift(id);
+  _setRecentCommands(current.slice(0, defaultConfig.maxRecentCommands));
+}

--- a/browser-features/chrome/common/command-palette/config.ts
+++ b/browser-features/chrome/common/command-palette/config.ts
@@ -48,7 +48,11 @@ function createEnabled(): [Accessor<boolean>, Setter<boolean>] {
   );
 
   createEffect(() => {
-    Services.prefs.setBoolPref(COMMAND_PALETTE_ENABLED_PREF, enabled());
+    try {
+      Services.prefs.setBoolPref(COMMAND_PALETTE_ENABLED_PREF, enabled());
+    } catch (e) {
+      console.error("[command-palette] Failed to persist enabled pref", e);
+    }
   });
 
   const enabledObserver = () => {
@@ -85,10 +89,14 @@ function createRecentCommands(): [
   );
 
   createEffect(() => {
-    Services.prefs.setStringPref(
-      COMMAND_PALETTE_RECENT_PREF,
-      JSON.stringify(recent()),
-    );
+    try {
+      Services.prefs.setStringPref(
+        COMMAND_PALETTE_RECENT_PREF,
+        JSON.stringify(recent()),
+      );
+    } catch (e) {
+      console.error("[command-palette] Failed to persist recent commands", e);
+    }
   });
 
   const recentObserver = () => {

--- a/browser-features/chrome/common/command-palette/config.ts
+++ b/browser-features/chrome/common/command-palette/config.ts
@@ -11,6 +11,7 @@ import { createRootHMR } from "@nora/solid-xul";
 
 export const COMMAND_PALETTE_ENABLED_PREF = "floorp.commandPalette.enabled";
 export const COMMAND_PALETTE_RECENT_PREF = "floorp.commandPalette.recentCommands";
+export const COMMAND_PALETTE_FREQUENCY_PREF = "floorp.commandPalette.commandFrequency";
 
 export interface CommandPaletteConfig {
   enabled: boolean;
@@ -138,4 +139,66 @@ export function addRecentCommand(id: string) {
   const current = _recentCommands().filter((c) => c !== id);
   current.unshift(id);
   _setRecentCommands(current.slice(0, defaultConfig.maxRecentCommands));
+}
+
+const parseFrequency = (jsonStr: string): Record<string, number> => {
+  try {
+    const parsed = JSON.parse(jsonStr);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, number>;
+    }
+  } catch {
+    // ignore
+  }
+  return {};
+};
+
+function createFrequency(): [
+  Accessor<Record<string, number>>,
+  Setter<Record<string, number>>,
+] {
+  const [freq, setFreq] = createSignal(
+    parseFrequency(
+      Services.prefs.getStringPref(COMMAND_PALETTE_FREQUENCY_PREF, "{}"),
+    ),
+  );
+
+  createEffect(() => {
+    try {
+      Services.prefs.setStringPref(
+        COMMAND_PALETTE_FREQUENCY_PREF,
+        JSON.stringify(freq()),
+      );
+    } catch (e) {
+      console.error("[command-palette] Failed to persist frequency", e);
+    }
+  });
+
+  const freqObserver = () => {
+    setFreq(
+      parseFrequency(
+        Services.prefs.getStringPref(COMMAND_PALETTE_FREQUENCY_PREF, "{}"),
+      ),
+    );
+  };
+
+  Services.prefs.addObserver(COMMAND_PALETTE_FREQUENCY_PREF, freqObserver);
+  onCleanup(() => {
+    Services.prefs.removeObserver(COMMAND_PALETTE_FREQUENCY_PREF, freqObserver);
+  });
+
+  return [freq, setFreq];
+}
+
+export const [_frequency, _setFrequency] = createRootHMR(
+  createFrequency,
+  import.meta.hot,
+);
+
+export const getFrequencies = () => _frequency();
+
+export function incrementFrequency(id: string) {
+  const current = { ..._frequency() };
+  current[id] = (current[id] ?? 0) + 1;
+  _setFrequency(current);
 }

--- a/browser-features/chrome/common/command-palette/controller.ts
+++ b/browser-features/chrome/common/command-palette/controller.ts
@@ -149,7 +149,7 @@ export class CommandPaletteController {
 
     // Focus the search input after render
     this.targetWindow.setTimeout(() => {
-      const input = this.targetWindow.document.getElementById(
+      const input = this.targetWindow.document?.getElementById(
         "command-palette-search",
       );
       if (input) (input as HTMLInputElement).focus();

--- a/browser-features/chrome/common/command-palette/controller.ts
+++ b/browser-features/chrome/common/command-palette/controller.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import { state, resetPaletteState } from "./data/state.ts";
+import { createPaletteState, type PaletteState } from "./data/state.ts";
 import { isEnabled, addRecentCommand, getRecentCommands } from "./config.ts";
 import { getPaletteCommands, searchCommands } from "./command-registry.ts";
 import type { PaletteCommand } from "./command-registry.ts";
@@ -8,6 +8,7 @@ import type { PaletteCommand } from "./command-registry.ts";
 export class CommandPaletteController {
   private eventListenersAttached = false;
   private targetWindow: Window;
+  readonly state: PaletteState = createPaletteState();
 
   constructor(win: Window = globalThis as unknown as Window) {
     this.targetWindow = win;
@@ -34,7 +35,7 @@ export class CommandPaletteController {
       );
       this.eventListenersAttached = false;
     }
-    if (state.isVisible()) {
+    if (this.state.isVisible()) {
       this.hidePalette();
     }
   }
@@ -42,7 +43,7 @@ export class CommandPaletteController {
   public togglePalette(): void {
     if (!isEnabled()) return;
 
-    if (state.isVisible()) {
+    if (this.state.isVisible()) {
       this.hidePalette();
     } else {
       this.showPalette();
@@ -50,7 +51,7 @@ export class CommandPaletteController {
   }
 
   private handlePaletteKeyDown = (event: KeyboardEvent): void => {
-    if (!state.isVisible()) return;
+    if (!this.state.isVisible()) return;
 
     switch (event.key) {
       case "Escape":
@@ -90,45 +91,35 @@ export class CommandPaletteController {
   };
 
   private handleArrowDown(): void {
-    const commands = state.filteredCommands();
-    const idx = state.selectedIndex();
+    const commands = this.state.filteredCommands();
+    const idx = this.state.selectedIndex();
     if (commands.length > 0) {
-      state.setSelectedIndex((idx + 1) % commands.length);
+      this.state.setSelectedIndex((idx + 1) % commands.length);
     }
   }
 
   private handleArrowUp(): void {
-    const commands = state.filteredCommands();
-    const idx = state.selectedIndex();
+    const commands = this.state.filteredCommands();
+    const idx = this.state.selectedIndex();
     if (commands.length > 0) {
-      state.setSelectedIndex(
+      this.state.setSelectedIndex(
         (idx - 1 + commands.length) % commands.length,
       );
     }
   }
 
   private handleEnter(): void {
-    const commands = state.filteredCommands();
-    const idx = state.selectedIndex();
+    const commands = this.state.filteredCommands();
+    const idx = this.state.selectedIndex();
     if (commands[idx]) {
       this.executeCommand(commands[idx]);
     }
   }
 
   private showPalette(): void {
-    resetPaletteState();
-
-    // Show recent commands first, then all others
-    const recentIds = getRecentCommands();
-    const allCommands = getPaletteCommands();
-    const recentSet = new Set(recentIds);
-    const recentCommands = recentIds
-      .map((id) => allCommands.find((c) => c.id === id))
-      .filter((c): c is PaletteCommand => c !== undefined);
-    const otherCommands = allCommands.filter((c) => !recentSet.has(c.id));
-
-    state.setFilteredCommands([...recentCommands, ...otherCommands]);
-    state.setIsVisible(true);
+    this.state.reset();
+    this.state.setFilteredCommands(this.buildInitialCommandList());
+    this.state.setIsVisible(true);
 
     // Focus the search input after render
     this.targetWindow.setTimeout(() => {
@@ -140,8 +131,8 @@ export class CommandPaletteController {
   }
 
   private hidePalette(): void {
-    state.setIsVisible(false);
-    resetPaletteState();
+    this.state.setIsVisible(false);
+    this.state.reset();
   }
 
   public executeCommand(cmd: PaletteCommand): void {
@@ -155,8 +146,21 @@ export class CommandPaletteController {
   }
 
   public updateSearch(query: string): void {
-    const filtered = searchCommands(query);
-    state.setFilteredCommands(filtered);
-    state.setSelectedIndex(0);
+    const filtered = query.trim()
+      ? searchCommands(query)
+      : this.buildInitialCommandList();
+    this.state.setFilteredCommands(filtered);
+    this.state.setSelectedIndex(0);
+  }
+
+  private buildInitialCommandList(): PaletteCommand[] {
+    const recentIds = getRecentCommands();
+    const allCommands = getPaletteCommands();
+    const recentSet = new Set(recentIds);
+    const recentCommands = recentIds
+      .map((id) => allCommands.find((c) => c.id === id))
+      .filter((c): c is PaletteCommand => c !== undefined);
+    const otherCommands = allCommands.filter((c) => !recentSet.has(c.id));
+    return [...recentCommands, ...otherCommands];
   }
 }

--- a/browser-features/chrome/common/command-palette/controller.ts
+++ b/browser-features/chrome/common/command-palette/controller.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { state, resetPaletteState } from "./data/state.ts";
+import { isEnabled, addRecentCommand, getRecentCommands } from "./config.ts";
+import { getPaletteCommands, searchCommands } from "./command-registry.ts";
+import type { PaletteCommand } from "./command-registry.ts";
+
+const TRIGGER_MODIFIERS = {
+  alt: false,
+  ctrl: true,
+  meta: false,
+  shift: true,
+};
+const TRIGGER_KEY = "KeyP";
+
+export class CommandPaletteController {
+  private eventListenersAttached = false;
+  private targetWindow: Window;
+
+  constructor(win: Window = globalThis as unknown as Window) {
+    this.targetWindow = win;
+    this.init();
+  }
+
+  private init(): void {
+    if (this.eventListenersAttached) return;
+
+    this.targetWindow.addEventListener(
+      "keydown",
+      this.handleTriggerKeyDown,
+      true, // capture phase
+    );
+    this.eventListenersAttached = true;
+  }
+
+  public destroy(): void {
+    if (this.eventListenersAttached) {
+      this.targetWindow.removeEventListener(
+        "keydown",
+        this.handleTriggerKeyDown,
+        true,
+      );
+      this.eventListenersAttached = false;
+    }
+    if (state.isVisible()) {
+      this.hidePalette();
+    }
+  }
+
+  private handleTriggerKeyDown = (event: KeyboardEvent): void => {
+    if (!isEnabled()) return;
+
+    // Toggle close with the same shortcut
+    if (state.isVisible()) {
+      if (this.isTriggerShortcut(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.hidePalette();
+        return;
+      }
+      this.handlePaletteKeyDown(event);
+      return;
+    }
+
+    if (this.isTriggerShortcut(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.showPalette();
+    }
+  };
+
+  private isTriggerShortcut(event: KeyboardEvent): boolean {
+    return (
+      event.altKey === TRIGGER_MODIFIERS.alt &&
+      event.ctrlKey === TRIGGER_MODIFIERS.ctrl &&
+      event.metaKey === TRIGGER_MODIFIERS.meta &&
+      event.shiftKey === TRIGGER_MODIFIERS.shift &&
+      event.code === TRIGGER_KEY
+    );
+  }
+
+  private handlePaletteKeyDown(event: KeyboardEvent): void {
+    const commands = state.filteredCommands();
+    const idx = state.selectedIndex();
+
+    switch (event.key) {
+      case "Escape":
+        event.preventDefault();
+        event.stopPropagation();
+        this.hidePalette();
+        break;
+
+      case "ArrowDown":
+        event.preventDefault();
+        event.stopPropagation();
+        if (commands.length > 0) {
+          state.setSelectedIndex((idx + 1) % commands.length);
+        }
+        break;
+
+      case "ArrowUp":
+        event.preventDefault();
+        event.stopPropagation();
+        if (commands.length > 0) {
+          state.setSelectedIndex(
+            (idx - 1 + commands.length) % commands.length,
+          );
+        }
+        break;
+
+      case "Enter":
+        event.preventDefault();
+        event.stopPropagation();
+        if (commands[idx]) {
+          this.executeCommand(commands[idx]);
+        }
+        break;
+
+      case "Tab":
+        event.preventDefault();
+        event.stopPropagation();
+        if (commands.length > 0) {
+          if (event.shiftKey) {
+            state.setSelectedIndex(
+              (idx - 1 + commands.length) % commands.length,
+            );
+          } else {
+            state.setSelectedIndex((idx + 1) % commands.length);
+          }
+        }
+        break;
+    }
+  }
+
+  private showPalette(): void {
+    resetPaletteState();
+
+    // Show recent commands first, then all others
+    const recentIds = getRecentCommands();
+    const allCommands = getPaletteCommands();
+    const recentSet = new Set(recentIds);
+    const recentCommands = recentIds
+      .map((id) => allCommands.find((c) => c.id === id))
+      .filter((c): c is PaletteCommand => c !== undefined);
+    const otherCommands = allCommands.filter((c) => !recentSet.has(c.id));
+
+    state.setFilteredCommands([...recentCommands, ...otherCommands]);
+    state.setIsVisible(true);
+
+    // Focus the search input after render
+    this.targetWindow.setTimeout(() => {
+      const input = this.targetWindow.document.getElementById(
+        "command-palette-search",
+      );
+      if (input) (input as HTMLInputElement).focus();
+    }, 0);
+  }
+
+  private hidePalette(): void {
+    state.setIsVisible(false);
+    resetPaletteState();
+  }
+
+  public executeCommand(cmd: PaletteCommand): void {
+    addRecentCommand(cmd.id);
+    this.hidePalette();
+    try {
+      cmd.fn(this.targetWindow);
+    } catch (e) {
+      console.error(`[command-palette] Action failed: ${cmd.id}`, e);
+    }
+  }
+
+  public updateSearch(query: string): void {
+    const filtered = searchCommands(query);
+    state.setFilteredCommands(filtered);
+    state.setSelectedIndex(0);
+  }
+}

--- a/browser-features/chrome/common/command-palette/controller.ts
+++ b/browser-features/chrome/common/command-palette/controller.ts
@@ -5,14 +5,6 @@ import { isEnabled, addRecentCommand, getRecentCommands } from "./config.ts";
 import { getPaletteCommands, searchCommands } from "./command-registry.ts";
 import type { PaletteCommand } from "./command-registry.ts";
 
-const TRIGGER_MODIFIERS = {
-  alt: false,
-  ctrl: true,
-  meta: false,
-  shift: true,
-};
-const TRIGGER_KEY = "KeyP";
-
 export class CommandPaletteController {
   private eventListenersAttached = false;
   private targetWindow: Window;
@@ -27,7 +19,7 @@ export class CommandPaletteController {
 
     this.targetWindow.addEventListener(
       "keydown",
-      this.handleTriggerKeyDown,
+      this.handlePaletteKeyDown,
       true, // capture phase
     );
     this.eventListenersAttached = true;
@@ -37,7 +29,7 @@ export class CommandPaletteController {
     if (this.eventListenersAttached) {
       this.targetWindow.removeEventListener(
         "keydown",
-        this.handleTriggerKeyDown,
+        this.handlePaletteKeyDown,
         true,
       );
       this.eventListenersAttached = false;
@@ -47,41 +39,18 @@ export class CommandPaletteController {
     }
   }
 
-  private handleTriggerKeyDown = (event: KeyboardEvent): void => {
+  public togglePalette(): void {
     if (!isEnabled()) return;
 
-    // Toggle close with the same shortcut
     if (state.isVisible()) {
-      if (this.isTriggerShortcut(event)) {
-        event.preventDefault();
-        event.stopPropagation();
-        this.hidePalette();
-        return;
-      }
-      this.handlePaletteKeyDown(event);
-      return;
-    }
-
-    if (this.isTriggerShortcut(event)) {
-      event.preventDefault();
-      event.stopPropagation();
+      this.hidePalette();
+    } else {
       this.showPalette();
     }
-  };
-
-  private isTriggerShortcut(event: KeyboardEvent): boolean {
-    return (
-      event.altKey === TRIGGER_MODIFIERS.alt &&
-      event.ctrlKey === TRIGGER_MODIFIERS.ctrl &&
-      event.metaKey === TRIGGER_MODIFIERS.meta &&
-      event.shiftKey === TRIGGER_MODIFIERS.shift &&
-      event.code === TRIGGER_KEY
-    );
   }
 
-  private handlePaletteKeyDown(event: KeyboardEvent): void {
-    const commands = state.filteredCommands();
-    const idx = state.selectedIndex();
+  private handlePaletteKeyDown = (event: KeyboardEvent): void => {
+    if (!state.isVisible()) return;
 
     switch (event.key) {
       case "Escape":
@@ -93,42 +62,56 @@ export class CommandPaletteController {
       case "ArrowDown":
         event.preventDefault();
         event.stopPropagation();
-        if (commands.length > 0) {
-          state.setSelectedIndex((idx + 1) % commands.length);
-        }
+        this.handleArrowDown();
         break;
 
       case "ArrowUp":
         event.preventDefault();
         event.stopPropagation();
-        if (commands.length > 0) {
-          state.setSelectedIndex(
-            (idx - 1 + commands.length) % commands.length,
-          );
-        }
+        this.handleArrowUp();
         break;
 
       case "Enter":
         event.preventDefault();
         event.stopPropagation();
-        if (commands[idx]) {
-          this.executeCommand(commands[idx]);
-        }
+        this.handleEnter();
         break;
 
       case "Tab":
         event.preventDefault();
         event.stopPropagation();
-        if (commands.length > 0) {
-          if (event.shiftKey) {
-            state.setSelectedIndex(
-              (idx - 1 + commands.length) % commands.length,
-            );
-          } else {
-            state.setSelectedIndex((idx + 1) % commands.length);
-          }
+        if (event.shiftKey) {
+          this.handleArrowUp();
+        } else {
+          this.handleArrowDown();
         }
         break;
+    }
+  };
+
+  private handleArrowDown(): void {
+    const commands = state.filteredCommands();
+    const idx = state.selectedIndex();
+    if (commands.length > 0) {
+      state.setSelectedIndex((idx + 1) % commands.length);
+    }
+  }
+
+  private handleArrowUp(): void {
+    const commands = state.filteredCommands();
+    const idx = state.selectedIndex();
+    if (commands.length > 0) {
+      state.setSelectedIndex(
+        (idx - 1 + commands.length) % commands.length,
+      );
+    }
+  }
+
+  private handleEnter(): void {
+    const commands = state.filteredCommands();
+    const idx = state.selectedIndex();
+    if (commands[idx]) {
+      this.executeCommand(commands[idx]);
     }
   }
 

--- a/browser-features/chrome/common/command-palette/controller.ts
+++ b/browser-features/chrome/common/command-palette/controller.ts
@@ -1,9 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
+import i18next from "i18next";
+import { debounce } from "@solid-primitives/scheduled";
 import { createPaletteState, type PaletteState } from "./data/state.ts";
-import { isEnabled, addRecentCommand, getRecentCommands } from "./config.ts";
+import { isEnabled, addRecentCommand, getRecentCommands, incrementFrequency, getFrequencies } from "./config.ts";
 import { getPaletteCommands, searchCommands } from "./command-registry.ts";
 import type { PaletteCommand } from "./command-registry.ts";
+
+function looksLikeUrl(query: string): boolean {
+  if (query.startsWith("http://") || query.startsWith("https://")) return true;
+  if (query.startsWith("about:") || query.startsWith("floorp://")) return true;
+  // domain-like: contains a dot with text on both sides and no spaces
+  if (!query.includes(" ") && /^[^\s]+\.[a-z]{2,}$/i.test(query)) return true;
+  return false;
+}
 
 export class CommandPaletteController {
   private eventListenersAttached = false;
@@ -35,6 +45,7 @@ export class CommandPaletteController {
       );
       this.eventListenersAttached = false;
     }
+    this.clearAnimOutTimer();
     if (this.state.isVisible()) {
       this.hidePalette();
     }
@@ -42,6 +53,7 @@ export class CommandPaletteController {
 
   public togglePalette(): void {
     if (!isEnabled()) return;
+    if (this.state.isAnimatingOut()) return;
 
     if (this.state.isVisible()) {
       this.hidePalette();
@@ -86,9 +98,19 @@ export class CommandPaletteController {
         } else {
           this.handleArrowDown();
         }
+        this.focusSelectedItem();
         break;
     }
   };
+
+  private focusSelectedItem(): void {
+    this.targetWindow.setTimeout(() => {
+      const selected = this.targetWindow.document?.querySelector(
+        '.command-palette-item[data-selected="true"]',
+      );
+      if (selected) (selected as HTMLElement).focus();
+    }, 0);
+  }
 
   private handleArrowDown(): void {
     const commands = this.state.filteredCommands();
@@ -130,13 +152,34 @@ export class CommandPaletteController {
     }, 0);
   }
 
-  private hidePalette(): void {
+  private animOutTimer: ReturnType<typeof setTimeout> | null = null;
+
+  public hidePalette(): void {
+    this.state.setIsAnimatingOut(true);
     this.state.setIsVisible(false);
-    this.state.reset();
+    this.debouncedUpdateSearch.clear();
+
+    // Safety fallback: reset isAnimatingOut even if transitionend never fires
+    // (prefers-reduced-motion, element removed, etc.)
+    this.clearAnimOutTimer();
+    this.animOutTimer = this.targetWindow.setTimeout(() => {
+      if (this.state.isAnimatingOut()) {
+        this.state.setIsAnimatingOut(false);
+      }
+      this.animOutTimer = null;
+    }, 300);
+  }
+
+  private clearAnimOutTimer(): void {
+    if (this.animOutTimer !== null) {
+      this.targetWindow.clearTimeout(this.animOutTimer);
+      this.animOutTimer = null;
+    }
   }
 
   public executeCommand(cmd: PaletteCommand): void {
     addRecentCommand(cmd.id);
+    incrementFrequency(cmd.id);
     this.hidePalette();
     try {
       cmd.fn(this.targetWindow);
@@ -145,22 +188,71 @@ export class CommandPaletteController {
     }
   }
 
-  public updateSearch(query: string): void {
-    const filtered = query.trim()
-      ? searchCommands(query)
+  private doUpdateSearch(query: string): void {
+    const trimmed = query.trim();
+    const results: PaletteCommand[] = [];
+
+    // URL navigation suggestion
+    if (trimmed && looksLikeUrl(trimmed)) {
+      const url = trimmed.startsWith("http") ? trimmed : `https://${trimmed}`;
+      results.push({
+        id: "__navigate-url",
+        label: i18next.t("commandPalette.navigateTo", {
+          defaultValue: `Go to ${trimmed}`,
+          url: trimmed,
+        }),
+        description: url,
+        category: "navigation-suggestion",
+        keywords: [],
+        fn: (win) => {
+          try {
+            const navUrl = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+            (win as any).gBrowser.loadURI(
+              Services.io.newURI(navUrl),
+            );
+          } catch (e) {
+            console.error("[command-palette] Navigation failed", e);
+          }
+        },
+      });
+    }
+
+    const commandResults = trimmed
+      ? searchCommands(trimmed, this.targetWindow)
       : this.buildInitialCommandList();
-    this.state.setFilteredCommands(filtered);
+    results.push(...commandResults);
+
+    this.state.setFilteredCommands(results);
     this.state.setSelectedIndex(0);
+  }
+
+  private debouncedUpdateSearch = debounce((query: string) => {
+    this.doUpdateSearch(query);
+  }, 30);
+
+  public updateSearch(query: string): void {
+    if (query.trim()) {
+      this.debouncedUpdateSearch(query);
+    } else {
+      this.doUpdateSearch(query);
+    }
   }
 
   private buildInitialCommandList(): PaletteCommand[] {
     const recentIds = getRecentCommands();
-    const allCommands = getPaletteCommands();
+    const allCommands = getPaletteCommands(this.targetWindow);
     const recentSet = new Set(recentIds);
+    const freqs = getFrequencies();
+
     const recentCommands = recentIds
       .map((id) => allCommands.find((c) => c.id === id))
-      .filter((c): c is PaletteCommand => c !== undefined);
-    const otherCommands = allCommands.filter((c) => !recentSet.has(c.id));
+      .filter((c): c is PaletteCommand => c !== undefined)
+      .map((c) => ({ ...c, category: "recent" as string }));
+
+    const otherCommands = allCommands
+      .filter((c) => !recentSet.has(c.id))
+      .sort((a, b) => (freqs[b.id] ?? 0) - (freqs[a.id] ?? 0));
+
     return [...recentCommands, ...otherCommands];
   }
 }

--- a/browser-features/chrome/common/command-palette/controller.ts
+++ b/browser-features/chrome/common/command-palette/controller.ts
@@ -204,10 +204,10 @@ export class CommandPaletteController {
         description: url,
         category: "navigation-suggestion",
         keywords: [],
-        fn: (win) => {
+        fn: (_win) => {
           try {
             const navUrl = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
-            (win as any).gBrowser.loadURI(
+            globalThis.gBrowser.loadURI?.(
               Services.io.newURI(navUrl),
             );
           } catch (e) {

--- a/browser-features/chrome/common/command-palette/data/state.ts
+++ b/browser-features/chrome/common/command-palette/data/state.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { createSignal } from "solid-js";
+import { createRootHMR } from "@nora/solid-xul";
+import type { PaletteCommand } from "../command-registry.ts";
+
+function createPaletteState() {
+  const [isVisible, setIsVisible] = createSignal(false);
+  const [query, setQuery] = createSignal("");
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  const [filteredCommands, setFilteredCommands] = createSignal<PaletteCommand[]>(
+    [],
+  );
+
+  return {
+    isVisible,
+    setIsVisible,
+    query,
+    setQuery,
+    selectedIndex,
+    setSelectedIndex,
+    filteredCommands,
+    setFilteredCommands,
+  };
+}
+
+export const state = createRootHMR(createPaletteState, import.meta.hot);
+
+export function resetPaletteState() {
+  state.setQuery("");
+  state.setSelectedIndex(0);
+  state.setFilteredCommands([]);
+}

--- a/browser-features/chrome/common/command-palette/data/state.ts
+++ b/browser-features/chrome/common/command-palette/data/state.ts
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { createSignal } from "solid-js";
-import { createRootHMR } from "@nora/solid-xul";
 import type { PaletteCommand } from "../command-registry.ts";
 
-function createPaletteState() {
+export function createPaletteState() {
   const [isVisible, setIsVisible] = createSignal(false);
   const [query, setQuery] = createSignal("");
   const [selectedIndex, setSelectedIndex] = createSignal(0);
@@ -21,13 +20,12 @@ function createPaletteState() {
     setSelectedIndex,
     filteredCommands,
     setFilteredCommands,
+    reset() {
+      setQuery("");
+      setSelectedIndex(0);
+      setFilteredCommands([]);
+    },
   };
 }
 
-export const state = createRootHMR(createPaletteState, import.meta.hot);
-
-export function resetPaletteState() {
-  state.setQuery("");
-  state.setSelectedIndex(0);
-  state.setFilteredCommands([]);
-}
+export type PaletteState = ReturnType<typeof createPaletteState>;

--- a/browser-features/chrome/common/command-palette/data/state.ts
+++ b/browser-features/chrome/common/command-palette/data/state.ts
@@ -5,6 +5,7 @@ import type { PaletteCommand } from "../command-registry.ts";
 
 export function createPaletteState() {
   const [isVisible, setIsVisible] = createSignal(false);
+  const [isAnimatingOut, setIsAnimatingOut] = createSignal(false);
   const [query, setQuery] = createSignal("");
   const [selectedIndex, setSelectedIndex] = createSignal(0);
   const [filteredCommands, setFilteredCommands] = createSignal<PaletteCommand[]>(
@@ -14,6 +15,8 @@ export function createPaletteState() {
   return {
     isVisible,
     setIsVisible,
+    isAnimatingOut,
+    setIsAnimatingOut,
     query,
     setQuery,
     selectedIndex,

--- a/browser-features/chrome/common/command-palette/fuzzy.ts
+++ b/browser-features/chrome/common/command-palette/fuzzy.ts
@@ -53,11 +53,12 @@ export function fuzzySearch<T extends FuzzyTarget>(
   items: T[],
   limit = 50,
 ): T[] {
-  if (!query.trim()) return items;
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) return items;
 
   const results: ScoredResult<T>[] = [];
   for (const item of items) {
-    const score = fuzzyScore(query, item);
+    const score = fuzzyScore(normalizedQuery, item);
     if (score > 0) {
       results.push({ item, score });
     }

--- a/browser-features/chrome/common/command-palette/fuzzy.ts
+++ b/browser-features/chrome/common/command-palette/fuzzy.ts
@@ -13,28 +13,22 @@ export interface ScoredResult<T extends FuzzyTarget> {
   score: number;
 }
 
-export function fuzzyScore(query: string, target: FuzzyTarget): number {
+function singleWordScore(query: string, target: FuzzyTarget): number {
   const q = query.toLowerCase();
   const label = target.label.toLowerCase();
   const desc = target.description.toLowerCase();
 
-  // Exact prefix match on label — highest priority
   if (label.startsWith(q)) return 100 + q.length;
 
-  // Word boundary match on label
   const words = label.split(/\s+/);
   if (words.some((w) => w.startsWith(q))) return 80 + q.length;
 
-  // Substring match on label
   if (label.includes(q)) return 60 + q.length;
 
-  // Keyword match
   if (target.keywords.some((kw) => kw.toLowerCase().includes(q))) return 50 + q.length;
 
-  // Substring match on description
   if (desc.includes(q)) return 30 + q.length;
 
-  // Fuzzy character sequence match on label
   let score = 0;
   let qi = 0;
   for (let i = 0; i < label.length && qi < q.length; i++) {
@@ -46,6 +40,22 @@ export function fuzzyScore(query: string, target: FuzzyTarget): number {
   if (qi === q.length) return score;
 
   return 0;
+}
+
+export function fuzzyScore(query: string, target: FuzzyTarget): number {
+  const words = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+
+  if (words.length <= 1) {
+    return singleWordScore(query.trim(), target);
+  }
+
+  let totalScore = 0;
+  for (const word of words) {
+    const wordScore = singleWordScore(word, target);
+    if (wordScore === 0) return 0;
+    totalScore += wordScore;
+  }
+  return totalScore;
 }
 
 export function fuzzySearch<T extends FuzzyTarget>(

--- a/browser-features/chrome/common/command-palette/fuzzy.ts
+++ b/browser-features/chrome/common/command-palette/fuzzy.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MPL-2.0
+
+export interface FuzzyTarget {
+  id: string;
+  label: string;
+  description: string;
+  category: string;
+  keywords: string[];
+}
+
+export interface ScoredResult<T extends FuzzyTarget> {
+  item: T;
+  score: number;
+}
+
+export function fuzzyScore(query: string, target: FuzzyTarget): number {
+  const q = query.toLowerCase();
+  const label = target.label.toLowerCase();
+  const desc = target.description.toLowerCase();
+
+  // Exact prefix match on label — highest priority
+  if (label.startsWith(q)) return 100 + q.length;
+
+  // Word boundary match on label
+  const words = label.split(/\s+/);
+  if (words.some((w) => w.startsWith(q))) return 80 + q.length;
+
+  // Substring match on label
+  if (label.includes(q)) return 60 + q.length;
+
+  // Keyword match
+  if (target.keywords.some((kw) => kw.toLowerCase().includes(q))) return 50 + q.length;
+
+  // Substring match on description
+  if (desc.includes(q)) return 30 + q.length;
+
+  // Fuzzy character sequence match on label
+  let score = 0;
+  let qi = 0;
+  for (let i = 0; i < label.length && qi < q.length; i++) {
+    if (label[i] === q[qi]) {
+      score += 1;
+      qi++;
+    }
+  }
+  if (qi === q.length) return score;
+
+  return 0;
+}
+
+export function fuzzySearch<T extends FuzzyTarget>(
+  query: string,
+  items: T[],
+  limit = 50,
+): T[] {
+  if (!query.trim()) return items;
+
+  const results: ScoredResult<T>[] = [];
+  for (const item of items) {
+    const score = fuzzyScore(query, item);
+    if (score > 0) {
+      results.push({ item, score });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, limit).map((r) => r.item);
+}

--- a/browser-features/chrome/common/command-palette/index.ts
+++ b/browser-features/chrome/common/command-palette/index.ts
@@ -12,10 +12,13 @@ import style from "./style.css?inline";
 @noraComponent(import.meta.hot)
 export default class CommandPalette extends NoraComponentBase {
   init(): void {
-    // Inject styles
-    const styleEl = document.createElement("style");
-    styleEl.textContent = style;
-    document.head?.appendChild(styleEl);
+    // Inject styles (idempotent)
+    if (!document.getElementById("command-palette-style")) {
+      const styleEl = document.createElement("style");
+      styleEl.id = "command-palette-style";
+      styleEl.textContent = style;
+      document.head?.appendChild(styleEl);
+    }
 
     // Render the palette overlay
     const mainWindow = document.getElementById("main-window");

--- a/browser-features/chrome/common/command-palette/index.ts
+++ b/browser-features/chrome/common/command-palette/index.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { render } from "@nora/solid-xul";
+import {
+  noraComponent,
+  NoraComponentBase,
+} from "#features-chrome/utils/base.ts";
+import { commandPaletteService } from "./service.ts";
+import { CommandPaletteUI } from "./components/CommandPalette.tsx";
+import style from "./style.css?inline";
+
+@noraComponent(import.meta.hot)
+export default class CommandPalette extends NoraComponentBase {
+  init(): void {
+    // Inject styles
+    const styleEl = document.createElement("style");
+    styleEl.textContent = style;
+    document.head?.appendChild(styleEl);
+
+    // Render the palette overlay
+    const mainWindow = document.getElementById("main-window");
+    if (mainWindow) {
+      render(CommandPaletteUI, mainWindow, {
+        hotCtx: import.meta.hot,
+      });
+    }
+
+    // Attach service — creates controller and manages lifecycle
+    commandPaletteService.attachToWindow(window);
+  }
+}

--- a/browser-features/chrome/common/command-palette/service.ts
+++ b/browser-features/chrome/common/command-palette/service.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import { isEnabled, setEnabled as setEnabledPref } from "./config.ts";
+import { isEnabled } from "./config.ts";
 import { CommandPaletteController } from "./controller.ts";
 import { createRootHMR } from "@nora/solid-xul";
 import { createEffect } from "solid-js";

--- a/browser-features/chrome/common/command-palette/service.ts
+++ b/browser-features/chrome/common/command-palette/service.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { isEnabled, setEnabled as setEnabledPref } from "./config.ts";
+import { CommandPaletteController } from "./controller.ts";
+import { createRootHMR } from "@nora/solid-xul";
+import { createEffect } from "solid-js";
+
+export class CommandPaletteService {
+  private controllers: Map<Window, CommandPaletteController> = new Map();
+
+  constructor() {
+    this.initialize();
+
+    createEffect(() => {
+      const enabled = isEnabled();
+      if (enabled) {
+        this.attachToAllWindows();
+      } else {
+        this.destroyAllControllers();
+      }
+    });
+  }
+
+  private initialize(): void {
+    if (isEnabled()) {
+      this.attachToAllWindows();
+    }
+  }
+
+  private attachToAllWindows(): void {
+    const windows = Services.wm.getEnumerator("navigator:browser");
+    while (windows.hasMoreElements()) {
+      const win = windows.getNext() as Window;
+      this.attachToWindow(win);
+    }
+  }
+
+  public attachToWindow(win: Window): void {
+    // deno-lint-ignore no-explicit-any
+    if ((win as any).__commandPaletteControllerAttached === true) return;
+    if (this.controllers.has(win)) return;
+
+    if (isEnabled()) {
+      const controller = new CommandPaletteController(win);
+      this.controllers.set(win, controller);
+
+      // deno-lint-ignore no-explicit-any
+      (win as any).__commandPaletteControllerAttached = true;
+
+      const onUnload = () => {
+        controller.destroy();
+        this.controllers.delete(win);
+        try {
+          // deno-lint-ignore no-explicit-any
+          delete (win as any).__commandPaletteControllerAttached;
+        } catch {
+          // Window might be already gone
+        }
+      };
+
+      win.addEventListener("unload", onUnload, { once: true });
+    }
+  }
+
+  public getController(win: Window): CommandPaletteController | undefined {
+    return this.controllers.get(win);
+  }
+
+  private destroyAllControllers(): void {
+    for (const [win, controller] of this.controllers.entries()) {
+      controller.destroy();
+      try {
+        // deno-lint-ignore no-explicit-any
+        delete (win as any).__commandPaletteControllerAttached;
+      } catch {
+        // Window might be already gone
+      }
+    }
+    this.controllers.clear();
+  }
+}
+
+function createCommandPaletteService() {
+  return new CommandPaletteService();
+}
+
+export const commandPaletteService = createRootHMR(
+  createCommandPaletteService,
+  import.meta.hot,
+);

--- a/browser-features/chrome/common/command-palette/service.ts
+++ b/browser-features/chrome/common/command-palette/service.ts
@@ -4,11 +4,13 @@ import { isEnabled } from "./config.ts";
 import { CommandPaletteController } from "./controller.ts";
 import { createRootHMR } from "@nora/solid-xul";
 import { createEffect } from "solid-js";
+import { gestureActions } from "../mouse-gesture/utils/gestures.ts";
 
 export class CommandPaletteService {
   private controllers: Map<Window, CommandPaletteController> = new Map();
 
   constructor() {
+    this.registerAction();
     this.initialize();
 
     createEffect(() => {
@@ -18,6 +20,18 @@ export class CommandPaletteService {
       } else {
         this.destroyAllControllers();
       }
+    });
+  }
+
+  private registerAction(): void {
+    gestureActions.registerAction({
+      name: "floorp-toggle-command-palette",
+      fn: (win) => {
+        const controller = this.controllers.get(win);
+        if (controller) {
+          controller.togglePalette();
+        }
+      },
     });
   }
 

--- a/browser-features/chrome/common/command-palette/style.css
+++ b/browser-features/chrome/common/command-palette/style.css
@@ -12,10 +12,18 @@
   justify-content: center;
   padding-top: 20vh;
   z-index: 1400;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+#command-palette-overlay[data-visible="true"] {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 #command-palette-container {
-  width: 560px;
+  width: min(560px, calc(100vw - 48px));
   max-height: 400px;
   background: var(--arrowpanel-background, -moz-dialog);
   color: var(--arrowpanel-color, -moz-dialogtext);
@@ -27,13 +35,37 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  transform: scale(0.96) translateY(-8px);
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.15s ease;
+  opacity: 0;
+}
+
+#command-palette-overlay[data-visible="true"] #command-palette-container {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+.command-palette-search-wrapper {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--arrowpanel-border-color, rgba(0, 0, 0, 0.1));
+}
+
+.command-palette-search-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: inherit;
+  -moz-context-properties: fill, fill-opacity;
+  fill: var(--toolbarbutton-icon-fill);
 }
 
 #command-palette-search {
   width: 100%;
-  padding: 12px 16px;
+  padding: 12px 4px 12px 8px;
   border: none;
-  border-bottom: 1px solid var(--arrowpanel-border-color, rgba(0, 0, 0, 0.1));
   background: transparent;
   color: inherit;
   font-size: 14px;
@@ -68,6 +100,7 @@
   cursor: pointer;
   gap: 12px;
   user-select: none;
+  border-left: 2px solid transparent;
 }
 
 .command-palette-item:hover {
@@ -76,6 +109,19 @@
 
 .command-palette-item[data-selected="true"] {
   background: color-mix(in srgb, currentcolor 12%, transparent);
+  border-left-color: var(--arrowpanel-color, -moz-dialogtext);
+}
+
+.command-palette-item:focus {
+  outline: none;
+}
+
+.command-palette-item-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  gap: 2px;
 }
 
 .command-palette-item-label {
@@ -94,17 +140,33 @@
   text-overflow: ellipsis;
 }
 
-.command-palette-item-info {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  overflow: hidden;
-  gap: 2px;
+.command-palette-match {
+  font-weight: 700;
+  color: inherit;
+}
+
+.command-palette-shortcut-badge {
+  font-family: inherit;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: color-mix(in srgb, currentcolor 8%, transparent);
+  color: var(--text-color-deemphasized, rgba(0, 0, 0, 0.6));
+  flex-shrink: 0;
 }
 
 .command-palette-empty {
-  padding: 24px 16px;
+  padding: 32px 16px;
   text-align: center;
+}
+
+.command-palette-empty-title {
+  color: var(--arrowpanel-color, -moz-dialogtext);
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.command-palette-empty-hint {
   color: var(--text-color-deemphasized, rgba(0, 0, 0, 0.5));
-  font-size: 13px;
+  font-size: 12px;
 }

--- a/browser-features/chrome/common/command-palette/style.css
+++ b/browser-features/chrome/common/command-palette/style.css
@@ -71,11 +71,11 @@
 }
 
 .command-palette-item:hover {
-  background: color-mix(in srgb, currentColor 8%, transparent);
+  background: color-mix(in srgb, currentcolor 8%, transparent);
 }
 
 .command-palette-item[data-selected="true"] {
-  background: color-mix(in srgb, currentColor 12%, transparent);
+  background: color-mix(in srgb, currentcolor 12%, transparent);
 }
 
 .command-palette-item-label {

--- a/browser-features/chrome/common/command-palette/style.css
+++ b/browser-features/chrome/common/command-palette/style.css
@@ -1,0 +1,110 @@
+/* Command Palette styles */
+
+#command-palette-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.48);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 20vh;
+  z-index: 1400;
+}
+
+#command-palette-container {
+  width: 560px;
+  max-height: 400px;
+  background: var(--arrowpanel-background, -moz-dialog);
+  color: var(--arrowpanel-color, -moz-dialogtext);
+  border: 1px solid var(--arrowpanel-border-color, rgba(0, 0, 0, 0.1));
+  border-radius: 8px;
+  box-shadow:
+    0 5px 10px rgba(0, 0, 0, 0.2),
+    0 15px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#command-palette-search {
+  width: 100%;
+  padding: 12px 16px;
+  border: none;
+  border-bottom: 1px solid var(--arrowpanel-border-color, rgba(0, 0, 0, 0.1));
+  background: transparent;
+  color: inherit;
+  font-size: 14px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+#command-palette-search::placeholder {
+  color: var(--text-color-deemphasized, rgba(0, 0, 0, 0.4));
+}
+
+.command-palette-list {
+  overflow-y: auto;
+  flex: 1;
+  padding: 4px 0;
+}
+
+.command-palette-category-header {
+  padding: 8px 16px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-color-deemphasized, rgba(0, 0, 0, 0.5));
+  user-select: none;
+}
+
+.command-palette-item {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  cursor: pointer;
+  gap: 12px;
+  user-select: none;
+}
+
+.command-palette-item:hover {
+  background: color-mix(in srgb, currentColor 8%, transparent);
+}
+
+.command-palette-item[data-selected="true"] {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.command-palette-item-label {
+  font-size: 13px;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette-item-description {
+  font-size: 11px;
+  color: var(--text-color-deemphasized, rgba(0, 0, 0, 0.5));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette-item-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  gap: 2px;
+}
+
+.command-palette-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-color-deemphasized, rgba(0, 0, 0, 0.5));
+  font-size: 13px;
+}

--- a/browser-features/chrome/common/command-palette/tab-provider.ts
+++ b/browser-features/chrome/common/command-palette/tab-provider.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import type { PaletteCommand } from "./command-registry.ts";
+
+const TAB_COMMAND_PREFIX = "__tab__";
+
+interface ChromeWindow extends Window {
+  gBrowser?: GBrowser;
+}
+
+interface BrowserWithContent extends XULBrowserElement {
+  contentTitle?: string;
+}
+
+interface TabWithId extends XULElement {
+  tabId?: number;
+}
+
+export function getTabCommands(win: Window): PaletteCommand[] {
+  const { gBrowser } = win as ChromeWindow;
+  if (!gBrowser?.tabs) return [];
+
+  const commands: PaletteCommand[] = [];
+  for (const tab of gBrowser.tabs) {
+    const browser = tab.linkedBrowser as BrowserWithContent | undefined;
+    if (!browser) continue;
+
+    const title = tab.getAttribute("label") || browser.contentTitle || "";
+    const url = browser.currentURI?.spec || "";
+    const tabId = (tab as TabWithId).tabId ?? tab._tPos;
+
+    commands.push({
+      id: `${TAB_COMMAND_PREFIX}${tabId}`,
+      label: title || url,
+      description: url,
+      category: "open-tabs",
+      keywords: [url, title],
+      fn: (w) => {
+        const gb = (w as ChromeWindow).gBrowser;
+        if (gb) gb.selectedTab = tab;
+      },
+    });
+  }
+  return commands;
+}
+
+export function isTabCommand(id: string): boolean {
+  return id.startsWith(TAB_COMMAND_PREFIX);
+}

--- a/browser-features/chrome/common/command-palette/test/commandPalette.test.ts
+++ b/browser-features/chrome/common/command-palette/test/commandPalette.test.ts
@@ -43,7 +43,7 @@ const rawTests: TestCase[] = [
     fn() {
       const target = makeTarget("Reload");
       const score = fuzzyScore("xyz", target);
-      assertEquals(score, 0);
+      assertEquals(score, 0, "no match should return 0");
     },
   },
   {
@@ -78,7 +78,7 @@ const rawTests: TestCase[] = [
         makeTarget("C"),
       ];
       const results = fuzzySearch("", items);
-      assertEquals(results.length, 3);
+      assertEquals(results.length, 3, "empty query should return all items");
     },
   },
   {
@@ -86,7 +86,7 @@ const rawTests: TestCase[] = [
     fn() {
       const items = Array.from({ length: 100 }, (_, i) => makeTarget(`Item ${i}`));
       const results = fuzzySearch("item", items, 5);
-      assertEquals(results.length, 5);
+      assertEquals(results.length, 5, "should respect limit parameter");
     },
   },
 
@@ -126,14 +126,14 @@ const rawTests: TestCase[] = [
     fn() {
       const cmd = getCommand("gecko-open-new-tab");
       assert(cmd !== undefined, "should find gecko-open-new-tab");
-      assertEquals(cmd.id, "gecko-open-new-tab");
+      assertEquals(cmd.id, "gecko-open-new-tab", "should return correct command id");
     },
   },
   {
     name: "getCommand returns undefined for unknown id",
     fn() {
       const cmd = getCommand("nonexistent-action");
-      assertEquals(cmd, undefined);
+      assertEquals(cmd, undefined, "should return undefined for unknown id");
     },
   },
   {
@@ -162,5 +162,5 @@ const rawTests: TestCase[] = [
 ];
 
 export function runAllTests() {
-  runTests(rawTests);
+  runTests("commandPalette.test.ts", rawTests);
 }

--- a/browser-features/chrome/common/command-palette/test/commandPalette.test.ts
+++ b/browser-features/chrome/common/command-palette/test/commandPalette.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import { fuzzyScore, fuzzySearch } from "../fuzzy.ts";
+import type { FuzzyTarget } from "../fuzzy.ts";
+import { getPaletteCommands, searchCommands, getCommand } from "../command-registry.ts";
+
+const makeTarget = (label: string, desc = "", category = "test", keywords: string[] = []): FuzzyTarget => ({
+  id: label.toLowerCase().replace(/\s+/g, "-"),
+  label,
+  description: desc,
+  category,
+  keywords,
+});
+
+const rawTests: TestCase[] = [
+  // --- Fuzzy Search ---
+  {
+    name: "fuzzyScore: exact prefix match scores highest",
+    fn() {
+      const target = makeTarget("New Tab");
+      const score = fuzzyScore("new", target);
+      assert(score >= 100, `prefix score should be >= 100, got ${score}`);
+    },
+  },
+  {
+    name: "fuzzyScore: substring match scores lower than prefix",
+    fn() {
+      const target = makeTarget("Open New Tab");
+      const prefixScore = fuzzyScore("open", target);
+      const subScore = fuzzyScore("new", target);
+      assert(prefixScore > subScore, `prefix (${prefixScore}) should score higher than substring (${subScore})`);
+    },
+  },
+  {
+    name: "fuzzyScore: no match returns 0",
+    fn() {
+      const target = makeTarget("Reload");
+      const score = fuzzyScore("xyz", target);
+      assertEquals(score, 0);
+    },
+  },
+  {
+    name: "fuzzyScore: keyword match scores",
+    fn() {
+      const target = makeTarget("Screenshot", "", "page", ["capture", "screen"]);
+      const score = fuzzyScore("capture", target);
+      assert(score > 0, `keyword match should score > 0, got ${score}`);
+    },
+  },
+  {
+    name: "fuzzySearch: returns filtered and sorted results",
+    fn() {
+      const items = [
+        makeTarget("Open New Tab"),
+        makeTarget("Close Tab"),
+        makeTarget("New Window"),
+        makeTarget("Reload"),
+      ];
+      const results = fuzzySearch("new", items);
+      assert(results.length > 0, "should have results");
+      // "New Window" has prefix match, "Open New Tab" has substring
+      assert(results.length <= 3, "should have at most 3 matches");
+    },
+  },
+  {
+    name: "fuzzySearch: empty query returns all items",
+    fn() {
+      const items = [
+        makeTarget("A"),
+        makeTarget("B"),
+        makeTarget("C"),
+      ];
+      const results = fuzzySearch("", items);
+      assertEquals(results.length, 3);
+    },
+  },
+  {
+    name: "fuzzySearch: respects limit parameter",
+    fn() {
+      const items = Array.from({ length: 100 }, (_, i) => makeTarget(`Item ${i}`));
+      const results = fuzzySearch("item", items, 5);
+      assertEquals(results.length, 5);
+    },
+  },
+
+  // --- Command Registry ---
+  {
+    name: "getPaletteCommands returns non-empty array",
+    fn() {
+      const commands = getPaletteCommands();
+      assert(Array.isArray(commands), "should return an array");
+      assert(commands.length > 0, "should have registered commands");
+    },
+  },
+  {
+    name: "each palette command has required properties",
+    fn() {
+      const commands = getPaletteCommands();
+      for (const cmd of commands) {
+        assert(typeof cmd.id === "string" && cmd.id.length > 0, `id should be non-empty string, got: ${cmd.id}`);
+        assert(typeof cmd.label === "string" && cmd.label.length > 0, `label should be non-empty string for ${cmd.id}`);
+        assert(typeof cmd.category === "string", `category should be string for ${cmd.id}`);
+        assert(typeof cmd.fn === "function", `fn should be function for ${cmd.id}`);
+        assert(Array.isArray(cmd.keywords), `keywords should be array for ${cmd.id}`);
+      }
+    },
+  },
+  {
+    name: "command IDs are unique",
+    fn() {
+      const commands = getPaletteCommands();
+      const ids = commands.map((c) => c.id);
+      const uniqueIds = new Set(ids);
+      assertEquals(ids.length, uniqueIds.size, "all command IDs should be unique");
+    },
+  },
+  {
+    name: "getCommand returns correct command by id",
+    fn() {
+      const cmd = getCommand("gecko-open-new-tab");
+      assert(cmd !== undefined, "should find gecko-open-new-tab");
+      assertEquals(cmd.id, "gecko-open-new-tab");
+    },
+  },
+  {
+    name: "getCommand returns undefined for unknown id",
+    fn() {
+      const cmd = getCommand("nonexistent-action");
+      assertEquals(cmd, undefined);
+    },
+  },
+  {
+    name: "searchCommands returns results for tab query",
+    fn() {
+      const results = searchCommands("tab");
+      assert(results.length > 0, "should find tab-related commands");
+      const labels = results.map((r) => r.label.toLowerCase());
+      assert(labels.some((l) => l.includes("tab")), "results should contain tab-related items");
+    },
+  },
+  {
+    name: "all commands have a valid category",
+    fn() {
+      const validCategories = new Set([
+        "navigation", "tabs", "zoom", "bookmarks", "page", "search",
+        "sidebar", "scrolling", "history", "window", "tools", "downloads",
+        "workspace", "floorp", "media",
+      ]);
+      const commands = getPaletteCommands();
+      for (const cmd of commands) {
+        assert(validCategories.has(cmd.category), `unknown category "${cmd.category}" for ${cmd.id}`);
+      }
+    },
+  },
+];
+
+export function runAllTests() {
+  runTests(rawTests);
+}

--- a/browser-features/chrome/common/command-palette/test/commandPalette.test.ts
+++ b/browser-features/chrome/common/command-palette/test/commandPalette.test.ts
@@ -10,6 +10,7 @@ import {
 import { fuzzyScore, fuzzySearch } from "../fuzzy.ts";
 import type { FuzzyTarget } from "../fuzzy.ts";
 import { getPaletteCommands, searchCommands, getCommand } from "../command-registry.ts";
+import { getHighlightSegments } from "../utils/highlight.ts";
 
 const makeTarget = (label: string, desc = "", category = "test", keywords: string[] = []): FuzzyTarget => ({
   id: label.toLowerCase().replace(/\s+/g, "-"),
@@ -55,6 +56,22 @@ const rawTests: TestCase[] = [
     },
   },
   {
+    name: "fuzzyScore: multi-word search requires all words to match",
+    fn() {
+      const target = makeTarget("Open New Tab");
+      const score = fuzzyScore("open tab", target);
+      assert(score > 0, "multi-word 'open tab' should match 'Open New Tab'");
+    },
+  },
+  {
+    name: "fuzzyScore: multi-word search returns 0 if any word misses",
+    fn() {
+      const target = makeTarget("Open New Tab");
+      const score = fuzzyScore("open xyz", target);
+      assertEquals(score, 0, "multi-word with non-matching word should return 0");
+    },
+  },
+  {
     name: "fuzzySearch: returns filtered and sorted results",
     fn() {
       const items = [
@@ -65,7 +82,6 @@ const rawTests: TestCase[] = [
       ];
       const results = fuzzySearch("new", items);
       assert(results.length > 0, "should have results");
-      // "New Window" has prefix match, "Open New Tab" has substring
       assert(results.length <= 3, "should have at most 3 matches");
     },
   },
@@ -87,6 +103,27 @@ const rawTests: TestCase[] = [
       const items = Array.from({ length: 100 }, (_, i) => makeTarget(`Item ${i}`));
       const results = fuzzySearch("item", items, 5);
       assertEquals(results.length, 5, "should respect limit parameter");
+    },
+  },
+
+  // --- Highlight ---
+  {
+    name: "getHighlightSegments: prefix match",
+    fn() {
+      const segments = getHighlightSegments("new", "New Tab");
+      assertEquals(segments.length, 2, "should have 2 segments");
+      assert(segments[0].matched, "first segment should be matched");
+      assertEquals(segments[0].text, "New", "first segment text should be 'New'");
+      assert(!segments[1].matched, "second segment should not be matched");
+      assertEquals(segments[1].text, " Tab", "second segment text should be ' Tab'");
+    },
+  },
+  {
+    name: "getHighlightSegments: empty query returns no match",
+    fn() {
+      const segments = getHighlightSegments("", "Hello");
+      assertEquals(segments.length, 1, "should have 1 segment");
+      assert(!segments[0].matched, "should not be matched");
     },
   },
 
@@ -151,7 +188,7 @@ const rawTests: TestCase[] = [
       const validCategories = new Set([
         "navigation", "tabs", "zoom", "bookmarks", "page", "search",
         "sidebar", "scrolling", "history", "window", "tools", "downloads",
-        "workspace", "floorp", "media",
+        "workspace", "floorp", "media", "open-tabs",
       ]);
       const commands = getPaletteCommands();
       for (const cmd of commands) {

--- a/browser-features/chrome/common/command-palette/utils/highlight.ts
+++ b/browser-features/chrome/common/command-palette/utils/highlight.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+
+export type TextSegment = { text: string; matched: boolean };
+
+export function getHighlightSegments(
+  query: string,
+  text: string,
+): TextSegment[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [{ text, matched: false }];
+
+  const lower = text.toLowerCase();
+  const ranges = findMatchRanges(q, lower);
+  if (ranges.length === 0) return [{ text, matched: false }];
+
+  const segments: TextSegment[] = [];
+  let lastEnd = 0;
+  for (const [start, end] of ranges) {
+    if (start > lastEnd) {
+      segments.push({ text: text.slice(lastEnd, start), matched: false });
+    }
+    segments.push({ text: text.slice(start, end), matched: true });
+    lastEnd = end;
+  }
+  if (lastEnd < text.length) {
+    segments.push({ text: text.slice(lastEnd), matched: false });
+  }
+  return segments;
+}
+
+function findMatchRanges(
+  query: string,
+  lowerText: string,
+): [number, number][] {
+  // Prefix match
+  if (lowerText.startsWith(query)) {
+    return [[0, query.length]];
+  }
+
+  // Word boundary match — find the word that starts with the query
+  const wordRegex = /\b\w/g;
+  let match: RegExpExecArray | null;
+  while ((match = wordRegex.exec(lowerText)) !== null) {
+    if (lowerText.slice(match.index).startsWith(query)) {
+      return [[match.index, match.index + query.length]];
+    }
+  }
+
+  // Substring match
+  const idx = lowerText.indexOf(query);
+  if (idx !== -1) {
+    return [[idx, idx + query.length]];
+  }
+
+  // Fuzzy character sequence — collect individual char positions
+  const positions: number[] = [];
+  let qi = 0;
+  for (let i = 0; i < lowerText.length && qi < query.length; i++) {
+    if (lowerText[i] === query[qi]) {
+      positions.push(i);
+      qi++;
+    }
+  }
+  if (qi === query.length && positions.length > 0) {
+    return mergePositions(positions);
+  }
+
+  return [];
+}
+
+function mergePositions(positions: number[]): [number, number][] {
+  const ranges: [number, number][] = [];
+  let start = positions[0];
+  let prev = positions[0];
+  for (let i = 1; i < positions.length; i++) {
+    if (positions[i] === prev + 1) {
+      prev = positions[i];
+    } else {
+      ranges.push([start, prev + 1]);
+      start = positions[i];
+      prev = positions[i];
+    }
+  }
+  ranges.push([start, prev + 1]);
+  return ranges;
+}

--- a/browser-features/chrome/common/keyboard-shortcut/config.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/config.ts
@@ -21,6 +21,8 @@ import { isRight } from "fp-ts/Either";
 
 export const KEYBOARD_SHORTCUT_ENABLED_PREF = "floorp.keyboardshortcut.enabled";
 export const KEYBOARD_SHORTCUT_CONFIG_PREF = "floorp.keyboardshortcut.config";
+export const KEYBOARD_SHORTCUT_SAFE_ERROR_HANDLING_PREF =
+  "floorp.keyboardshortcut.safeErrorHandling";
 
 const createDefaultShortcuts = (): Record<string, ShortcutConfig> => {
   return {};
@@ -161,6 +163,17 @@ export const isEnabled = () => _enabled();
 export const setEnabled = (value: boolean) => _setEnabled(value);
 export const getConfig = () => _config();
 export const setConfig = (value: KeyboardShortcutConfig) => _setConfig(value);
+
+/**
+ * Experiment "ks_safe_error_handling" — wraps getAction + fn invocation
+ * in a single try-catch so callers can always run their cleanup.
+ */
+export function isSafeErrorHandling(): boolean {
+  return Services.prefs.getBoolPref(
+    KEYBOARD_SHORTCUT_SAFE_ERROR_HANDLING_PREF,
+    true, // default: enabled (safe behavior)
+  );
+}
 
 export function shortcutToString(shortcut: ShortcutConfig): string {
   const modifiers = [];

--- a/browser-features/chrome/common/keyboard-shortcut/configs/ks_safe_error_handling_safe.json
+++ b/browser-features/chrome/common/keyboard-shortcut/configs/ks_safe_error_handling_safe.json
@@ -1,0 +1,3 @@
+{
+  "floorp.keyboardshortcut.safeErrorHandling": true
+}

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -131,16 +131,16 @@ export class KeyboardShortcutController {
   }
 
   private executeShortcut(shortcut: ShortcutConfig): void {
-    const fn = gestureActions.getAction(shortcut.action);
-    if (fn) {
-      try {
+    try {
+      const fn = gestureActions.getAction(shortcut.action);
+      if (fn) {
         fn(this.targetWindow);
-      } catch (e) {
-        console.error(
-          `[keyboard-shortcut] Action "${shortcut.action}" failed:`,
-          e,
-        );
       }
+    } catch (e) {
+      console.error(
+        `[keyboard-shortcut] Action "${shortcut.action}" failed:`,
+        e,
+      );
     }
   }
 }

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getConfig, isEnabled } from "./config.ts";
+import { getConfig, isEnabled, isSafeErrorHandling } from "./config.ts";
 import { gestureActions } from "../mouse-gesture/utils/gestures.ts";
 import type { ShortcutConfig } from "./type.ts";
 
@@ -131,16 +131,34 @@ export class KeyboardShortcutController {
   }
 
   private executeShortcut(shortcut: ShortcutConfig): void {
-    try {
+    if (isSafeErrorHandling()) {
+      // Experiment: ks_safe_error_handling (treatment)
+      // Expanded try-catch covers both getAction() resolution and fn()
+      // invocation so callers can always run cleanup.
+      try {
+        const fn = gestureActions.getAction(shortcut.action);
+        if (fn) {
+          fn(this.targetWindow);
+        }
+      } catch (e) {
+        console.error(
+          `[keyboard-shortcut] Action "${shortcut.action}" failed:`,
+          e,
+        );
+      }
+    } else {
+      // Control: original behaviour (try-catch only around fn call)
       const fn = gestureActions.getAction(shortcut.action);
       if (fn) {
-        fn(this.targetWindow);
+        try {
+          fn(this.targetWindow);
+        } catch (e) {
+          console.error(
+            `[keyboard-shortcut] Action "${shortcut.action}" failed:`,
+            e,
+          );
+        }
       }
-    } catch (e) {
-      console.error(
-        `[keyboard-shortcut] Action "${shortcut.action}" failed:`,
-        e,
-      );
     }
   }
 }

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -27,15 +27,15 @@ export class KeyboardShortcutController {
   private init(): void {
     if (this.eventListenersAttached) return;
 
-    this.targetWindow.addEventListener("keydown", this.handleKeyDown);
-    this.targetWindow.addEventListener("keyup", this.handleKeyUp);
+    this.targetWindow.addEventListener("keydown", this.handleKeyDown, true);
+    this.targetWindow.addEventListener("keyup", this.handleKeyUp, true);
     this.eventListenersAttached = true;
   }
 
   public destroy(): void {
     if (this.eventListenersAttached) {
-      this.targetWindow.removeEventListener("keydown", this.handleKeyDown);
-      this.targetWindow.removeEventListener("keyup", this.handleKeyUp);
+      this.targetWindow.removeEventListener("keydown", this.handleKeyDown, true);
+      this.targetWindow.removeEventListener("keyup", this.handleKeyUp, true);
       this.eventListenersAttached = false;
     }
     this.resetState();

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getConfig, isEnabled } from "./config.ts";
-import { actions } from "../mouse-gesture/utils/actions.ts";
+import { gestureActions } from "../mouse-gesture/utils/gestures.ts";
 import type { ShortcutConfig } from "./type.ts";
 
 export class KeyboardShortcutController {
@@ -131,9 +131,9 @@ export class KeyboardShortcutController {
   }
 
   private executeShortcut(shortcut: ShortcutConfig): void {
-    const action = actions.find((a) => a.name === shortcut.action);
-    if (action) {
-      action.fn(this.targetWindow);
+    const fn = gestureActions.getAction(shortcut.action);
+    if (fn) {
+      fn(this.targetWindow);
     }
   }
 }

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -133,7 +133,14 @@ export class KeyboardShortcutController {
   private executeShortcut(shortcut: ShortcutConfig): void {
     const fn = gestureActions.getAction(shortcut.action);
     if (fn) {
-      fn(this.targetWindow);
+      try {
+        fn(this.targetWindow);
+      } catch (e) {
+        console.error(
+          `[keyboard-shortcut] Action "${shortcut.action}" failed:`,
+          e,
+        );
+      }
     }
   }
 }

--- a/browser-features/chrome/common/keyboard-shortcut/experiments.sample.json
+++ b/browser-features/chrome/common/keyboard-shortcut/experiments.sample.json
@@ -1,0 +1,28 @@
+{
+  "experiments": [
+    {
+      "id": "ks_safe_error_handling",
+      "name": "Keyboard Shortcut Safe Error Handling",
+      "description": "Wraps both getAction() and fn() in a single try-catch so that exceptions never prevent callers from running their cleanup (e.g. event.preventDefault / stopPropagation).",
+      "salt": "ks_safe_error_handling_v1_2025",
+      "rollout": 100,
+      "start": "2025-01-01",
+      "end": "2026-12-31",
+      "variants": [
+        {
+          "id": "control",
+          "weight": 0,
+          "name": "Control",
+          "description": "Original behaviour — try-catch only around fn() call."
+        },
+        {
+          "id": "safe",
+          "weight": 100,
+          "name": "Safe error handling",
+          "description": "Expanded try-catch covers both getAction() and fn() so callers always continue.",
+          "configUrl": "configs/ks_safe_error_handling_safe.json"
+        }
+      ]
+    }
+  ]
+}

--- a/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutController.test.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutController.test.ts
@@ -1323,6 +1323,52 @@ function testStatePreservedAfterUnmatchedKey(): void {
   });
 }
 
+function testCapturePhaseBlocksBubbleListener(): void {
+  withPrefs(() => {
+    const CTRL_SHIFT_P_CONFIG: KeyboardShortcutConfig = {
+      enabled: true,
+      shortcuts: {
+        "test-ctrl-shift-p": {
+          key: "P",
+          modifiers: { alt: false, ctrl: true, meta: false, shift: true },
+          action: "test-ctrl-shift-p",
+        },
+      },
+    };
+    applyTestConfig(CTRL_SHIFT_P_CONFIG);
+    const fakeWin = createFakeWindow();
+
+    // Simulate a XUL-style bubble-phase handler
+    let bubbleHandlerCalled = false;
+    const bubbleHandler = () => {
+      bubbleHandlerCalled = true;
+    };
+    fakeWin.addEventListener("keydown", bubbleHandler);
+
+    const controller = new KeyboardShortcutController(fakeWin);
+
+    const event = dispatchKeyEvent(fakeWin, "keydown", {
+      code: "KeyP",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "Ctrl+Shift+P should match in capture phase",
+    );
+    assertEquals(
+      bubbleHandlerCalled,
+      false,
+      "bubble-phase handler should NOT fire when capture handler stops propagation",
+    );
+
+    controller.destroy();
+    fakeWin.removeEventListener("keydown", bubbleHandler);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
@@ -1512,6 +1558,11 @@ export async function runAllTests(): Promise<void> {
     {
       name: "state preserved after unmatched key",
       fn: testStatePreservedAfterUnmatchedKey,
+    },
+    // Capture phase priority
+    {
+      name: "capture phase blocks bubble listener",
+      fn: testCapturePhaseBlocksBubbleListener,
     },
   ];
 

--- a/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutController.test.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutController.test.ts
@@ -12,6 +12,7 @@ import {
   setConfig,
   KEYBOARD_SHORTCUT_ENABLED_PREF,
   KEYBOARD_SHORTCUT_CONFIG_PREF,
+  KEYBOARD_SHORTCUT_SAFE_ERROR_HANDLING_PREF,
 } from "../config.ts";
 import type { KeyboardShortcutConfig } from "../type.ts";
 
@@ -21,16 +22,21 @@ import type { KeyboardShortcutConfig } from "../type.ts";
 
 const TEST_ENABLED_PREF = KEYBOARD_SHORTCUT_ENABLED_PREF;
 const TEST_CONFIG_PREF = KEYBOARD_SHORTCUT_CONFIG_PREF;
+const TEST_SAFE_ERR_PREF = KEYBOARD_SHORTCUT_SAFE_ERROR_HANDLING_PREF;
 
 /** Save current pref state and restore after fn runs. */
 function withPrefs(fn: () => void): void {
   const hadEnabled = Services.prefs.prefHasUserValue(TEST_ENABLED_PREF);
   const hadConfig = Services.prefs.prefHasUserValue(TEST_CONFIG_PREF);
+  const hadSafeErr = Services.prefs.prefHasUserValue(TEST_SAFE_ERR_PREF);
   const savedEnabled = hadEnabled
     ? Services.prefs.getBoolPref(TEST_ENABLED_PREF)
     : null;
   const savedConfig = hadConfig
     ? Services.prefs.getStringPref(TEST_CONFIG_PREF)
+    : null;
+  const savedSafeErr = hadSafeErr
+    ? Services.prefs.getBoolPref(TEST_SAFE_ERR_PREF)
     : null;
 
   try {
@@ -45,6 +51,11 @@ function withPrefs(fn: () => void): void {
       Services.prefs.setStringPref(TEST_CONFIG_PREF, savedConfig);
     } else {
       Services.prefs.clearUserPref(TEST_CONFIG_PREF);
+    }
+    if (hadSafeErr && savedSafeErr !== null) {
+      Services.prefs.setBoolPref(TEST_SAFE_ERR_PREF, savedSafeErr);
+    } else {
+      Services.prefs.clearUserPref(TEST_SAFE_ERR_PREF);
     }
   }
 }
@@ -1015,9 +1026,72 @@ function testActionNotFoundNoError(): void {
   });
 }
 
-// ---------------------------------------------------------------------------
-// Tests — Key state tracking
-// ---------------------------------------------------------------------------
+function testSafeErrorHandlingExperimentEnabled(): void {
+  withPrefs(() => {
+    Services.prefs.setBoolPref(TEST_SAFE_ERR_PREF, true);
+    const config: KeyboardShortcutConfig = {
+      enabled: true,
+      shortcuts: {
+        "throwing-action": {
+          key: "Z",
+          modifiers: { alt: false, ctrl: true, meta: false, shift: false },
+          action: "__nonexistent_throwing__",
+        },
+      },
+    };
+    applyTestConfig(config);
+    const fakeWin = createFakeWindow();
+    const controller = new KeyboardShortcutController(fakeWin);
+
+    // getAction returns undefined for unknown action → no throw.
+    // Even if it did throw, the expanded try-catch would swallow it.
+    const event = dispatchKeyEvent(fakeWin, "keydown", {
+      code: "KeyZ",
+      ctrlKey: true,
+    });
+
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "event should be prevented even when safeErrorHandling is enabled",
+    );
+
+    controller.destroy();
+  });
+}
+
+function testSafeErrorHandlingExperimentDisabled(): void {
+  withPrefs(() => {
+    Services.prefs.setBoolPref(TEST_SAFE_ERR_PREF, false);
+    const config: KeyboardShortcutConfig = {
+      enabled: true,
+      shortcuts: {
+        "safe-action": {
+          key: "Y",
+          modifiers: { alt: false, ctrl: true, meta: false, shift: false },
+          action: "non-existent-safe-action",
+        },
+      },
+    };
+    applyTestConfig(config);
+    const fakeWin = createFakeWindow();
+    const controller = new KeyboardShortcutController(fakeWin);
+
+    // Control branch: getAction returns undefined, no fn call, no throw.
+    const event = dispatchKeyEvent(fakeWin, "keydown", {
+      code: "KeyY",
+      ctrlKey: true,
+    });
+
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "event should be prevented in control branch too",
+    );
+
+    controller.destroy();
+  });
+}
 
 function testKeyUpClearsKeyState(): void {
   withPrefs(() => {
@@ -1393,6 +1467,15 @@ export async function runAllTests(): Promise<void> {
     {
       name: "action not found no error",
       fn: testActionNotFoundNoError,
+    },
+    // Experiment: safe error handling
+    {
+      name: "safe error handling experiment enabled",
+      fn: testSafeErrorHandlingExperimentEnabled,
+    },
+    {
+      name: "safe error handling experiment disabled",
+      fn: testSafeErrorHandlingExperimentDisabled,
     },
     // Key state tracking
     {

--- a/browser-features/pages-modal-child/vite.config.ts
+++ b/browser-features/pages-modal-child/vite.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
@@ -5,7 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { genJarmnPlugin } from "../../libs/vite-plugin-gen-jarmn/plugin.ts";
 import { disableCspInDevPlugin } from "../../libs/vite-plugin-disable-csp/plugin.ts";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command }) => {
+  if (command === "serve") process.env.NODE_ENV = "development";
+  return {
   build: {
     outDir: "_dist",
   },
@@ -26,4 +29,5 @@ export default defineConfig(({ command }) => ({
       overlay: true,
     },
   },
-}));
+  };
+});

--- a/browser-features/pages-newtab/vite.config.ts
+++ b/browser-features/pages-newtab/vite.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
@@ -5,7 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { genJarmnPlugin } from "../../libs/vite-plugin-gen-jarmn/plugin.ts";
 import { disableCspInDevPlugin } from "../../libs/vite-plugin-disable-csp/plugin.ts";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command }) => {
+  if (command === "serve") process.env.NODE_ENV = "development";
+  return {
   base: "./",
   build: {
     outDir: "_dist",
@@ -27,4 +30,5 @@ export default defineConfig(({ command }) => ({
       overlay: true,
     },
   },
-}));
+  };
+});

--- a/browser-features/pages-notes/vite.config.ts
+++ b/browser-features/pages-notes/vite.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
@@ -5,7 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { genJarmnPlugin } from "../../libs/vite-plugin-gen-jarmn/plugin.ts";
 import { disableCspInDevPlugin } from "../../libs/vite-plugin-disable-csp/plugin.ts";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command }) => {
+  if (command === "serve") process.env.NODE_ENV = "development";
+  return {
   build: {
     outDir: "_dist",
   },
@@ -26,4 +29,5 @@ export default defineConfig(({ command }) => ({
       overlay: true,
     },
   },
-}));
+  };
+});

--- a/browser-features/pages-profile-manager/vite.config.ts
+++ b/browser-features/pages-profile-manager/vite.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
@@ -5,7 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { genJarmnPlugin } from "../../libs/vite-plugin-gen-jarmn/plugin.ts";
 import { disableCspInDevPlugin } from "../../libs/vite-plugin-disable-csp/plugin.ts";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command }) => {
+  if (command === "serve") process.env.NODE_ENV = "development";
+  return {
   build: {
     outDir: "_dist",
   },
@@ -30,4 +33,5 @@ export default defineConfig(({ command }) => ({
       overlay: true,
     },
   },
-}));
+  };
+});

--- a/browser-features/pages-settings/src/app/gesture/useAvailableActions.ts
+++ b/browser-features/pages-settings/src/app/gesture/useAvailableActions.ts
@@ -87,6 +87,7 @@ export const GESTURE_ACTIONS = [
   "gecko-workspace-next",
   "gecko-workspace-previous",
   "floorp-toggle-zen-mode",
+  "floorp-toggle-command-palette",
 ] as const;
 
 export const useAvailableActions = () => {

--- a/browser-features/pages-settings/vite.config.ts
+++ b/browser-features/pages-settings/vite.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
@@ -5,7 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { genJarmnPlugin } from "../../libs/vite-plugin-gen-jarmn/plugin.ts";
 import { disableCspInDevPlugin } from "../../libs/vite-plugin-disable-csp/plugin.ts";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command }) => {
+  if (command === "serve") process.env.NODE_ENV = "development";
+  return {
   build: {
     outDir: "_dist",
   },
@@ -26,4 +29,5 @@ export default defineConfig(({ command }) => ({
       overlay: true,
     },
   },
-}));
+  };
+});

--- a/browser-features/pages-welcome/vite.config.ts
+++ b/browser-features/pages-welcome/vite.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
@@ -5,7 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { genJarmnPlugin } from "../../libs/vite-plugin-gen-jarmn/plugin.ts";
 import { disableCspInDevPlugin } from "../../libs/vite-plugin-disable-csp/plugin.ts";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command }) => {
+  if (command === "serve") process.env.NODE_ENV = "development";
+  return {
   build: {
     outDir: "_dist",
   },
@@ -26,4 +29,5 @@ export default defineConfig(({ command }) => ({
       overlay: true,
     },
   },
-}));
+  };
+});

--- a/browser-features/pages-workflow-progress/vite.config.ts
+++ b/browser-features/pages-workflow-progress/vite.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
@@ -5,7 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { genJarmnPlugin } from "../../libs/vite-plugin-gen-jarmn/plugin.ts";
 import { disableCspInDevPlugin } from "../../libs/vite-plugin-disable-csp/plugin.ts";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command }) => {
+  if (command === "serve") process.env.NODE_ENV = "development";
+  return {
   build: {
     outDir: "_dist",
   },
@@ -27,4 +30,5 @@ export default defineConfig(({ command }) => ({
       overlay: true,
     },
   },
-}));
+  };
+});

--- a/i18n/en-US/browser-chrome.json
+++ b/i18n/en-US/browser-chrome.json
@@ -396,5 +396,27 @@
     "label": "Zen Mode",
     "tooltiptext": "Toggle Zen Mode",
     "menu-label": "Toggle Zen Mode"
+  },
+  "commandPalette": {
+    "placeholder": "Type a command...",
+    "categories": {
+      "recent": "Recently Used",
+      "navigation": "Navigation",
+      "tabs": "Tabs",
+      "zoom": "Zoom",
+      "bookmarks": "Bookmarks",
+      "page": "Page",
+      "search": "Search",
+      "sidebar": "Sidebar",
+      "scrolling": "Scrolling",
+      "history": "History",
+      "window": "Window",
+      "tools": "Tools",
+      "downloads": "Downloads",
+      "workspace": "Workspaces",
+      "floorp": "Floorp",
+      "media": "Media"
+    },
+    "noResults": "No commands found"
   }
 }

--- a/i18n/en-US/browser-chrome.json
+++ b/i18n/en-US/browser-chrome.json
@@ -201,7 +201,8 @@
       "gecko-scroll-to-bottom": "Scroll to Bottom",
       "gecko-workspace-next": "Switch to Next Workspace",
       "gecko-workspace-previous": "Switch to Previous Workspace",
-      "floorp-toggle-zen-mode": "Toggle Zen Mode"
+      "floorp-toggle-zen-mode": "Toggle Zen Mode",
+      "floorp-toggle-command-palette": "Toggle Command Palette"
     },
     "descriptions": {
       "gecko-back": "Navigate back to the previous page",
@@ -212,7 +213,8 @@
       "gecko-duplicate-tab": "Duplicate the current tab",
       "gecko-reload-all-tabs": "Reload all tabs",
       "gecko-restore-last-tab": "Reopen the last closed tab",
-      "floorp-toggle-zen-mode": "Toggle Zen Mode to hide all UI elements for distraction-free browsing"
+      "floorp-toggle-zen-mode": "Toggle Zen Mode to hide all UI elements for distraction-free browsing",
+      "floorp-toggle-command-palette": "Open or close the command palette to search and execute commands"
     }
   },
   "qrCode": {

--- a/i18n/en-US/browser-chrome.json
+++ b/i18n/en-US/browser-chrome.json
@@ -400,7 +400,9 @@
     "menu-label": "Toggle Zen Mode"
   },
   "commandPalette": {
+    "dialogLabel": "Command Palette",
     "placeholder": "Type a command...",
+    "navigateTo": "Go to {{url}}",
     "categories": {
       "recent": "Recently Used",
       "navigation": "Navigation",
@@ -417,8 +419,10 @@
       "downloads": "Downloads",
       "workspace": "Workspaces",
       "floorp": "Floorp",
-      "media": "Media"
+      "media": "Media",
+      "open-tabs": "Open Tabs"
     },
-    "noResults": "No commands found"
+    "noResults": "No commands found",
+    "noResultsHint": "Try a different search term"
   }
 }


### PR DESCRIPTION
## Summary

- Add a searchable command palette overlay triggered by **Ctrl+Shift+P** that provides quick access to all 50+ browser actions registered in the shared `GestureActionsRegistry` — the same action source used by mouse gestures and custom keyboard shortcuts.
- Includes fuzzy search, keyboard navigation, recently-used commands, category grouping, multi-window support, and i18n (en-US source; other locales managed via Crowdin).

### New files

| File | Purpose |
|------|---------|
| `command-palette/index.ts` | Feature entry point (`@noraComponent`, auto-discovered by `mod.ts`) |
| `command-palette/controller.ts` | Keyboard event handling (trigger + navigation) |
| `command-palette/service.ts` | Multi-window lifecycle management |
| `command-palette/config.ts` | Preference-backed reactive config |
| `command-palette/command-registry.ts` | Aggregates actions from `GestureActionsRegistry` |
| `command-palette/fuzzy.ts` | Fuzzy search with priority scoring |
| `command-palette/data/state.ts` | Reactive signals (isVisible, query, selectedIndex) |
| `command-palette/components/*.tsx` | SolidJS UI components (overlay, search input, list, items) |
| `command-palette/style.css` | Scoped styles using Firefox CSS custom properties |
| `command-palette/test/commandPalette.test.ts` | Unit tests |
| `i18n/en-US/browser-chrome.json` | Added `commandPalette` i18n block |

### Key design decisions

- **Shared action source**: Consumes `getAllGestureActions()` from `mouse-gesture/utils/gestures.ts`. No duplication — new actions added to `actions.ts` automatically appear in the palette, mouse gestures, and keyboard shortcuts.
- **Service-managed controllers**: Single controller per window via `CommandPaletteService`, avoiding duplicate event listeners.
- **Config reactivity**: `createEffect` on `isEnabled()` dynamically attaches/detaches controllers at runtime.

## Test plan

- [ ] Press Ctrl+Shift+P → palette opens centered on screen
- [ ] Type "tab" → shows tab-related actions
- [ ] Arrow/Tab keys navigate, Enter executes, Escape closes
- [ ] Ctrl+Shift+P toggles palette closed when already open
- [ ] Execute a command, reopen palette → recently used command appears first
- [ ] Open second browser window → Ctrl+Shift+P works independently
- [ ] Set `floorp.commandPalette.enabled` to false → palette disabled at runtime
- [ ] Run browser test harness → all test cases pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command Palette: searchable, categorized commands with fuzzy matching, recent-commands history, and execute-from-palette behavior.
* **UI / Style**
  * Full-screen overlay with centered palette, search input, category headers, item highlighting, auto-scrolling selected item, and empty-state messaging.
* **Settings**
  * Toggle and recent-command persistence exposed in preferences; gesture/shortcut support to toggle the palette.
* **Tests**
  * Unit tests for fuzzy search and command registry.
* **Localization**
  * English strings for placeholder, categories, and no-results message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->