### PR TITLE
README: fix signpath avatar url

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Floorp Browser is a free and open-source project. If you like Floorp Browser, pl
     <h4 style="text-align: center;">1Password</h4>
   </a>
   <a href="https://signpath.io/" style="margin: 10px; overflow: hidden; padding: 0px 30px;">
-    <img src="https://avatars.githubusercontent.com/SignPath?s=200&v=4" alt="SignPath" width="100" height="100">
+    <img src="https://avatars.githubusercontent.com/u/34448643?s=200&v=4" alt="SignPath" width="100" height="100">
     <h4 style="text-align: center;">SignPath</h4>
   </a>
 </div>


### PR DESCRIPTION
Update SignPath image src to use the numeric GitHub avatar path (/u/34448643?s=200&v=4) instead of the previous 'SignPath' path so the correct avatar displays in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sponsor avatar image reference to use the latest GitHub avatar URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Floorp-Projects/Floorp/pull/2453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->