### PR TITLE
fix: prevent browser close when container tab is the only tab open

### DIFF
--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -38,6 +38,11 @@ export class WorkspacesTabManager {
   // "auto-created replacement tab" right after last-tab close.
   private recentOpenedAtByTab = new WeakMap<XULElement, number>();
   private recentOpenedAtPerWorkspace = new Map<TWorkspaceID, number>();
+  // Timestamp (Date.now()) of when the current handleTabClose invocation
+  // started. Used to distinguish tabs created by reopen/container-switch
+  // operations (created BEFORE the close) from Firefox auto-replacement tabs
+  // (created DURING the close). Fixes #2193.
+  private tabCloseStartTime = 0;
   // When true, handleTabClose skips its workspace-empty logic. Used during
   // bulk tab removal (workspace deletion) so that closing tabs one-by-one
   // does not interfere with the deletion flow (fixes #2247).
@@ -208,6 +213,8 @@ export class WorkspacesTabManager {
     // Skip workspace-empty logic when bulk-removing tabs (e.g. workspace deletion)
     if (this.suppressTabCloseHandling) return;
 
+    this.tabCloseStartTime = Date.now();
+
     const tab = event.target as XULElement;
     let workspaceId = this.getWorkspaceIdFromAttribute(tab);
 
@@ -243,6 +250,12 @@ export class WorkspacesTabManager {
       // auto-generated replacement tab from Firefox's closeWindowWithLastTab=false behavior.
       // We should ignore it when checking if the workspace is empty.
       if (createdAt && now - createdAt < 500) {
+        // If the tab was created BEFORE this handleTabClose started, it's from a
+        // reopen/container-switch operation (Floorp code or extension), not a
+        // Firefox auto-replacement tab. Always keep it. Fixes #2193.
+        if (createdAt <= this.tabCloseStartTime) {
+          return true;
+        }
         try {
           const browser = globalThis.gBrowser.getBrowserForTab(
             t as unknown as XULElement,


### PR DESCRIPTION
## Summary

Fixes #2193

When the only tab open is in a container, any operation that moves a tab between containers (extensions like Google Container, proxy containers, Floorp's own "Reopen in Private Container", command palette "Reopen in Container") caused the browser to close unexpectedly.

## Root Cause

The `validWorkspaceTabs` filter in `WorkspacesTabManager.handleTabClose()` was designed to exclude Firefox's auto-created replacement tabs (from `closeWindowWithLastTab=false`). However, it also incorrectly excluded tabs created by **any** "create new tab + close old tab" operation, because:

1. The new tab was created <500ms ago (check: ✅)
2. The new tab's `currentURI.spec` was still `about:blank` because the page hadn't started loading yet (check: ✅)

This caused the workspace to appear empty → browser closes.

## Fix

**Timestamp comparison approach** — The key insight is timing order:

| Scenario | Tab created | handleTabClose starts | Result |
|----------|-------------|----------------------|--------|
| Extension container switch | T1 | T2 (T2 > T1) | Tab kept ✅ |
| Reopen in Private Container | T1 | T2 (T2 > T1) | Tab kept ✅ |
| Reopen in Container (palette) | T1 | T2 (T2 > T1) | Tab kept ✅ |
| Firefox auto-replacement | T2 | T1 (T1 < T2) | URL filter applies ✅ |

Tabs created **before** `handleTabClose` started are from reopen/container-switch operations — always keep them. Tabs created **after** may be Firefox auto-replacement tabs — apply the existing URL filter.

This approach works for **all** cases without requiring changes to reopen code or extensions.

## Changes

- `workspacesTabManager.tsx`: Add `tabCloseStartTime` field, record timestamp at start of `handleTabClose`, compare in `validWorkspaceTabs` filter

## Test Plan

- [x] Workspace-related tests pass (6/6)
- [x] Private container tests pass (1/1)
- [ ] Manual: Open only 1 tab in any container → "Reopen in Private Container" → browser should NOT close
- [ ] Manual: Open only 1 tab in private container → "Reopen in Private Container" (toggle) → browser should NOT close
- [ ] Manual: Open only 1 tab → command palette "Reopen in Container" → choose different container → browser should NOT close
- [ ] Manual: Install container extension (e.g., Google Container) → open only 1 tab → navigate to google.com → browser should NOT close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab management in workspaces during close operations. The system now more accurately distinguishes between tabs created automatically during the close process and tabs that were opened beforehand, enhancing retention logic for when workspaces become empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->