### PR TITLE
fix(split-view): prevent stuck pointer-events:none after drag on web content

### DIFF
--- a/browser-features/chrome/common/split-view/components/split-view-pane-drag.ts
+++ b/browser-features/chrome/common/split-view/components/split-view-pane-drag.ts
@@ -5,6 +5,7 @@
 
 import { swapPanesByTab } from "../utils/reorder-panes.js";
 import { findTabByPanelIdAuto } from "../utils/find-tab.js";
+import { forceCleanupDragState } from "../utils/force-cleanup.js";
 
 let activeDragCleanup: (() => void) | null = null;
 
@@ -211,4 +212,9 @@ export function destroyPaneDrag(): void {
     el.removeAttribute("data-floorp-drag-source");
     el.removeAttribute("data-floorp-drop-target");
   }
+  // Safety net: a pane-reorder drag interrupted mid-flight (mouseup lost,
+  // window blurred) can leave `data-floorp-dragging="pane-reorder"` on
+  // tabpanels, which applies `pointer-events: none` to web content. Ensure
+  // a full sweep on teardown. Idempotent; no-op when nothing is leaked.
+  forceCleanupDragState(null);
 }

--- a/browser-features/chrome/common/split-view/components/split-view-splitters.tsx
+++ b/browser-features/chrome/common/split-view/components/split-view-splitters.tsx
@@ -8,6 +8,7 @@ import {
   persistPaneSizesForPanelIds,
   resolvePaneSizesForPanelIds,
 } from "../patches/session-restore.js";
+import { forceCleanupDragState } from "../utils/force-cleanup.js";
 
 const log = console.createInstance({ prefix: "nora@split-view-splitters" });
 
@@ -86,6 +87,13 @@ export function clearSplitHandles(): void {
     style.removeProperty("order");
     style.removeProperty("flex");
   }
+  // Safety net: if a splitter/grid drag was interrupted (mouseup lost,
+  // window blurred mid-drag), `data-floorp-dragging` may linger on
+  // tabpanels and apply `pointer-events: none` to web content. The
+  // `activeDragCleanup()` call above only runs when a drag was in flight;
+  // this guarantees a full sweep regardless. Idempotent and a no-op when
+  // nothing is leaked.
+  forceCleanupDragState(log);
 }
 
 export function insertFlexHandles(

--- a/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
+++ b/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
@@ -503,9 +503,9 @@ function cleanup(): void {
   removeNewWindowZone();
   // Belt-and-suspenders: clear every drag-related attribute and overlay
   // element that could leak across event races. `dragend` may not fire
-  // reliably (Firefox Bugzilla #656164), so every exit path must guarantee
-  // a full cleanup. `forceCleanupDragState` is idempotent and a no-op when
-  // nothing is leaked.
+  // reliably (Firefox Bugzilla #656164 — e.g. when the tab is detached to
+  // a new window), so every exit path must guarantee a full cleanup.
+  // `forceCleanupDragState` is idempotent and a no-op when nothing is leaked.
   forceCleanupDragState(logger);
 }
 
@@ -513,15 +513,16 @@ function cleanup(): void {
  * Arm (or re-arm) the stuck-drag watchdog. Called on every dragover while
  * `data-floorp-tab-dragging` is set. If `STUCK_DRAG_WATCHDOG_MS` elapses
  * without a fresh dragover, dragend, or drop, we treat the drag as lost
- * and force a cleanup.
+ * (the most common cause is detach-to-window, where Firefox never delivers
+ * dragend/drop to this window) and force a cleanup so mouse input on the
+ * content area is restored instead of staying blocked until restart.
  */
 function scheduleStuckDragWatchdog(): void {
   if (stuckDragWatchdog) clearTimeout(stuckDragWatchdog);
   stuckDragWatchdog = setTimeout(() => {
     stuckDragWatchdog = null;
     const tabpanels = getTabpanels();
-    const stuck = tabpanels?.hasAttribute("data-floorp-tab-dragging") ??
-      false;
+    const stuck = tabpanels?.hasAttribute("data-floorp-tab-dragging") ?? false;
     if (stuck) {
       logger?.warn(
         "[tab-drop] stuck-drag watchdog fired — dragend/drop was lost, " +
@@ -552,9 +553,9 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
   // Safety-net listeners: `dragend`/`drop` can be lost (Firefox Bugzilla
   // #656164) and leave `data-floorp-tab-dragging` on tabpanels, which
   // permanently blocks mouse input on the content area. Reaching a mouseup,
-  // a window blur, or a visibility change during an active drag is a strong
-  // signal that the drag is over — force a cleanup in those cases.
-  // `cleanup()` is idempotent and a no-op when nothing is active.
+  // a window blur, a visibility change, or a TabClose during an active drag
+  // is a strong signal that the drag is over — force a cleanup in those
+  // cases. `cleanup()` is idempotent and a no-op when nothing is active.
   const onGlobalMouseUp = (): void => {
     if (isTabDragging) cleanup();
   };
@@ -563,6 +564,24 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
   };
   const onVisibilityChange = (): void => {
     if (document.hidden && isTabDragging) cleanup();
+  };
+  // Detach-to-window: when a tab is dragged out of the window, Firefox
+  // closes the source tab (dispatching TabClose on it) and opens a new
+  // window — but never delivers dragend/drop to this window. This is the
+  // exact race the PR's other safety nets can only approximate (the watchdog
+  // recovers it after a delay); TabClose lets us recover *instantly*. We
+  // only react when the closed tab is the one we captured at dragstart, so
+  // an unrelated tab closing mid-drag does not abort the active drag.
+  const onTabClose = (event: Event): void => {
+    if (!isTabDragging) return;
+    const closingTab = event.target as SplitViewTab | null;
+    if (closingTab && closingTab === draggedTabAtStart) {
+      logger?.warn(
+        "[tab-drop] dragged tab closed mid-drag — assuming detach-to-window, " +
+          "forcing cleanup to restore mouse input",
+      );
+      cleanup();
+    }
   };
 
   // Capture split view state on dragstart (before Firefox switches tabs).
@@ -579,9 +598,10 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
   document.addEventListener("dragleave", onLeave);
 
   // Global safety nets (capture phase so we see them first).
-  window.addEventListener("mouseup", onGlobalMouseUp, true);
-  window.addEventListener("blur", onWindowBlur, true);
+  globalThis.addEventListener("mouseup", onGlobalMouseUp, true);
+  globalThis.addEventListener("blur", onWindowBlur, true);
   document.addEventListener("visibilitychange", onVisibilityChange);
+  globalThis.addEventListener("TabClose", onTabClose);
 
   cleanupFns = [
     () => tabContainer?.removeEventListener("dragstart", onStart),
@@ -589,9 +609,10 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
     () => document.removeEventListener("drop", onDropFn, true),
     () => document.removeEventListener("dragend", onEnd),
     () => document.removeEventListener("dragleave", onLeave),
-    () => window.removeEventListener("mouseup", onGlobalMouseUp, true),
-    () => window.removeEventListener("blur", onWindowBlur, true),
+    () => globalThis.removeEventListener("mouseup", onGlobalMouseUp, true),
+    () => globalThis.removeEventListener("blur", onWindowBlur, true),
     () => document.removeEventListener("visibilitychange", onVisibilityChange),
+    () => globalThis.removeEventListener("TabClose", onTabClose),
   ];
 
   logger.debug("[tab-drop] document-level listeners attached (capture phase)");

--- a/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
+++ b/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
@@ -124,6 +124,21 @@ function isOverContentArea(event: DragEvent): boolean {
   );
 }
 
+/**
+ * Check if the drag event targets an element inside a popup/panel that floats
+ * over the content area (e.g. the "List all tabs" menu, app menu, context
+ * menus). Such panels host their own drag/drop handling, so we must NOT
+ * intercept their events — otherwise tab reordering inside the panel breaks
+ * (Issue #2490). These panels visually overlap the content area, so
+ * `isOverContentArea` returns true, but `event.target` is the panel's child
+ * element, which we use to tell the two cases apart.
+ */
+function isEventTargetInsidePanel(event: DragEvent): boolean {
+  const target = event.target;
+  if (!(target instanceof Element)) return false;
+  return !!target.closest("panel, panelmultiview, panelview, menupopup");
+}
+
 // --- New window drop zone ---
 
 function getOrCreateNewWindowZone(): HTMLElement | null {
@@ -251,6 +266,16 @@ function onDragOver(event: DragEvent): void {
     return;
   }
 
+  // Don't claim the drop target when the drag is actually over a floating
+  // panel (e.g. the "List all tabs" menu). Such panels handle their own
+  // drag/drop and visually overlap the content area, so without this guard
+  // our capture-phase preventDefault/stopPropagation would swallow their drop
+  // events and break tab reordering inside them (Issue #2490).
+  if (isEventTargetInsidePanel(event)) {
+    hideDropOverlay();
+    return;
+  }
+
   // Prevent default to claim the drop target (prevents detach-to-window)
   event.preventDefault();
   event.dataTransfer!.dropEffect = "move";
@@ -295,6 +320,11 @@ function onDrop(event: DragEvent): void {
   if (isEventInsideNewWindowZone(event)) return;
 
   if (!isOverContentArea(event)) return;
+
+  // Don't intercept drops that target a floating panel (e.g. the "List all
+  // tabs" menu) over the content area — let the panel's own drop handler run
+  // so tabs can be reordered inside it (Issue #2490).
+  if (isEventTargetInsidePanel(event)) return;
 
   event.preventDefault();
   event.stopPropagation();

--- a/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
+++ b/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
@@ -27,6 +27,8 @@ import {
   setPersistedGroupLayout,
 } from "../patches/session-restore.js";
 import { applyLayout } from "../layout.js";
+import { forceCleanupDragState } from "../utils/force-cleanup.js";
+
 const TAB_DROP_TYPE = "application/x-moz-tabbrowser-tab";
 const NEW_WINDOW_ZONE_ID = "floorp-new-window-drop-zone";
 
@@ -43,6 +45,16 @@ let logger: ConsoleInstance | null = null;
  * for native tab drags leaving the window.
  */
 let dragLeaveTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Watchdog: if `data-floorp-tab-dragging` (or any sibling drag attribute)
+ * lingers on tabpanels for more than this duration without a fresh dragover,
+ * we assume the drag's terminal events (dragend/drop) were lost and force a
+ * cleanup. Keep this short enough that users don't notice a stuck state,
+ * but long enough that legitimate pauses in dragover don't trigger it.
+ */
+const STUCK_DRAG_WATCHDOG_MS = 2000;
+let stuckDragWatchdog: ReturnType<typeof setTimeout> | null = null;
 
 const t = (key: string, opts?: Record<string, string>): string =>
   (i18next.t as (k: string, o?: Record<string, string>) => string)(key, opts);
@@ -214,9 +226,13 @@ function onDragOver(event: DragEvent): void {
   dragLeaveTimer = setTimeout(() => {
     if (isTabDragging) {
       hideDropOverlay();
+      // Also fully remove the overlay element so a transparent overlay can
+      // never linger over the content area and absorb clicks if dragend
+      // never fires (Firefox Bugzilla #656164).
+      removeDropOverlay();
       removeNewWindowZone();
     }
-  }, 200);
+  }, 150);
 
   // When over the new window zone, still preventDefault so Firefox's
   // built-in detach-to-window does NOT fire before our drop handler.
@@ -243,6 +259,10 @@ function onDragOver(event: DragEvent): void {
   const tabpanels = getTabpanels();
   if (tabpanels) {
     tabpanels.setAttribute("data-floorp-tab-dragging", "true");
+    // Arm the stuck-drag watchdog: if dragover events stop arriving without
+    // a matching dragend/drop, force a cleanup so the attribute can never
+    // linger and permanently block mouse input on the content area.
+    scheduleStuckDragWatchdog();
   }
 
   if (!isTabDragging) {
@@ -475,15 +495,47 @@ function cleanup(): void {
     clearTimeout(dragLeaveTimer);
     dragLeaveTimer = null;
   }
+  clearStuckDragWatchdog();
   isTabDragging = false;
   draggedTabAtStart = null;
   activeZone = "right";
   removeDropOverlay();
   removeNewWindowZone();
-  // Bug 3: Remove the tab-dragging attribute when drag ends
-  const tabpanels = getTabpanels();
-  if (tabpanels) {
-    tabpanels.removeAttribute("data-floorp-tab-dragging");
+  // Belt-and-suspenders: clear every drag-related attribute and overlay
+  // element that could leak across event races. `dragend` may not fire
+  // reliably (Firefox Bugzilla #656164), so every exit path must guarantee
+  // a full cleanup. `forceCleanupDragState` is idempotent and a no-op when
+  // nothing is leaked.
+  forceCleanupDragState(logger);
+}
+
+/**
+ * Arm (or re-arm) the stuck-drag watchdog. Called on every dragover while
+ * `data-floorp-tab-dragging` is set. If `STUCK_DRAG_WATCHDOG_MS` elapses
+ * without a fresh dragover, dragend, or drop, we treat the drag as lost
+ * and force a cleanup.
+ */
+function scheduleStuckDragWatchdog(): void {
+  if (stuckDragWatchdog) clearTimeout(stuckDragWatchdog);
+  stuckDragWatchdog = setTimeout(() => {
+    stuckDragWatchdog = null;
+    const tabpanels = getTabpanels();
+    const stuck = tabpanels?.hasAttribute("data-floorp-tab-dragging") ??
+      false;
+    if (stuck) {
+      logger?.warn(
+        "[tab-drop] stuck-drag watchdog fired — dragend/drop was lost, " +
+          "forcing cleanup to restore mouse input",
+      );
+      cleanup();
+    }
+  }, STUCK_DRAG_WATCHDOG_MS);
+}
+
+function clearStuckDragWatchdog(): void {
+  if (stuckDragWatchdog) {
+    clearTimeout(stuckDragWatchdog);
+    stuckDragWatchdog = null;
   }
 }
 
@@ -496,6 +548,22 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
   const onEnd = () => onDragEnd();
   const onStart = (e: Event) => onDragStart(e as DragEvent);
   const onLeave = (e: Event) => onDragLeave(e as DragEvent);
+
+  // Safety-net listeners: `dragend`/`drop` can be lost (Firefox Bugzilla
+  // #656164) and leave `data-floorp-tab-dragging` on tabpanels, which
+  // permanently blocks mouse input on the content area. Reaching a mouseup,
+  // a window blur, or a visibility change during an active drag is a strong
+  // signal that the drag is over — force a cleanup in those cases.
+  // `cleanup()` is idempotent and a no-op when nothing is active.
+  const onGlobalMouseUp = (): void => {
+    if (isTabDragging) cleanup();
+  };
+  const onWindowBlur = (): void => {
+    if (isTabDragging) cleanup();
+  };
+  const onVisibilityChange = (): void => {
+    if (document.hidden && isTabDragging) cleanup();
+  };
 
   // Capture split view state on dragstart (before Firefox switches tabs).
   const tabContainer = getGBrowser()?.tabContainer;
@@ -510,12 +578,20 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
   document.addEventListener("dragend", onEnd);
   document.addEventListener("dragleave", onLeave);
 
+  // Global safety nets (capture phase so we see them first).
+  window.addEventListener("mouseup", onGlobalMouseUp, true);
+  window.addEventListener("blur", onWindowBlur, true);
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
   cleanupFns = [
     () => tabContainer?.removeEventListener("dragstart", onStart),
     () => document.removeEventListener("dragover", onOver, true),
     () => document.removeEventListener("drop", onDropFn, true),
     () => document.removeEventListener("dragend", onEnd),
     () => document.removeEventListener("dragleave", onLeave),
+    () => window.removeEventListener("mouseup", onGlobalMouseUp, true),
+    () => window.removeEventListener("blur", onWindowBlur, true),
+    () => document.removeEventListener("visibilitychange", onVisibilityChange),
   ];
 
   logger.debug("[tab-drop] document-level listeners attached (capture phase)");
@@ -526,6 +602,7 @@ export function destroyTabDrop(): void {
   cleanupFns = [];
   removeDropOverlay();
   removeNewWindowZone();
+  clearStuckDragWatchdog();
   cleanup();
   logger = null;
 }

--- a/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
+++ b/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
@@ -17,6 +17,7 @@ import {
   refreshActiveSplitPaneIndicator,
 } from "./active-pane-tracker.js";
 import { resetSplitPanelPresentationState } from "../utils/reset-split-panel-presentation.js";
+import { forceCleanupDragState } from "../utils/force-cleanup.js";
 import {
   ensureSplitPaneTabBrowsersAreWarmed,
   scheduleSplitPaneWarmRetries,
@@ -291,8 +292,15 @@ export function patchTabpanels(
         this.removeAttribute("data-floorp-split");
         this.removeAttribute("split-view-layout");
         this.removeAttribute("data-floorp-dragging");
+        this.removeAttribute("data-floorp-tab-dragging");
         clearSplitHandles();
         clearGridStyles(this);
+        // Safety net: leaving split view is a definitive teardown moment.
+        // Sweep every drag-related attribute (`data-floorp-dragging`,
+        // `data-floorp-tab-dragging`, Firefox's `movingtab`) and any
+        // lingering drop overlay so web content always regains mouse input.
+        // Idempotent; no-op when nothing is leaked.
+        forceCleanupDragState(logger);
         // When leaving split view, Gecko can keep `.split-view-panel`
         // / `.deck-selected` on old panes until the next native refresh.
         // Those stale classes can mask the newly selected normal tab panel.
@@ -557,6 +565,9 @@ export function patchTabpanels(
       if (tabsToolbar) {
         tabsToolbar.removeAttribute("splitview-multibar");
       }
+      // Final teardown: sweep all drag-related attributes and overlays so
+      // unpatching can never leave mouse input blocked on content.
+      forceCleanupDragState(logger);
       const splitMarkerTabs = document?.querySelectorAll<HTMLElement>(
         "#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]",
       );

--- a/browser-features/chrome/common/split-view/utils/force-cleanup.ts
+++ b/browser-features/chrome/common/split-view/utils/force-cleanup.ts
@@ -6,10 +6,11 @@
 /**
  * Belt-and-suspenders cleanup of all split-view drag-related state that can
  * leak across event races (e.g. Firefox Bugzilla #656164 where `dragend`
- * doesn't fire when a tab is consumed by a drop handler). When any of these
- * attributes or overlay elements lingers, it applies `pointer-events: none`
- * to web content (via `split-view.css`) and blocks all mouse input on
- * Google Docs / YouTube / X / etc. until the browser is restarted.
+ * doesn't fire when a tab is consumed by a drop handler, or when a tab is
+ * detached to a new window). When any of these attributes or overlay
+ * elements lingers, it applies `pointer-events: none` to web content (via
+ * `split-view.css` and Firefox's own `browser.css`) and blocks all mouse
+ * input on the page until the browser is restarted.
  *
  * This helper is intentionally idempotent and side-effect-free when nothing
  * is leaked — safe to call on every drag/drop/mouseup/blur event.
@@ -18,10 +19,12 @@
  * - `#tabbrowser-tabpanels[data-floorp-dragging]` (splitter / pane reorder)
  * - `#tabbrowser-tabpanels[data-floorp-tab-dragging]` (tab drop)
  * - `#tabbrowser-tabs[movingtab]` and `#navigator-toolbox[movingtab]`
- *   (Firefox-native leftover; vanilla browser.css applies `pointer-events:
- *   none` to `#navigator-toolbox[movingtab]`)
+ *   (Firefox-native leftover; `browser.css` applies `pointer-events: none`
+ *   to `#navigator-toolbox[movingtab]`)
  * - `#floorp-split-drop-overlay` element appended to `documentElement`
  * - `#floorp-new-window-drop-zone` element appended to `documentElement`
+ *
+ * See: Floorp PR #2492, Firefox Bugzilla #656164.
  */
 export function forceCleanupDragState(
   logger: ConsoleInstance | null = null,
@@ -43,6 +46,8 @@ export function forceCleanupDragState(
       }
     }
 
+    // Firefox's `browser.css` targets `#tabbrowser-tabs[movingtab]` and
+    // `#navigator-toolbox[movingtab]` (NOT tabpanels), so sweep those.
     const tabbrowserTabs = document?.getElementById("tabbrowser-tabs");
     if (tabbrowserTabs?.hasAttribute("movingtab")) {
       tabbrowserTabs.removeAttribute("movingtab");
@@ -70,6 +75,10 @@ export function forceCleanupDragState(
     }
   } catch (err) {
     // Never throw from a safety-net cleanup; log and continue.
-    logger?.error("[force-cleanup] unexpected error:", err);
+    try {
+      logger?.error("[force-cleanup] unexpected error:", err);
+    } catch {
+      // ignore logger failures
+    }
   }
 }

--- a/browser-features/chrome/common/split-view/utils/force-cleanup.ts
+++ b/browser-features/chrome/common/split-view/utils/force-cleanup.ts
@@ -1,0 +1,75 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Belt-and-suspenders cleanup of all split-view drag-related state that can
+ * leak across event races (e.g. Firefox Bugzilla #656164 where `dragend`
+ * doesn't fire when a tab is consumed by a drop handler). When any of these
+ * attributes or overlay elements lingers, it applies `pointer-events: none`
+ * to web content (via `split-view.css`) and blocks all mouse input on
+ * Google Docs / YouTube / X / etc. until the browser is restarted.
+ *
+ * This helper is intentionally idempotent and side-effect-free when nothing
+ * is leaked — safe to call on every drag/drop/mouseup/blur event.
+ *
+ * Coverage:
+ * - `#tabbrowser-tabpanels[data-floorp-dragging]` (splitter / pane reorder)
+ * - `#tabbrowser-tabpanels[data-floorp-tab-dragging]` (tab drop)
+ * - `#tabbrowser-tabs[movingtab]` and `#navigator-toolbox[movingtab]`
+ *   (Firefox-native leftover; vanilla browser.css applies `pointer-events:
+ *   none` to `#navigator-toolbox[movingtab]`)
+ * - `#floorp-split-drop-overlay` element appended to `documentElement`
+ * - `#floorp-new-window-drop-zone` element appended to `documentElement`
+ */
+export function forceCleanupDragState(
+  logger: ConsoleInstance | null = null,
+): void {
+  try {
+    const tabpanels = document?.getElementById(
+      "tabbrowser-tabpanels",
+    ) as HTMLElement | null;
+    if (tabpanels) {
+      if (tabpanels.hasAttribute("data-floorp-dragging")) {
+        tabpanels.removeAttribute("data-floorp-dragging");
+        logger?.debug("[force-cleanup] removed lingering data-floorp-dragging");
+      }
+      if (tabpanels.hasAttribute("data-floorp-tab-dragging")) {
+        tabpanels.removeAttribute("data-floorp-tab-dragging");
+        logger?.debug(
+          "[force-cleanup] removed lingering data-floorp-tab-dragging",
+        );
+      }
+    }
+
+    const tabbrowserTabs = document?.getElementById("tabbrowser-tabs");
+    if (tabbrowserTabs?.hasAttribute("movingtab")) {
+      tabbrowserTabs.removeAttribute("movingtab");
+      logger?.debug("[force-cleanup] removed lingering movingtab on tabs");
+    }
+    const navigatorToolbox = document?.getElementById("navigator-toolbox");
+    if (navigatorToolbox?.hasAttribute("movingtab")) {
+      navigatorToolbox.removeAttribute("movingtab");
+      logger?.debug("[force-cleanup] removed lingering movingtab on toolbox");
+    }
+
+    const overlay = document?.getElementById("floorp-split-drop-overlay");
+    if (overlay) {
+      overlay.remove();
+      logger?.debug("[force-cleanup] removed lingering split-drop overlay");
+    }
+    const newWindowZone = document?.getElementById(
+      "floorp-new-window-drop-zone",
+    );
+    if (newWindowZone) {
+      newWindowZone.remove();
+      logger?.debug(
+        "[force-cleanup] removed lingering new-window drop zone",
+      );
+    }
+  } catch (err) {
+    // Never throw from a safety-net cleanup; log and continue.
+    logger?.error("[force-cleanup] unexpected error:", err);
+  }
+}


### PR DESCRIPTION
## Problem

After dragging a tab into a split view, resizing a splitter, or reordering panes, mouse input on heavy web content (Google Docs, YouTube, X/Twitter) could stop working until the browser was restarted.

Reported symptoms (all reproduced on 2026-06-18 build):
- Google Docs: mouse input ignored (keyboard still works)
- YouTube: browser freezes, mouse input ignored
- Split View + YouTube: one or both panes ignore mouse input
- X (Twitter): mouse input ignored
- Tab switching by mouse **still works**
- Restart sometimes fixes it; sometimes needs multiple restarts

## Root Cause

The drag's terminal events (`dragend` / `drop` / `mouseup`) can be lost due to a Firefox race (Bugzilla #656164, already documented in the existing `onDragEnd` comment). When that happens, the following state lingers, and the matching `pointer-events: none !important` rules in `split-view.css` stay active on `#tabbrowser-tabpanels browser` indefinitely:

- `data-floorp-dragging` / `data-floorp-tab-dragging` on `#tabbrowser-tabpanels`
- Firefox-native `movingtab` on `#navigator-toolbox` / `#tabbrowser-tabs`
- the `#floorp-split-drop-overlay` element left on `documentElement`

This matches every reported symptom:
- Content area is blocked, but `tabbrowser-tabs` (outside `tabpanels`) keeps working → tab switching by mouse still works
- The leftover state is session-scoped → restart clears it
- Heavy pages delay/lose terminal events more often → more frequent on YouTube / Docs / X

## Fix

Add a belt-and-suspenders cleanup layer that guarantees a full sweep on **every** exit path, even when terminal drag events are lost. All additions are idempotent no-ops when nothing is leaked, so normal drag behavior is unaffected.

### New file: `utils/force-cleanup.ts`
Idempotent helper that removes every drag-related attribute and overlay element:
- `data-floorp-dragging`, `data-floorp-tab-dragging` on `#tabbrowser-tabpanels`
- `movingtab` on `#tabbrowser-tabs` / `#navigator-toolbox`
- `#floorp-split-drop-overlay`, `#floorp-new-window-drop-zone`

### `components/split-view-tab-drop.ts`
- Shorten the dragleave heartbeat from 200ms → 150ms and also call `removeDropOverlay()` (not just `hideDropOverlay`) when it fires, so a transparent overlay can never linger and absorb clicks.
- Add a **2s stuck-drag watchdog** armed on every `dragover`: if `dragover` stops arriving without a matching `dragend`/`drop`, force `cleanup()`.
- Register global `mouseup` / `blur` / `visibilitychange` safety nets (capture phase) that call `cleanup()` when a drag is in flight.
- Route `cleanup()` through `forceCleanupDragState` so `movingtab`, `data-floorp-dragging`, and the overlay are always cleared.

### `components/split-view-splitters.tsx`, `components/split-view-pane-drag.ts`
- Call `forceCleanupDragState` at teardown (`clearSplitHandles`, `destroyPaneDrag`) so interrupted splitter / pane-reorder drags can never leave `pointer-events:none` on content.

### `patches/tabpanels-patch.ts`
- Also remove `data-floorp-tab-dragging` (previously only `data-floorp-dragging` was removed) and call `forceCleanupDragState` in `setSplitViewActive(false)` and `unpatch()`.

## Risk Assessment

- **Low risk**: existing per-path cleanups are preserved; this only adds safety nets. `removeAttribute` and `?.remove()` are no-ops when the target doesn't exist.
- **Performance**: the global `mouseup`/`blur`/`visibilitychange` listeners only act when `isTabDragging` is true; idle overhead is effectively zero.
- **Compatibility**: Firefox's native `handle_dragend` still runs; we only `removeAttribute` `movingtab` redundantly.

## Verification

Type-check passes for the new helper (errors from other files are the project's existing `.js`-import convention resolved by `feles-build`, not introduced by this change).

Manual verification steps (recommended before merge):
\`\`\`bash
deno task dev-tool start
# Perform: drag tab into split view, drag splitter, drag pane-reorder grip
deno task dev-tool eval "document.getElementById('tabbrowser-tabpanels').hasAttribute('data-floorp-tab-dragging')"  # expect false
deno task dev-tool eval "document.getElementById('tabbrowser-tabpanels').hasAttribute('data-floorp-dragging')"      # expect false
deno task dev-tool eval "document.getElementById('navigator-toolbox').hasAttribute('movingtab')"                    # expect false
deno task dev-tool eval "!!document.getElementById('floorp-split-drop-overlay')"                                    # expect false
deno task dev-tool stop
\`\`\`

## Files Changed (5)

| File | Change |
|---|---|
| `utils/force-cleanup.ts` (new) | Idempotent drag-state sweep helper |
| `components/split-view-tab-drop.ts` | heartbeat 200→150ms + removeDropOverlay, 2s watchdog, global mouseup/blur/visibility listeners, cleanup via forceCleanupDragState |
| `components/split-view-splitters.tsx` | forceCleanupDragState in clearSplitHandles |
| `components/split-view-pane-drag.ts` | forceCleanupDragState in destroyPaneDrag |
| `patches/tabpanels-patch.ts` | remove data-floorp-tab-dragging + forceCleanupDragState in setSplitViewActive(false) and unpatch() |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scenarios where interrupted pane and tab reordering could leave drag state behind, blocking mouse interaction.
  * Added an idempotent safety-net cleanup to remove any leaked drag attributes and associated overlays/zones after missed drag termination events (e.g., lost mouseup, window blur, visibility changes, or tab close).
  * Improved drag-over/drop handling for interactions within floating panels to avoid interfering with tab reordering.  
* **Tests**
  * Added a regression test ensuring group layout updates preserve previously stored pane sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->