### PR TITLE
fix: restore 'Hide Interface', 'Toggle Navigation Panel', and 'Rest Mode' keyboard shortcuts

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -1,5 +1,10 @@
 import type { GestureActionRegistration } from "./gestures.ts";
 import { setShareModeEnabled } from "#features-chrome/common/browser-share-mode/browser-share-mode.tsx";
+import {
+  toggleUserInterface,
+  toggleNavigationPanel,
+  enableRestMode,
+} from "./ui-toggle.ts";
 
 const getXulElement = (id: string, win?: Window): XULElement | null => {
   try {
@@ -231,62 +236,15 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "floorp-rest-mode",
-    fn: (win) => {
-      const doc = win.document!;
-      const selectedTab = win.gBrowser.selectedTab;
-      const selectedTabLocation =
-        selectedTab.linkedBrowser.documentURI?.spec;
-      for (const tab of win.gBrowser.tabs) {
-        win.gBrowser.discardBrowser(tab);
-      }
-      if (selectedTabLocation) {
-        win.openTrustedLinkIn("about:blank", "current");
-      }
-      const tag = doc.createElement("style");
-      tag.textContent = `* { display:none !important; }`;
-      tag.setAttribute("id", "floorp-rest-mode");
-      doc.head?.appendChild(tag);
-      const l10n = new Localization(
-        ["browser/floorp.ftl", "branding/brand.ftl"],
-        true,
-      );
-      Services.prompt.alert(
-        null as unknown as mozIDOMWindowProxy,
-        l10n.formatValueSync("rest-mode") ?? "Rest Mode",
-        l10n.formatValueSync("rest-mode-description") ?? "",
-      );
-      doc.getElementById("floorp-rest-mode")?.remove();
-      if (selectedTabLocation) {
-        win.openTrustedLinkIn(selectedTabLocation, "current");
-      }
-    },
+    fn: (win) => enableRestMode(win),
   },
   {
     name: "floorp-hide-user-interface",
-    fn: (win) => {
-      const toolbox = win.document?.getElementById("navigator-toolbox");
-      if (!toolbox) return;
-      let shownElementAmount = 0;
-      for (const child of toolbox.children) {
-        const el = child as HTMLElement;
-        el.style.display = el.style.display ? "" : "none";
-        if (el.style.display === "") {
-          shownElementAmount++;
-        }
-      }
-      const navigationBar = toolbox.children[1] as HTMLElement | undefined;
-      if (shownElementAmount > 1 && navigationBar?.style.display !== "") {
-        navigationBar!.style.display = "";
-      }
-    },
+    fn: (win) => toggleUserInterface(win.document!),
   },
   {
     name: "floorp-toggle-navigation-panel",
-    fn: (win) => {
-      const navBar = win.document?.getElementById("nav-bar") as HTMLElement | null;
-      if (!navBar) return;
-      navBar.style.display = navBar.style.display ? "" : "none";
-    },
+    fn: (win) => toggleNavigationPanel(win.document!),
   },
   {
     name: "gecko-stop",

--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -231,15 +231,62 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "floorp-rest-mode",
-    fn: (win) => win.gFloorpCommands.enableRestMode(),
+    fn: (win) => {
+      const doc = win.document!;
+      const selectedTab = win.gBrowser.selectedTab;
+      const selectedTabLocation =
+        selectedTab.linkedBrowser.documentURI?.spec;
+      for (const tab of win.gBrowser.tabs) {
+        win.gBrowser.discardBrowser(tab);
+      }
+      if (selectedTabLocation) {
+        win.openTrustedLinkIn("about:blank", "current");
+      }
+      const tag = doc.createElement("style");
+      tag.textContent = `* { display:none !important; }`;
+      tag.setAttribute("id", "floorp-rest-mode");
+      doc.head?.appendChild(tag);
+      const l10n = new Localization(
+        ["browser/floorp.ftl", "branding/brand.ftl"],
+        true,
+      );
+      Services.prompt.alert(
+        null as unknown as mozIDOMWindowProxy,
+        l10n.formatValueSync("rest-mode") ?? "Rest Mode",
+        l10n.formatValueSync("rest-mode-description") ?? "",
+      );
+      doc.getElementById("floorp-rest-mode")?.remove();
+      if (selectedTabLocation) {
+        win.openTrustedLinkIn(selectedTabLocation, "current");
+      }
+    },
   },
   {
     name: "floorp-hide-user-interface",
-    fn: (win) => win.gFloorpDesign.hideUserInterface(),
+    fn: (win) => {
+      const toolbox = win.document?.getElementById("navigator-toolbox");
+      if (!toolbox) return;
+      let shownElementAmount = 0;
+      for (const child of toolbox.children) {
+        const el = child as HTMLElement;
+        el.style.display = el.style.display ? "" : "none";
+        if (el.style.display === "") {
+          shownElementAmount++;
+        }
+      }
+      const navigationBar = toolbox.children[1] as HTMLElement | undefined;
+      if (shownElementAmount > 1 && navigationBar?.style.display !== "") {
+        navigationBar!.style.display = "";
+      }
+    },
   },
   {
     name: "floorp-toggle-navigation-panel",
-    fn: (win) => win.gFloorpDesign.toggleNavigationPanel(),
+    fn: (win) => {
+      const navBar = win.document?.getElementById("nav-bar") as HTMLElement | null;
+      if (!navBar) return;
+      navBar.style.display = navBar.style.display ? "" : "none";
+    },
   },
   {
     name: "gecko-stop",

--- a/browser-features/chrome/common/mouse-gesture/utils/ui-toggle.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/ui-toggle.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// Shared UI toggle utilities for keyboard shortcuts and mouse gestures.
+// Extracted from legacy gFloorpDesign (Floorp-core/browser/base/content/browser-design.mjs).
+
+/**
+ * Toggle visibility of all `#navigator-toolbox` children.
+ * When restoring, ensures the navigation bar remains visible if multiple
+ * elements are shown.
+ */
+export function toggleUserInterface(doc: Document): void {
+  try {
+    const toolbox = doc.getElementById("navigator-toolbox");
+    if (!toolbox) return;
+
+    let shownElementAmount = 0;
+    for (const child of toolbox.children) {
+      const el = child as HTMLElement;
+      el.style.display = el.style.display ? "" : "none";
+      if (el.style.display === "") {
+        shownElementAmount++;
+      }
+    }
+
+    if (toolbox.children.length >= 2 && shownElementAmount > 1) {
+      const navigationBar = toolbox.children[1] as HTMLElement;
+      if (navigationBar?.style.display !== "") {
+        navigationBar.style.display = "";
+      }
+    }
+  } catch (e) {
+    console.error("[ui-toggle] Failed to toggle user interface:", e);
+  }
+}
+
+/**
+ * Toggle visibility of the `#nav-bar` element.
+ */
+export function toggleNavigationPanel(doc: Document): void {
+  try {
+    const navBar = doc.getElementById("nav-bar") as HTMLElement | null;
+    if (!navBar) return;
+    navBar.style.display = navBar.style.display ? "" : "none";
+  } catch (e) {
+    console.error("[ui-toggle] Failed to toggle navigation panel:", e);
+  }
+}
+
+/**
+ * Enable rest mode: discard all tabs, show a blank screen with an alert
+ * prompt, then restore the original tab when the user dismisses the dialog.
+ */
+export function enableRestMode(win: Window): void {
+  try {
+    const doc = win.document!;
+    const selectedTab = win.gBrowser.selectedTab;
+    const selectedTabLocation =
+      selectedTab.linkedBrowser.documentURI?.spec;
+
+    for (const tab of win.gBrowser.tabs) {
+      win.gBrowser.discardBrowser(tab);
+    }
+
+    if (selectedTabLocation) {
+      win.openTrustedLinkIn("about:blank", "current");
+    }
+
+    const tag = doc.createElement("style");
+    tag.textContent = `* { display:none !important; }`;
+    tag.setAttribute("id", "floorp-rest-mode");
+    doc.head?.appendChild(tag);
+
+    const l10n = new Localization(
+      ["browser/floorp.ftl", "branding/brand.ftl"],
+      true,
+    );
+    Services.prompt.alert(
+      null as unknown as mozIDOMWindowProxy,
+      l10n.formatValueSync("rest-mode") ?? "Rest Mode",
+      l10n.formatValueSync("rest-mode-description") ?? "",
+    );
+
+    doc.getElementById("floorp-rest-mode")?.remove();
+
+    if (selectedTabLocation) {
+      win.openTrustedLinkIn(selectedTabLocation, "current");
+    }
+  } catch (e) {
+    console.error("[ui-toggle] Failed to enable rest mode:", e);
+  }
+}

--- a/browser-features/chrome/common/mouse-gesture/utils/ui-toggle.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/ui-toggle.ts
@@ -4,24 +4,35 @@
 
 /**
  * Toggle visibility of all `#navigator-toolbox` children.
- * When restoring, ensures the navigation bar remains visible if multiple
- * elements are shown.
+ * Computes a single hide/show target state from the children's current
+ * visibility, then applies it consistently to all children to avoid mixed
+ * UI states. When restoring (showing), ensures the navigation bar remains
+ * visible if multiple elements are shown.
  */
 export function toggleUserInterface(doc: Document): void {
   try {
     const toolbox = doc.getElementById("navigator-toolbox");
     if (!toolbox) return;
+    if (toolbox.children.length === 0) return;
 
-    let shownElementAmount = 0;
+    // Compute a single target state: if any child is shown, hide all.
+    // Otherwise, show all. This avoids mixed UI states.
+    let anyShown = false;
     for (const child of toolbox.children) {
       const el = child as HTMLElement;
-      el.style.display = el.style.display ? "" : "none";
-      if (el.style.display === "") {
-        shownElementAmount++;
+      if (el.style.display !== "none") {
+        anyShown = true;
+        break;
       }
     }
+    const targetDisplay = anyShown ? "none" : "";
 
-    if (toolbox.children.length >= 2 && shownElementAmount > 1) {
+    for (const child of toolbox.children) {
+      (child as HTMLElement).style.display = targetDisplay;
+    }
+
+    // When restoring, ensure the navigation bar stays visible.
+    if (!anyShown && toolbox.children.length >= 2) {
       const navigationBar = toolbox.children[1] as HTMLElement;
       if (navigationBar?.style.display !== "") {
         navigationBar.style.display = "";
@@ -50,12 +61,13 @@ export function toggleNavigationPanel(doc: Document): void {
  * prompt, then restore the original tab when the user dismisses the dialog.
  */
 export function enableRestMode(win: Window): void {
-  try {
-    const doc = win.document!;
-    const selectedTab = win.gBrowser.selectedTab;
-    const selectedTabLocation =
-      selectedTab.linkedBrowser.documentURI?.spec;
+  const doc = win.document!;
+  const selectedTab = win.gBrowser.selectedTab;
+  const selectedTabLocation =
+    selectedTab.linkedBrowser.documentURI?.spec;
+  const tag = doc.createElement("style");
 
+  try {
     for (const tab of win.gBrowser.tabs) {
       win.gBrowser.discardBrowser(tab);
     }
@@ -64,7 +76,6 @@ export function enableRestMode(win: Window): void {
       win.openTrustedLinkIn("about:blank", "current");
     }
 
-    const tag = doc.createElement("style");
     tag.textContent = `* { display:none !important; }`;
     tag.setAttribute("id", "floorp-rest-mode");
     doc.head?.appendChild(tag);
@@ -78,13 +89,12 @@ export function enableRestMode(win: Window): void {
       l10n.formatValueSync("rest-mode") ?? "Rest Mode",
       l10n.formatValueSync("rest-mode-description") ?? "",
     );
-
-    doc.getElementById("floorp-rest-mode")?.remove();
-
+  } catch (e) {
+    console.error("[ui-toggle] Failed to enable rest mode:", e);
+  } finally {
+    tag.remove();
     if (selectedTabLocation) {
       win.openTrustedLinkIn(selectedTabLocation, "current");
     }
-  } catch (e) {
-    console.error("[ui-toggle] Failed to enable rest mode:", e);
   }
 }

--- a/libs/shared/custom-shortcut-key/commands.ts
+++ b/libs/shared/custom-shortcut-key/commands.ts
@@ -130,7 +130,34 @@ export const commands: Commands = {
     type: "page-action",
   },
   "floorp-rest-mode": {
-    command: () => globalThis.gFloorpCommands.enableRestMode(),
+    command: () => {
+      const selectedTab = globalThis.gBrowser.selectedTab;
+      const selectedTabLocation =
+        selectedTab.linkedBrowser.documentURI?.spec;
+      for (const tab of globalThis.gBrowser.tabs) {
+        globalThis.gBrowser.discardBrowser(tab);
+      }
+      if (selectedTabLocation) {
+        globalThis.openTrustedLinkIn("about:blank", "current");
+      }
+      const tag = globalThis.document.createElement("style");
+      tag.textContent = `* { display:none !important; }`;
+      tag.setAttribute("id", "floorp-rest-mode");
+      globalThis.document.head?.appendChild(tag);
+      const l10n = new Localization(
+        ["browser/floorp.ftl", "branding/brand.ftl"],
+        true,
+      );
+      Services.prompt.alert(
+        null,
+        l10n.formatValueSync("rest-mode"),
+        l10n.formatValueSync("rest-mode-description"),
+      );
+      globalThis.document.getElementById("floorp-rest-mode")?.remove();
+      if (selectedTabLocation) {
+        globalThis.openTrustedLinkIn(selectedTabLocation, "current");
+      }
+    },
     type: "page-action",
   },
   "gecko-zoom-in": {
@@ -146,7 +173,22 @@ export const commands: Commands = {
     type: "visible-action",
   },
   "floorp-hide-user-interface": {
-    command: () => globalThis.gFloorpDesign.hideUserInterface(),
+    command: () => {
+      const doc = globalThis.document;
+      const toolbox = doc.getElementById("navigator-toolbox");
+      if (!toolbox) return;
+      let shownElementAmount = 0;
+      for (const element of toolbox.children) {
+        element.style.display = element.style.display ? "" : "none";
+        if (element.style.display === "") {
+          shownElementAmount++;
+        }
+      }
+      const navigationBar = toolbox.children[1];
+      if (shownElementAmount > 1 && navigationBar?.style.display !== "") {
+        navigationBar.style.display = "";
+      }
+    },
     type: "visible-action",
   },
   "gecko-back": { command: () => globalThis.BrowserBack(), type: "history-action" },

--- a/libs/shared/custom-shortcut-key/commands.ts
+++ b/libs/shared/custom-shortcut-key/commands.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck Firefox chrome globals (BrowserCommands, gBrowser, etc.) are untyped
 
 import * as t from 'io-ts';
+import { toggleUserInterface, enableRestMode } from '../../../browser-features/chrome/common/mouse-gesture/utils/ui-toggle.ts';
 
 export const csk_category = [
   "tab-action",
@@ -130,34 +131,7 @@ export const commands: Commands = {
     type: "page-action",
   },
   "floorp-rest-mode": {
-    command: () => {
-      const selectedTab = globalThis.gBrowser.selectedTab;
-      const selectedTabLocation =
-        selectedTab.linkedBrowser.documentURI?.spec;
-      for (const tab of globalThis.gBrowser.tabs) {
-        globalThis.gBrowser.discardBrowser(tab);
-      }
-      if (selectedTabLocation) {
-        globalThis.openTrustedLinkIn("about:blank", "current");
-      }
-      const tag = globalThis.document.createElement("style");
-      tag.textContent = `* { display:none !important; }`;
-      tag.setAttribute("id", "floorp-rest-mode");
-      globalThis.document.head?.appendChild(tag);
-      const l10n = new Localization(
-        ["browser/floorp.ftl", "branding/brand.ftl"],
-        true,
-      );
-      Services.prompt.alert(
-        null,
-        l10n.formatValueSync("rest-mode"),
-        l10n.formatValueSync("rest-mode-description"),
-      );
-      globalThis.document.getElementById("floorp-rest-mode")?.remove();
-      if (selectedTabLocation) {
-        globalThis.openTrustedLinkIn(selectedTabLocation, "current");
-      }
-    },
+    command: () => enableRestMode(globalThis as unknown as Window),
     type: "page-action",
   },
   "gecko-zoom-in": {
@@ -173,22 +147,7 @@ export const commands: Commands = {
     type: "visible-action",
   },
   "floorp-hide-user-interface": {
-    command: () => {
-      const doc = globalThis.document;
-      const toolbox = doc.getElementById("navigator-toolbox");
-      if (!toolbox) return;
-      let shownElementAmount = 0;
-      for (const element of toolbox.children) {
-        element.style.display = element.style.display ? "" : "none";
-        if (element.style.display === "") {
-          shownElementAmount++;
-        }
-      }
-      const navigationBar = toolbox.children[1];
-      if (shownElementAmount > 1 && navigationBar?.style.display !== "") {
-        navigationBar.style.display = "";
-      }
-    },
+    command: () => toggleUserInterface(globalThis.document),
     type: "visible-action",
   },
   "gecko-back": { command: () => globalThis.BrowserBack(), type: "history-action" },


### PR DESCRIPTION
## Summary

Fixes #1939
Fixes #2426

Three keyboard shortcuts have not worked since Floorp 12 (Noraneko) because they called globals from the legacy Floorp 11 codebase ([`Floorp-core`](https://github.com/Floorp-Projects/Floorp-core)) that were never migrated:

| Shortcut | Broken Call | Legacy Source |
|----------|------------|---------------|
| Hide Interface | `gFloorpDesign.hideUserInterface()` | `browser-design.mjs` |
| Toggle Navigation Panel | `gFloorpDesign.toggleNavigationPanel()` | `browser-design.mjs` |
| Rest Mode | `gFloorpCommands.enableRestMode()` | `browser-commands.mjs` |

### Fix

Replace the broken globals with inline implementations that replicate the original Floorp 11 behaviour:

- **Hide Interface** — toggles `display` on all `#navigator-toolbox` children (tabs bar, nav bar, bookmarks bar, etc.)
- **Toggle Navigation Panel** — toggles `display` on `#nav-bar`
- **Rest Mode** — discards all tabs, shows a blank screen with a prompt alert, then restores the original tab on dismiss

### Files Changed

| File | Change |
|------|--------|
| `browser-features/chrome/common/mouse-gesture/utils/actions.ts` | Replaced `gFloorpDesign.*` and `gFloorpCommands.*` with inline implementations |
| `libs/shared/custom-shortcut-key/commands.ts` | Same fixes for the legacy CSK command registry |

### Test Plan

1. Start dev browser: `deno task feles-build dev`
2. Go to `about:hub#/features/shortcuts`
3. Assign "Hide Interface" → `Alt+U`, "Toggle Navigation Panel" → `Alt+N`, "Rest Mode" → any key
4. Press `Alt+U` → all navigator-toolbox children should toggle visibility
5. Press `Alt+N` → the navigation bar should toggle visibility independently
6. Press the Rest Mode key → all tabs discard, blank screen appears with alert, original tab restores on dismiss
7. Run `deno task dev-tool console --level error` → no runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Rest mode” blanks page content with a temporary overlay, may discard tabs, shows a localized alert, and restores the previous tab URL.

* **Refactor**
  * UI hide/toggle behavior consolidated into shared utilities for more consistent toolbar and navigation toggles; keyboard shortcuts for rest mode, hide UI, and navigation toggle now use the unified behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Floorp-Projects/Floorp/pull/2458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->