### PR TITLE
fix: prevent private container tab from saving first page to history

### DIFF
--- a/browser-features/chrome/@types/xul-window.d.ts
+++ b/browser-features/chrome/@types/xul-window.d.ts
@@ -66,6 +66,7 @@ interface GBrowser {
   removeTabsProgressListener(
     listener: Pick<nsIWebProgressListener, "onLocationChange">,
   ): void;
+  createBrowser(...args: unknown[]): XULElement;
 }
 
 interface TabContextMenu {

--- a/browser-features/chrome/common/private-container/browser-private-container.tsx
+++ b/browser-features/chrome/common/private-container/browser-private-container.tsx
@@ -317,6 +317,30 @@ export class FloorpPrivateContainer {
         },
       );
 
+      // Defense-in-depth: the createBrowser override handles disableglobalhistory
+      // during element creation, but also apply tab-level attributes here.
+      if (
+        userContextId ===
+          PrivateContainer.getPrivateContainerUserContextId() &&
+        newTab?.linkedBrowser
+      ) {
+        try {
+          FloorpPrivateContainer.applyDoNotSaveHistoryToTab(
+            newTab as unknown as {
+              linkedBrowser: {
+                setAttribute: (arg0: string, arg1: string) => void;
+              };
+              setAttribute: (arg0: string, arg1: string) => void;
+            },
+          );
+        } catch (e) {
+          console.error(
+            "[FloorpPrivateContainer] Failed to apply history disabling to reopened tab:",
+            e,
+          );
+        }
+      }
+
       if (globalThis.gBrowser.selectedTab === tab) {
         globalThis.gBrowser.selectedTab = newTab;
       }

--- a/browser-features/chrome/static/overrides/modules/private-container/index.ts
+++ b/browser-features/chrome/static/overrides/modules/private-container/index.ts
@@ -1,0 +1,46 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { PrivateContainer } from "#features-chrome/common/private-container/PrivateContainer.ts";
+
+export const overrides = [
+  () => {
+    const gBrowser = globalThis.gBrowser;
+    if (!gBrowser || typeof gBrowser.createBrowser !== "function") {
+      console.warn(
+        "[FloorpPrivateContainer] gBrowser.createBrowser not available for override",
+      );
+      return;
+    }
+
+    const originalCreateBrowser = gBrowser.createBrowser.bind(gBrowser);
+
+    gBrowser.createBrowser = function (...args: unknown[]) {
+      const browser = originalCreateBrowser(...args);
+      if (!browser) return browser;
+
+      try {
+        const options = args[0] as { userContextId?: number } | undefined;
+        const privateContainerUserContextId =
+          PrivateContainer.getPrivateContainerUserContextId();
+
+        if (
+          options?.userContextId != null &&
+          options.userContextId === privateContainerUserContextId
+        ) {
+          browser.setAttribute("disableglobalhistory", "true");
+          browser.setAttribute("disablehistory", "true");
+        }
+      } catch (e) {
+        console.error(
+          "[FloorpPrivateContainer] Error in createBrowser override:",
+          e,
+        );
+      }
+
+      return browser;
+    };
+  },
+];


### PR DESCRIPTION
## Fixes #1886

### Problem

When opening a link in a Private Container tab (right-click → "Open in Private Container"), only the **first page** visited in that tab gets saved to browsing history. Subsequent navigations are correctly NOT saved.

### Root Cause

The `disableglobalhistory="true"` attribute is set on the browser element **after** it is created and connected to the DOM. Firefox's `browser-custom-element.mjs` checks for this attribute during `connectedCallback()` → `construct()`. If absent, it sets `useGlobalHistory = true` synchronously, causing the initial `about:blank` load to be recorded to history.

Floorp 11 worked because it overrode `gBrowser.createBrowser()` to set `disableglobalhistory` during browser element creation (before DOM insertion). This override was never migrated to Noraneko.

```
Timeline (broken):
1. addTrustedTab("about:blank") → createBrowser() → element created (no disableglobalhistory)
2. connectedCallback() → useGlobalHistory = true
3. about:blank loads → HISTORY RECORDED ← the leak
4. applyDoNotSaveHistoryToTab() → sets disableglobalhistory (too late)
5. loadURI(actual URL) → history disabled (correctly)
```

### Fix

- **New file**: `browser-features/chrome/static/overrides/modules/private-container/index.ts` — Overrides `gBrowser.createBrowser` to set `disableglobalhistory` and `disablehistory` on the browser element during creation (before DOM insertion), matching the Floorp 11 approach.
- **Modified**: `browser-private-container.tsx` — Added `applyDoNotSaveHistoryToTab()` as defense-in-depth in `reopenInPrivateContainer`, which previously had no history disabling at all.
- **Modified**: `xul-window.d.ts` — Added `createBrowser` to the `GBrowser` type interface.

### Testing

1. Right-click a link → "Open in Private Container"
2. Navigate to several pages within the tab
3. Check history → **no pages** from the private container tab should appear
4. Test "Reopen in Private Container" (tab context menu)
5. Verify regular tabs still record history correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy in private containers by ensuring history is properly disabled for tabs assigned to private containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Floorp-Projects/Floorp/pull/2459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->