### PR TITLE
fix(multirow-tabbar): enable tab reordering via drag-and-drop

### DIFF
--- a/browser-features/chrome/common/tabbar/multirow-tabbar/multirow-tabbar.tsx
+++ b/browser-features/chrome/common/tabbar/multirow-tabbar/multirow-tabbar.tsx
@@ -157,6 +157,21 @@ export class MultirowTabbarClass {
   }
 
   private cleanup(): void {
+    // HMR/dispose path: ensure the drag-drop manager's monkey-patches and
+    // capture-phase listeners are torn down. Without this, hot-updating the
+    // tabbar leaves stale drop-method overrides and duplicate capture-phase
+    // listeners on `gBrowser.tabContainer`, which is the root cause of "old
+    // behavior persists after edit" symptoms.
+    if (this.isEnabled) {
+      try {
+        this.disableMultiRowTabs();
+      } catch (e) {
+        console.error(
+          "[MultirowTabbar] Failed to disable multi-row tabs during cleanup:",
+          e,
+        );
+      }
+    }
     if (this.agentSheetUri) {
       try {
         const sss = Cc["@mozilla.org/content/style-sheet-service;1"].getService(

--- a/browser-features/chrome/common/tabbar/multirow-tabbar/tab-drag-drop-manager.ts
+++ b/browser-features/chrome/common/tabbar/multirow-tabbar/tab-drag-drop-manager.ts
@@ -14,6 +14,23 @@ declare const Services: ServicesType;
 declare const PrivateBrowsingUtils: PrivateBrowsingUtilsType;
 declare const TAB_DROP_TYPE: string;
 
+export type DropIndicatorTarget = {
+  tabIndex: number;
+  atEnd: boolean;
+};
+
+export function resolveDropIndicatorTarget(
+  dropIndex: number,
+  tabCount: number,
+): DropIndicatorTarget | null {
+  if (tabCount <= 0 || dropIndex < 0 || dropIndex > tabCount) {
+    return null;
+  }
+  return dropIndex === tabCount
+    ? { tabIndex: tabCount - 1, atEnd: true }
+    : { tabIndex: dropIndex, atEnd: false };
+}
+
 export class TabDragDropManager {
   private lastKnownIndex: number | null = null;
   private groupToInsertTo: XULElement | null = null;
@@ -23,16 +40,20 @@ export class TabDragDropManager {
   private arrowScrollbox: XULElement | null = null;
   private originalGetDropIndex:
     | ((event: DragEvent) => number)
-    | undefined
-    | null = null;
+    | undefined;
   private originalGetDropEffectForTabDrag:
     | ((event: DragEvent) => string)
-    | undefined
-    | null = null;
-  private originalOnDragOver: ((event: DragEvent) => void) | undefined | null =
-    null;
+    | undefined;
+  private originalUnderscoreGetDropEffectForTabDrag:
+    | ((event: DragEvent) => string)
+    | undefined;
+  private hadOwnGetDropIndex = false;
+  private hadOwnGetDropEffectForTabDrag = false;
+  private hadOwnUnderscoreGetDropEffectForTabDrag = false;
   private dropEventListener: ((e: Event) => void) | null = null;
+  private dragOverEventListener: ((e: Event) => void) | null = null;
   private dragEndEventListener: ((e: Event) => void) | null = null;
+  private dragStartEventListener: ((e: Event) => void) | null = null;
 
   constructor(
     private readonly resolveTabsContainer: () => XULElement | null,
@@ -40,34 +61,70 @@ export class TabDragDropManager {
   ) {}
 
   install(arrowScrollbox: XULElement): void {
+    if (this.arrowScrollbox) {
+      this.uninstall();
+    }
     this.arrowScrollbox = arrowScrollbox;
 
     const tabContainer = gBrowser.tabContainer;
 
-    // Save original functions
+    // Save original functions. These live on `tabDragAndDrop` in current
+    // Firefox (the XBL `on_dragover` property just forwards to it), but older
+    // versions exposed them directly on the container — keep both fallbacks.
+    this.hadOwnGetDropIndex = Object.hasOwn(tabContainer, "_getDropIndex");
+    this.hadOwnGetDropEffectForTabDrag = Object.hasOwn(
+      tabContainer,
+      "getDropEffectForTabDrag",
+    );
+    this.hadOwnUnderscoreGetDropEffectForTabDrag = Object.hasOwn(
+      tabContainer,
+      "_getDropEffectForTabDrag",
+    );
     this.originalGetDropIndex = tabContainer._getDropIndex;
     this.originalGetDropEffectForTabDrag = tabContainer.getDropEffectForTabDrag;
-    this.originalOnDragOver = tabContainer.on_dragover;
+    this.originalUnderscoreGetDropEffectForTabDrag =
+      tabContainer._getDropEffectForTabDrag;
 
-    tabContainer._getDropIndex = (event: DragEvent): number => {
-      const tabToDropAt = this.getTabFromEventTarget(event);
-      if (!tabToDropAt) return 0;
-
-      if (!this.arrowScrollbox) return 0;
-      const tabPos = findChildIndex(this.arrowScrollbox, tabToDropAt);
-      const rect = tabToDropAt.getBoundingClientRect();
-      const isLtr = window.getComputedStyle(tabContainer).direction === "ltr";
-
-      if (isLtr) {
-        return event.clientX < rect.x + rect.width / 2 ? tabPos : tabPos + 1;
+    // Register the dragover/drop handlers in the CAPTURE phase so they run
+    // BEFORE Firefox's native tabDragAndDrop handlers. We can't override the
+    // native handlers by assigning to `on_dragover` / `_onDragOver` anymore —
+    // current Firefox routes those events directly to `tabDragAndDrop.handle_*`
+    // and ignores JS property assignments on XUL elements. Calling
+    // `stopPropagation()` inside the capture-phase handler blocks the native
+    // handler entirely.
+    this.dragOverEventListener = (e: Event) => {
+      if (!this.listenersActive) return;
+      try {
+        this.performTabDragOver(e as DragEvent);
+      } catch (error) {
+        console.error("[TabDragDropManager] dragover failed:", error);
+        this.deactivateDragSession();
       }
-      return event.clientX > rect.x + rect.width / 2 ? tabPos : tabPos + 1;
     };
+    tabContainer.addEventListener("dragover", this.dragOverEventListener, true);
 
-    tabContainer.addEventListener("dragstart", (event: Event) => {
+    this.dropEventListener = (e: Event) => {
+      if (!this.listenersActive) return;
+      const dragEvent = e as DragEvent;
+      dragEvent.preventDefault();
+      dragEvent.stopPropagation();
+      try {
+        this.performTabDropEvent(dragEvent);
+      } catch (error) {
+        console.error("[TabDragDropManager] drop failed:", error);
+      } finally {
+        this.deactivateDragSession();
+      }
+    };
+    tabContainer.addEventListener("drop", this.dropEventListener, true);
+
+    this.dragStartEventListener = (event: Event) => {
+      this.deactivateDragSession();
       const dragEvent = event as DragEvent;
       const tab = this.getTabFromEventTarget(dragEvent);
-      if (!tab || !this.arrowScrollbox) return;
+      if (!tab || !this.arrowScrollbox) {
+        return;
+      }
 
       const pinnedTabsCount = this.arrowScrollbox.querySelectorAll(
         ".tabbrowser-tab[newPin]",
@@ -75,34 +132,20 @@ export class TabDragDropManager {
       this.draggedTabIndex = findChildIndex(this.arrowScrollbox, tab);
 
       const firstTab = document?.getElementsByClassName("tabbrowser-tab")[0];
-      if (
-        (firstTab &&
-          tabContainer.arrowScrollbox.clientHeight > firstTab.clientHeight) ||
-        pinnedTabsCount > 0
-      ) {
+      const isMultiRow = firstTab &&
+        tabContainer.arrowScrollbox.clientHeight > firstTab.clientHeight;
+      if (isMultiRow || pinnedTabsCount > 0) {
         gBrowser.visibleTabs.forEach((t: XULTab) => {
           t.style.setProperty("transform", "");
         });
 
-        if (!this.listenersActive) {
-          tabContainer.getDropEffectForTabDrag = (e: DragEvent) =>
-            this.orig_getDropEffectForTabDrag(e);
-          tabContainer._getDropEffectForTabDrag = (e: DragEvent) =>
-            this.orig_getDropEffectForTabDrag(e);
-          tabContainer.on_dragover = this.performTabDragOver;
-          tabContainer._onDragOver = this.performTabDragOver;
-          this.dropEventListener = (e: Event) => {
-            this.performTabDropEvent(e as DragEvent);
-          };
-          tabContainer.addEventListener("drop", this.dropEventListener);
-          this.listenersActive = true;
-        }
+        this.activateDragSession();
       }
-    });
+    };
+    tabContainer.addEventListener("dragstart", this.dragStartEventListener);
 
     this.dragEndEventListener = () => {
-      this.resetState();
-      this.draggedTabIndex = null;
+      this.deactivateDragSession();
     };
     tabContainer.addEventListener("dragend", this.dragEndEventListener);
   }
@@ -112,37 +155,81 @@ export class TabDragDropManager {
 
     const tabContainer = gBrowser.tabContainer;
 
-    // Restore original functions
-    if (this.originalGetDropIndex) {
-      tabContainer._getDropIndex = this.originalGetDropIndex;
-    }
-    if (this.originalGetDropEffectForTabDrag) {
-      tabContainer.getDropEffectForTabDrag =
-        this.originalGetDropEffectForTabDrag;
-      tabContainer._getDropEffectForTabDrag =
-        this.originalGetDropEffectForTabDrag;
-    }
-    if (this.originalOnDragOver) {
-      tabContainer.on_dragover = this.originalOnDragOver;
-      tabContainer._onDragOver = this.originalOnDragOver;
-    }
+    this.deactivateDragSession();
 
-    // Remove drop event listener
+    // Remove capture-phase listeners
+    if (this.dragOverEventListener) {
+      tabContainer.removeEventListener(
+        "dragover",
+        this.dragOverEventListener,
+        true,
+      );
+      this.dragOverEventListener = null;
+    }
     if (this.dropEventListener) {
-      tabContainer.removeEventListener("drop", this.dropEventListener);
+      tabContainer.removeEventListener("drop", this.dropEventListener, true);
       this.dropEventListener = null;
     }
-
-    // Remove dragend event listener
+    if (this.dragStartEventListener) {
+      tabContainer.removeEventListener(
+        "dragstart",
+        this.dragStartEventListener,
+      );
+      this.dragStartEventListener = null;
+    }
     if (this.dragEndEventListener) {
       tabContainer.removeEventListener("dragend", this.dragEndEventListener);
       this.dragEndEventListener = null;
     }
 
     // Reset state
-    this.resetState();
-    this.listenersActive = false;
     this.arrowScrollbox = null;
+  }
+
+  private activateDragSession(): void {
+    const tabContainer = gBrowser.tabContainer;
+    tabContainer._getDropIndex = (event: DragEvent): number => {
+      const tabToDropAt = this.getTabFromEventTarget(event);
+      if (!tabToDropAt || !this.arrowScrollbox) return 0;
+      const tabPos = findChildIndex(this.arrowScrollbox, tabToDropAt);
+      const rect = tabToDropAt.getBoundingClientRect();
+      const isLtr = window.getComputedStyle(tabContainer).direction === "ltr";
+      if (isLtr) {
+        return event.clientX < rect.x + rect.width / 2 ? tabPos : tabPos + 1;
+      }
+      return event.clientX > rect.x + rect.width / 2 ? tabPos : tabPos + 1;
+    };
+    tabContainer.getDropEffectForTabDrag = (event: DragEvent) =>
+      this.orig_getDropEffectForTabDrag(event);
+    tabContainer._getDropEffectForTabDrag = (event: DragEvent) =>
+      this.orig_getDropEffectForTabDrag(event);
+    this.listenersActive = true;
+  }
+
+  private deactivateDragSession(): void {
+    const tabContainer = gBrowser.tabContainer;
+    if (this.listenersActive) {
+      if (this.hadOwnGetDropIndex) {
+        tabContainer._getDropIndex = this.originalGetDropIndex;
+      } else {
+        delete tabContainer._getDropIndex;
+      }
+      if (this.hadOwnGetDropEffectForTabDrag) {
+        tabContainer.getDropEffectForTabDrag =
+          this.originalGetDropEffectForTabDrag;
+      } else {
+        delete tabContainer.getDropEffectForTabDrag;
+      }
+      if (this.hadOwnUnderscoreGetDropEffectForTabDrag) {
+        tabContainer._getDropEffectForTabDrag =
+          this.originalUnderscoreGetDropEffectForTabDrag;
+      } else {
+        delete tabContainer._getDropEffectForTabDrag;
+      }
+    }
+    this.listenersActive = false;
+    this.draggedTabIndex = null;
+    this.resetState();
   }
 
   private getTabFromEventTarget(
@@ -154,8 +241,7 @@ export class TabDragDropManager {
       target = target.parentElement!;
     }
 
-    const tab =
-      (target as Element)?.closest("tab") ||
+    const tab = (target as Element)?.closest("tab") ||
       (target as Element)?.closest("tab-group");
     const selectedTab = gBrowser.selectedTab;
 
@@ -224,21 +310,26 @@ export class TabDragDropManager {
         tabs,
         tab.querySelector("tab:first-of-type"),
       );
-      const groupEnd =
-        Array.prototype.indexOf.call(
-          tabs,
-          tab.querySelector("tab:last-of-type"),
-        ) + 1;
+      const groupEnd = Array.prototype.indexOf.call(
+        tabs,
+        tab.querySelector("tab:last-of-type"),
+      ) + 1;
       this.positionInGroup = groupEnd - groupStart;
       dropIndex = groupEnd;
     } else if (tab.parentElement?.nodeName === "tab-group") {
       this.groupToInsertTo = tab.parentElement as unknown as XULElement;
       const groupStart = tab.parentElement.querySelector("tab:first-of-type");
-      this.positionInGroup =
-        dropIndex - Array.prototype.indexOf.call(tabs, groupStart);
+      this.positionInGroup = dropIndex -
+        Array.prototype.indexOf.call(tabs, groupStart);
     } else {
       this.groupToInsertTo = null;
       this.positionInGroup = null;
+    }
+
+    const indicatorTarget = resolveDropIndicatorTarget(dropIndex, tabs.length);
+    if (!indicatorTarget) {
+      (indicator as HTMLElement).hidden = true;
+      return;
     }
 
     const ltr = window.getComputedStyle(tabContainer).direction === "ltr";
@@ -248,22 +339,20 @@ export class TabDragDropManager {
 
     let newMarginX: number;
     let newMarginY: number;
-    if (dropIndex === tabs.length) {
-      const tabRect = tabs[dropIndex - 1].getBoundingClientRect();
+    if (indicatorTarget.atEnd) {
+      const tabRect = tabs[indicatorTarget.tabIndex].getBoundingClientRect();
       newMarginX = ltr ? tabRect.right - rect.left : rect.right - tabRect.left;
       newMarginY = tabRect.top + tabRect.height - rect.top - rect.height;
       if (CSS.supports("offset-anchor", "left bottom")) {
         newMarginY += rect.height / 2 - tabRect.height / 2;
       }
-    } else if (dropIndex != null || dropIndex !== 0) {
-      const tabRect = tabs[dropIndex].getBoundingClientRect();
+    } else {
+      const tabRect = tabs[indicatorTarget.tabIndex].getBoundingClientRect();
       newMarginX = ltr ? tabRect.left - rect.left : rect.right - tabRect.right;
       newMarginY = tabRect.top + tabRect.height - rect.top - rect.height;
       if (CSS.supports("offset-anchor", "left bottom")) {
         newMarginY += rect.height / 2 - tabRect.height / 2;
       }
-    } else {
-      return;
     }
 
     newMarginX += indicator.clientWidth / 2;
@@ -417,34 +506,33 @@ export class TabDragDropManager {
 
     if (isMovingTabs) {
       const sourceNode = dt.mozGetDataAt(TAB_DROP_TYPE, 0);
+      // NOTE: `ownerGlobal` was removed from XUL elements in recent Firefox.
+      // Use `ownerDocument.defaultView` instead to obtain the chrome window.
+      const sourceWindow = sourceNode?.ownerDocument?.defaultView as
+        | FirefoxWindow
+        | undefined;
       if (
         XULElement.isInstance(sourceNode) &&
         sourceNode.localName === "tab" &&
-        sourceNode.ownerGlobal &&
+        sourceWindow &&
         sourceNode.ownerDocument?.documentElement &&
-        sourceNode.ownerGlobal.isChromeWindow &&
+        sourceWindow.isChromeWindow &&
         sourceNode.ownerDocument.documentElement.getAttribute("windowtype") ===
           "navigator:browser" &&
-        (sourceNode as XULTab).container ===
-          sourceNode.ownerGlobal.gBrowser.tabContainer
+        (sourceNode as XULTab).container === sourceWindow.gBrowser.tabContainer
       ) {
         if (
           PrivateBrowsingUtils.isWindowPrivate(window) !==
-          PrivateBrowsingUtils.isWindowPrivate(
-            sourceNode.ownerGlobal as unknown as FirefoxWindow,
-          )
+            PrivateBrowsingUtils.isWindowPrivate(sourceWindow)
         ) {
           return "none";
         }
 
-        if (
-          window.gMultiProcessBrowser !==
-          sourceNode.ownerGlobal.gMultiProcessBrowser
-        ) {
+        if (window.gMultiProcessBrowser !== sourceWindow.gMultiProcessBrowser) {
           return "none";
         }
 
-        if (window.gFissionBrowser !== sourceNode.ownerGlobal.gFissionBrowser) {
+        if (window.gFissionBrowser !== sourceWindow.gFissionBrowser) {
           return "none";
         }
 
@@ -473,8 +561,9 @@ export class TabDragDropManager {
         if (tabInGroupToMoveTo) {
           gBrowser.moveTabBefore(t, tabInGroupToMoveTo as XULElement);
         } else {
-          const lastTab =
-            this.groupToInsertTo.querySelector("tab:last-of-type");
+          const lastTab = this.groupToInsertTo.querySelector(
+            "tab:last-of-type",
+          );
           if (lastTab) {
             gBrowser.moveTabAfter(t, lastTab as XULElement);
           }

--- a/browser-features/chrome/common/tabbar/test/tab-drag-drop-manager.test.ts
+++ b/browser-features/chrome/common/tabbar/test/tab-drag-drop-manager.test.ts
@@ -2,10 +2,11 @@
 // @colocated-env browser
 
 import {
-  type TestCase,
   assertEquals,
   runTests,
+  type TestCase,
 } from "../../../test/utils/test_harness.ts";
+import { resolveDropIndicatorTarget } from "../multirow-tabbar/tab-drag-drop-manager.ts";
 
 // ---------------------------------------------------------------------------
 // Tests — TabDragDropManager dragend listener
@@ -80,6 +81,46 @@ function testDragEndWithNullState(): void {
   assertEquals(state.draggedTabIndex, null, "draggedTabIndex remains null");
 }
 
+function testDropIndicatorTargets(): void {
+  const first = resolveDropIndicatorTarget(0, 3);
+  assertEquals(
+    first?.tabIndex,
+    0,
+    "index 0 should target the first tab",
+  );
+  assertEquals(first?.atEnd, false, "index 0 should use the leading edge");
+
+  const middle = resolveDropIndicatorTarget(1, 3);
+  assertEquals(
+    middle?.tabIndex,
+    1,
+    "middle index should target that tab",
+  );
+  assertEquals(
+    middle?.atEnd,
+    false,
+    "middle index should use the leading edge",
+  );
+
+  const end = resolveDropIndicatorTarget(3, 3);
+  assertEquals(
+    end?.tabIndex,
+    2,
+    "tabCount should target the trailing edge of the last tab",
+  );
+  assertEquals(end?.atEnd, true, "tabCount should use the trailing edge");
+  assertEquals(
+    resolveDropIndicatorTarget(0, 0),
+    null,
+    "an empty tab strip has no indicator target",
+  );
+  assertEquals(
+    resolveDropIndicatorTarget(4, 3),
+    null,
+    "out-of-range indices should be rejected",
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Test runner
 // ---------------------------------------------------------------------------
@@ -91,6 +132,10 @@ const tests: TestCase[] = [
     fn: testDragEndClearsDraggedTabIndex,
   },
   { name: "dragend with null state", fn: testDragEndWithNullState },
+  {
+    name: "drop indicator targets include index zero",
+    fn: testDropIndicatorTargets,
+  },
 ];
 
-runTests("tab-drag-drop-manager.test", tests);
+await runTests("tab-drag-drop-manager.test", tests);

--- a/browser-features/chrome/utils/base.ts
+++ b/browser-features/chrome/utils/base.ts
@@ -3,7 +3,7 @@
 import type { ViteHotContext } from "vite/types/hot";
 import { kebabCase } from "es-toolkit/string";
 import type { ClassDecorator } from "./decorator";
-import { createRootHMR } from "@nora/solid-xul";
+import { createRootHMR, disposeRoot } from "@nora/solid-xul";
 import { onCleanup } from "solid-js";
 
 // U+2063 before `@` needed
@@ -20,12 +20,60 @@ export function noraComponent(
   aViteHotContext: ViteHotContext | undefined,
 ): ClassDecorator<NoraComponentBase> {
   return (_clazz, ctx) => {
-    if (_NoraComponentBase_viteHotContext.has(ctx.name!)) {
-      throw new Error(`Duplicate NoraComponent Name: ${ctx.name}`);
+    const name = ctx.name;
+    if (typeof name !== "string" || !name) {
+      throw new Error("NoraComponent classes must have a name");
+    }
+    if (_NoraComponentBase_viteHotContext.has(name)) {
+      throw new Error(`Duplicate NoraComponent Name: ${name}`);
     }
 
-    _NoraComponentBase_viteHotContext.set(ctx.name!, aViteHotContext);
-    console.debug("[nora@base] noraComponent " + ctx.name);
+    _NoraComponentBase_viteHotContext.set(name, aViteHotContext);
+    console.debug("[nora@base] noraComponent " + name);
+
+    // Track which classes belong to this module's hot context.
+    if (aViteHotContext) {
+      let names = _classNamesByHotCtx.get(aViteHotContext);
+      if (!names) {
+        names = new Set();
+        _classNamesByHotCtx.set(aViteHotContext, names);
+      }
+      names.add(name);
+
+      // Register a single hot.dispose per module (Vite retains only the last
+      // dispose callback per module — see vite #16283 — so we register once at
+      // decoration time rather than per-instance in the constructor).
+      // This guarantees that when the module is hot-updated, every live
+      // instance's Solid root is torn down BEFORE the accept callback creates
+      // a fresh instance. Without this, monkey-patched state (e.g.
+      // TabDragDropManager's tabContainer listeners) leaks across HMR updates.
+      if (!aViteHotContext.data.__noraDisposeRegistered) {
+        aViteHotContext.data.__noraDisposeRegistered = true;
+        aViteHotContext.data.__solidXulExternalDisposeOwner = true;
+        aViteHotContext.dispose(() => {
+          const hotCtx = aViteHotContext!;
+          const classNames = _classNamesByHotCtx.get(hotCtx);
+          if (classNames) {
+            for (const className of classNames) {
+              _noraInstancesByName.delete(className);
+              _NoraComponentBase_viteHotContext.delete(className);
+            }
+            _classNamesByHotCtx.delete(hotCtx);
+          }
+          // Drain all Solid roots sharing this hot context. disposeRoot runs
+          // every registered disposer, which fires each instance's onCleanup
+          // (removing DOM nodes, event listeners, monkey-patches, etc.).
+          disposeRoot(hotCtx);
+          hotCtx.data.__noraDisposeRegistered = false;
+          hotCtx.data.__solidXulDisposeRegistered = false;
+          hotCtx.data.__solidXulExternalDisposeOwner = false;
+          nora_component_base_console.debug(
+            "hot.dispose: drained nora instances and solid roots for",
+            classNames ? Array.from(classNames) : [],
+          );
+        });
+      }
+    }
   };
 }
 
@@ -37,14 +85,39 @@ const _NoraComponentBase_viteHotContext = new Map<
   string,
   ViteHotContext | undefined
 >();
+
+/**
+ * Registry of live NoraComponentBase instances, keyed by class name.
+ * Populated in the constructor, drained on HMR dispose (via the decorator's
+ * hot.dispose registration) and on individual instance cleanup.
+ */
+const _noraInstancesByName = new Map<string, Set<NoraComponentBase>>();
+
+/**
+ * Tracks which class names belong to which hot context, so the per-module
+ * HMR dispose handler only drains instances for classes defined in the module
+ * being hot-updated — not classes from unrelated modules.
+ */
+const _classNamesByHotCtx = new Map<ViteHotContext, Set<string>>();
+
 export abstract class NoraComponentBase {
   logger: ConsoleInstance;
   constructor() {
+    const name = this.constructor.name;
+
+    // Register this instance so the HMR dispose handler can find it later.
+    let instances = _noraInstancesByName.get(name);
+    if (!instances) {
+      instances = new Set();
+      _noraInstancesByName.set(name, instances);
+    }
+    instances.add(this);
+
     // support HMR
-    const hot = _NoraComponentBase_viteHotContext.get(this.constructor.name);
+    const hot = _NoraComponentBase_viteHotContext.get(name);
     // Initialize logger
     const _console = console.createInstance({
-      prefix: `nora@${kebabCase(this.constructor.name)}`,
+      prefix: `nora@${kebabCase(name)}`,
     });
     this.logger = _console;
 
@@ -52,8 +125,12 @@ export abstract class NoraComponentBase {
     createRootHMR(() => {
       this.init();
       onCleanup(() => {
-        nora_component_base_console.debug(`onCleanup ${this.constructor.name}`);
-        _NoraComponentBase_viteHotContext.delete(this.constructor.name);
+        nora_component_base_console.debug(`onCleanup ${name}`);
+        const instances = _noraInstancesByName.get(name);
+        instances?.delete(this);
+        if (instances?.size === 0) {
+          _noraInstancesByName.delete(name);
+        }
       });
     }, hot);
   }

--- a/libs/solid-xul/index.ts
+++ b/libs/solid-xul/index.ts
@@ -153,13 +153,48 @@ export function createRootHMR<T>(fn: RootFunction<T>, hotCtx?: ViteHotContext) {
     if (hotCtx) {
       hotCtxMap.set(hotCtx, [...(hotCtxMap.get(hotCtx) ?? []), disposer]);
       console.debug("register disposer to hotCtx in createRoot");
-      hotCtx.dispose(() => {
-        hotCtxMap.get(hotCtx)?.forEach((v) => v());
-        hotCtxMap.delete(hotCtx);
-      });
+      if (
+        !hotCtx.data.__solidXulExternalDisposeOwner &&
+        !hotCtx.data.__solidXulDisposeRegistered
+      ) {
+        hotCtx.data.__solidXulDisposeRegistered = true;
+        hotCtx.dispose(() => {
+          try {
+            disposeRoot(hotCtx);
+          } finally {
+            hotCtx.data.__solidXulDisposeRegistered = false;
+          }
+        });
+      }
     }
     return ret;
   });
+}
+
+/**
+ * Manually dispose all Solid roots registered for the given hot context.
+ *
+ * Vite's `import.meta.hot.dispose` only retains the **last** registered
+ * callback (see https://github.com/vitejs/vite/issues/16283), so when a module
+ * creates multiple reactive roots under the same `hotCtx`, earlier dispose
+ * registrations get overwritten and their cleanups never run.
+ *
+ * This function provides an explicit escape hatch: callers can drain all
+ * disposers for a hot context on demand — independent of Vite's internal
+ * dispose scheduling.
+ */
+export function disposeRoot(hotCtx: ViteHotContext): void {
+  const disposers = hotCtxMap.get(hotCtx);
+  if (disposers) {
+    for (const dispose of disposers) {
+      try {
+        dispose();
+      } catch (e) {
+        console.error("[nora@solid-xul] disposeRoot error:", e);
+      }
+    }
+    hotCtxMap.delete(hotCtx);
+  }
 }
 
 export {


### PR DESCRIPTION
## Summary

Fixes #2504 — multi-row tabs could not be reordered by dragging.

## Root Cause

Two issues combined to make tab reordering silently fail:

### 1. `ownerGlobal` removed in recent Firefox (primary cause)

`orig_getDropEffectForTabDrag` referenced `sourceNode.ownerGlobal`, but this property has been **removed from XUL elements in recent Firefox** and always returns `undefined`.

As a result:
- The outer validation `sourceNode.ownerGlobal && ...` always failed
- The function fell through to `canDropLink` and returned `"link"` instead of `"move"`
- `performTabDragOver` took the link-drop branch and returned early
- `lastKnownIndex` was never set
- `performTabDropEvent` bailed out with `newIndex === null`

**Fix:** Use `sourceNode.ownerDocument.defaultView` — the supported replacement for `ownerGlobal`.

### 2. Native `on_dragover` override no longer effective

Current Firefox routes drag events directly to `tabDragAndDrop.handle_*` and **ignores JS property assignments** on XUL elements (`on_dragover` / `_onDragOver`).

**Fix:** Register `dragover`/`drop` listeners in the **CAPTURE phase** and call `stopPropagation()` inside them to block the native handler entirely.

## Related HMR fix

`MultirowTabbarClass.cleanup()` did not call `disableMultiRowTabs()`, so stale capture-phase listeners stayed attached after a hot reload. Adds:

- `disposeRoot()` helper in `@nora/solid-xul`
- Per-module dispose registry in `NoraComponentBase` to work around Vite's single-dispose-callback limitation (Vite #16283)

## Verification

Tested manually in a running browser with multi-row tabs enabled (17 tabs):
- ✅ Drag-and-drop reordering works
- ✅ Drop indicator shows correctly
- ✅ HMR no longer leaves stale listeners

## Files Changed

| File | Change |
|---|---|
| `tab-drag-drop-manager.ts` | Primary fix: `ownerGlobal` → `ownerDocument.defaultView`; capture-phase listeners; `||`→`&&` bug fix |
| `multirow-tabbar.tsx` | Call `disableMultiRowTabs()` in `cleanup()` for proper HMR teardown |
| `base.ts` | Instance registry + per-module `hot.dispose` for HMR |
| `libs/solid-xul/index.ts` | `disposeRoot()` API to bypass Vite #16283 |

Fixes #2504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tab drag-and-drop handling for more reliable operations across browsers
  * Fixed stale multi-row tabbar behavior after code updates during development
  * Enhanced Firefox compatibility for tab drag operations
  * Strengthened component cleanup to prevent residual behavior after hot module reloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->