### PR TITLE
fix(statusbar): add event listener for buttons in status bar

### DIFF
--- a/browser-features/chrome/common/statusbar/statusbar-manager.tsx
+++ b/browser-features/chrome/common/statusbar/statusbar-manager.tsx
@@ -68,6 +68,31 @@ export class StatusBarManager {
       appContent.appendChild(statusbarNode);
     }
 
+    // Set up button press handler
+    statusbarNode.addEventListener("mousedown", (event) => {
+      let toolbarButton = event.target.closest("toolbarbutton");
+
+      if (!toolbarButton) {
+        // No button pressed
+        return;
+      }
+
+      switch (toolbarButton.id) {
+        case "firefox-view-button":
+          globalThis.FirefoxViewHandler.openToolbarMouseEvent(event);
+          break;
+        case "alltabs-button":
+          globalThis.gTabsPanel.showAllTabsPanel(event, "alltabs-button");
+          break;
+        case "downloads-button":
+          globalThis.DownloadsIndicatorView.onCommand(event);
+          break;
+        case "library-button":
+          globalThis.PanelUI.showSubView("appMenu-libraryView", toolbarButton, event);
+          break;
+      }
+    });
+
     createEffect(() => {
       const statuspanelLabel = document?.querySelector("#statuspanel-label");
       const statuspanel = document?.querySelector<XULElement>("#statuspanel") ??

--- a/browser-features/chrome/common/statusbar/statusbar-manager.tsx
+++ b/browser-features/chrome/common/statusbar/statusbar-manager.tsx
@@ -70,6 +70,11 @@ export class StatusBarManager {
 
     // Set up button press handler
     statusbarNode.addEventListener("mousedown", (event) => {
+      if (!event.target) {
+        // Event target is null
+        return;
+      }
+
       let toolbarButton = event.target.closest("toolbarbutton");
 
       if (!toolbarButton) {
@@ -77,19 +82,23 @@ export class StatusBarManager {
         return;
       }
 
-      switch (toolbarButton.id) {
-        case "firefox-view-button":
-          globalThis.FirefoxViewHandler.openToolbarMouseEvent(event);
-          break;
-        case "alltabs-button":
-          globalThis.gTabsPanel.showAllTabsPanel(event, "alltabs-button");
-          break;
-        case "downloads-button":
-          globalThis.DownloadsIndicatorView.onCommand(event);
-          break;
-        case "library-button":
-          globalThis.PanelUI.showSubView("appMenu-libraryView", toolbarButton, event);
-          break;
+      try {
+        switch (toolbarButton.id) {
+          case "firefox-view-button":
+            globalThis.FirefoxViewHandler.openToolbarMouseEvent(event);
+            break;
+          case "alltabs-button":
+            globalThis.gTabsPanel.showAllTabsPanel(event, "alltabs-button");
+            break;
+          case "downloads-button":
+            globalThis.DownloadsIndicatorView.onCommand(event);
+            break;
+          case "library-button":
+            globalThis.PanelUI.showSubView("appMenu-libraryView", toolbarButton, event);
+            break;
+        }
+      } catch(e) {
+        console.error("[StatusBarManager] Error handling button press:", event);
       }
     });
 

--- a/browser-features/chrome/common/statusbar/statusbar-manager.tsx
+++ b/browser-features/chrome/common/statusbar/statusbar-manager.tsx
@@ -98,7 +98,7 @@ export class StatusBarManager {
             break;
         }
       } catch(e) {
-        console.error("[StatusBarManager] Error handling button press:", event);
+        console.error("[StatusBarManager] Error handling button press:", e);
       }
     });
 


### PR DESCRIPTION
This PR adds an event listener to the status bar to handle buttons that do not have their own event listeners, allowing buttons like the library button to work as expected in the status bar. Fixes #1887.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced status bar button interactions: clicking the status bar now routes the action to the correct UI handler based on the nearest status bar toolbar button identifier.
  * Improved resilience for click handling: the interaction safely does nothing when the target can’t be determined, and reports errors to the console if the routed action fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->