### PR TITLE
Fix gesture command

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -67,7 +67,15 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-reload-all-tabs",
-    fn: (win) => win.gBrowser.reloadTabs(win.gBrowser.tabs),
+    fn: (win) => {
+      if (typeof win.gBrowser?.reloadTabs === "function") {
+        win.gBrowser.reloadTabs(win.gBrowser.tabs);
+      } else if (typeof win.BrowserReload === "function") {
+        for (const _tab of win.gBrowser.tabs) {
+          win.BrowserReload();
+        }
+      }
+    },
   },
   {
     name: "gecko-open-new-window",
@@ -115,7 +123,13 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-force-reload",
-    fn: (win) => win.BrowserCommands.reloadSkipCache(),
+    fn: (win) => {
+      if (typeof win.BrowserCommands?.reloadSkipCache === "function") {
+        win.BrowserCommands.reloadSkipCache();
+      } else if (typeof win.BrowserReloadSkipCache === "function") {
+        win.BrowserReloadSkipCache();
+      }
+    },
   },
   {
     name: "gecko-zoom-in",
@@ -143,7 +157,13 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-open-addons-manager",
-    fn: (win) => win.BrowserAddonUI.openAddonsMgr(),
+    fn: (win) => {
+      if (typeof win.BrowserAddonUI?.openAddonsMgr === "function") {
+        win.BrowserAddonUI.openAddonsMgr();
+      } else if (typeof win.BrowserOpenAddonsMgr === "function") {
+        win.BrowserOpenAddonsMgr();
+      }
+    },
   },
   {
     name: "gecko-send-with-mail",
@@ -172,7 +192,13 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-show-page-info",
-    fn: (win) => win.BrowserCommands.pageInfo(),
+    fn: (win) => {
+      if (typeof win.BrowserCommands?.pageInfo === "function") {
+        win.BrowserCommands.pageInfo();
+      } else if (typeof win.BrowserPageInfo === "function") {
+        win.BrowserPageInfo();
+      }
+    },
   },
   {
     name: "floorp-rest-mode",

--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -143,7 +143,7 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-open-addons-manager",
-    fn: (win) => win.BrowserOpenAddonsMgr(),
+    fn: (win) => win.BrowserAddonUI.openAddonsMgr(),
   },
   {
     name: "gecko-send-with-mail",

--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -115,7 +115,7 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-force-reload",
-    fn: (win) => win.BrowserReloadSkipCache(),
+    fn: (win) => win.BrowserCommands.reloadSkipCache(),
   },
   {
     name: "gecko-zoom-in",

--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -67,7 +67,7 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-reload-all-tabs",
-    fn: (win) => win.gBrowser.reloadAllTabs(),
+    fn: (win) => win.gBrowser.reloadTabs(win.gBrowser.tabs),
   },
   {
     name: "gecko-open-new-window",

--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -172,7 +172,7 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "gecko-show-page-info",
-    fn: (win) => win.BrowserPageInfo(),
+    fn: (win) => win.BrowserCommands.pageInfo(),
   },
   {
     name: "floorp-rest-mode",


### PR DESCRIPTION
Firefoxの内部APIが変更されていて、一部Gestureが機能していなかった問題を修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated mouse-gesture actions to use modern browser window command APIs for reloads, add-ons manager, and page info.
* **Bug Fixes**
  * Added runtime fallbacks so gestures continue to work when preferred APIs are unavailable, improving reliability across browser variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Floorp-Projects/Floorp/pull/2425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->