### PR TITLE
feat(ci): patch macOS entitlements for passkey (WebAuthn) support

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1170,7 +1170,7 @@ jobs:
                 # Production entitlements do NOT include get-task-allow (which would
                 # cause macOS to block the app from launching with error 163).
                 ./mach macos-sign -v -r -c "release" \
-                  -e security/mac/hardenedruntime/production/firefox.browser.xml \
+                  -e production \
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
                   --rcodesign-p12-password-file floorpCertPassword.passwd

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1059,10 +1059,20 @@ jobs:
                 fi
 
                 # Extract the team ID (OU field) from the P12 certificate
-                FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys $OPENSSL_NOENC 2>/dev/null | openssl x509 -noout -subject -nameopt oneline,-esc_msb | grep -oE 'OU = [A-Za-z0-9]+' | head -1 | awk '{print $NF}')
+                # Use -clcerts to extract only the client (leaf) certificate, avoiding
+                # intermediate CA certificates that have different OU values.
+                # Append || true so failures don't abort the step (set -euo pipefail is active).
+                FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts $OPENSSL_NOENC 2>/dev/null \
+                  | openssl x509 -noout -subject -nameopt oneline,-esc_msb 2>/dev/null \
+                  | grep -oE 'OU = [A-Za-z0-9]+' \
+                  | head -1 \
+                  | awk '{print $NF}' || true)
                 if [ -z "$FLOORP_TEAM_ID" ]; then
                   # Fallback: try alternative extraction method
-                  FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys $OPENSSL_NOENC 2>/dev/null | openssl x509 -noout -subject | sed -n 's/.*OU=\([^/]*\).*/\1/p' | head -1)
+                  FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts $OPENSSL_NOENC 2>/dev/null \
+                    | openssl x509 -noout -subject 2>/dev/null \
+                    | sed -n 's/.*OU=\([^/]*\).*/\1/p' \
+                    | head -1 || true)
                 fi
 
                 # Validate Team ID format (Apple Team IDs are alphanumeric, e.g. 43AQ936H96)
@@ -1088,8 +1098,17 @@ jobs:
                 ENTITLEMENTS_FILE="security/mac/hardenedruntime/production/firefox.browser.xml"
                 if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
                   echo "Patching entitlements: replacing 43AQ936H96.org.mozilla.firefox with ${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}"
-                  sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$ENTITLEMENTS_FILE"
-                  echo "Entitlements patched successfully."
+                  if grep -q '43AQ936H96\.org\.mozilla\.firefox' "$ENTITLEMENTS_FILE"; then
+                    sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$ENTITLEMENTS_FILE"
+                    # Verify the substitution actually occurred
+                    if grep -q "${FLOORP_TEAM_ID}\.${FLOORP_BUNDLE_ID}" "$ENTITLEMENTS_FILE"; then
+                      echo "Entitlements patched successfully."
+                    else
+                      echo "Warning: sed completed but the new application-identifier was not found in $ENTITLEMENTS_FILE" >&2
+                    fi
+                  else
+                    echo "Warning: expected literal '43AQ936H96.org.mozilla.firefox' not found in $ENTITLEMENTS_FILE; passkey entitlement may be missing." >&2
+                  fi
                   grep -A1 "application-identifier" "$ENTITLEMENTS_FILE" || true
                 else
                   echo "Warning: Could not extract team ID or bundle ID. Entitlements not patched."

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1072,13 +1072,16 @@ jobs:
                 if [ -z "$FLOORP_TEAM_ID" ]; then
                   echo "APPLE_DEVELOPER_TEAM_ID secret not set; falling back to P12 certificate extraction."
                   # Use -clcerts to extract only the client (leaf) certificate
-                  FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts $OPENSSL_NOENC 2>/dev/null \
+                  # -legacy loads the legacy provider on OpenSSL 3.x for P12s
+                  # that use RC2/3DES (common with Apple Developer certs).
+                  # Harmless on OpenSSL 1.x or when the P12 uses modern AES.
+                  FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts -legacy $OPENSSL_NOENC 2>/dev/null \
                     | openssl x509 -noout -subject -nameopt oneline,-esc_msb 2>/dev/null \
                     | grep -oE 'OU = [A-Za-z0-9]+' \
                     | head -1 \
                     | awk '{print $NF}' || true)
                   if [ -z "$FLOORP_TEAM_ID" ]; then
-                    FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts $OPENSSL_NOENC 2>/dev/null \
+                    FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts -legacy $OPENSSL_NOENC 2>/dev/null \
                       | openssl x509 -noout -subject 2>/dev/null \
                       | sed -n 's/.*OU=\([^/]*\).*/\1/p' \
                       | head -1 || true)
@@ -1175,10 +1178,19 @@ jobs:
                   --rcodesign-p12-file floorpCert.p12 \
                   --rcodesign-p12-password-file floorpCertPassword.passwd
 
-                # Verify signed entitlements to confirm passkey entitlement is embedded
+                # Verify signed entitlements — fail CI if passkey entitlement is missing.
                 echo "=== Verifying signed bundle entitlements ==="
-                rcodesign print-signature-info "$APP_FILE" 2>&1 | head -100 || true
+                ENTITLEMENT_INFO=$(rcodesign print-signature-info "$APP_FILE" 2>&1 || true)
+                echo "$ENTITLEMENT_INFO" | head -100
                 echo "=== End entitlement verification ==="
+
+                # Assert: passkey entitlement must be present in the signed binary
+                if ! echo "$ENTITLEMENT_INFO" | grep -q 'public-key-credential'; then
+                  echo "ERROR: com.apple.developer.web-browser.public-key-credential not found in signed entitlements!" >&2
+                  echo "The passkey (WebAuthn) entitlement was not embedded during signing." >&2
+                  exit 1
+                fi
+                echo "✓ Passkey (public-key-credential) entitlement verified in signed bundle"
 
                 if [ "${{inputs.beta}}" == "true" ]; then
                   DS_STORE_PATH="$GITHUB_WORKSPACE/noraneko/.github/workflows/assets/mac/daylight/DS_Store"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1062,29 +1062,35 @@ jobs:
                   OPENSSL_NOENC="-nodes"
                 fi
 
-                # Extract the team ID (OU field) from the P12 certificate
-                # Use -clcerts to extract only the client (leaf) certificate, avoiding
-                # intermediate CA certificates that have different OU values.
-                # Append || true so failures don't abort the step (set -euo pipefail is active).
-                FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts $OPENSSL_NOENC 2>/dev/null \
-                  | openssl x509 -noout -subject -nameopt oneline,-esc_msb 2>/dev/null \
-                  | grep -oE 'OU = [A-Za-z0-9]+' \
-                  | head -1 \
-                  | awk '{print $NF}' || true)
+                # Obtain the Apple Team ID.
+                # Priority: 1) APPLE_DEVELOPER_TEAM_ID GitHub Secret (most reliable)
+                #           2) Extract from P12 certificate OU field (fallback)
+                # Apple Team IDs are alphanumeric (e.g. 43AQ936H96).
+                FLOORP_TEAM_ID="${{ secrets.APPLE_DEVELOPER_TEAM_ID }}"
                 if [ -z "$FLOORP_TEAM_ID" ]; then
-                  # Fallback: try alternative extraction method
+                  echo "APPLE_DEVELOPER_TEAM_ID secret not set; falling back to P12 certificate extraction."
+                  # Use -clcerts to extract only the client (leaf) certificate
                   FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts $OPENSSL_NOENC 2>/dev/null \
-                    | openssl x509 -noout -subject 2>/dev/null \
-                    | sed -n 's/.*OU=\([^/]*\).*/\1/p' \
-                    | head -1 || true)
+                    | openssl x509 -noout -subject -nameopt oneline,-esc_msb 2>/dev/null \
+                    | grep -oE 'OU = [A-Za-z0-9]+' \
+                    | head -1 \
+                    | awk '{print $NF}' || true)
+                  if [ -z "$FLOORP_TEAM_ID" ]; then
+                    FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys -clcerts $OPENSSL_NOENC 2>/dev/null \
+                      | openssl x509 -noout -subject 2>/dev/null \
+                      | sed -n 's/.*OU=\([^/]*\).*/\1/p' \
+                      | head -1 || true)
+                  fi
+                else
+                  echo "Using APPLE_TEAM_ID from GitHub Secrets."
                 fi
 
-                # Validate Team ID format (Apple Team IDs are alphanumeric, e.g. 43AQ936H96)
+                # Validate Team ID format
                 if [[ ! "$FLOORP_TEAM_ID" =~ ^[A-Za-z0-9]+$ ]]; then
                   echo "Warning: Invalid or missing Team ID format: '${FLOORP_TEAM_ID:-empty}'"
                   FLOORP_TEAM_ID=""
                 fi
-                echo "Extracted Floorp Team ID: ${FLOORP_TEAM_ID:-not found}"
+                echo "Floorp Team ID: ${FLOORP_TEAM_ID:-not found}"
 
                 # Extract the bundle identifier from the app's Info.plist (Linux-compatible)
                 # Pass path via environment variable to avoid shell injection in Python string
@@ -1098,40 +1104,40 @@ jobs:
                 fi
                 echo "Extracted Floorp Bundle ID: ${FLOORP_BUNDLE_ID:-not found}"
 
-                # Patch the production browser entitlements if we have the team ID
-                ENTITLEMENTS_FILE="security/mac/hardenedruntime/production/firefox.browser.xml"
-                if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
-                  echo "=== Pre-patch entitlements ==="
-                  cat "$ENTITLEMENTS_FILE" || true
-                  echo "=== End pre-patch entitlements ==="
-                  echo "Patching entitlements: replacing 43AQ936H96.org.mozilla.firefox with ${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}"
-                  if grep -q '43AQ936H96\.org\.mozilla\.firefox' "$ENTITLEMENTS_FILE"; then
-                    sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$ENTITLEMENTS_FILE"
-                    # Verify the substitution actually occurred
-                    if grep -q "${FLOORP_TEAM_ID}\.${FLOORP_BUNDLE_ID}" "$ENTITLEMENTS_FILE"; then
-                      echo "Entitlements patched successfully."
+                # Patch the browser entitlements with Floorp's application-identifier.
+                # The ./mach macos-sign -e production flag selects production/firefox.browser.xml.
+                # Patch BOTH developer and production files to ensure coverage regardless of flags.
+                for ENTITLEMENTS_FILE in \
+                  security/mac/hardenedruntime/production/firefox.browser.xml \
+                  security/mac/hardenedruntime/developer/browser.xml; do
+                  if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
+                    echo "=== Patching $ENTITLEMENTS_FILE ==="
+                    if grep -q '43AQ936H96\.org\.mozilla\.firefox' "$ENTITLEMENTS_FILE"; then
+                      sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$ENTITLEMENTS_FILE"
+                      if grep -q "${FLOORP_TEAM_ID}\.${FLOORP_BUNDLE_ID}" "$ENTITLEMENTS_FILE"; then
+                        echo "Patched successfully: 43AQ936H96.org.mozilla.firefox -> ${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}"
+                      else
+                        echo "Warning: sed completed but substitution not confirmed in $ENTITLEMENTS_FILE" >&2
+                      fi
                     else
-                      echo "Warning: sed completed but the new application-identifier was not found in $ENTITLEMENTS_FILE" >&2
+                      echo "Info: '43AQ936H96.org.mozilla.firefox' not found in $ENTITLEMENTS_FILE (may already be patched or not present)"
                     fi
                   else
-                    echo "Warning: expected literal '43AQ936H96.org.mozilla.firefox' not found in $ENTITLEMENTS_FILE; passkey entitlement may be missing." >&2
+                    echo "Skipping $ENTITLEMENTS_FILE (missing team ID, bundle ID, or file)"
                   fi
-                  echo "=== Post-patch entitlements ==="
-                  cat "$ENTITLEMENTS_FILE" || true
-                  echo "=== End post-patch entitlements ==="
-                else
-                  echo "Warning: Could not extract team ID or bundle ID. Entitlements not patched."
-                  echo "Passkey (WebAuthn) support may not work correctly without the correct application-identifier."
-                fi
+                done
 
-                ./mach macos-sign -v -r -c "release" \
+                # Use production entitlements (-e production) for passkey (WebAuthn) support.
+                # Without this flag, mach_commands.py defaults to developer entitlements
+                # which resolves to developer/browser.xml instead of production/firefox.browser.xml.
+                ./mach macos-sign -v -r -c "release" -e production \
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
                   --rcodesign-p12-password-file floorpCertPassword.passwd
 
                 # Verify signed entitlements to confirm passkey entitlement is embedded
                 echo "=== Verifying signed bundle entitlements ==="
-                rcodesign analyze-bundle "$APP_FILE" 2>&1 | head -80 || true
+                rcodesign print-signature-info "$APP_FILE" 2>&1 | head -100 || true
                 echo "=== End entitlement verification ==="
 
                 if [ "${{inputs.beta}}" == "true" ]; then

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1108,55 +1108,52 @@ jobs:
 
                 # Patch the browser entitlements for Floorp passkey (WebAuthn) support.
                 #
-                # IMPORTANT: We use developer entitlements (no -e flag) because production
-                # entitlements lack com.apple.security.cs.allow-dyld-environment-variables,
-                # which is required for the app to launch successfully with rcodesign on Linux.
-                # The developer/browser.xml already has all the entitlements needed for a
-                # working build; we only need to add the passkey entitlement.
+                # IMPORTANT: We use PRODUCTION entitlements for the main app signing.
+                # Developer entitlements contain com.apple.security.get-task-allow which
+                # causes macOS to block the app from launching on end-user machines with
+                # "Launchd job spawn failed" (POSIX error 163).
                 #
-                # Step 1: Add com.apple.developer.web-browser.public-key-credential to
-                #         developer/browser.xml if it's not already present.
-                # Step 2: Patch application-identifier in production/firefox.browser.xml
-                #         (used by nested frameworks/plugins if mach resolves them).
-                DEV_ENTITLEMENTS="security/mac/hardenedruntime/developer/browser.xml"
+                # The production/firefox.browser.xml already has
+                # com.apple.developer.web-browser.public-key-credential, but is missing
+                # com.apple.security.cs.allow-dyld-environment-variables which some
+                # browser components need for proper dylib loading.
+                #
+                # Steps:
+                #   1. Add allow-dyld-environment-variables to production/firefox.browser.xml
+                #   2. Patch application-identifier in production/firefox.browser.xml
+                #   3. Use production/firefox.browser.xml for main app signing (-e flag)
+                PROD_ENTITLEMENTS="security/mac/hardenedruntime/production/firefox.browser.xml"
 
-                # Add passkey entitlement to developer/browser.xml
-                if [ -f "$DEV_ENTITLEMENTS" ]; then
-                  echo "=== Patching $DEV_ENTITLEMENTS for passkey support ==="
-                  if ! grep -q 'com.apple.developer.web-browser.public-key-credential' "$DEV_ENTITLEMENTS"; then
-                    # Insert before closing </dict> tag
-                    sed -i 's|</dict>|<key>com.apple.developer.web-browser.public-key-credential</key>\n\t\t<true/>\n\t</dict>|' "$DEV_ENTITLEMENTS"
-                    if grep -q 'com.apple.developer.web-browser.public-key-credential' "$DEV_ENTITLEMENTS"; then
-                      echo "Added public-key-credential entitlement to $DEV_ENTITLEMENTS"
-                    else
-                      echo "Warning: Failed to add public-key-credential to $DEV_ENTITLEMENTS" >&2
-                    fi
+                # Patch production/firefox.browser.xml for Floorp
+                if [ -f "$PROD_ENTITLEMENTS" ]; then
+                  echo "=== Patching $PROD_ENTITLEMENTS for Floorp ==="
+
+                  # Add allow-dyld-environment-variables if not present
+                  if ! grep -q 'com.apple.security.cs.allow-dyld-environment-variables' "$PROD_ENTITLEMENTS"; then
+                    sed -i 's|</dict>|<key>com.apple.security.cs.allow-dyld-environment-variables</key>\n\t<true/>\n</dict>|' "$PROD_ENTITLEMENTS"
+                    echo "Added allow-dyld-environment-variables to $PROD_ENTITLEMENTS"
                   else
-                    echo "Info: public-key-credential already present in $DEV_ENTITLEMENTS"
+                    echo "Info: allow-dyld-environment-variables already present in $PROD_ENTITLEMENTS"
                   fi
-                else
-                  echo "Warning: $DEV_ENTITLEMENTS not found" >&2
-                fi
 
-                # Patch application-identifier in production entitlements (for nested signing)
-                for ENTITLEMENTS_FILE in \
-                  security/mac/hardenedruntime/production/firefox.browser.xml; do
-                  if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
-                    echo "=== Patching $ENTITLEMENTS_FILE ==="
-                    if grep -q '43AQ936H96\.org\.mozilla\.firefox' "$ENTITLEMENTS_FILE"; then
-                      sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$ENTITLEMENTS_FILE"
-                      if grep -q "${FLOORP_TEAM_ID}\.${FLOORP_BUNDLE_ID}" "$ENTITLEMENTS_FILE"; then
-                        echo "Patched successfully: 43AQ936H96.org.mozilla.firefox -> ${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}"
+                  # Patch application-identifier for Floorp's Apple Developer account
+                  if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ]; then
+                    if grep -q '43AQ936H96\.org\.mozilla\.firefox' "$PROD_ENTITLEMENTS"; then
+                      sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$PROD_ENTITLEMENTS"
+                      if grep -q "${FLOORP_TEAM_ID}\.${FLOORP_BUNDLE_ID}" "$PROD_ENTITLEMENTS"; then
+                        echo "Patched application-identifier: 43AQ936H96.org.mozilla.firefox -> ${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}"
                       else
-                        echo "Warning: sed completed but substitution not confirmed in $ENTITLEMENTS_FILE" >&2
+                        echo "Warning: application-identifier patch not confirmed in $PROD_ENTITLEMENTS" >&2
                       fi
                     else
-                      echo "Info: '43AQ936H96.org.mozilla.firefox' not found in $ENTITLEMENTS_FILE (may already be patched or not present)"
+                      echo "Info: '43AQ936H96.org.mozilla.firefox' not found in $PROD_ENTITLEMENTS (may already be patched)"
                     fi
                   else
-                    echo "Skipping $ENTITLEMENTS_FILE (missing team ID, bundle ID, or file)"
+                    echo "Warning: Skipping application-identifier patch (missing team ID or bundle ID)" >&2
                   fi
-                done
+                else
+                  echo "Warning: $PROD_ENTITLEMENTS not found" >&2
+                fi
 
                 # Embed provisioning profile for passkey (WebAuthn) support BEFORE signing.
                 # The provisioning profile must be placed at Contents/embedded.provisionprofile
@@ -1169,10 +1166,11 @@ jobs:
                   echo "Warning: Floorp.provisionprofile not found, skipping embedding" >&2
                 fi
 
-                # Use developer entitlements (no -e flag) for the main app signing.
-                # Developer entitlements include allow-dyld-environment-variables which is
-                # required for proper dylib loading with rcodesign-signed builds.
+                # Use production entitlements (-e flag) for the main app signing.
+                # Production entitlements do NOT include get-task-allow (which would
+                # cause macOS to block the app from launching with error 163).
                 ./mach macos-sign -v -r -c "release" \
+                  -e security/mac/hardenedruntime/production/firefox.browser.xml \
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
                   --rcodesign-p12-password-file floorpCertPassword.passwd

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1104,12 +1104,41 @@ jobs:
                 fi
                 echo "Extracted Floorp Bundle ID: ${FLOORP_BUNDLE_ID:-not found}"
 
-                # Patch the browser entitlements with Floorp's application-identifier.
-                # The ./mach macos-sign -e production flag selects production/firefox.browser.xml.
-                # Patch BOTH developer and production files to ensure coverage regardless of flags.
+                # Patch the browser entitlements for Floorp passkey (WebAuthn) support.
+                #
+                # IMPORTANT: We use developer entitlements (no -e flag) because production
+                # entitlements lack com.apple.security.cs.allow-dyld-environment-variables,
+                # which is required for the app to launch successfully with rcodesign on Linux.
+                # The developer/browser.xml already has all the entitlements needed for a
+                # working build; we only need to add the passkey entitlement.
+                #
+                # Step 1: Add com.apple.developer.web-browser.public-key-credential to
+                #         developer/browser.xml if it's not already present.
+                # Step 2: Patch application-identifier in production/firefox.browser.xml
+                #         (used by nested frameworks/plugins if mach resolves them).
+                DEV_ENTITLEMENTS="security/mac/hardenedruntime/developer/browser.xml"
+
+                # Add passkey entitlement to developer/browser.xml
+                if [ -f "$DEV_ENTITLEMENTS" ]; then
+                  echo "=== Patching $DEV_ENTITLEMENTS for passkey support ==="
+                  if ! grep -q 'com.apple.developer.web-browser.public-key-credential' "$DEV_ENTITLEMENTS"; then
+                    # Insert before closing </dict> tag
+                    sed -i 's|</dict>|<key>com.apple.developer.web-browser.public-key-credential</key>\n\t\t<true/>\n\t</dict>|' "$DEV_ENTITLEMENTS"
+                    if grep -q 'com.apple.developer.web-browser.public-key-credential' "$DEV_ENTITLEMENTS"; then
+                      echo "Added public-key-credential entitlement to $DEV_ENTITLEMENTS"
+                    else
+                      echo "Warning: Failed to add public-key-credential to $DEV_ENTITLEMENTS" >&2
+                    fi
+                  else
+                    echo "Info: public-key-credential already present in $DEV_ENTITLEMENTS"
+                  fi
+                else
+                  echo "Warning: $DEV_ENTITLEMENTS not found" >&2
+                fi
+
+                # Patch application-identifier in production entitlements (for nested signing)
                 for ENTITLEMENTS_FILE in \
-                  security/mac/hardenedruntime/production/firefox.browser.xml \
-                  security/mac/hardenedruntime/developer/browser.xml; do
+                  security/mac/hardenedruntime/production/firefox.browser.xml; do
                   if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
                     echo "=== Patching $ENTITLEMENTS_FILE ==="
                     if grep -q '43AQ936H96\.org\.mozilla\.firefox' "$ENTITLEMENTS_FILE"; then
@@ -1127,10 +1156,10 @@ jobs:
                   fi
                 done
 
-                # Use production entitlements (-e production) for passkey (WebAuthn) support.
-                # Without this flag, mach_commands.py defaults to developer entitlements
-                # which resolves to developer/browser.xml instead of production/firefox.browser.xml.
-                ./mach macos-sign -v -r -c "release" -e production \
+                # Use developer entitlements (no -e flag) for the main app signing.
+                # Developer entitlements include allow-dyld-environment-variables which is
+                # required for proper dylib loading with rcodesign-signed builds.
+                ./mach macos-sign -v -r -c "release" \
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
                   --rcodesign-p12-password-file floorpCertPassword.passwd

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1164,8 +1164,19 @@ jobs:
                 ./mach macos-sign -v -r -c "release" \
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
-                  --rcodesign-p12-password-file floorpCertPassword.passwd \
-                  --provisioning-profile Floorp.provisionprofile
+                  --rcodesign-p12-password-file floorpCertPassword.passwd
+
+                # Embed provisioning profile for passkey (WebAuthn) support.
+                # The provisioning profile must be placed at the standard location
+                # inside the app bundle. This is normally done by rcodesign's
+                # --provisioning-profile flag, but mach macos-sign does not expose
+                # that flag, so we embed it manually after signing.
+                if [ -f "Floorp.provisionprofile" ]; then
+                  cp Floorp.provisionprofile "$APP_FILE/Contents/embedded.provisionprofile"
+                  echo "Embedded provisioning profile into app bundle"
+                else
+                  echo "Warning: Floorp.provisionprofile not found, skipping embedding" >&2
+                fi
 
                 # Verify signed entitlements to confirm passkey entitlement is embedded
                 echo "=== Verifying signed bundle entitlements ==="

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1158,6 +1158,17 @@ jobs:
                   fi
                 done
 
+                # Embed provisioning profile for passkey (WebAuthn) support BEFORE signing.
+                # The provisioning profile must be placed at Contents/embedded.provisionprofile
+                # before code signing so the signature includes the profile. Adding it after
+                # signing would invalidate the code signature.
+                if [ -f "Floorp.provisionprofile" ]; then
+                  cp Floorp.provisionprofile "$APP_FILE/Contents/embedded.provisionprofile"
+                  echo "Embedded provisioning profile into app bundle (pre-signing)"
+                else
+                  echo "Warning: Floorp.provisionprofile not found, skipping embedding" >&2
+                fi
+
                 # Use developer entitlements (no -e flag) for the main app signing.
                 # Developer entitlements include allow-dyld-environment-variables which is
                 # required for proper dylib loading with rcodesign-signed builds.
@@ -1165,18 +1176,6 @@ jobs:
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
                   --rcodesign-p12-password-file floorpCertPassword.passwd
-
-                # Embed provisioning profile for passkey (WebAuthn) support.
-                # The provisioning profile must be placed at the standard location
-                # inside the app bundle. This is normally done by rcodesign's
-                # --provisioning-profile flag, but mach macos-sign does not expose
-                # that flag, so we embed it manually after signing.
-                if [ -f "Floorp.provisionprofile" ]; then
-                  cp Floorp.provisionprofile "$APP_FILE/Contents/embedded.provisionprofile"
-                  echo "Embedded provisioning profile into app bundle"
-                else
-                  echo "Warning: Floorp.provisionprofile not found, skipping embedding" >&2
-                fi
 
                 # Verify signed entitlements to confirm passkey entitlement is embedded
                 echo "=== Verifying signed bundle entitlements ==="

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1046,6 +1046,10 @@ jobs:
                 APP_FILE=$(find ~/mac-code-signing/old -name "*.app" -type d | head -n 1)
                 echo "Found app file: $APP_FILE"
 
+                # Show rcodesign version for diagnostics
+                echo "=== rcodesign version ==="
+                rcodesign --version || true
+
                 # Patch Firefox production entitlements for Floorp passkey (WebAuthn) support
                 # Replace Firefox's application-identifier with Floorp's team ID + bundle ID
                 # The com.apple.developer.web-browser.public-key-credential entitlement is already
@@ -1097,6 +1101,9 @@ jobs:
                 # Patch the production browser entitlements if we have the team ID
                 ENTITLEMENTS_FILE="security/mac/hardenedruntime/production/firefox.browser.xml"
                 if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
+                  echo "=== Pre-patch entitlements ==="
+                  cat "$ENTITLEMENTS_FILE" || true
+                  echo "=== End pre-patch entitlements ==="
                   echo "Patching entitlements: replacing 43AQ936H96.org.mozilla.firefox with ${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}"
                   if grep -q '43AQ936H96\.org\.mozilla\.firefox' "$ENTITLEMENTS_FILE"; then
                     sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$ENTITLEMENTS_FILE"
@@ -1109,7 +1116,9 @@ jobs:
                   else
                     echo "Warning: expected literal '43AQ936H96.org.mozilla.firefox' not found in $ENTITLEMENTS_FILE; passkey entitlement may be missing." >&2
                   fi
-                  grep -A1 "application-identifier" "$ENTITLEMENTS_FILE" || true
+                  echo "=== Post-patch entitlements ==="
+                  cat "$ENTITLEMENTS_FILE" || true
+                  echo "=== End post-patch entitlements ==="
                 else
                   echo "Warning: Could not extract team ID or bundle ID. Entitlements not patched."
                   echo "Passkey (WebAuthn) support may not work correctly without the correct application-identifier."
@@ -1119,6 +1128,12 @@ jobs:
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
                   --rcodesign-p12-password-file floorpCertPassword.passwd
+
+                # Verify signed entitlements to confirm passkey entitlement is embedded
+                echo "=== Verifying signed bundle entitlements ==="
+                rcodesign analyze-bundle "$APP_FILE" 2>&1 | head -80 || true
+                echo "=== End entitlement verification ==="
+
                 if [ "${{inputs.beta}}" == "true" ]; then
                   DS_STORE_PATH="$GITHUB_WORKSPACE/noraneko/.github/workflows/assets/mac/daylight/DS_Store"
                   BACKGROUND_PATH="$GITHUB_WORKSPACE/noraneko/.github/workflows/assets/mac/daylight/background.tiff"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1045,6 +1045,57 @@ jobs:
                 echo ${{ secrets.APPLE_DEVELOPER_P12_PASSWORD }} > floorpCertPassword.passwd
                 APP_FILE=$(find ~/mac-code-signing/old -name "*.app" -type d | head -n 1)
                 echo "Found app file: $APP_FILE"
+
+                # Patch Firefox production entitlements for Floorp passkey (WebAuthn) support
+                # Replace Firefox's application-identifier with Floorp's team ID + bundle ID
+                # The com.apple.developer.web-browser.public-key-credential entitlement is already
+                # present in Firefox's production browser entitlements; we only need to correct
+                # the application-identifier to match Floorp's Apple Developer account.
+                #
+                # Determine the correct flag for unencrypted PKCS12 output (OpenSSL 3.x vs 1.x)
+                OPENSSL_NOENC="-noenc"
+                if ! openssl pkcs12 -help 2>&1 | grep -q -- '-noenc'; then
+                  OPENSSL_NOENC="-nodes"
+                fi
+
+                # Extract the team ID (OU field) from the P12 certificate
+                FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys $OPENSSL_NOENC 2>/dev/null | openssl x509 -noout -subject -nameopt oneline,-esc_msb | grep -oE 'OU = [A-Za-z0-9]+' | head -1 | awk '{print $NF}')
+                if [ -z "$FLOORP_TEAM_ID" ]; then
+                  # Fallback: try alternative extraction method
+                  FLOORP_TEAM_ID=$(openssl pkcs12 -in floorpCert.p12 -passin file:floorpCertPassword.passwd -nokeys $OPENSSL_NOENC 2>/dev/null | openssl x509 -noout -subject | sed -n 's/.*OU=\([^/]*\).*/\1/p' | head -1)
+                fi
+
+                # Validate Team ID format (Apple Team IDs are alphanumeric, e.g. 43AQ936H96)
+                if [[ ! "$FLOORP_TEAM_ID" =~ ^[A-Za-z0-9]+$ ]]; then
+                  echo "Warning: Invalid or missing Team ID format: '${FLOORP_TEAM_ID:-empty}'"
+                  FLOORP_TEAM_ID=""
+                fi
+                echo "Extracted Floorp Team ID: ${FLOORP_TEAM_ID:-not found}"
+
+                # Extract the bundle identifier from the app's Info.plist (Linux-compatible)
+                # Pass path via environment variable to avoid shell injection in Python string
+                export FLOORP_PLIST_PATH="$APP_FILE/Contents/Info.plist"
+                FLOORP_BUNDLE_ID=$(python3 -c "import plistlib,os; f=open(os.environ['FLOORP_PLIST_PATH'],'rb'); plist=plistlib.load(f); f.close(); print(plist.get('CFBundleIdentifier',''))" 2>/dev/null || echo "")
+
+                # Validate Bundle ID format (reverse domain notation, e.g. app.floorp.Floorp)
+                if [[ ! "$FLOORP_BUNDLE_ID" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                  echo "Warning: Invalid or missing Bundle ID format: '${FLOORP_BUNDLE_ID:-empty}'"
+                  FLOORP_BUNDLE_ID=""
+                fi
+                echo "Extracted Floorp Bundle ID: ${FLOORP_BUNDLE_ID:-not found}"
+
+                # Patch the production browser entitlements if we have the team ID
+                ENTITLEMENTS_FILE="security/mac/hardenedruntime/production/firefox.browser.xml"
+                if [ -n "$FLOORP_TEAM_ID" ] && [ -n "$FLOORP_BUNDLE_ID" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
+                  echo "Patching entitlements: replacing 43AQ936H96.org.mozilla.firefox with ${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}"
+                  sed -i "s|43AQ936H96\.org\.mozilla\.firefox|${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}|g" "$ENTITLEMENTS_FILE"
+                  echo "Entitlements patched successfully."
+                  grep -A1 "application-identifier" "$ENTITLEMENTS_FILE" || true
+                else
+                  echo "Warning: Could not extract team ID or bundle ID. Entitlements not patched."
+                  echo "Passkey (WebAuthn) support may not work correctly without the correct application-identifier."
+                fi
+
                 ./mach macos-sign -v -r -c "release" \
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1043,6 +1043,8 @@ jobs:
                 echo ${{ secrets.APPLE_DEVELOPER_P12_BASE64 }} > floorp-cert.txt
                 base64 --decode floorp-cert.txt > floorpCert.p12
                 echo ${{ secrets.APPLE_DEVELOPER_P12_PASSWORD }} > floorpCertPassword.passwd
+                echo ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }} > provisioning-profile.txt
+                base64 --decode provisioning-profile.txt > Floorp.provisionprofile
                 APP_FILE=$(find ~/mac-code-signing/old -name "*.app" -type d | head -n 1)
                 echo "Found app file: $APP_FILE"
 
@@ -1162,7 +1164,8 @@ jobs:
                 ./mach macos-sign -v -r -c "release" \
                   -a "$APP_FILE" \
                   --rcodesign-p12-file floorpCert.p12 \
-                  --rcodesign-p12-password-file floorpCertPassword.passwd
+                  --rcodesign-p12-password-file floorpCertPassword.passwd \
+                  --provisioning-profile Floorp.provisionprofile
 
                 # Verify signed entitlements to confirm passkey entitlement is embedded
                 echo "=== Verifying signed bundle entitlements ==="


### PR DESCRIPTION
## Summary

This PR adds entitlement patching to the macOS code signing CI workflow to enable **passkey (WebAuthn) support** for Floorp on macOS.

## Background

Apple requires third-party macOS browsers to hold the `com.apple.developer.web-browser.public-key-credential` entitlement with a matching `com.apple.application-identifier` to use WebAuthn/passkeys. We have been granted this entitlement for `app.floorp.Floorp`.

Firefox's production browser entitlements (`security/mac/hardenedruntime/production/firefox.browser.xml`) already include the `public-key-credential` entitlement, but the associated `application-identifier` is hardcoded to Firefox's team ID: `43AQ936H96.org.mozilla.firefox`.

## What This Does

Before running `./mach macos-sign`, the workflow now:

1. **Extracts Team ID** — Parses the OU field from the P12 certificate via OpenSSL (with fallback extraction method)
2. **Extracts Bundle ID** — Reads `CFBundleIdentifier` from the app's `Info.plist` via Python `plistlib` (Linux-compatible)
3. **Validates values** — Regex validation for Team ID (`^[A-Za-z0-9]+$`) and Bundle ID (`^[a-zA-Z0-9._-]+$`)
4. **Patches entitlements** — Replaces `43AQ936H96.org.mozilla.firefox` with `${FLOORP_TEAM_ID}.${FLOORP_BUNDLE_ID}` in `firefox.browser.xml`

## Implementation Details

- **OpenSSL compatibility**: Auto-detects `-noenc` (OpenSSL 3.x) vs `-nodes` (1.x) flag
- **Shell injection prevention**: Passes file paths to Python via environment variable (`os.environ`) instead of string interpolation
- **Non-blocking**: If extraction fails, warns but continues — signing still works, just without passkey entitlement
- **Linux-compatible**: CI runner is `ubuntu-22.04`; uses `python3` + `plistlib` instead of macOS-only `PlistBuddy`

## Testing

This change needs to be validated with an actual macOS CI build run to verify:
- Team ID extraction from the P12 certificate
- Bundle ID extraction from `Info.plist`
- Entitlement XML patching applies correctly
- Signed app includes the correct entitlements

## Files Changed

- `.github/workflows/package.yml` — Added ~50 lines to the `macOS-x86_64` signing case block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * macOS installer build now performs entitlements patching prior to signing to ensure correct app identifiers for both production and developer builds.
  * Improved certificate and bundle identifier extraction and validation; patching is skipped with clear warnings when values are missing or invalid.
  * Emits diagnostic dumps of entitlements and signing tool information (pre/post) to aid troubleshooting, then continues with normal signing and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->