### PR TITLE
fix(designs): keep Lepton's right sidebar on-screen on Gecko 152

### DIFF
--- a/browser-features/chrome/common/designs/test/lepton-compat.test.ts
+++ b/browser-features/chrome/common/designs/test/lepton-compat.test.ts
@@ -103,6 +103,32 @@ function extractVarDecl(css: string, name: string): string {
   return m ? m[1].trim() : "";
 }
 
+/** Extract the selector of the compat rule that restores the right-sidebar
+ * direction. Keeping this derived from the emitted CSS makes the selector
+ * semantics below a regression test for the actual production stylesheet. */
+function extractSidebarPositionEndSelector(): string {
+  const match = LEPTON_COMPAT_152_CSS.match(
+    /([^{}]+)\{\s*direction:\s*rtl\s*;\s*\}/,
+  );
+  const selector = match?.[1]?.trim() ?? "";
+  assert(
+    selector.includes("#sidebar-box"),
+    "compat layer should provide a direction rule for #sidebar-box",
+  );
+  return selector;
+}
+
+function makeSidebarBox(
+  positionEndValue: string | null,
+): HTMLDivElement {
+  const sidebarBox = document.createElement("div");
+  sidebarBox.id = "sidebar-box";
+  if (positionEndValue !== null) {
+    sidebarBox.setAttribute("sidebar-positionend", positionEndValue);
+  }
+  return sidebarBox;
+}
+
 // ---------------------------------------------------------------------------
 // Tests — the alias table matches the 151 -> 152 rename evidence
 // ---------------------------------------------------------------------------
@@ -424,6 +450,48 @@ function testCompatFixesPanelBackground(): void {
   );
 }
 
+/** Gecko 152 uses [sidebar-positionend] as a boolean presence attribute. The
+ *  compat selector must therefore match every present value, not only
+ *  [sidebar-positionend="true"]. */
+function testCompatFixesRightSidebarByAttributePresence(): void {
+  const selector = extractSidebarPositionEndSelector();
+  assert(
+    selector.includes("[sidebar-positionend]"),
+    "right-sidebar compat should target Gecko 152's attribute",
+  );
+  assert(
+    !selector.includes('[sidebar-positionend="true"]'),
+    "right-sidebar compat must use presence semantics, not value equality",
+  );
+
+  for (const value of ["", "true", "false"]) {
+    assert(
+      makeSidebarBox(value).matches(selector),
+      `right-sidebar selector should match present value ${
+        JSON.stringify(value)
+      }`,
+    );
+  }
+}
+
+/** A left sidebar has neither position-end attribute. It must retain its
+ *  normal LTR direction; older Gecko's [positionend] marker remains accepted
+ *  for backward compatibility. */
+function testCompatPreservesLeftAndLegacySidebarSemantics(): void {
+  const selector = extractSidebarPositionEndSelector();
+  assert(
+    !makeSidebarBox(null).matches(selector),
+    "right-sidebar compat must not match a left sidebar",
+  );
+
+  const legacyRightSidebar = makeSidebarBox(null);
+  legacyRightSidebar.setAttribute("positionend", "");
+  assert(
+    legacyRightSidebar.matches(selector),
+    "right-sidebar compat should retain the legacy presence attribute",
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests — Floorp-specific icon patches are preserved out-of-vendor
 // ---------------------------------------------------------------------------
@@ -506,6 +574,14 @@ export async function runAllTests(): Promise<void> {
     // symptom coverage
     { name: "compat fixes dialog background (black dialog symptom)", fn: testCompatFixesDialogBackground },
     { name: "compat fixes panel background (transparent panel symptom)", fn: testCompatFixesPanelBackground },
+    {
+      name: "right-sidebar compat uses attribute presence",
+      fn: testCompatFixesRightSidebarByAttributePresence,
+    },
+    {
+      name: "right-sidebar compat preserves left and legacy semantics",
+      fn: testCompatPreservesLeftAndLegacySidebarSemantics,
+    },
     // icon patches
     { name: "floorp icon patches present", fn: testFloorpIconPatchesPresent },
     { name: "bundled compat is color + lepton + icons", fn: testBundledCompatIsColorPlusLeptonPlusIcons },

--- a/browser-features/chrome/common/designs/utils/lepton-compat-152.css.ts
+++ b/browser-features/chrome/common/designs/utils/lepton-compat-152.css.ts
@@ -17,9 +17,9 @@
  *      symptoms — they hit any chrome component that reads `--lwt-accent-color`
  *      / `--in-content-page-background` / `--arrowpanel-background` once the
  *      built-in-theme block stops matching.
- *   2. `LEPTON_COMPAT_152_CSS` — Lepton-only tab/toolbox variable aliases and
- *      palette restoration that mirrors Lepton's intended colors. Applied
- *      only to the `lepton` / `photon` / `protonfix` designs.
+ *   2. `LEPTON_COMPAT_152_CSS` — Lepton-only tab/toolbox variable aliases,
+ *      palette restoration, and native-sidebar positioning compatibility.
+ *      Applied only to the `lepton` / `photon` / `protonfix` designs.
  *   3. `FLOORP_ICON_PATCHES` — Floorp-only icon rules extracted from the
  *      vendored leptonChrome.css so the daily upstream sync cannot delete
  *      them. Lepton-family only (the IDs are Lepton-scoped).
@@ -201,6 +201,21 @@ export const LEPTON_COMPAT_152_CSS = `
   --in-content-primary-button-background: var(--blue-60, #0060df);
   --in-content-primary-button-background-hover: var(--blue-50, #0a84ff);
   --in-content-primary-button-background-active: var(--blue-40, #4595ff);
+}
+
+/*= Right-positioned native sidebar (Issue #2556) ============================
+ * Gecko 152 exposes the native sidebar's end position on #sidebar-box as the
+ * presence-only [sidebar-positionend] attribute. Vendored Lepton still keys
+ * its overlap layout's direction flip to the former [positionend] attribute,
+ * so its inline-start offset is applied on the wrong side and pushes a right
+ * sidebar partly outside the window.
+ *
+ * Keep the legacy attribute in the selector for older Gecko versions. These
+ * are boolean presence attributes, so intentionally do not match a value. */
+@media -moz-pref("userChrome.sidebar.overlap") {
+  #sidebar-box:is([positionend], [sidebar-positionend]) {
+    direction: rtl;
+  }
 }
 `;
 


### PR DESCRIPTION
## Summary

- recognize Gecko 152''s presence-only `sidebar-positionend` attribute
- preserve the legacy `positionend` selector for older Gecko versions
- add regression coverage for right/left and legacy sidebar states

## Verification

- `deno task test --near browser-features/chrome/common/designs/test/lepton-compat.test.ts` — 1 passed, 0 failed
- affected `bridge/loader-features` production bundle — passed
- live Floorp check with Lepton overlap mode: removing the Gecko 152 attribute reproduced the clipped 42 px sidebar; restoring it applied RTL layout and restored the full 216 px header/content

## Build note

The repository-wide before-mach build reaches an unchanged `pages-newtab` `lucide-react@0.562.0` `MISSING_EXPORT` failure. The same failure reproduces on a clean `origin/main` worktree; the affected production bundle above passes.

Closes #2556