### PR TITLE
fix: prevent unified extensions panel from closing on bottom navbar (#2079)

### DIFF
--- a/browser-features/chrome/common/ui-custom/layout/dom-manipulator.ts
+++ b/browser-features/chrome/common/ui-custom/layout/dom-manipulator.ts
@@ -307,6 +307,21 @@ function updateForwardingTarget(target: EventTarget | null): void {
         // Event was handled, don't forward
         return;
       }
+
+      // Skip click forwarding for buttons with dedicated fallback handlers.
+      // Their panels are opened on mousedown by attachFallbackNavbarHandlers,
+      // and forwarding the click causes the panel to close immediately.
+      // See Issue #2079.
+      const toolbarBtn = target?.closest("toolbarbutton, button");
+      if (toolbarBtn) {
+        const btnId = toolbarBtn.id || "";
+        if (
+          btnId === "fxa-toolbar-menu-button" ||
+          btnId === "unified-extensions-button"
+        ) {
+          return;
+        }
+      }
     }
 
     forwardEventToNavigatorToolbox(event, toolbox);
@@ -334,8 +349,14 @@ function isXULButton(element: Element | null): boolean {
     return false;
   }
 
-  // Check if it's a URL bar button (star-button, reload-button, etc.)
+  // Skip buttons handled by fallback navbar handlers — their click→command
+  // conversion is harmful when the panel is open. See Issue #2079.
   const id = button.id || "";
+  if (id === "fxa-toolbar-menu-button" || id === "unified-extensions-button") {
+    return false;
+  }
+
+  // Check if it's a URL bar button (star-button, reload-button, etc.)
   const isUrlbarButton =
     id.includes("button") ||
     id.includes("star") ||


### PR DESCRIPTION
## Summary

Fixes #2079

When the navbar is positioned at the bottom, clicking the Unified Extensions button opened the panel briefly but it closed immediately.

### Root Cause

The event forwarding handler (`updateForwardingTarget`) forwards click events from the moved navbar to `navigator-toolbox`. For `#unified-extensions-button` (and `#fxa-toolbar-menu-button`), the `isXULButton()` check matched because the ID contains `"button"`, triggering `doCommand()` and synthetic command event dispatch — which caused the panel to close right after it was opened by the mousedown fallback handler.

### Changes

- **Skip click event forwarding** for `#fxa-toolbar-menu-button` and `#unified-extensions-button` in the forwarding handler (`updateForwardingTarget`). These buttons are already handled by the dedicated fallback handler (`attachFallbackNavbarHandlers`) on mousedown.
- **Exclude from `isXULButton()`** as a safety net — prevents click→command conversion even if the click event somehow reaches the forwarding path.

### Testing

- Navbar positioned at bottom
- Unified Extensions button: click opens panel, click again closes (toggle works)
- Sync profile button: still works correctly
- Other toolbar buttons (reload, downloads, etc.): unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed click handling for specific toolbar buttons to prevent unintended event routing interference and ensure proper button functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->