### PR TITLE
Add Mac OS formatting for modifier keys in shortcut editor

### DIFF
--- a/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutEditor.tsx
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutEditor.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ShortcutConfig } from "../../../types/pref.ts";
 import { Input } from "@/components/common/input.tsx";
+import { formatModifierLabel, formatModifierSymbol } from "../platform.ts";
 
 interface ShortcutEditorProps {
     isOpen: boolean;
@@ -117,10 +118,10 @@ export const ShortcutEditor = ({
 
     const previewShortcut = () => {
         const modifiers = [];
-        if (shortcut.modifiers.alt) modifiers.push("Alt");
-        if (shortcut.modifiers.ctrl) modifiers.push("Ctrl");
-        if (shortcut.modifiers.meta) modifiers.push("Meta");
-        if (shortcut.modifiers.shift) modifiers.push("Shift");
+        if (shortcut.modifiers.alt) modifiers.push(formatModifierSymbol("alt"));
+        if (shortcut.modifiers.ctrl) modifiers.push(formatModifierSymbol("ctrl"));
+        if (shortcut.modifiers.meta) modifiers.push(formatModifierSymbol("meta"));
+        if (shortcut.modifiers.shift) modifiers.push(formatModifierSymbol("shift"));
         if (shortcut.key) modifiers.push(formatKeyCode(shortcut.key).toUpperCase());
         return modifiers.join(" + ");
     };
@@ -161,7 +162,7 @@ export const ShortcutEditor = ({
                                     }))
                                 }
                             />
-                            <span>Alt</span>
+                            <span>{formatModifierLabel("alt")}</span>
                         </div>
                         <div className="flex items-center space-x-2 p-3 bg-base-200 rounded-lg">
                             <input
@@ -175,7 +176,7 @@ export const ShortcutEditor = ({
                                     }))
                                 }
                             />
-                            <span>Ctrl</span>
+                            <span>{formatModifierLabel("ctrl")}</span>
                         </div>
                         <div className="flex items-center space-x-2 p-3 bg-base-200 rounded-lg">
                             <input
@@ -189,7 +190,7 @@ export const ShortcutEditor = ({
                                     }))
                                 }
                             />
-                            <span>Meta</span>
+                            <span>{formatModifierLabel("meta")}</span>
                         </div>
                         <div className="flex items-center space-x-2 p-3 bg-base-200 rounded-lg">
                             <input
@@ -203,7 +204,7 @@ export const ShortcutEditor = ({
                                     }))
                                 }
                             />
-                            <span>Shift</span>
+                            <span>{formatModifierLabel("shift")}</span>
                         </div>
                     </div>
 

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutsSettings.tsx
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutsSettings.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/common/card.tsx";
 import { Keyboard } from "lucide-react";
 import { InfoTip } from "@/components/common/infotip.tsx";
+import { formatModifierSymbol } from "../platform.ts";
 
 interface ShortcutsSettingsProps {
     config: KeyboardShortcutConfig;
@@ -84,10 +85,10 @@ export const ShortcutsSettings = ({
                                         <td>
                                             {shortcut ? (
                                                 <div className="flex items-center space-x-2">
-                                                    {shortcut.modifiers.alt && <span>Alt</span>}
-                                                    {shortcut.modifiers.ctrl && <span>Ctrl</span>}
-                                                    {shortcut.modifiers.meta && <span>Meta</span>}
-                                                    {shortcut.modifiers.shift && <span>Shift</span>}
+                                                    {shortcut.modifiers.alt && <span>{formatModifierSymbol("alt")}</span>}
+                                                    {shortcut.modifiers.ctrl && <span>{formatModifierSymbol("ctrl")}</span>}
+                                                    {shortcut.modifiers.meta && <span>{formatModifierSymbol("meta")}</span>}
+                                                    {shortcut.modifiers.shift && <span>{formatModifierSymbol("shift")}</span>}
                                                     <span>{shortcut.key.toUpperCase()}</span>
                                                 </div>
                                             ) : (

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/platform.ts
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/platform.ts
@@ -3,7 +3,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const isMac = navigator.platform.toUpperCase().includes("MAC");
+let _isMac: boolean | undefined;
+
+function isMac(): boolean {
+  if (_isMac === undefined) {
+    _isMac =
+      typeof navigator !== "undefined" &&
+      navigator?.platform?.toUpperCase().includes("MAC") === true;
+  }
+  return _isMac;
+}
 
 /**
  * Format a modifier key name for display.
@@ -12,7 +21,7 @@ const isMac = navigator.platform.toUpperCase().includes("MAC");
 export function formatModifierLabel(
   modifier: "alt" | "ctrl" | "meta" | "shift",
 ): string {
-  if (isMac) {
+  if (isMac()) {
     switch (modifier) {
       case "alt":
         return "⌥ Option";
@@ -43,7 +52,7 @@ export function formatModifierLabel(
 export function formatModifierSymbol(
   modifier: "alt" | "ctrl" | "meta" | "shift",
 ): string {
-  if (isMac) {
+  if (isMac()) {
     switch (modifier) {
       case "alt":
         return "⌥";

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/platform.ts
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/platform.ts
@@ -1,0 +1,70 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const isMac = navigator.platform.toUpperCase().includes("MAC");
+
+/**
+ * Format a modifier key name for display.
+ * On macOS, uses Mac-specific symbols and names.
+ */
+export function formatModifierLabel(
+  modifier: "alt" | "ctrl" | "meta" | "shift",
+): string {
+  if (isMac) {
+    switch (modifier) {
+      case "alt":
+        return "⌥ Option";
+      case "ctrl":
+        return "⌃ Control";
+      case "meta":
+        return "⌘ Command";
+      case "shift":
+        return "⇧ Shift";
+    }
+  }
+  switch (modifier) {
+    case "alt":
+      return "Alt";
+    case "ctrl":
+      return "Ctrl";
+    case "meta":
+      return "Meta";
+    case "shift":
+      return "Shift";
+  }
+}
+
+/**
+ * Format a modifier key as a compact symbol for preview.
+ * On macOS, uses Mac-specific symbols.
+ */
+export function formatModifierSymbol(
+  modifier: "alt" | "ctrl" | "meta" | "shift",
+): string {
+  if (isMac) {
+    switch (modifier) {
+      case "alt":
+        return "⌥";
+      case "ctrl":
+        return "⌃";
+      case "meta":
+        return "⌘";
+      case "shift":
+        return "⇧";
+    }
+  }
+  switch (modifier) {
+    case "alt":
+      return "Alt";
+    case "ctrl":
+      return "Ctrl";
+    case "meta":
+      return "Meta";
+    case "shift":
+      return "Shift";
+  }
+}
+
+export { isMac };


### PR DESCRIPTION
MacOSで、キーボードショートカットの表記が、会っていなかったので修正しました。

Before
<img width="1001" height="970" alt="image" src="https://github.com/user-attachments/assets/10fd091e-5549-49a9-81af-192033d0c55f" />
<img width="719" height="159" alt="image" src="https://github.com/user-attachments/assets/f9512cdd-7af2-43ed-805e-9174d93b8f45" />
After
<img width="1287" height="969" alt="image" src="https://github.com/user-attachments/assets/e02670fe-ad68-475b-9ad2-33461b966471" />
<img width="667" height="194" alt="image" src="https://github.com/user-attachments/assets/2365d2d7-5f24-41b4-8a53-c8c1073fc550" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Keyboard shortcut displays now use platform-specific formatting for modifier labels and compact symbols, improving clarity and consistency across operating systems.
* **New Features**
  * macOS-style modifier names and symbols are applied where appropriate while shortcut behavior and editing remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Floorp-Projects/Floorp/pull/2424)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->