### PR TITLE
fix(about): change broken discord link

### DIFF
--- a/browser-features/pages-aboutDialog/src/AboutDialog.tsx
+++ b/browser-features/pages-aboutDialog/src/AboutDialog.tsx
@@ -410,7 +410,7 @@ export function AboutDialog() {
                 class="ad-community-item"
                 onClick={(e) => {
                   e.preventDefault();
-                  openExternalUrl("https://discord.gg/floorp");
+                  openExternalUrl("https://floorp.app/discord");
                 }}
               >
                 <span class="ad-community-icon">


### PR DESCRIPTION
Fix broken link to the Floorp Discord in the "About" menu.