### PR TITLE
Integrate IP Protection without Gecko patches

### DIFF
--- a/bridge/startup/src/about-preferences.ts
+++ b/bridge/startup/src/about-preferences.ts
@@ -7,9 +7,45 @@ interface FirefoxWindow extends Window {
 
 interface XULElement extends Element {}
 
+type FloorpIPProtectionDisclosureStrings = Readonly<{
+  title: string;
+  scope: string;
+  fullDisclosure: string;
+  settingsPromoHeading: string;
+  settingsPromoMessage: string;
+}>;
+
+type IPProtectionSettingItem = Readonly<{
+  id?: string;
+  l10nId?: string;
+  controlAttrs?: Readonly<Record<string, unknown>>;
+}>;
+
+type IPProtectionSettingGroupConfig = Readonly<{
+  l10nId?: string;
+  controlAttrs?: Readonly<Record<string, unknown>>;
+  items?: readonly IPProtectionSettingItem[];
+}>;
+
+type IPProtectionSettingGroup = HTMLElement & {
+  config?: IPProtectionSettingGroupConfig;
+  requestUpdate?: () => void;
+};
+
+type IPProtectionPromo = HTMLElement & {
+  heading?: string;
+  message?: string;
+};
+
 // In Firefox browser chrome context, document is always available.
 // Gecko types declare it as `Document | null`, but it is never null here.
 const doc = document!;
+
+const { getFloorpIPProtectionDisclosureStrings } = ChromeUtils.importESModule(
+  "resource://noraneko/modules/ipprotection/FloorpIPProtectionDisclosure.sys.mjs",
+);
+const FLOORP_IP_PROTECTION_DISCLOSURE =
+  getFloorpIPProtectionDisclosureStrings() as FloorpIPProtectionDisclosureStrings;
 
 const FLOORP_HUB_WARNING_IDS = {
   container: "floorp-hub-warning",
@@ -1013,8 +1049,219 @@ function initHideNewTabPage(): void {
   }
 }
 
+const FLOORP_IP_PROTECTION_READY_ATTRIBUTE = "data-floorp-ipprotection-ready";
+const FLOORP_IP_PROTECTION_DISCLOSURE_ID = "floorpIPProtectionDisclosure";
+
+function setElementAttributeIfChanged(
+  element: Element,
+  name: string,
+  value: string,
+): void {
+  if (element.getAttribute(name) !== value) {
+    element.setAttribute(name, value);
+  }
+}
+
+function ensureFloorpIPProtectionPreferencesStyle(): void {
+  const id = "floorp-ipprotection-preferences-style";
+  if (doc.getElementById(id)) {
+    return;
+  }
+  const style = doc.createElement("style");
+  style.id = id;
+  style.textContent = `
+    setting-group[groupid="ipprotection"]:not([${FLOORP_IP_PROTECTION_READY_ATTRIBUTE}="true"]) {
+      visibility: hidden !important;
+      pointer-events: none !important;
+    }
+
+    #${FLOORP_IP_PROTECTION_DISCLOSURE_ID} {
+      color: var(--text-color-deemphasized);
+      background-color: var(--background-color-box-info);
+      border-radius: var(--border-radius-medium);
+      margin-block-end: var(--space-medium);
+      padding: var(--space-medium);
+      line-height: 1.4;
+    }
+  `;
+  doc.documentElement.append(style);
+}
+
+function updateFloorpIPProtectionGroupConfig(
+  group: IPProtectionSettingGroup,
+): void {
+  const config = group.config;
+  if (!config?.items) {
+    return;
+  }
+  const items = config.items;
+  const promoItem = items.find(
+    (item) => item.id === "ipProtectionNotOptedInSection",
+  );
+  if (
+    config.l10nId === undefined &&
+    config.controlAttrs?.label === FLOORP_IP_PROTECTION_DISCLOSURE.title &&
+    promoItem?.l10nId === undefined &&
+    promoItem?.controlAttrs?.heading ===
+      FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoHeading &&
+    promoItem.controlAttrs.message ===
+      FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoMessage
+  ) {
+    return;
+  }
+  group.config = {
+    ...config,
+    l10nId: undefined,
+    controlAttrs: {
+      ...config.controlAttrs,
+      label: FLOORP_IP_PROTECTION_DISCLOSURE.title,
+    },
+    items: items.map((item) =>
+      item.id === "ipProtectionNotOptedInSection"
+        ? {
+          ...item,
+          l10nId: undefined,
+          controlAttrs: {
+            ...item.controlAttrs,
+            heading: FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoHeading,
+            message: FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoMessage,
+          },
+        }
+        : item
+    ),
+  };
+  group.requestUpdate?.();
+}
+
+function ensureOneFloorpIPProtectionPreferences(
+  group: IPProtectionSettingGroup,
+): void {
+  group.removeAttribute(FLOORP_IP_PROTECTION_READY_ATTRIBUTE);
+  updateFloorpIPProtectionGroupConfig(group);
+
+  const fieldset = group.querySelector("moz-fieldset") as
+    | (HTMLElement & { label?: string })
+    | null;
+  const promo = group.querySelector(
+    "#setting-control-ipProtectionNotOptedInSection > moz-promo",
+  ) as IPProtectionPromo | null;
+  const promoControl = group.querySelector(
+    "#setting-control-ipProtectionNotOptedInSection",
+  );
+  if (!fieldset || !promo || !promoControl) {
+    return;
+  }
+
+  fieldset.removeAttribute("data-l10n-id");
+  if (fieldset.label !== FLOORP_IP_PROTECTION_DISCLOSURE.title) {
+    fieldset.label = FLOORP_IP_PROTECTION_DISCLOSURE.title;
+  }
+  setElementAttributeIfChanged(
+    fieldset,
+    "label",
+    FLOORP_IP_PROTECTION_DISCLOSURE.title,
+  );
+
+  promo.removeAttribute("data-l10n-id");
+  if (
+    promo.heading !== FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoHeading
+  ) {
+    promo.heading = FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoHeading;
+  }
+  if (
+    promo.message !== FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoMessage
+  ) {
+    promo.message = FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoMessage;
+  }
+  setElementAttributeIfChanged(
+    promo,
+    "heading",
+    FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoHeading,
+  );
+  setElementAttributeIfChanged(
+    promo,
+    "message",
+    FLOORP_IP_PROTECTION_DISCLOSURE.settingsPromoMessage,
+  );
+
+  let disclosure = group.querySelector(
+    `#${FLOORP_IP_PROTECTION_DISCLOSURE_ID}`,
+  );
+  if (!disclosure) {
+    disclosure = doc.createElement("div");
+    disclosure.id = FLOORP_IP_PROTECTION_DISCLOSURE_ID;
+    disclosure.setAttribute("role", "note");
+    promoControl.before(disclosure);
+  }
+  const disclosureText =
+    `${FLOORP_IP_PROTECTION_DISCLOSURE.scope} ${FLOORP_IP_PROTECTION_DISCLOSURE.fullDisclosure}`;
+  if (disclosure.textContent !== disclosureText) {
+    disclosure.textContent = disclosureText;
+  }
+  setElementAttributeIfChanged(
+    group,
+    FLOORP_IP_PROTECTION_READY_ATTRIBUTE,
+    "true",
+  );
+}
+
+function ensureFloorpIPProtectionPreferences(): void {
+  ensureFloorpIPProtectionPreferencesStyle();
+  const groups = doc.querySelectorAll<IPProtectionSettingGroup>(
+    'setting-group[groupid="ipprotection"]',
+  );
+  for (const group of groups) {
+    ensureOneFloorpIPProtectionPreferences(group);
+  }
+}
+
+let floorpIPProtectionPreferencesObserver: MutationObserver | null = null;
+
+function initFloorpIPProtectionPreferences(): void {
+  const run = (): void => {
+    ensureFloorpIPProtectionPreferences();
+    if (floorpIPProtectionPreferencesObserver) {
+      return;
+    }
+    floorpIPProtectionPreferencesObserver = new (doc.defaultView as unknown as {
+      MutationObserver: typeof MutationObserver;
+    }).MutationObserver(() => {
+      ensureFloorpIPProtectionPreferences();
+    });
+    const target = doc.getElementById("mainPrefPane") ?? doc.body;
+    if (target) {
+      floorpIPProtectionPreferencesObserver.observe(target, {
+        attributes: true,
+        attributeFilter: [
+          "data-l10n-id",
+          "label",
+          "heading",
+          "message",
+        ],
+        childList: true,
+        subtree: true,
+      });
+    }
+    doc.defaultView?.addEventListener(
+      "unload",
+      () => {
+        floorpIPProtectionPreferencesObserver?.disconnect();
+        floorpIPProtectionPreferencesObserver = null;
+      },
+      { once: true },
+    );
+  };
+
+  if (doc.readyState === "loading") {
+    doc.addEventListener("DOMContentLoaded", run, { once: true });
+  } else {
+    run();
+  }
+}
+
 ensureI18NInitialized();
 addFloorpHubCategory();
 ensureFloorpHubWarning();
 ensureFloorpStartWarning();
 initHideNewTabPage();
+initFloorpIPProtectionPreferences();

--- a/bridge/startup/src/about-preferences.ts
+++ b/bridge/startup/src/about-preferences.ts
@@ -1067,6 +1067,10 @@ function ensureFloorpIPProtectionPreferencesStyle(): void {
   if (doc.getElementById(id)) {
     return;
   }
+  const documentElement = doc.documentElement;
+  if (!documentElement) {
+    return;
+  }
   const style = doc.createElement("style");
   style.id = id;
   style.textContent = `
@@ -1084,7 +1088,7 @@ function ensureFloorpIPProtectionPreferencesStyle(): void {
       line-height: 1.4;
     }
   `;
-  doc.documentElement.append(style);
+  documentElement.append(style);
 }
 
 function updateFloorpIPProtectionGroupConfig(

--- a/browser-features/modules/actors/NRAboutPreferencesChild.sys.mts
+++ b/browser-features/modules/actors/NRAboutPreferencesChild.sys.mts
@@ -1,5 +1,25 @@
 export class NRAboutPreferencesChild extends JSWindowActorChild {
-  handleEvent(event) {
+  handleEvent(event: Event): void {
+    if (event.type === "DOMDocElementInserted") {
+      const doc = this.contentWindow?.document;
+      if (!doc?.documentElement) {
+        return;
+      }
+      const styleId = "floorp-ipprotection-preferences-guard";
+      if (doc.getElementById(styleId)) {
+        return;
+      }
+      const style = doc.createElement("style");
+      style.id = styleId;
+      style.textContent = `
+        setting-group[groupid="ipprotection"]:not([data-floorp-ipprotection-ready="true"]) {
+          visibility: hidden !important;
+          pointer-events: none !important;
+        }
+      `;
+      doc.documentElement.append(style);
+      return;
+    }
     if (event.type === "DOMContentLoaded") {
       //https://searchfox.org/mozilla-central/rev/3a34b4616994bd8d2b6ede2644afa62eaec817d1/browser/actors/AboutNewTabChild.sys.mjs#70
       Services.scriptloader.loadSubScript(

--- a/browser-features/modules/modules/BrowserGlue.sys.mts
+++ b/browser-features/modules/modules/BrowserGlue.sys.mts
@@ -28,6 +28,7 @@ const JS_WINDOW_ACTORS: {
       ),
       events: {
         DOMContentLoaded: {},
+        DOMDocElementInserted: {},
       },
     },
     matches: ["about:preferences*", "about:settings*"],

--- a/browser-features/modules/modules/NoranekoStartup.sys.mts
+++ b/browser-features/modules/modules/NoranekoStartup.sys.mts
@@ -16,10 +16,22 @@ const { setTimeout } = ChromeUtils.importESModule(
   "resource://gre/modules/Timer.sys.mjs",
 );
 
-const { FloorpIPProtectionUI } = ChromeUtils.importESModule(
-  "resource://noraneko/modules/ipprotection/FloorpIPProtectionUI.sys.mjs",
-);
-const isFloorpIPProtectionUIReady = FloorpIPProtectionUI.installEarly();
+function installFloorpIPProtectionUIEarly(): boolean {
+  try {
+    const { FloorpIPProtectionUI } = ChromeUtils.importESModule(
+      "resource://noraneko/modules/ipprotection/FloorpIPProtectionUI.sys.mjs",
+    );
+    return FloorpIPProtectionUI.installEarly();
+  } catch (error) {
+    console.error(
+      "[FloorpIPProtectionUI] Failed to install the early runtime adapter:",
+      error,
+    );
+    return false;
+  }
+}
+
+const isFloorpIPProtectionUIReady = installFloorpIPProtectionUIEarly();
 
 export const env = Services.env;
 export const isMainBrowser = env.get("MOZ_BROWSER_TOOLBOX_PORT") === "";

--- a/browser-features/modules/modules/NoranekoStartup.sys.mts
+++ b/browser-features/modules/modules/NoranekoStartup.sys.mts
@@ -16,6 +16,11 @@ const { setTimeout } = ChromeUtils.importESModule(
   "resource://gre/modules/Timer.sys.mjs",
 );
 
+const { FloorpIPProtectionUI } = ChromeUtils.importESModule(
+  "resource://noraneko/modules/ipprotection/FloorpIPProtectionUI.sys.mjs",
+);
+const isFloorpIPProtectionUIReady = FloorpIPProtectionUI.installEarly();
+
 export const env = Services.env;
 export const isMainBrowser = env.get("MOZ_BROWSER_TOOLBOX_PORT") === "";
 
@@ -458,6 +463,11 @@ async function initializeExperiments() {
     "resource://noraneko/modules/experiments/Experiments.sys.mjs",
   );
   await Experiments.init();
+
+  const { FloorpIPProtectionGate } = await ChromeUtils.importESModule(
+    "resource://noraneko/modules/ipprotection/FloorpIPProtectionGate.sys.mjs",
+  );
+  FloorpIPProtectionGate.apply(isFloorpIPProtectionUIReady);
 }
 
 (async () => {

--- a/browser-features/modules/modules/ipprotection/FloorpIPProtectionDisclosure.sys.mts
+++ b/browser-features/modules/modules/ipprotection/FloorpIPProtectionDisclosure.sys.mts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import enUSBrowserChrome from "../../../../i18n/en-US/browser-chrome.json" with {
+  type: "json",
+};
+import jaJPBrowserChrome from "../../../../i18n/ja-JP/browser-chrome.json" with {
+  type: "json",
+};
+
+export type FloorpIPProtectionDisclosureStrings = Readonly<{
+  title: string;
+  toolbarActiveTooltip: string;
+  toolbarInactiveTooltip: string;
+  toolbarExcludedTooltip: string;
+  toolbarPausedTooltip: string;
+  toolbarErrorTooltip: string;
+  helpTooltip: string;
+  scope: string;
+  fullDisclosure: string;
+  unauthenticatedTitle: string;
+  settingsPromoHeading: string;
+  settingsPromoMessage: string;
+  termsPrefix: string;
+  termsOfUse: string;
+  termsConjunction: string;
+  privacyNotice: string;
+  termsSuffix: string;
+}>;
+
+type FloorpIPProtectionDisclosureResource = Readonly<{
+  title: string;
+  toolbar: Readonly<{
+    activeTooltip: string;
+    inactiveTooltip: string;
+    excludedTooltip: string;
+    pausedTooltip: string;
+    errorTooltip: string;
+    helpTooltip: string;
+  }>;
+  scope: Readonly<{
+    summary: string;
+    fullDisclosure: string;
+  }>;
+  unauthenticated: Readonly<{
+    title: string;
+  }>;
+  settings: Readonly<{
+    promoHeading: string;
+    promoMessage: string;
+  }>;
+  terms: Readonly<{
+    prefix: string;
+    termsOfUse: string;
+    conjunction: string;
+    privacyNotice: string;
+    suffix: string;
+  }>;
+}>;
+
+function createDisclosureStrings(
+  resource: FloorpIPProtectionDisclosureResource,
+): FloorpIPProtectionDisclosureStrings {
+  return Object.freeze({
+    title: resource.title,
+    toolbarActiveTooltip: resource.toolbar.activeTooltip,
+    toolbarInactiveTooltip: resource.toolbar.inactiveTooltip,
+    toolbarExcludedTooltip: resource.toolbar.excludedTooltip,
+    toolbarPausedTooltip: resource.toolbar.pausedTooltip,
+    toolbarErrorTooltip: resource.toolbar.errorTooltip,
+    helpTooltip: resource.toolbar.helpTooltip,
+    scope: resource.scope.summary,
+    fullDisclosure: resource.scope.fullDisclosure,
+    unauthenticatedTitle: resource.unauthenticated.title,
+    settingsPromoHeading: resource.settings.promoHeading,
+    settingsPromoMessage: resource.settings.promoMessage,
+    termsPrefix: resource.terms.prefix,
+    termsOfUse: resource.terms.termsOfUse,
+    termsConjunction: resource.terms.conjunction,
+    privacyNotice: resource.terms.privacyNotice,
+    termsSuffix: resource.terms.suffix,
+  });
+}
+
+const ENGLISH_STRINGS = createDisclosureStrings(
+  enUSBrowserChrome.ipProtection,
+);
+const JAPANESE_STRINGS = createDisclosureStrings(
+  jaJPBrowserChrome.ipProtection,
+);
+
+export function resolveFloorpIPProtectionDisclosureStrings(
+  locale: string,
+): FloorpIPProtectionDisclosureStrings {
+  return locale.toLowerCase() === "ja" || locale.toLowerCase().startsWith("ja-")
+    ? JAPANESE_STRINGS
+    : ENGLISH_STRINGS;
+}
+
+export function getFloorpIPProtectionDisclosureStrings(): FloorpIPProtectionDisclosureStrings {
+  return resolveFloorpIPProtectionDisclosureStrings(
+    Services.locale.appLocaleAsBCP47,
+  );
+}

--- a/browser-features/modules/modules/ipprotection/FloorpIPProtectionGate.sys.mts
+++ b/browser-features/modules/modules/ipprotection/FloorpIPProtectionGate.sys.mts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+export const FLOORP_IP_PROTECTION_EXPERIMENT = "floorp_ip_protection";
+export const FIREFOX_IP_PROTECTION_ENABLED_PREF =
+  "browser.ipProtection.enabled";
+export const FIREFOX_IP_PROTECTION_BLOCK_CALLOUTS_PREF =
+  "browser.ipProtection.blockIPProtectionCallouts";
+
+type ExperimentsLike = {
+  getVariant(experimentId: string): string | null;
+};
+
+type PrefsLike = {
+  setBoolPref(prefName: string, value: boolean): void;
+};
+
+export function isFloorpIPProtectionVariantEnabled(
+  variant: string | null,
+): boolean {
+  return variant === "enabled";
+}
+
+export function shouldEnableFloorpIPProtection(
+  experiments: ExperimentsLike,
+): boolean {
+  try {
+    return isFloorpIPProtectionVariantEnabled(
+      experiments.getVariant(FLOORP_IP_PROTECTION_EXPERIMENT),
+    );
+  } catch (error) {
+    console.error(
+      "[FloorpIPProtectionGate] Failed to check floorp_ip_protection Flasco:",
+      error,
+    );
+    return false;
+  }
+}
+
+export function resolveFloorpIPProtectionEnabled(
+  experimentEnabled: boolean,
+  runtimeReady: boolean,
+): boolean {
+  return experimentEnabled && runtimeReady;
+}
+
+export function applyFloorpIPProtectionPref(
+  prefs: PrefsLike,
+  enabled: boolean,
+): void {
+  prefs.setBoolPref(FIREFOX_IP_PROTECTION_ENABLED_PREF, enabled);
+  prefs.setBoolPref(FIREFOX_IP_PROTECTION_BLOCK_CALLOUTS_PREF, true);
+}
+
+export const FloorpIPProtectionGate = {
+  isEnabled(): boolean {
+    const { Experiments } = ChromeUtils.importESModule(
+      "resource://noraneko/modules/experiments/Experiments.sys.mjs",
+    );
+    return shouldEnableFloorpIPProtection(Experiments);
+  },
+
+  apply(runtimeReady = true): boolean {
+    const enabled = resolveFloorpIPProtectionEnabled(
+      runtimeReady ? this.isEnabled() : false,
+      runtimeReady,
+    );
+    if (!runtimeReady) {
+      console.error(
+        "[FloorpIPProtectionGate] Runtime adapter was not ready; disabling IP Protection.",
+      );
+    }
+    applyFloorpIPProtectionPref(Services.prefs, enabled);
+    return enabled;
+  },
+} as const;

--- a/browser-features/modules/modules/ipprotection/FloorpIPProtectionUI.sys.mts
+++ b/browser-features/modules/modules/ipprotection/FloorpIPProtectionUI.sys.mts
@@ -153,7 +153,11 @@ function ensureStyle(
 ): void {
   let style = root.getElementById(id) as HTMLStyleElement | null;
   if (!style) {
-    style = root.ownerDocument.createElement("style");
+    const doc = root.ownerDocument;
+    if (!doc) {
+      return;
+    }
+    style = doc.createElement("style");
     style.id = id;
     root.prepend(style);
   }
@@ -210,7 +214,9 @@ function updateToolbarButton(
   button.removeAttribute("data-l10n-id");
   setAttributeIfChanged(button, "label", strings.title);
   const tooltip = resolveFloorpIPProtectionToolbarTooltip(
-    button.classList,
+    Array.from(button.classList).filter(
+      (className): className is string => className !== null,
+    ),
     strings,
   );
   setAttributeIfChanged(button, "tooltiptext", tooltip);
@@ -238,6 +244,10 @@ function updateUnauthenticatedPanel(
   root: ShadowRoot,
   strings: FloorpIPProtectionDisclosureStrings,
 ): boolean {
+  const doc = root.ownerDocument;
+  if (!doc) {
+    return false;
+  }
   const title = root.getElementById("unauthenticated-vpn-title");
   const message = root.getElementById("unauthenticated-vpn-message");
   const getStarted = root.getElementById("unauthenticated-get-started");
@@ -254,7 +264,7 @@ function updateUnauthenticatedPanel(
 
   let disclosure = root.getElementById(FULL_DISCLOSURE_ID);
   if (!disclosure) {
-    disclosure = root.ownerDocument.createElement("div");
+    disclosure = doc.createElement("div");
     disclosure.id = FULL_DISCLOSURE_ID;
     disclosure.setAttribute("role", "note");
     getStarted.before(disclosure);
@@ -279,11 +289,11 @@ function updateUnauthenticatedPanel(
     setTextIfChanged(terms, strings.termsOfUse);
     setTextIfChanged(privacy, strings.privacyNotice);
     footer.replaceChildren(
-      root.ownerDocument.createTextNode(strings.termsPrefix),
+      doc.createTextNode(strings.termsPrefix),
       terms,
-      root.ownerDocument.createTextNode(strings.termsConjunction),
+      doc.createTextNode(strings.termsConjunction),
       privacy,
-      root.ownerDocument.createTextNode(strings.termsSuffix),
+      doc.createTextNode(strings.termsSuffix),
     );
   }
   markReady(footer);
@@ -327,8 +337,12 @@ function ensurePanelHeaderObserver(
   panel: Element,
   strings: FloorpIPProtectionDisclosureStrings,
 ): void {
-  const header = win.document.getElementById(HEADER_CONTENT_ID);
-  const helpButton = win.document.getElementById(HEADER_BUTTON_ID);
+  const doc = win.document;
+  if (!doc) {
+    return;
+  }
+  const header = doc.getElementById(HEADER_CONTENT_ID);
+  const helpButton = doc.getElementById(HEADER_BUTTON_ID);
   if (!header || !helpButton) {
     return;
   }
@@ -364,6 +378,9 @@ function ensurePanel(
   strings: FloorpIPProtectionDisclosureStrings,
 ): void {
   const doc = win.document;
+  if (!doc) {
+    return;
+  }
   const panel = doc.getElementById(PANEL_ID);
   if (!panel || state.panelRepairing) {
     return;
@@ -411,7 +428,11 @@ function ensurePanel(
     ensureStyle(outerRoot, OUTER_STYLE_ID, OUTER_SHADOW_STYLES);
     let scope = outerRoot.getElementById(SCOPE_ID);
     if (!scope) {
-      scope = outerRoot.ownerDocument.createElement("div");
+      const ownerDocument = outerRoot.ownerDocument;
+      if (!ownerDocument) {
+        return;
+      }
+      scope = ownerDocument.createElement("div");
       scope.id = SCOPE_ID;
       scope.setAttribute("role", "note");
       wrapper.append(scope);
@@ -467,7 +488,11 @@ function ensureToolbar(
   state: WindowObserver,
   strings: FloorpIPProtectionDisclosureStrings,
 ): void {
-  const button = win.document.getElementById(TOOLBAR_BUTTON_ID);
+  const doc = win.document;
+  if (!doc) {
+    return;
+  }
+  const button = doc.getElementById(TOOLBAR_BUTTON_ID);
   if (!button) {
     return;
   }
@@ -493,9 +518,14 @@ function ensureToolbar(
 }
 
 function initializeBrowserDocument(win: BrowserWindow): void {
+  const doc = win.document;
+  const documentElement = doc?.documentElement;
+  if (!doc || !documentElement) {
+    return;
+  }
   if (
     observedWindows.has(win) ||
-    win.document.documentElement.getAttribute("windowtype") !==
+    documentElement.getAttribute("windowtype") !==
       "navigator:browser"
   ) {
     return;
@@ -519,7 +549,7 @@ function initializeBrowserDocument(win: BrowserWindow): void {
     panelRepairing: false,
   };
   observedWindows.set(win, state);
-  state.documentObserver.observe(win.document.documentElement, {
+  state.documentObserver.observe(documentElement, {
     childList: true,
     subtree: true,
   });
@@ -529,7 +559,7 @@ function initializeBrowserDocument(win: BrowserWindow): void {
     if (target?.id !== PANEL_ID) {
       return;
     }
-    const panel = win.document.getElementById(PANEL_ID);
+    const panel = doc.getElementById(PANEL_ID);
     markNotReady(panel);
     if (event.type === "ViewHiding") {
       cancelPanelRetry(win, state);
@@ -539,8 +569,8 @@ function initializeBrowserDocument(win: BrowserWindow): void {
     state.panelRetryAttempts = 0;
     ensurePanel(win, state, strings);
   };
-  win.document.addEventListener("ViewShowing", onPanelEvent, true);
-  win.document.addEventListener("ViewHiding", onPanelEvent, true);
+  doc.addEventListener("ViewShowing", onPanelEvent, true);
+  doc.addEventListener("ViewHiding", onPanelEvent, true);
 
   win.addEventListener(
     "unload",
@@ -551,8 +581,8 @@ function initializeBrowserDocument(win: BrowserWindow): void {
       state.panelOuterObserver?.disconnect();
       state.panelInnerObserver?.disconnect();
       cancelPanelRetry(win, state);
-      win.document.removeEventListener("ViewShowing", onPanelEvent, true);
-      win.document.removeEventListener("ViewHiding", onPanelEvent, true);
+      doc.removeEventListener("ViewShowing", onPanelEvent, true);
+      doc.removeEventListener("ViewHiding", onPanelEvent, true);
       observedWindows.delete(win);
     },
     { once: true },
@@ -563,7 +593,11 @@ function initializeBrowserDocument(win: BrowserWindow): void {
 }
 
 function observeBrowserWindow(win: BrowserWindow): void {
-  if (win.document.readyState === "loading") {
+  const doc = win.document;
+  if (!doc) {
+    return;
+  }
+  if (doc.readyState === "loading") {
     win.addEventListener(
       "DOMContentLoaded",
       () => initializeBrowserDocument(win),

--- a/browser-features/modules/modules/ipprotection/FloorpIPProtectionUI.sys.mts
+++ b/browser-features/modules/modules/ipprotection/FloorpIPProtectionUI.sys.mts
@@ -1,0 +1,620 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import type { FloorpIPProtectionDisclosureStrings } from "./FloorpIPProtectionDisclosure.sys.mts";
+
+const BLOCK_CALLOUTS_PREF = "browser.ipProtection.blockIPProtectionCallouts";
+const ENABLED_PREF = "browser.ipProtection.enabled";
+const MAX_PANEL_RETRY_FRAMES = 120;
+const READY_ATTRIBUTE = "data-floorp-ipprotection-ready";
+const TOOLBAR_BUTTON_ID = "ipprotection-button";
+const PANEL_ID = "PanelUI-ipprotection";
+const PANEL_CONTENT_ID = "PanelUI-ipprotection-content";
+const HEADER_CONTENT_ID = "ipprotection-header-content";
+const HEADER_BUTTON_ID = "ipprotection-header-button";
+const SCOPE_ID = "floorp-ipprotection-scope";
+const FULL_DISCLOSURE_ID = "floorp-ipprotection-full-disclosure";
+const OUTER_STYLE_ID = "floorp-ipprotection-outer-style";
+const INNER_STYLE_ID = "floorp-ipprotection-inner-style";
+
+const GUARD_STYLES = `
+#${TOOLBAR_BUTTON_ID}:not([${READY_ATTRIBUTE}="true"]),
+#${PANEL_ID}:not([${READY_ATTRIBUTE}="true"]) {
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
+@-moz-document url-prefix("about:preferences"), url-prefix("about:settings") {
+  setting-group[groupid="ipprotection"]:not([${READY_ATTRIBUTE}="true"]) {
+    visibility: hidden !important;
+    pointer-events: none !important;
+  }
+}
+`;
+
+const OUTER_SHADOW_STYLES = `
+#${SCOPE_ID} {
+  color: var(--text-color-deemphasized);
+  border-block-start: 1px solid var(--panel-separator-color);
+  margin-block-start: var(--space-medium);
+  padding: var(--space-medium) var(--space-large) 0;
+  line-height: 1.4;
+}
+`;
+
+const INNER_SHADOW_STYLES = `
+#${FULL_DISCLOSURE_ID} {
+  color: var(--text-color-deemphasized);
+  background-color: var(--background-color-box-info);
+  border-radius: var(--border-radius-medium);
+  margin-block-end: var(--space-medium);
+  padding: var(--space-medium);
+  line-height: 1.4;
+}
+`;
+
+type CalloutMessage = Readonly<{ id?: unknown }>;
+type FeatureCalloutMessagesLike = {
+  getMessages(...args: unknown[]): unknown;
+};
+
+type BrowserWindow = Window & {
+  MutationObserver: typeof MutationObserver;
+};
+
+type WindowObserver = {
+  documentObserver: MutationObserver;
+  toolbarObserver: MutationObserver | null;
+  panelHeaderObserver: MutationObserver | null;
+  panelOuterObserver: MutationObserver | null;
+  panelInnerObserver: MutationObserver | null;
+  toolbarNode: Element | null;
+  panelHeaderNodes: readonly [Element, Element] | null;
+  panelOuterRoot: ShadowRoot | null;
+  panelInnerRoot: ShadowRoot | null;
+  panelRetryFrame: number | null;
+  panelRetryAttempts: number;
+  panelRepairing: boolean;
+};
+
+const observedWindows = new WeakMap<BrowserWindow, WindowObserver>();
+let guardSheetURI: nsIURI | null = null;
+let calloutHookInstalled = false;
+let windowObserverInstalled = false;
+let earlyInstallResult: boolean | null = null;
+
+export function filterFloorpIPProtectionCallouts<T extends CalloutMessage>(
+  messages: readonly T[],
+): T[] {
+  return messages.filter(
+    (message) =>
+      typeof message.id !== "string" ||
+      !message.id.startsWith("IP_PROTECTION_"),
+  );
+}
+
+export function resolveFloorpIPProtectionToolbarTooltip(
+  classNames: Iterable<string>,
+  strings: FloorpIPProtectionDisclosureStrings,
+): string {
+  const classes = new Set(classNames);
+  if (
+    classes.has("ipprotection-error") ||
+    classes.has("ipprotection-network-error")
+  ) {
+    return strings.toolbarErrorTooltip;
+  }
+  if (classes.has("ipprotection-paused")) {
+    return strings.toolbarPausedTooltip;
+  }
+  if (classes.has("ipprotection-excluded")) {
+    return strings.toolbarExcludedTooltip;
+  }
+  if (classes.has("ipprotection-on")) {
+    return strings.toolbarActiveTooltip;
+  }
+  return strings.toolbarInactiveTooltip;
+}
+
+function getDisclosureStrings(): FloorpIPProtectionDisclosureStrings {
+  const { getFloorpIPProtectionDisclosureStrings } = ChromeUtils.importESModule(
+    "resource://noraneko/modules/ipprotection/FloorpIPProtectionDisclosure.sys.mjs",
+  );
+  return getFloorpIPProtectionDisclosureStrings();
+}
+
+function setAttributeIfChanged(
+  element: Element,
+  name: string,
+  value: string,
+): void {
+  if (element.getAttribute(name) !== value) {
+    element.setAttribute(name, value);
+  }
+}
+
+function setTextIfChanged(element: Element, value: string): void {
+  if (element.textContent !== value) {
+    element.textContent = value;
+  }
+}
+
+function markReady(element: Element): void {
+  setAttributeIfChanged(element, READY_ATTRIBUTE, "true");
+}
+
+function markNotReady(element: Element | null): void {
+  element?.removeAttribute(READY_ATTRIBUTE);
+}
+
+function ensureStyle(
+  root: ShadowRoot,
+  id: string,
+  cssText: string,
+): void {
+  let style = root.getElementById(id) as HTMLStyleElement | null;
+  if (!style) {
+    style = root.ownerDocument.createElement("style");
+    style.id = id;
+    root.prepend(style);
+  }
+  if (style.textContent !== cssText) {
+    style.textContent = cssText;
+  }
+}
+
+function registerGuardSheet(): void {
+  if (guardSheetURI) {
+    return;
+  }
+  const styleSheetService = Cc[
+    "@mozilla.org/content/style-sheet-service;1"
+  ].getService(Ci.nsIStyleSheetService);
+  const uri = Services.io.newURI(
+    `data:text/css;charset=utf-8,${encodeURIComponent(GUARD_STYLES)}`,
+  );
+  const sheetType = Ci.nsIStyleSheetService.AGENT_SHEET as number;
+  if (!styleSheetService.sheetRegistered(uri, sheetType)) {
+    styleSheetService.loadAndRegisterSheet(uri, sheetType);
+  }
+  guardSheetURI = uri;
+}
+
+function installCalloutHook(): void {
+  if (calloutHookInstalled) {
+    return;
+  }
+  const { FeatureCalloutMessages } = ChromeUtils.importESModule(
+    "resource:///modules/asrouter/FeatureCalloutMessages.sys.mjs",
+  ) as { FeatureCalloutMessages: FeatureCalloutMessagesLike };
+  const originalGetMessages = FeatureCalloutMessages.getMessages;
+  FeatureCalloutMessages.getMessages = function (
+    this: FeatureCalloutMessagesLike,
+    ...args: unknown[]
+  ): unknown {
+    const messages = Reflect.apply(originalGetMessages, this, args);
+    if (!Array.isArray(messages)) {
+      return messages;
+    }
+    if (!Services.prefs.getBoolPref(BLOCK_CALLOUTS_PREF, false)) {
+      return messages;
+    }
+    return filterFloorpIPProtectionCallouts(messages as CalloutMessage[]);
+  };
+  calloutHookInstalled = true;
+}
+
+function updateToolbarButton(
+  button: Element,
+  strings: FloorpIPProtectionDisclosureStrings,
+): void {
+  button.removeAttribute("data-l10n-id");
+  setAttributeIfChanged(button, "label", strings.title);
+  const tooltip = resolveFloorpIPProtectionToolbarTooltip(
+    button.classList,
+    strings,
+  );
+  setAttributeIfChanged(button, "tooltiptext", tooltip);
+  setAttributeIfChanged(button, "aria-label", tooltip);
+  markReady(button);
+}
+
+function updatePanelHeader(
+  doc: Document,
+  strings: FloorpIPProtectionDisclosureStrings,
+): boolean {
+  const header = doc.getElementById(HEADER_CONTENT_ID);
+  const helpButton = doc.getElementById(HEADER_BUTTON_ID);
+  if (!header || !helpButton) {
+    return false;
+  }
+  header.removeAttribute("data-l10n-id");
+  setTextIfChanged(header, strings.title);
+  helpButton.removeAttribute("data-l10n-id");
+  setAttributeIfChanged(helpButton, "tooltiptext", strings.helpTooltip);
+  return true;
+}
+
+function updateUnauthenticatedPanel(
+  root: ShadowRoot,
+  strings: FloorpIPProtectionDisclosureStrings,
+): boolean {
+  const title = root.getElementById("unauthenticated-vpn-title");
+  const message = root.getElementById("unauthenticated-vpn-message");
+  const getStarted = root.getElementById("unauthenticated-get-started");
+  const footer = root.getElementById("unauthenticated-footer");
+  const terms = root.getElementById("vpn-terms-of-service");
+  const privacy = root.getElementById("vpn-privacy-notice");
+  if (!title || !message || !getStarted || !footer || !terms || !privacy) {
+    return false;
+  }
+
+  ensureStyle(root, INNER_STYLE_ID, INNER_SHADOW_STYLES);
+  title.removeAttribute("data-l10n-id");
+  setTextIfChanged(title, strings.unauthenticatedTitle);
+
+  let disclosure = root.getElementById(FULL_DISCLOSURE_ID);
+  if (!disclosure) {
+    disclosure = root.ownerDocument.createElement("div");
+    disclosure.id = FULL_DISCLOSURE_ID;
+    disclosure.setAttribute("role", "note");
+    getStarted.before(disclosure);
+  }
+  setTextIfChanged(
+    disclosure,
+    `${strings.scope} ${strings.fullDisclosure}`,
+  );
+
+  footer.removeAttribute("data-l10n-id");
+  terms.removeAttribute("data-l10n-id");
+  privacy.removeAttribute("data-l10n-id");
+  const expectedFooterText =
+    `${strings.termsPrefix}${strings.termsOfUse}${strings.termsConjunction}${strings.privacyNotice}${strings.termsSuffix}`;
+  if (
+    terms.parentElement !== footer ||
+    privacy.parentElement !== footer ||
+    terms.textContent !== strings.termsOfUse ||
+    privacy.textContent !== strings.privacyNotice ||
+    footer.textContent !== expectedFooterText
+  ) {
+    setTextIfChanged(terms, strings.termsOfUse);
+    setTextIfChanged(privacy, strings.privacyNotice);
+    footer.replaceChildren(
+      root.ownerDocument.createTextNode(strings.termsPrefix),
+      terms,
+      root.ownerDocument.createTextNode(strings.termsConjunction),
+      privacy,
+      root.ownerDocument.createTextNode(strings.termsSuffix),
+    );
+  }
+  markReady(footer);
+  return true;
+}
+
+function cancelPanelRetry(win: BrowserWindow, state: WindowObserver): void {
+  if (state.panelRetryFrame !== null) {
+    win.cancelAnimationFrame(state.panelRetryFrame);
+    state.panelRetryFrame = null;
+  }
+}
+
+function schedulePanelRetry(
+  win: BrowserWindow,
+  state: WindowObserver,
+  strings: FloorpIPProtectionDisclosureStrings,
+): void {
+  if (
+    state.panelRetryFrame !== null ||
+    state.panelRetryAttempts >= MAX_PANEL_RETRY_FRAMES
+  ) {
+    if (state.panelRetryAttempts === MAX_PANEL_RETRY_FRAMES) {
+      state.panelRetryAttempts++;
+      console.error(
+        "[FloorpIPProtectionUI] Panel did not become ready within the retry window.",
+      );
+    }
+    return;
+  }
+  state.panelRetryAttempts++;
+  state.panelRetryFrame = win.requestAnimationFrame(() => {
+    state.panelRetryFrame = null;
+    ensurePanel(win, state, strings);
+  });
+}
+
+function ensurePanelHeaderObserver(
+  win: BrowserWindow,
+  state: WindowObserver,
+  panel: Element,
+  strings: FloorpIPProtectionDisclosureStrings,
+): void {
+  const header = win.document.getElementById(HEADER_CONTENT_ID);
+  const helpButton = win.document.getElementById(HEADER_BUTTON_ID);
+  if (!header || !helpButton) {
+    return;
+  }
+  if (
+    state.panelHeaderNodes?.[0] === header &&
+    state.panelHeaderNodes[1] === helpButton
+  ) {
+    return;
+  }
+  state.panelHeaderObserver?.disconnect();
+  state.panelHeaderNodes = [header, helpButton];
+  state.panelHeaderObserver = new win.MutationObserver(() => {
+    if (state.panelRepairing) {
+      return;
+    }
+    markNotReady(panel);
+    ensurePanel(win, state, strings);
+  });
+  const options: MutationObserverInit = {
+    attributes: true,
+    attributeFilter: [
+      "data-l10n-id",
+      "tooltiptext",
+    ],
+  };
+  state.panelHeaderObserver.observe(header, options);
+  state.panelHeaderObserver.observe(helpButton, options);
+}
+
+function ensurePanel(
+  win: BrowserWindow,
+  state: WindowObserver,
+  strings: FloorpIPProtectionDisclosureStrings,
+): void {
+  const doc = win.document;
+  const panel = doc.getElementById(PANEL_ID);
+  if (!panel || state.panelRepairing) {
+    return;
+  }
+  state.panelRepairing = true;
+  try {
+    markNotReady(panel);
+    if (!updatePanelHeader(doc, strings)) {
+      return;
+    }
+    ensurePanelHeaderObserver(win, state, panel, strings);
+    const contentArea = doc.getElementById(PANEL_CONTENT_ID);
+    const content = contentArea?.querySelector("ipprotection-content") as
+      | HTMLElement
+      | null;
+    const outerRoot = content?.shadowRoot;
+    if (!outerRoot) {
+      if (content) {
+        schedulePanelRetry(win, state, strings);
+      }
+      return;
+    }
+
+    if (state.panelOuterRoot !== outerRoot) {
+      state.panelOuterObserver?.disconnect();
+      state.panelOuterRoot = outerRoot;
+      state.panelOuterObserver = new win.MutationObserver(() => {
+        if (state.panelRepairing) {
+          return;
+        }
+        markNotReady(panel);
+        ensurePanel(win, state, strings);
+      });
+      state.panelOuterObserver.observe(outerRoot, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    const wrapper = outerRoot.getElementById("ipprotection-content-wrapper");
+    if (!wrapper) {
+      schedulePanelRetry(win, state, strings);
+      return;
+    }
+    ensureStyle(outerRoot, OUTER_STYLE_ID, OUTER_SHADOW_STYLES);
+    let scope = outerRoot.getElementById(SCOPE_ID);
+    if (!scope) {
+      scope = outerRoot.ownerDocument.createElement("div");
+      scope.id = SCOPE_ID;
+      scope.setAttribute("role", "note");
+      wrapper.append(scope);
+    }
+    setTextIfChanged(scope, strings.scope);
+
+    const unauthenticated = wrapper.querySelector(
+      "ipprotection-unauthenticated",
+    ) as HTMLElement | null;
+    if (unauthenticated) {
+      const innerRoot = unauthenticated.shadowRoot;
+      if (!innerRoot) {
+        schedulePanelRetry(win, state, strings);
+        return;
+      }
+      if (state.panelInnerRoot !== innerRoot) {
+        state.panelInnerObserver?.disconnect();
+        state.panelInnerRoot = innerRoot;
+        state.panelInnerObserver = new win.MutationObserver(() => {
+          if (state.panelRepairing) {
+            return;
+          }
+          markNotReady(panel);
+          ensurePanel(win, state, strings);
+        });
+        state.panelInnerObserver.observe(innerRoot, {
+          childList: true,
+          subtree: true,
+        });
+      }
+      if (!updateUnauthenticatedPanel(innerRoot, strings)) {
+        schedulePanelRetry(win, state, strings);
+        return;
+      }
+    } else {
+      state.panelInnerObserver?.disconnect();
+      state.panelInnerObserver = null;
+      state.panelInnerRoot = null;
+    }
+
+    cancelPanelRetry(win, state);
+    state.panelRetryAttempts = 0;
+    markReady(panel);
+  } finally {
+    win.queueMicrotask(() => {
+      state.panelRepairing = false;
+    });
+  }
+}
+
+function ensureToolbar(
+  win: BrowserWindow,
+  state: WindowObserver,
+  strings: FloorpIPProtectionDisclosureStrings,
+): void {
+  const button = win.document.getElementById(TOOLBAR_BUTTON_ID);
+  if (!button) {
+    return;
+  }
+  if (state.toolbarNode !== button) {
+    state.toolbarObserver?.disconnect();
+    state.toolbarNode = button;
+    state.toolbarObserver = new win.MutationObserver(() => {
+      markNotReady(button);
+      updateToolbarButton(button, strings);
+    });
+    state.toolbarObserver.observe(button, {
+      attributes: true,
+      attributeFilter: [
+        "class",
+        "data-l10n-id",
+        "label",
+        "tooltiptext",
+        "aria-label",
+      ],
+    });
+  }
+  updateToolbarButton(button, strings);
+}
+
+function initializeBrowserDocument(win: BrowserWindow): void {
+  if (
+    observedWindows.has(win) ||
+    win.document.documentElement.getAttribute("windowtype") !==
+      "navigator:browser"
+  ) {
+    return;
+  }
+  const strings = getDisclosureStrings();
+  const state: WindowObserver = {
+    documentObserver: new win.MutationObserver(() => {
+      ensureToolbar(win, state, strings);
+      ensurePanel(win, state, strings);
+    }),
+    toolbarObserver: null,
+    panelHeaderObserver: null,
+    panelOuterObserver: null,
+    panelInnerObserver: null,
+    toolbarNode: null,
+    panelHeaderNodes: null,
+    panelOuterRoot: null,
+    panelInnerRoot: null,
+    panelRetryFrame: null,
+    panelRetryAttempts: 0,
+    panelRepairing: false,
+  };
+  observedWindows.set(win, state);
+  state.documentObserver.observe(win.document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  const onPanelEvent = (event: Event): void => {
+    const target = event.target as Element | null;
+    if (target?.id !== PANEL_ID) {
+      return;
+    }
+    const panel = win.document.getElementById(PANEL_ID);
+    markNotReady(panel);
+    if (event.type === "ViewHiding") {
+      cancelPanelRetry(win, state);
+      state.panelRetryAttempts = 0;
+      return;
+    }
+    state.panelRetryAttempts = 0;
+    ensurePanel(win, state, strings);
+  };
+  win.document.addEventListener("ViewShowing", onPanelEvent, true);
+  win.document.addEventListener("ViewHiding", onPanelEvent, true);
+
+  win.addEventListener(
+    "unload",
+    () => {
+      state.documentObserver.disconnect();
+      state.toolbarObserver?.disconnect();
+      state.panelHeaderObserver?.disconnect();
+      state.panelOuterObserver?.disconnect();
+      state.panelInnerObserver?.disconnect();
+      cancelPanelRetry(win, state);
+      win.document.removeEventListener("ViewShowing", onPanelEvent, true);
+      win.document.removeEventListener("ViewHiding", onPanelEvent, true);
+      observedWindows.delete(win);
+    },
+    { once: true },
+  );
+
+  ensureToolbar(win, state, strings);
+  ensurePanel(win, state, strings);
+}
+
+function observeBrowserWindow(win: BrowserWindow): void {
+  if (win.document.readyState === "loading") {
+    win.addEventListener(
+      "DOMContentLoaded",
+      () => initializeBrowserDocument(win),
+      { once: true },
+    );
+    return;
+  }
+  initializeBrowserDocument(win);
+}
+
+function installWindowObserver(): void {
+  if (windowObserverInstalled) {
+    return;
+  }
+  Services.obs.addObserver((subject) => {
+    observeBrowserWindow(subject as BrowserWindow);
+  }, "domwindowopened");
+  Services.obs.addObserver((subject) => {
+    observeBrowserWindow(subject as BrowserWindow);
+  }, "browser-delayed-startup-finished");
+  const windows = Services.wm.getEnumerator("navigator:browser");
+  while (windows.hasMoreElements()) {
+    observeBrowserWindow(windows.getNext() as BrowserWindow);
+  }
+  windowObserverInstalled = true;
+}
+
+export const FloorpIPProtectionUI = {
+  installEarly(): boolean {
+    if (earlyInstallResult !== null) {
+      return earlyInstallResult;
+    }
+    try {
+      Services.prefs.setBoolPref(ENABLED_PREF, false);
+      Services.prefs.setBoolPref(BLOCK_CALLOUTS_PREF, true);
+      registerGuardSheet();
+      installCalloutHook();
+      installWindowObserver();
+      earlyInstallResult = true;
+    } catch (error) {
+      try {
+        Services.prefs.setBoolPref(ENABLED_PREF, false);
+      } catch {
+        // The adapter must remain fail-closed even if startup is incomplete.
+      }
+      earlyInstallResult = false;
+      console.error(
+        "[FloorpIPProtectionUI] Failed to install fail-closed UI adapter:",
+        error,
+      );
+    }
+    return earlyInstallResult;
+  },
+} as const;

--- a/browser-features/modules/modules/ipprotection/test/FloorpIPProtectionDisclosure.test.mts
+++ b/browser-features/modules/modules/ipprotection/test/FloorpIPProtectionDisclosure.test.mts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import { resolveFloorpIPProtectionDisclosureStrings } from "../FloorpIPProtectionDisclosure.sys.mts";
+
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+
+function testJapaneseLocalesUseJapanese(): void {
+  const japanese = resolveFloorpIPProtectionDisclosureStrings("ja-JP");
+  for (const locale of ["ja", "ja-JP"]) {
+    assertEquals(
+      resolveFloorpIPProtectionDisclosureStrings(locale),
+      japanese,
+      `${locale} should use the Japanese disclosure`,
+    );
+  }
+}
+
+function testEnglishLocalesUseEnglish(): void {
+  const english = resolveFloorpIPProtectionDisclosureStrings("en-US");
+  for (const locale of ["en", "en-US", "en-GB"]) {
+    assertEquals(
+      resolveFloorpIPProtectionDisclosureStrings(locale),
+      english,
+      `${locale} should use the English disclosure`,
+    );
+  }
+}
+
+function testUnsupportedLocalesFallBackToEnglish(): void {
+  const english = resolveFloorpIPProtectionDisclosureStrings("en-US");
+  for (const locale of ["de", "fr-FR", "zh-CN"]) {
+    assertEquals(
+      resolveFloorpIPProtectionDisclosureStrings(locale),
+      english,
+      `${locale} should fall back to English`,
+    );
+  }
+}
+
+function testResourcesHaveMatchingNonEmptyStrings(): void {
+  const english = resolveFloorpIPProtectionDisclosureStrings("en-US");
+  const japanese = resolveFloorpIPProtectionDisclosureStrings("ja-JP");
+  const englishKeys = Object.keys(english);
+  const japaneseKeys = Object.keys(japanese);
+
+  assertEquals(
+    JSON.stringify(japaneseKeys),
+    JSON.stringify(englishKeys),
+    "English and Japanese disclosures should contain the same keys",
+  );
+  assertNotEquals(
+    JSON.stringify(japanese),
+    JSON.stringify(english),
+    "English and Japanese disclosures should not be identical",
+  );
+
+  for (
+    const [locale, strings] of [
+      ["en-US", english],
+      ["ja-JP", japanese],
+    ] as const
+  ) {
+    for (const [key, value] of Object.entries(strings)) {
+      assert(
+        typeof value === "string" && value.length > 0,
+        `${locale} disclosure ${key} should be a non-empty string`,
+      );
+    }
+  }
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "Japanese locales use Japanese disclosures",
+      fn: testJapaneseLocalesUseJapanese,
+    },
+    {
+      name: "English locales use English disclosures",
+      fn: testEnglishLocalesUseEnglish,
+    },
+    {
+      name: "unsupported locales fall back to English disclosures",
+      fn: testUnsupportedLocalesFallBackToEnglish,
+    },
+    {
+      name: "English and Japanese disclosure resources are complete",
+      fn: testResourcesHaveMatchingNonEmptyStrings,
+    },
+  ];
+
+  await runTests("FloorpIPProtectionDisclosure.test.mts", tests);
+}

--- a/browser-features/modules/modules/ipprotection/test/FloorpIPProtectionGate.test.mts
+++ b/browser-features/modules/modules/ipprotection/test/FloorpIPProtectionGate.test.mts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  applyFloorpIPProtectionPref,
+  FIREFOX_IP_PROTECTION_BLOCK_CALLOUTS_PREF,
+  FIREFOX_IP_PROTECTION_ENABLED_PREF,
+  FLOORP_IP_PROTECTION_EXPERIMENT,
+  isFloorpIPProtectionVariantEnabled,
+  resolveFloorpIPProtectionEnabled,
+  shouldEnableFloorpIPProtection,
+} from "../FloorpIPProtectionGate.sys.mts";
+
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+
+function testOnlyEnabledVariantEnablesFeature(): void {
+  assertEquals(
+    isFloorpIPProtectionVariantEnabled("enabled"),
+    true,
+    "enabled variant should enable IP Protection",
+  );
+  assertEquals(
+    isFloorpIPProtectionVariantEnabled("control"),
+    false,
+    "control variant should disable IP Protection",
+  );
+  assertEquals(
+    isFloorpIPProtectionVariantEnabled("disabled"),
+    false,
+    "unknown variants should disable IP Protection",
+  );
+  assertEquals(
+    isFloorpIPProtectionVariantEnabled(null),
+    false,
+    "missing assignment should disable IP Protection",
+  );
+}
+
+function testReadsExpectedFlascoId(): void {
+  const requestedIds: string[] = [];
+  const enabled = shouldEnableFloorpIPProtection({
+    getVariant(experimentId: string): string | null {
+      requestedIds.push(experimentId);
+      return "enabled";
+    },
+  });
+
+  assertEquals(enabled, true, "enabled Flasco should enable IP Protection");
+  assertEquals(
+    JSON.stringify(requestedIds),
+    JSON.stringify([FLOORP_IP_PROTECTION_EXPERIMENT]),
+    "gate should read the expected Flasco id",
+  );
+}
+
+function testFailsClosedWhenExperimentReadFails(): void {
+  const enabled = shouldEnableFloorpIPProtection({
+    getVariant(): string | null {
+      throw new Error("manifest unavailable");
+    },
+  });
+
+  assertEquals(
+    enabled,
+    false,
+    "experiment read failures should disable IP Protection",
+  );
+}
+
+function testAppliesFirefoxIpProtectionPref(): void {
+  const writes: Array<[string, boolean]> = [];
+  applyFloorpIPProtectionPref(
+    {
+      setBoolPref(prefName: string, value: boolean): void {
+        writes.push([prefName, value]);
+      },
+    },
+    false,
+  );
+
+  assertEquals(
+    JSON.stringify(writes),
+    JSON.stringify([
+      [FIREFOX_IP_PROTECTION_ENABLED_PREF, false],
+      [FIREFOX_IP_PROTECTION_BLOCK_CALLOUTS_PREF, true],
+    ]),
+    "gate should write the Firefox IP Protection and callout prefs",
+  );
+}
+
+function testRuntimeFailureDisablesFeature(): void {
+  assertEquals(
+    resolveFloorpIPProtectionEnabled(true, true),
+    true,
+    "enabled Flasco and a ready runtime should enable IP Protection",
+  );
+  assertEquals(
+    resolveFloorpIPProtectionEnabled(true, false),
+    false,
+    "runtime adapter failure should fail closed",
+  );
+  assertEquals(
+    resolveFloorpIPProtectionEnabled(false, true),
+    false,
+    "a ready runtime should not override a disabled Flasco",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "only enabled variant enables feature",
+      fn: testOnlyEnabledVariantEnablesFeature,
+    },
+    { name: "reads expected Flasco id", fn: testReadsExpectedFlascoId },
+    {
+      name: "fails closed when experiment read fails",
+      fn: testFailsClosedWhenExperimentReadFails,
+    },
+    {
+      name: "applies Firefox IP Protection pref",
+      fn: testAppliesFirefoxIpProtectionPref,
+    },
+    {
+      name: "runtime adapter failures disable the feature",
+      fn: testRuntimeFailureDisablesFeature,
+    },
+  ];
+
+  await runTests("FloorpIPProtectionGate.test.mts", tests);
+}

--- a/browser-features/modules/modules/ipprotection/test/FloorpIPProtectionUI.test.mts
+++ b/browser-features/modules/modules/ipprotection/test/FloorpIPProtectionUI.test.mts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import { resolveFloorpIPProtectionDisclosureStrings } from "../FloorpIPProtectionDisclosure.sys.mts";
+import {
+  filterFloorpIPProtectionCallouts,
+  resolveFloorpIPProtectionToolbarTooltip,
+} from "../FloorpIPProtectionUI.sys.mts";
+
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+
+function testFiltersOnlyIPProtectionCallouts(): void {
+  const messages = [
+    { id: "IP_PROTECTION_FIRST_RUN" },
+    { id: "OTHER_FEATURE" },
+    { id: "IP_PROTECTION_REMINDER" },
+    { id: 42 },
+  ];
+  assertEquals(
+    JSON.stringify(filterFloorpIPProtectionCallouts(messages)),
+    JSON.stringify([{ id: "OTHER_FEATURE" }, { id: 42 }]),
+    "IP Protection callouts should be removed without affecting other messages",
+  );
+}
+
+function testToolbarTooltipPrecedence(): void {
+  const strings = resolveFloorpIPProtectionDisclosureStrings("en-US");
+  const cases: Array<[string[], string]> = [
+    [[], strings.toolbarInactiveTooltip],
+    [["ipprotection-on"], strings.toolbarActiveTooltip],
+    [["ipprotection-excluded"], strings.toolbarExcludedTooltip],
+    [["ipprotection-paused"], strings.toolbarPausedTooltip],
+    [["ipprotection-error"], strings.toolbarErrorTooltip],
+    [["ipprotection-network-error"], strings.toolbarErrorTooltip],
+    [
+      ["ipprotection-on", "ipprotection-paused"],
+      strings.toolbarPausedTooltip,
+    ],
+    [
+      ["ipprotection-on", "ipprotection-error"],
+      strings.toolbarErrorTooltip,
+    ],
+  ];
+
+  for (const [classes, expected] of cases) {
+    assertEquals(
+      resolveFloorpIPProtectionToolbarTooltip(classes, strings),
+      expected,
+      `toolbar classes ${
+        classes.join(",") || "inactive"
+      } should resolve correctly`,
+    );
+  }
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "filters only IP Protection callouts",
+      fn: testFiltersOnlyIPProtectionCallouts,
+    },
+    {
+      name: "resolves toolbar tooltip precedence",
+      fn: testToolbarTooltipPrecedence,
+    },
+  ];
+  await runTests("FloorpIPProtectionUI.test.mts", tests);
+}

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "5a0ffa953e51935961c389aa01cd7785b84e74f9"
+floorp_commit: "7e2e9c05e1c6c0113f74e9d4ea72654cb63e7500"
 generated: true
 ---
 # Architecture Overview
@@ -30,7 +30,7 @@ The loader development server is configured by `bridge/loader-features/vite.conf
 
 ## Privileged Modules And Window Actors
 
-Window Actors are registered from `browser-features/modules/modules/BrowserGlue.sys.mts:397`. The current inventory lists 22 actors:
+Window Actors are registered from `browser-features/modules/modules/BrowserGlue.sys.mts:398`. The current inventory lists 22 actors:
 
 - `NRAboutPreferences`
 - `NRAppConstants`

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "5a0ffa953e51935961c389aa01cd7785b84e74f9"
+floorp_commit: "7e2e9c05e1c6c0113f74e9d4ea72654cb63e7500"
 generated: true
 ---
 # Common Chrome Features
@@ -97,6 +97,6 @@ All discovered common chrome features are currently assigned to a generated cate
 
 ## Relationship To Other Layers
 
-- Window Actor integration is registered in `browser-features/modules/modules/BrowserGlue.sys.mts:397`.
+- Window Actor integration is registered in `browser-features/modules/modules/BrowserGlue.sys.mts:398`.
 - Settings pages may expose user-facing controls for selected common features; use the settings route catalog for route ownership.
 - Static chrome features live in the separate static catalog and are not duplicated in this common-feature directory page.

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "d129e2a2e9c5983b277fc850b61d6a2995b2acff"
+floorp_commit: "7e2e9c05e1c6c0113f74e9d4ea72654cb63e7500"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors
@@ -12,7 +12,7 @@ Actors that support PWA windows, workspace state, PWA management, and profile ma
 
 | Actor | Source |
 |---|---|
-| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:208` |
-| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:165` |
-| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:181` |
-| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:149` |
+| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:209` |
+| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:166` |
+| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:182` |
+| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:150` |

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "d129e2a2e9c5983b277fc850b61d6a2995b2acff"
+floorp_commit: "7e2e9c05e1c6c0113f74e9d4ea72654cb63e7500"
 generated: true
 ---
 # Settings & Internal Page Actors
@@ -13,15 +13,15 @@ Actors used by settings, internal pages, localization, browser constants, restar
 | Actor | Source |
 |---|---|
 | NRAboutPreferences | `browser-features/modules/modules/BrowserGlue.sys.mts:24` |
-| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:117` |
-| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:197` |
-| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:53` |
-| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:321` |
-| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:69` |
-| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:133` |
-| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:262` |
-| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:35` |
-| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:230` |
-| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:101` |
-| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:85` |
-| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:245` |
+| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:118` |
+| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:198` |
+| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:54` |
+| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:322` |
+| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:70` |
+| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:134` |
+| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:263` |
+| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:36` |
+| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:231` |
+| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:102` |
+| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:86` |
+| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:246` |

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "d129e2a2e9c5983b277fc850b61d6a2995b2acff"
+floorp_commit: "7e2e9c05e1c6c0113f74e9d4ea72654cb63e7500"
 generated: true
 ---
 # Web Content & Store Actors
@@ -12,8 +12,8 @@ Actors that connect browser chrome with web content, scraping, automation, plugi
 
 | Actor | Source |
 |---|---|
-| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:338` |
-| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:381` |
-| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:304` |
-| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:358` |
-| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:286` |
+| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:339` |
+| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:382` |
+| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:305` |
+| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:359` |
+| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:287` |

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "d129e2a2e9c5983b277fc850b61d6a2995b2acff"
+floorp_commit: "7e2e9c05e1c6c0113f74e9d4ea72654cb63e7500"
 generated: true
 ---
 # Window Actor Catalog
@@ -11,24 +11,24 @@ This page is generated from the `JS_WINDOW_ACTORS` table in `browser-features/mo
 | Actor | Source |
 |---|---|
 | NRAboutPreferences | `browser-features/modules/modules/BrowserGlue.sys.mts:24` |
-| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:117` |
-| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:197` |
-| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:338` |
-| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:53` |
-| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:321` |
-| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:381` |
-| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:304` |
-| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:69` |
-| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:358` |
-| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:208` |
-| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:165` |
-| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:181` |
-| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:133` |
-| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:262` |
-| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:35` |
-| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:230` |
-| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:101` |
-| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:85` |
-| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:286` |
-| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:245` |
-| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:149` |
+| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:118` |
+| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:198` |
+| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:339` |
+| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:54` |
+| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:322` |
+| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:382` |
+| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:305` |
+| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:70` |
+| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:359` |
+| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:209` |
+| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:166` |
+| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:182` |
+| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:134` |
+| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:263` |
+| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:36` |
+| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:231` |
+| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:102` |
+| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:86` |
+| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:287` |
+| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:246` |
+| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:150` |

--- a/i18n/en-US/browser-chrome.json
+++ b/i18n/en-US/browser-chrome.json
@@ -448,6 +448,35 @@
     "tooltiptext": "Toggle Zen Mode",
     "menu-label": "Toggle Zen Mode"
   },
+  "ipProtection": {
+    "title": "Browser VPN",
+    "toolbar": {
+      "activeTooltip": "Browser VPN is on for eligible web browsing traffic in Floorp",
+      "inactiveTooltip": "Browser VPN is off — web browsing traffic is not protected",
+      "excludedTooltip": "Browser VPN is off for this site — this site is not protected",
+      "pausedTooltip": "Browser VPN is paused — web browsing traffic is not protected",
+      "errorTooltip": "Browser VPN — connection error; eligible web browsing traffic is not protected",
+      "helpTooltip": "Open Browser VPN support page"
+    },
+    "scope": {
+      "summary": "When active, Browser VPN can protect eligible web browsing traffic in Floorp. Its scope does not include your operating system or other apps.",
+      "fullDisclosure": "This feature uses a Mozilla account and Mozilla service infrastructure. Floorp is an independent project and is not affiliated with, endorsed by, or sponsored by Mozilla. Availability depends on your region, account status, and Mozilla’s service eligibility requirements."
+    },
+    "unauthenticated": {
+      "title": "Try Browser VPN"
+    },
+    "settings": {
+      "promoHeading": "Try Browser VPN",
+      "promoMessage": "Protect eligible web browsing traffic in Floorp after signing in and confirming service availability."
+    },
+    "terms": {
+      "prefix": "By continuing, you agree to ",
+      "termsOfUse": "Mozilla Firefox Terms of Use",
+      "conjunction": " and acknowledge ",
+      "privacyNotice": "Mozilla Firefox Privacy Notice",
+      "suffix": "."
+    }
+  },
   "commandPalette": {
     "dialogLabel": "Command Palette",
     "placeholder": "Type a command...",

--- a/i18n/ja-JP/browser-chrome.json
+++ b/i18n/ja-JP/browser-chrome.json
@@ -440,6 +440,35 @@
     "tooltiptext": "禅モードの表示を切り替える",
     "menu-label": "禅モードの表示を切り替える"
   },
+  "ipProtection": {
+    "title": "ブラウザー VPN",
+    "toolbar": {
+      "activeTooltip": "ブラウザー VPN はオンです — Floorp での対象ウェブ閲覧通信を保護中",
+      "inactiveTooltip": "ブラウザー VPN はオフです — ウェブ閲覧通信は保護されていません",
+      "excludedTooltip": "このサイトではブラウザー VPN がオフです — このサイトは保護されていません",
+      "pausedTooltip": "ブラウザー VPN は一時停止中です — ウェブ閲覧通信は保護されていません",
+      "errorTooltip": "ブラウザー VPN — 接続エラーのため、対象ウェブ閲覧通信は保護されていません",
+      "helpTooltip": "ブラウザー VPN のサポートページを開く"
+    },
+    "scope": {
+      "summary": "有効時は、Floorp での対象ウェブ閲覧通信を保護できます。保護範囲に OS や他のアプリの通信は含まれません。",
+      "fullDisclosure": "この機能は Mozilla アカウントと Mozilla のサービス基盤を使用します。Floorp は Mozilla とは独立したプロジェクトであり、Mozilla による提携、承認、推奨を示すものではありません。利用可否は、地域、アカウント状態、Mozilla 側の提供条件によって決まります。"
+    },
+    "unauthenticated": {
+      "title": "ブラウザー VPN を試す"
+    },
+    "settings": {
+      "promoHeading": "ブラウザー VPN を試す",
+      "promoMessage": "サインインして利用可否を確認した後、Floorp での対象ウェブ閲覧通信を保護できます。"
+    },
+    "terms": {
+      "prefix": "続行すると、",
+      "termsOfUse": "Mozilla Firefox 利用規約",
+      "conjunction": "に同意し、",
+      "privacyNotice": "Mozilla Firefox プライバシー通知",
+      "suffix": "を確認したものとみなされます。"
+    }
+  },
   "commandPalette": {
     "dialogLabel": "コマンドパレット",
     "placeholder": "コマンドを入力...",


### PR DESCRIPTION
## Summary

- replace the initial seven-patch IP Protection approach with an early, fail-closed runtime adapter
- gate `browser.ipProtection.enabled` through the existing Flasco experiment and suppress upstream IP Protection callouts
- inject accurate Floorp-specific scope and independence disclosures into the toolbar, panel, and privacy settings UI
- provide English and Japanese strings through the existing i18n resources
- repair dynamically recreated XUL, Lit, and Shadow DOM nodes without exposing untranslated or misleading UI

## Why

Firefox's IP Protection UI is assembled across browser XUL, Lit components, and nested Shadow DOM. Maintaining Floorp wording directly in Gecko patches increased update cost and could briefly expose upstream VPN wording that does not accurately describe Floorp's browser-only scope or its independence from Mozilla.

The runtime adapter keeps the upstream Gecko files unchanged, hides the feature until the Floorp UI is ready, and leaves the feature disabled if initialization fails.

## Validation

- `deno check` passed for all changed TypeScript modules
- `git diff --check` passed
- `deno task test --near browser-features/modules/modules/ipprotection` passed: 3/3 browser tests
- `deno task feles-build build --phase before-mach` passed
- verified in the real Floorp development runtime:
  - cold start is fail-closed
  - direct and cached ASRouter IP Protection callouts are absent
  - first panel open and close/reopen both recreate the localized disclosures
  - toolbar, panel, and `about:preferences#privacy` repair overwritten UI
  - observer updates settle without sustained CPU usage or retry errors

The local `after-mach` phase was not run because the required Gecko build artifact was not present in `obj-artifact-build-output`.

## Scope

The initial implementation required seven IP Protection-specific Gecko patches. This PR avoids adding those patches, so no tracked patch files are deleted by this diff. Unrelated Gecko patches remain unchanged.
