### PR TITLE
fix(workspaces): hide split view wrapper when all tabs are hidden

### DIFF
--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -429,7 +429,7 @@ export class WorkspacesTabManager {
       selectedTab &&
       !selectedTab.hasAttribute(WORKSPACE_LAST_SHOW_ID) &&
       selectedTab.getAttribute(WORKSPACE_TAB_ATTRIBUTION_ID) ===
-        currentWorkspaceId
+      currentWorkspaceId
     ) {
       const lastShowWorkspaceTabs = document?.querySelectorAll(
         `[${WORKSPACE_LAST_SHOW_ID}="${currentWorkspaceId}"]`,
@@ -467,10 +467,30 @@ export class WorkspacesTabManager {
     // Hide tab groups that have no visible tabs, show those that do
     const tabGroups = globalThis.gBrowser.tabGroups;
     for (const group of tabGroups) {
-      const hasVisibleTabInGroup = (group.tabs as Array<XULElement>).some(
-        (tab) => this.getWorkspaceIdFromAttribute(tab) === currentWorkspaceId,
-      );
+      const hasVisibleTabInGroup = (group.tabs as Array<XULElement>)
+        .slice(0, 10)
+        .some((tab) => this.getWorkspaceIdFromAttribute(tab) === currentWorkspaceId);
       group.style.display = hasVisibleTabInGroup ? "" : "none";
+    }
+
+    // Hide split view wrappers that have no visible tabs, show those that do
+    const splitViewWrappers = document.querySelectorAll(
+      "tab-split-view-wrapper",
+    );
+    for (const wrapper of splitViewWrappers) {
+      const children = Array.from(wrapper.children) as Element[];
+      const hasVisibleTabInWrapper = children.some(
+        (child) => {
+          if (child.tagName !== "tab") return false;
+          return (
+            this.getWorkspaceIdFromAttribute(child as XULElement) ===
+            currentWorkspaceId
+          );
+        },
+      );
+      (wrapper as HTMLElement).style.display = hasVisibleTabInWrapper
+        ? ""
+        : "none";
     }
   }
 
@@ -543,8 +563,8 @@ export class WorkspacesTabManager {
         const targetWorkspaceId = defaultId !== workspaceId
           ? defaultId
           : fallbackWorkspaceId && fallbackWorkspaceId !== workspaceId
-          ? fallbackWorkspaceId
-          : null;
+            ? fallbackWorkspaceId
+            : null;
 
         if (targetWorkspaceId) {
           const defaultTabs = document?.querySelectorAll(
@@ -636,7 +656,7 @@ export class WorkspacesTabManager {
       if (
         currentlySelectedTab &&
         this.getWorkspaceIdFromAttribute(currentlySelectedTab) ===
-          prevWorkspaceId
+        prevWorkspaceId
       ) {
         currentlySelectedTab.setAttribute(
           WORKSPACE_LAST_SHOW_ID,

--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -468,7 +468,6 @@ export class WorkspacesTabManager {
     const tabGroups = globalThis.gBrowser.tabGroups;
     for (const group of tabGroups) {
       const hasVisibleTabInGroup = (group.tabs as Array<XULElement>)
-        .slice(0, 10)
         .some((tab) => this.getWorkspaceIdFromAttribute(tab) === currentWorkspaceId);
       group.style.display = hasVisibleTabInGroup ? "" : "none";
     }


### PR DESCRIPTION
When switching workspaces, individual tabs were hidden via hideTab() but the tab-split-view-wrapper element remained visible, leaving empty space in the tab bar.

Added logic to updateTabsVisibility() to hide/show split view wrappers based on whether they contain tabs belonging to the current workspace.

Fixes #2476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed workspace-specific visibility for split-view tab wrappers so they only appear when they contain matching workspace tabs.
  * Improved tab/tab-group show/hide behavior when switching between workspaces.
  * Enhanced workspace deletion and navigation handling, including more reliable preservation of the last shown workspace tab state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->