### PR TITLE
fix(settings): change broken link to Floorp Docs

### DIFF
--- a/browser-features/pages-settings/src/app/pwa/components/Preferences.tsx
+++ b/browser-features/pages-settings/src/app/pwa/components/Preferences.tsx
@@ -83,7 +83,7 @@ export function Preferences() {
 
           <div>
             <a
-              href="https://docs.floorp.app/docs/features/how-to-use-pwa"
+              href="https://docs.floorp.app/docs/features/webapps"
               target="_blank"
               className="text-[var(--link-text-color)] hover:underline inline-flex items-center gap-2"
             >


### PR DESCRIPTION
This PR changes the broken link pointing to a non-existent article to the existing one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Learn more" link in PWA preferences settings to direct users to updated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->