### PR TITLE
fix(os-server): auto-generate auth token on enable

### DIFF
--- a/browser-features/modules/actors/NROSAutomotorParent.sys.mts
+++ b/browser-features/modules/actors/NROSAutomotorParent.sys.mts
@@ -56,6 +56,10 @@ export class NROSAutomotorParent extends JSWindowActorParent {
             enabled: osAutomotorManager.isEnabled(),
             platformSupported: osAutomotorManager.isPlatformSupported(),
             installedVersion: osAutomotorManager.getInstalledVersion(),
+            serverToken: Services.prefs.getStringPref(
+              "floorp.os.server.token",
+              "",
+            ),
           });
 
         case "OSAutomotor:GetPlatformDebugInfo":

--- a/browser-features/modules/modules/os-automotor/OSAutomotor-manager.sys.mts
+++ b/browser-features/modules/modules/os-automotor/OSAutomotor-manager.sys.mts
@@ -651,6 +651,15 @@ class OSAutomotorManager {
       console.error("[Floorp OS] Error during filesystem cleanup:", e);
     }
 
+    // Remove token file
+    try {
+      const homeDir = Services.dirsvc.get("Home", Ci.nsIFile).path;
+      const tokenFile = PathUtils.join(homeDir, ".floorp", "os-server-token");
+      await IOUtils.remove(tokenFile, { ignoreAbsent: true });
+    } catch (e) {
+      console.error("[Floorp OS] Failed to remove token file:", e);
+    }
+
     // Clear preferences
     try {
       try {
@@ -689,6 +698,14 @@ class OSAutomotorManager {
         }
       } catch (e) {
         console.error("[Floorp OS] Failed to clear frontend version pref:", e);
+      }
+
+      try {
+        if (Services.prefs.prefHasUserValue("floorp.os.server.token")) {
+          Services.prefs.clearUserPref("floorp.os.server.token");
+        }
+      } catch (e) {
+        console.error("[Floorp OS] Failed to clear server token pref:", e);
       }
     } catch (e) {
       console.error("[Floorp OS] Error clearing prefs during reset:", e);

--- a/browser-features/modules/modules/os-automotor/OSAutomotor-manager.sys.mts
+++ b/browser-features/modules/modules/os-automotor/OSAutomotor-manager.sys.mts
@@ -509,6 +509,17 @@ class OSAutomotorManager {
     }
 
     try {
+      // Ensure auth token exists before enabling
+      const existingToken = Services.prefs.getStringPref(
+        "floorp.os.server.token",
+        "",
+      );
+      if (!existingToken) {
+        const generated = Services.uuid.generateUUID().toString()
+          .replace(/[{}]/g, "");
+        Services.prefs.setStringPref("floorp.os.server.token", generated);
+      }
+
       // Download and verify binary first
       await this.ensureBinaryInstalled();
 

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -282,11 +282,14 @@ class LocalHttpServer implements nsIServerSocketListener {
 
   private writeTokenFile(token: string): void {
     try {
-      const profileDir = Services.dirsvc.get("ProfD", Ci.nsIFile).path;
-      const tokenFile = PathUtils.join(profileDir, "floorp-os-server-token");
+      const homeDir = Services.dirsvc.get("Home", Ci.nsIFile).path;
+      const floorpDir = PathUtils.join(homeDir, ".floorp");
+      const tokenFile = PathUtils.join(floorpDir, "server-token");
       const encoder = new TextEncoder();
       const content = encoder.encode(token);
-      void IOUtils.write(tokenFile, content, { mode: "overwrite" }).catch(
+      void IOUtils.makeDirectory(floorpDir, { ignoreExisting: true }).then(
+        () => IOUtils.write(tokenFile, content, { mode: "overwrite" }),
+      ).catch(
         (e: unknown) => {
           err("Failed to write token file:", e);
         },

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -267,12 +267,21 @@ class LocalHttpServer implements nsIServerSocketListener {
     }
   }
 
+  private ensureToken(): string {
+    const existing = Services.prefs.getStringPref(PREF_TOKEN, "");
+    if (existing) return existing;
+    const generated = Services.uuid.generateUUID().toString()
+      .replace(/[{}]/g, "");
+    Services.prefs.setStringPref(PREF_TOKEN, generated);
+    return generated;
+  }
+
   private _updateFromPrefs() {
     const enabled = Services.prefs.getBoolPref(PREF_ENABLED, false);
     const mcpEnabled = Services.prefs.getBoolPref(PREF_MCP_ENABLED, false);
     if (enabled || mcpEnabled) {
       const port = Services.prefs.getIntPref(PREF_PORT, DEFAULT_PORT);
-      const token = Services.prefs.getStringPref(PREF_TOKEN, "");
+      const token = this.ensureToken();
       if (!this._server) {
         this.start(port, token);
       } else {
@@ -592,7 +601,7 @@ function initializeServer() {
     const mcpEnabled = Services.prefs.getBoolPref(PREF_MCP_ENABLED, false);
     if (enabled || mcpEnabled) {
       const port = Services.prefs.getIntPref(PREF_PORT, DEFAULT_PORT);
-      const token = Services.prefs.getStringPref(PREF_TOKEN, "");
+      const token = osLocalServer.ensureToken();
       osLocalServer.start(port, token);
     }
   } catch (e) {

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -268,7 +268,7 @@ class LocalHttpServer implements nsIServerSocketListener {
     }
   }
 
-  private ensureToken(): string {
+  public ensureToken(): string {
     const existing = Services.prefs.getStringPref(PREF_TOKEN, "");
     if (existing) {
       this.writeTokenFile(existing);
@@ -276,7 +276,11 @@ class LocalHttpServer implements nsIServerSocketListener {
     }
     const generated = Services.uuid.generateUUID().toString()
       .replace(/[{}]/g, "");
-    Services.prefs.setStringPref(PREF_TOKEN, generated);
+    try {
+      Services.prefs.setStringPref(PREF_TOKEN, generated);
+    } catch (e) {
+      err("Failed to persist server token to preferences:", e);
+    }
     this.writeTokenFile(generated);
     return generated;
   }
@@ -664,5 +668,5 @@ initializeServer();
 
 // Also export explicit control API
 export const startServer = (port = DEFAULT_PORT, token = "") =>
-  osLocalServer.start(port, token);
+  osLocalServer.start(port, token || osLocalServer.ensureToken());
 export const stopServer = () => osLocalServer.stop();

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -269,11 +269,31 @@ class LocalHttpServer implements nsIServerSocketListener {
 
   private ensureToken(): string {
     const existing = Services.prefs.getStringPref(PREF_TOKEN, "");
-    if (existing) return existing;
+    if (existing) {
+      this.writeTokenFile(existing);
+      return existing;
+    }
     const generated = Services.uuid.generateUUID().toString()
       .replace(/[{}]/g, "");
     Services.prefs.setStringPref(PREF_TOKEN, generated);
+    this.writeTokenFile(generated);
     return generated;
+  }
+
+  private writeTokenFile(token: string): void {
+    try {
+      const profileDir = Services.dirsvc.get("ProfD", Ci.nsIFile).path;
+      const tokenFile = PathUtils.join(profileDir, "floorp-os-server-token");
+      const encoder = new TextEncoder();
+      const content = encoder.encode(token);
+      void IOUtils.write(tokenFile, content, { mode: "overwrite" }).catch(
+        (e: unknown) => {
+          err("Failed to write token file:", e);
+        },
+      );
+    } catch (e) {
+      err("Failed to write token file:", e);
+    }
   }
 
   private _updateFromPrefs() {

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -284,7 +284,7 @@ class LocalHttpServer implements nsIServerSocketListener {
     try {
       const homeDir = Services.dirsvc.get("Home", Ci.nsIFile).path;
       const floorpDir = PathUtils.join(homeDir, ".floorp");
-      const tokenFile = PathUtils.join(floorpDir, "server-token");
+      const tokenFile = PathUtils.join(floorpDir, "os-server-token");
       const encoder = new TextEncoder();
       const content = encoder.encode(token);
       void IOUtils.makeDirectory(floorpDir, { ignoreExisting: true }).then(

--- a/browser-features/modules/modules/os-server/server.sys.mts
+++ b/browser-features/modules/modules/os-server/server.sys.mts
@@ -92,6 +92,7 @@ class LocalHttpServer implements nsIServerSocketListener {
   private _token = "";
   private _router: _Router | null = null;
   private _activeConnections = 0;
+  private _updatingFromPrefs = false;
   private static readonly READ_HEAD_TIMEOUT_MS = 5000;
   private static readonly READ_BODY_TIMEOUT_MS = 8000;
   private static readonly MAX_BODY_BYTES = 2 * 1024 * 1024; // 2MB
@@ -289,6 +290,8 @@ class LocalHttpServer implements nsIServerSocketListener {
       const content = encoder.encode(token);
       void IOUtils.makeDirectory(floorpDir, { ignoreExisting: true }).then(
         () => IOUtils.write(tokenFile, content, { mode: "overwrite" }),
+      ).then(
+        () => IOUtils.setPermissions(tokenFile, 0o600),
       ).catch(
         (e: unknown) => {
           err("Failed to write token file:", e);
@@ -299,7 +302,31 @@ class LocalHttpServer implements nsIServerSocketListener {
     }
   }
 
+  public deleteTokenFile(): void {
+    try {
+      const homeDir = Services.dirsvc.get("Home", Ci.nsIFile).path;
+      const tokenFile = PathUtils.join(homeDir, ".floorp", "os-server-token");
+      void IOUtils.remove(tokenFile, { ignoreAbsent: true }).catch(
+        (e: unknown) => {
+          err("Failed to delete token file:", e);
+        },
+      );
+    } catch (e) {
+      err("Failed to delete token file:", e);
+    }
+  }
+
   private _updateFromPrefs() {
+    if (this._updatingFromPrefs) return;
+    this._updatingFromPrefs = true;
+    try {
+      this._updateFromPrefsInner();
+    } finally {
+      this._updatingFromPrefs = false;
+    }
+  }
+
+  private _updateFromPrefsInner() {
     const enabled = Services.prefs.getBoolPref(PREF_ENABLED, false);
     const mcpEnabled = Services.prefs.getBoolPref(PREF_MCP_ENABLED, false);
     if (enabled || mcpEnabled) {

--- a/browser-features/pages-settings/src/app/floorp-os/page.tsx
+++ b/browser-features/pages-settings/src/app/floorp-os/page.tsx
@@ -232,12 +232,15 @@ export default function FloorpOS() {
                   <Button
                     size="sm"
                     variant="secondary"
-                    onClick={() => {
-                      navigator.clipboard.writeText(status.serverToken).catch(
-                        (e) => {
-                          console.error("[Floorp OS]", "Failed to copy token:", e);
-                        },
-                      );
+                    onClick={async () => {
+                      try {
+                        if (!navigator.clipboard?.writeText) {
+                          throw new Error("Clipboard API unavailable");
+                        }
+                        await navigator.clipboard.writeText(status.serverToken);
+                      } catch (e) {
+                        console.error("[Floorp OS]", "Failed to copy token:", e);
+                      }
                     }}
                   >
                     {t("floorpOS.statusCard.copyToken")}

--- a/browser-features/pages-settings/src/app/floorp-os/page.tsx
+++ b/browser-features/pages-settings/src/app/floorp-os/page.tsx
@@ -232,9 +232,13 @@ export default function FloorpOS() {
                   <Button
                     size="sm"
                     variant="secondary"
-                    onClick={() =>
-                      navigator.clipboard.writeText(status.serverToken)
-                    }
+                    onClick={() => {
+                      navigator.clipboard.writeText(status.serverToken).catch(
+                        (e) => {
+                          console.error("[Floorp OS]", "Failed to copy token:", e);
+                        },
+                      );
+                    }}
                   >
                     {t("floorpOS.statusCard.copyToken")}
                   </Button>

--- a/browser-features/pages-settings/src/app/floorp-os/page.tsx
+++ b/browser-features/pages-settings/src/app/floorp-os/page.tsx
@@ -31,6 +31,7 @@ declare global {
       enabled: boolean;
       platformSupported: boolean;
       installedVersion: string;
+      serverToken: string;
     }>;
     getPlatformDebugInfo(): Promise<{
       os: string;
@@ -44,6 +45,7 @@ interface FloorpOSStatus {
   enabled: boolean;
   platformSupported: boolean;
   installedVersion: string;
+  serverToken: string;
 }
 
 export default function FloorpOS() {
@@ -216,6 +218,28 @@ export default function FloorpOS() {
                   }`}
                 />
               </div>
+
+              {status.enabled && status.serverToken && (
+                <div className="flex items-center justify-between">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">
+                      {t("floorpOS.statusCard.serverToken")}
+                    </p>
+                    <p className="text-sm text-muted-foreground font-mono break-all">
+                      {status.serverToken}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() =>
+                      navigator.clipboard.writeText(status.serverToken)
+                    }
+                  >
+                    {t("floorpOS.statusCard.copyToken")}
+                  </Button>
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
@@ -467,7 +467,9 @@
             "running": "Running",
             "stopped": "Stopped",
             "enabledBadge": "Enabled",
-            "disabledBadge": "Disabled"
+            "disabledBadge": "Disabled",
+            "serverToken": "Server Token",
+            "copyToken": "Copy"
         },
         "controlsCard": {
             "title": "Controls",

--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP-mac.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP-mac.json
@@ -467,7 +467,9 @@
             "running": "実行中",
             "stopped": "停止中",
             "enabledBadge": "有効",
-            "disabledBadge": "無効"
+            "disabledBadge": "無効",
+            "serverToken": "サーバートークン",
+            "copyToken": "コピー"
         },
         "controlsCard": {
             "title": "制御",

--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -467,7 +467,9 @@
             "running": "実行中",
             "stopped": "停止中",
             "enabledBadge": "有効",
-            "disabledBadge": "無効"
+            "disabledBadge": "無効",
+            "serverToken": "サーバートークン",
+            "copyToken": "コピー"
         },
         "controlsCard": {
             "title": "制御",


### PR DESCRIPTION
## Summary

When Floorp OS is enabled, the server at 127.0.0.1:58261 now automatically generates and persists an auth token. Previously, floorp.os.server.token remained empty, causing the server to run without authentication while Access-Control-Allow-Origin: * allowed any local web page to access the API.

## Changes

- server.sys.mts: Added ensureToken() method — generates a UUID via Services.uuid.generateUUID() and persists it to the pref when empty. Called in _updateFromPrefs() and initializeServer(), covering both floorp.os.enabled and floorp.mcp.enabled paths.
- OSAutomotor-manager.sys.mts: Added token generation in enableFloorpOS() before setting the enabled pref (defense-in-depth).
- NROSAutomotorParent.sys.mts: Extended GetStatus response with serverToken.
- page.tsx: Added token display with copy button in the Status Card (visible when enabled).
- en-US.json / ja-JP.json: Added serverToken and copyToken i18n keys.

## Behavior

| Scenario | Behavior |
|----------|----------|
| First enable | Token auto-generated, persisted, server starts with auth |
| Re-enable | Existing token reused |
| User set custom token | User's token preserved |
| MCP path | Same auto-generation covers it |

## Security Assessment

- Vulnerability was confirmed by code review: empty token → auth bypass
- ensureToken() guarantees non-empty token before server starts
- Token is cryptographically random (v4 UUID, 128-bit)
- CORS policy unchanged (*) — token auth is the defense layer

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server token is now displayed in FloorpOS settings with a copy-to-clipboard button when the service is enabled.
  * System status responses now include the server token and the local server will derive/ensure a token when starting.
  * The app auto-generates, persists, and writes a token file with restricted permissions when needed.

* **Bug Fixes / Improvements**
  * Token persistence and startup flows hardened; token is removed during FloorpOS reset.

* **Localization**
  * UI strings for token display and copy action added in English and Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->