### PR TITLE
Refine appearance of Start top sites and Hub sidebar

### DIFF
--- a/browser-features/pages-newtab/src/components/TopSites/TopSiteTile.tsx
+++ b/browser-features/pages-newtab/src/components/TopSites/TopSiteTile.tsx
@@ -35,7 +35,7 @@ export function TopSiteTile(
     <a
       key={site.url}
       href={site.url}
-      className={`group flex flex-col items-center p-2 rounded-lg transition-all duration-200 hover:bg-gray-900/50 ${
+      className={`group flex flex-col items-center p-2 rounded-lg transition-all duration-200 hover:bg-gray-100/20 ${
         isFirefoxMode ? "w-20 md:w-24" : "w-16"
       }`}
       onContextMenu={(e) => onContextMenu(e, site)}

--- a/browser-features/pages-newtab/src/components/TopSites/TopSiteTile.tsx
+++ b/browser-features/pages-newtab/src/components/TopSites/TopSiteTile.tsx
@@ -35,7 +35,7 @@ export function TopSiteTile(
     <a
       key={site.url}
       href={site.url}
-      className={`group flex flex-col items-center p-2 rounded-lg transition-all duration-200 hover:backdrop-blur-sm hover:bg-gray-700/50 ${
+      className={`group flex flex-col items-center p-2 rounded-lg transition-all duration-200 hover:bg-gray-900/50 ${
         isFirefoxMode ? "w-20 md:w-24" : "w-16"
       }`}
       onContextMenu={(e) => onContextMenu(e, site)}
@@ -68,7 +68,7 @@ export function TopSiteTile(
         </div>
         {isPinnedSite && (
           <div className="absolute top-0 right-0 transform translate-x-1/2 -translate-y-1/2">
-            <div className="w-4 h-4 rounded-full bg-gray-700 flex items-center justify-center shadow-sm">
+            <div className="w-5 h-5 rounded-full bg-gray-700 flex items-center justify-center">
               <PinIcon className="w-3 h-3 text-white" />
             </div>
           </div>

--- a/browser-features/pages-newtab/src/components/TopSites/index.tsx
+++ b/browser-features/pages-newtab/src/components/TopSites/index.tsx
@@ -364,7 +364,7 @@ export function TopSites({ isFirefoxMode = false }: { isFirefoxMode?: boolean })
           <button
             type="button"
             onClick={() => setShowAddModal(true)}
-            className={`group flex flex-col items-center p-2 rounded-lg border border-dashed border-gray-400/50 text-gray-300 hover:text-white hover:bg-gray-900/50 transition-all ${
+            className={`group flex flex-col items-center p-2 rounded-lg border border-dashed border-gray-400/50 text-gray-300 hover:text-white hover:bg-gray-100/20 transition-all ${
               isFirefoxMode ? "w-20 md:w-24" : "w-16"
             }`}
             title={t("topSites.addSite")}

--- a/browser-features/pages-newtab/src/components/TopSites/index.tsx
+++ b/browser-features/pages-newtab/src/components/TopSites/index.tsx
@@ -364,7 +364,7 @@ export function TopSites({ isFirefoxMode = false }: { isFirefoxMode?: boolean })
           <button
             type="button"
             onClick={() => setShowAddModal(true)}
-            className={`group flex flex-col items-center p-2 rounded-lg border border-dashed border-gray-400/50 text-gray-300 hover:text-white hover:backdrop-blur-sm hover:bg-gray-700/50 transition-all ${
+            className={`group flex flex-col items-center p-2 rounded-lg border border-dashed border-gray-400/50 text-gray-300 hover:text-white hover:bg-gray-900/50 transition-all ${
               isFirefoxMode ? "w-20 md:w-24" : "w-16"
             }`}
             title={t("topSites.addSite")}

--- a/browser-features/pages-settings/src/components/common/sidebar.tsx
+++ b/browser-features/pages-settings/src/components/common/sidebar.tsx
@@ -74,14 +74,14 @@ export function SidebarFooter({ children, className }: SidebarProps) {
 }
 
 export function SidebarGroup({ children, className }: SidebarProps) {
-  return <div className={cn("px-2 py-2", className)}>{children}</div>;
+  return <div className={cn("px-2 pt-2 pb-4", className)}>{children}</div>;
 }
 
 export function SidebarGroupLabel({ children, className }: SidebarProps) {
   return (
     <h3
       className={cn(
-        "mb-2 px-4 text-sm font-medium text-base-content/60",
+        "mb-4 px-4 text-sm font-medium text-base-content/60",
         className,
       )}
     >
@@ -91,7 +91,7 @@ export function SidebarGroupLabel({ children, className }: SidebarProps) {
 }
 
 export function SidebarMenu({ children, className }: SidebarProps) {
-  return <div className={cn("space-y-1", className)}>{children}</div>;
+  return <div className={cn(className)}>{children}</div>;
 }
 
 export function SidebarMenuItem(

--- a/browser-features/pages-settings/src/components/nav-features.tsx
+++ b/browser-features/pages-settings/src/components/nav-features.tsx
@@ -36,7 +36,7 @@ function InternalItem({
   isActive: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors">
+    <div className="flex items-center gap-2 rounded-lg px-3 transition-colors">
       <Link
         to={feature.url}
         className={`${
@@ -55,7 +55,7 @@ function InternalItem({
 // External item renderer without SidebarMenuItem wrapper
 function ExternalItem({ feature }: { feature: ExternalFeature }) {
   return (
-    <div className="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors">
+    <div className="flex items-center gap-2 rounded-lg px-3 transition-colors">
       <button
         type="button"
         onClick={feature.onClick}


### PR DESCRIPTION
マジで見当違いな変更してたらごめんなさい！！

## Floorp Start
- ホバー時にぼかしを追加適用する処理をなくし、アニメーションの不自然さを減らします
- ホバー時の背景色を白寄りに変更し、ホバー中であることをわかりやすくします
- ピンのアイコンの周りにある円のサイズを大きく、シャドウを削除し、外観上の窮屈さを減らします

## Floorp Hub
- クリック可能なサイドバー項目間の隙間をなくします
  - 左右、およびカテゴリーラベルの上下のマージン/パディングは極力変更しないよう努めています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- Adjusted styling and hover effects for top sites tiles and the "Add new site" button
- Updated spacing and padding layout in settings sidebar and navigation components
- Refined icon badge sizing in pinned site overlays

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Floorp-Projects/Floorp/pull/2435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->