### PR TITLE
fix(i18n): include About dialog and Noraneko copy in localization

### DIFF
--- a/browser-features/pages-settings/src/app/about/noraneko.tsx
+++ b/browser-features/pages-settings/src/app/about/noraneko.tsx
@@ -43,7 +43,7 @@ export default function Page() {
             <div className="flex items-center gap-4">
               <img
                 src="chrome://branding/content/about-logo@2x.png"
-                alt="Browser Logo"
+                alt={t("about.noraneko.logoAlt")}
                 className="w-11 h-11"
               />
               <p className="text-xl">
@@ -55,11 +55,8 @@ export default function Page() {
                 })}
               </p>
             </div>
-            <p>
-              Noraneko is a browser as testhead of Floorp 12. Floorp is based on
-              Firefox & Noraneko.
-            </p>
-            <p>Made by Noraneko Community with ❤</p>
+            <p>{t("about.noraneko.description")}</p>
+            <p>{t("about.noraneko.communityCredit")}</p>
           </CardContent>
           <CardFooter>
             <Button asChild>
@@ -105,7 +102,7 @@ export default function Page() {
                 className="flex items-center gap-2"
               >
                 <SiGithub className="size-4" />
-                GitHub Repository: Floorp-Projects/Floorp
+                {t("about.noraneko.repositoryLabel")}
                 <ExternalLink className="size-4" />
               </a>
             </Button>

--- a/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
@@ -300,7 +300,13 @@
         "openSourceLicense": "{{productName}} is open-source software available under the Mozilla Public License 2.0, made possible by the Firefox open-source project and other open-source software.",
         "openSourceLicenseNotice": "Open Source License",
         "versionInfo": "Version",
-        "license": "License"
+        "license": "License",
+        "noraneko": {
+            "logoAlt": "Browser Logo",
+            "description": "Noraneko is a browser as testhead of Floorp 12. Floorp is based on Firefox & Noraneko.",
+            "communityCredit": "Made by Noraneko Community with ❤",
+            "repositoryLabel": "GitHub Repository: Floorp-Projects/Floorp"
+        }
     },
     "updates": {
         "title": "Updates & Experiments",

--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -300,7 +300,13 @@
         "openSourceLicense": "{{productName}} は、 Mozilla Public License 2.0 の下で利用可能なオープンソースソフトウェアです。 Firefox オープンソースプロジェクトやその他のオープンソースソフトウェアによって実現されています。",
         "openSourceLicenseNotice": "オープンソースライセンス",
         "versionInfo": "バージョン",
-        "license": "ライセンス"
+        "license": "ライセンス",
+        "noraneko": {
+            "logoAlt": "ブラウザーのロゴ",
+            "description": "Noraneko は Floorp 12 のテストベッドとして使用されるブラウザーです。Floorp は Firefox と Noraneko をベースにしています。",
+            "communityCredit": "Noraneko Community が ❤ を込めて開発しています",
+            "repositoryLabel": "GitHub リポジトリ: Floorp-Projects/Floorp"
+        }
     },
     "updates": {
         "title": "更新と実験",

--- a/i18n/translation-targets.json
+++ b/i18n/translation-targets.json
@@ -30,6 +30,13 @@
       "f18n_path": "welcome/"
     },
     {
+      "name": "about-dialog",
+      "type": "file",
+      "source_path": "browser-features/pages-aboutDialog/src/lib/i18n/locales",
+      "source_file": "en-US.json",
+      "f18n_path": "about-dialog/"
+    },
+    {
       "name": "stub-win64-installer",
       "type": "file",
       "source_path": "static/installers/stub-win64-installer/src/lib/i18n/locales",

--- a/tools/src/localization_targets.test.ts
+++ b/tools/src/localization_targets.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assert, assertEquals } from "@std/assert";
+import { resolveFromRoot } from "./utils.ts";
+
+const TRANSLATION_TARGETS_PATH = resolveFromRoot(
+  "i18n/translation-targets.json",
+);
+const NORANEKO_PAGE_PATH = resolveFromRoot(
+  "browser-features/pages-settings/src/app/about/noraneko.tsx",
+);
+const SETTINGS_LOCALES_PATH =
+  "browser-features/pages-settings/src/lib/i18n/locales";
+const NORANEKO_KEYS = [
+  "communityCredit",
+  "description",
+  "logoAlt",
+  "repositoryLabel",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await Deno.readTextFile(path)) as unknown;
+}
+
+async function readNoranekoLocale(
+  locale: "en-US" | "ja-JP",
+): Promise<Record<string, unknown>> {
+  const localePath = resolveFromRoot(
+    `${SETTINGS_LOCALES_PATH}/${locale}.json`,
+  );
+  const root = await readJson(localePath);
+  assert(isRecord(root), `${locale} locale must be a JSON object`);
+  assert(isRecord(root.about), `${locale} locale must define about`);
+  assert(
+    isRecord(root.about.noraneko),
+    `${locale} locale must define about.noraneko`,
+  );
+  return root.about.noraneko;
+}
+
+Deno.test("About Dialog is an exact f18n file target", async () => {
+  const manifest = await readJson(TRANSLATION_TARGETS_PATH);
+  assert(isRecord(manifest), "translation target manifest must be an object");
+  assert(Array.isArray(manifest.targets), "manifest must define targets");
+
+  const aboutDialogTarget = manifest.targets.find((target) =>
+    isRecord(target) && target.name === "about-dialog"
+  );
+  assert(aboutDialogTarget, "about-dialog target must exist");
+  assertEquals(aboutDialogTarget, {
+    name: "about-dialog",
+    type: "file",
+    source_path: "browser-features/pages-aboutDialog/src/lib/i18n/locales",
+    source_file: "en-US.json",
+    f18n_path: "about-dialog/",
+  });
+
+  const sourceLocale = await readJson(
+    resolveFromRoot(
+      `${aboutDialogTarget.source_path}/${aboutDialogTarget.source_file}`,
+    ),
+  );
+  assert(isRecord(sourceLocale), "About Dialog source locale must parse");
+});
+
+Deno.test("Noraneko locale keys stay in parity", async () => {
+  const [enUS, jaJP] = await Promise.all([
+    readNoranekoLocale("en-US"),
+    readNoranekoLocale("ja-JP"),
+  ]);
+
+  assertEquals(Object.keys(enUS).sort(), Object.keys(jaJP).sort());
+  for (const key of NORANEKO_KEYS) {
+    assert(
+      typeof enUS[key] === "string" && enUS[key].trim().length > 0,
+      `en-US about.noraneko.${key} must be non-empty`,
+    );
+    assert(
+      typeof jaJP[key] === "string" && jaJP[key].trim().length > 0,
+      `ja-JP about.noraneko.${key} must be non-empty`,
+    );
+  }
+});
+
+Deno.test("Noraneko page uses locale keys instead of raw visible text", async () => {
+  const source = await Deno.readTextFile(NORANEKO_PAGE_PATH);
+  const legacyRawLiterals = [
+    'alt="Browser Logo"',
+    "Noraneko is a browser as testhead",
+    "Made by Noraneko Community with ❤",
+    "GitHub Repository: Floorp-Projects/Floorp",
+  ];
+
+  for (const literal of legacyRawLiterals) {
+    assert(!source.includes(literal), `raw literal remains: ${literal}`);
+  }
+  for (const key of NORANEKO_KEYS) {
+    assert(
+      source.includes(`t("about.noraneko.${key}")`),
+      `Noraneko page must use about.noraneko.${key}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- register the About dialog locale source in `translation-targets.json`
- replace four visible Noraneko About literals with i18n keys
- add en-US/ja-JP strings and target/parity regression tests

## Verification

- `deno test -A tools/src/localization_targets.test.ts` — 3 passed, 0 failed
- production builds for `loader-features`, settings, and About dialog — passed
- live Floorp Hub check in Japanese: description, community credit, repository label, and logo alt all rendered from ja-JP; the former English literals were absent

## Build note

The repository-wide before-mach build reaches an unchanged `pages-newtab` `lucide-react@0.562.0` `MISSING_EXPORT` failure. The same failure reproduces on a clean `origin/main` worktree; all affected production bundles above pass.

Closes #2547