### PR TITLE
fix(panel-sidebar): route web-panel find commands locally

### DIFF
--- a/browser-features/chrome/common/panel-sidebar/test/webPanelFindController.test.ts
+++ b/browser-features/chrome/common/panel-sidebar/test/webPanelFindController.test.ts
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  WebPanelFindController,
+  type WebPanelFindDocument,
+  type WebPanelFindWindow,
+} from "../utils/web-panel-find-controller.ts";
+import type { WebPanelBrowserElement } from "../utils/web-panel-browser.ts";
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+
+const FIND_COMMAND_IDS = [
+  "cmd_find",
+  "cmd_findAgain",
+  "cmd_findPrevious",
+  "cmd_findSelection",
+] as const;
+
+class FakeCommandElement extends EventTarget {
+  constructor(readonly id: string) {
+    super();
+  }
+}
+
+class FakeFindbarElement extends EventTarget {
+  id = "";
+  browser: WebPanelBrowserElement | null = null;
+  isConnected = false;
+  destroyCount = 0;
+  removeCount = 0;
+  closeCount = 0;
+  readonly closeButton = new EventTarget();
+  readonly calls: string[] = [];
+
+  constructor() {
+    super();
+    this.addEventListener(
+      "keypress",
+      (event) => {
+        if ((event as KeyboardEvent).keyCode === 27) {
+          this.close();
+          event.preventDefault();
+        }
+      },
+      true,
+    );
+    this.closeButton.addEventListener("command", () => this.close());
+  }
+
+  private close(): void {
+    this.closeCount += 1;
+  }
+
+  onFindCommand(): void {
+    this.calls.push("find");
+  }
+
+  onFindAgainCommand(findPrevious: boolean): void {
+    this.calls.push(`again:${String(findPrevious)}`);
+  }
+
+  onFindSelectionCommand(): void {
+    this.calls.push("selection");
+  }
+
+  destroy(): void {
+    this.destroyCount += 1;
+  }
+
+  remove(): void {
+    this.removeCount += 1;
+    this.isConnected = false;
+  }
+}
+
+class FakeBrowserElement {
+  isConnected = true;
+  insertedFindbar: FakeFindbarElement | null = null;
+
+  insertAdjacentElement(_position: string, element: Element): Element | null {
+    const findbar = element as unknown as FakeFindbarElement;
+    findbar.isConnected = true;
+    this.insertedFindbar = findbar;
+    return element;
+  }
+}
+
+class FakeDocument implements WebPanelFindDocument {
+  private readonly commands = new Map<string, FakeCommandElement>();
+  readonly createdFindbars: FakeFindbarElement[] = [];
+
+  constructor(commandIds: readonly string[]) {
+    for (const commandId of commandIds) {
+      this.commands.set(commandId, new FakeCommandElement(commandId));
+    }
+  }
+
+  getElementById(id: string): Element | null {
+    const command = this.commands.get(id);
+    if (command) {
+      return command as unknown as Element;
+    }
+
+    const findbar = this.createdFindbars.find((element) => element.id === id);
+    return (findbar as unknown as Element | undefined) ?? null;
+  }
+
+  createXULElement(name: string): Element {
+    assertEquals(name, "findbar", "controller should only create a findbar");
+    const findbar = new FakeFindbarElement();
+    this.createdFindbars.push(findbar);
+    return findbar as unknown as Element;
+  }
+
+  getCommand(id: string): FakeCommandElement {
+    const command = this.commands.get(id);
+    assert(command, `missing fake command: ${id}`);
+    return command;
+  }
+}
+
+class FakeWindow extends EventTarget implements WebPanelFindWindow {
+  private readonly animationFrameCallbacks: FrameRequestCallback[] = [];
+
+  requestAnimationFrame(callback: FrameRequestCallback): number {
+    this.animationFrameCallbacks.push(callback);
+    return this.animationFrameCallbacks.length;
+  }
+
+  flushAnimationFrames(): void {
+    const callbacks = this.animationFrameCallbacks.splice(0);
+    for (const callback of callbacks) {
+      callback(0);
+    }
+  }
+}
+
+type ControllerHarness = {
+  browser: FakeBrowserElement;
+  controller: WebPanelFindController;
+  document: FakeDocument;
+  window: FakeWindow;
+};
+
+function createHarness(
+  commandIds: readonly string[] = FIND_COMMAND_IDS,
+): ControllerHarness {
+  const browser = new FakeBrowserElement();
+  const panelDocument = new FakeDocument(commandIds);
+  const panelWindow = new FakeWindow();
+  const controller = new WebPanelFindController(
+    browser as unknown as WebPanelBrowserElement,
+    panelDocument,
+    panelWindow,
+  );
+  return { browser, controller, document: panelDocument, window: panelWindow };
+}
+
+function dispatchCommand(command: FakeCommandElement): Event {
+  const event = new Event("command", { bubbles: true, cancelable: true });
+  command.dispatchEvent(event);
+  return event;
+}
+
+async function settleFindbarCreation(panelWindow: FakeWindow): Promise<void> {
+  panelWindow.flushAnimationFrames();
+  await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+}
+
+async function testRoutesOnlyFindCommandsToOneLazyFindbar(): Promise<void> {
+  const harness = createHarness();
+  let builtInHandlerCalls = 0;
+  for (const commandId of FIND_COMMAND_IDS) {
+    harness.document.getCommand(commandId).addEventListener("command", () => {
+      builtInHandlerCalls += 1;
+    });
+  }
+
+  harness.controller.init();
+  harness.controller.init();
+
+  assertEquals(
+    harness.document.createdFindbars.length,
+    0,
+    "init should not eagerly create a findbar",
+  );
+
+  const findEvent = dispatchCommand(harness.document.getCommand("cmd_find"));
+  assert(findEvent.defaultPrevented, "cmd_find should be intercepted");
+  await settleFindbarCreation(harness.window);
+
+  assertEquals(
+    harness.document.createdFindbars.length,
+    1,
+    "the first find command should create exactly one findbar",
+  );
+  const findbar = harness.document.createdFindbars[0];
+  assertEquals(
+    findbar.browser,
+    harness.browser as unknown as WebPanelBrowserElement,
+    "the findbar should bind directly to the web panel content browser",
+  );
+
+  dispatchCommand(harness.document.getCommand("cmd_findAgain"));
+  dispatchCommand(harness.document.getCommand("cmd_findPrevious"));
+  dispatchCommand(harness.document.getCommand("cmd_findSelection"));
+  await settleFindbarCreation(harness.window);
+
+  assertEquals(
+    findbar.calls.join(","),
+    "find,again:false,again:true,selection",
+    "each supported command should route to the matching findbar API",
+  );
+  assertEquals(
+    builtInHandlerCalls,
+    0,
+    "intercepted commands should not reach the browser.xhtml handler",
+  );
+  assertEquals(
+    harness.document.createdFindbars.length,
+    1,
+    "repeated commands and double init should reuse the findbar",
+  );
+}
+
+function testLeavesCloseAndUnrelatedCommandsUntouched(): void {
+  const harness = createHarness([
+    "cmd_find",
+    "cmd_findAgain",
+    "cmd_findPrevious",
+    "cmd_findClose",
+    "Browser:Reload",
+  ]);
+  harness.controller.init();
+
+  let untouchedHandlerCalls = 0;
+  const closeCommand = harness.document.getCommand("cmd_findClose");
+  const reloadCommand = harness.document.getCommand("Browser:Reload");
+  closeCommand.addEventListener("command", () => untouchedHandlerCalls += 1);
+  reloadCommand.addEventListener("command", () => untouchedHandlerCalls += 1);
+
+  const closeEvent = dispatchCommand(closeCommand);
+  const reloadEvent = dispatchCommand(reloadCommand);
+
+  assert(!closeEvent.defaultPrevented, "cmd_findClose should remain untouched");
+  assert(
+    !reloadEvent.defaultPrevented,
+    "unrelated commands should remain untouched",
+  );
+  assertEquals(
+    untouchedHandlerCalls,
+    2,
+    "untargeted command handlers should still run",
+  );
+  assertEquals(
+    harness.document.createdFindbars.length,
+    0,
+    "untargeted commands should not create a findbar",
+  );
+}
+
+async function testLeavesFindbarEscapeAndCloseBehaviorUntouched(): Promise<
+  void
+> {
+  const harness = createHarness();
+  harness.controller.init();
+  dispatchCommand(harness.document.getCommand("cmd_find"));
+  await settleFindbarCreation(harness.window);
+
+  const findbar = harness.document.createdFindbars[0];
+  const escapeEvent = new KeyboardEvent("keypress", {
+    key: "Escape",
+    keyCode: 27,
+    bubbles: true,
+    cancelable: true,
+  });
+  findbar.dispatchEvent(escapeEvent);
+  findbar.closeButton.dispatchEvent(
+    new Event("command", { bubbles: true, cancelable: true }),
+  );
+
+  assert(escapeEvent.defaultPrevented, "the findbar should handle Escape");
+  assertEquals(
+    findbar.closeCount,
+    2,
+    "the findbar should retain ownership of Escape and its close button",
+  );
+}
+
+async function testUnloadDestroysAndDetachesOnce(): Promise<void> {
+  const harness = createHarness();
+  harness.controller.init();
+  dispatchCommand(harness.document.getCommand("cmd_find"));
+  await settleFindbarCreation(harness.window);
+
+  const findbar = harness.document.createdFindbars[0];
+  harness.window.dispatchEvent(new Event("unload"));
+  harness.controller.destroy();
+
+  assertEquals(findbar.destroyCount, 1, "findbar should be destroyed once");
+  assertEquals(findbar.removeCount, 1, "findbar should be removed once");
+
+  let commandCallsAfterDestroy = 0;
+  const command = harness.document.getCommand("cmd_find");
+  command.addEventListener("command", () => commandCallsAfterDestroy += 1);
+  const event = dispatchCommand(command);
+
+  assert(!event.defaultPrevented, "destroy should detach the command listener");
+  assertEquals(
+    commandCallsAfterDestroy,
+    1,
+    "commands should continue normally after controller destruction",
+  );
+  assertEquals(
+    findbar.calls.length,
+    1,
+    "destroyed controller should not dispatch another find command",
+  );
+}
+
+async function testDestroyDuringLazyCreationIsSafe(): Promise<void> {
+  const harness = createHarness();
+  harness.controller.init();
+  dispatchCommand(harness.document.getCommand("cmd_find"));
+
+  assertEquals(
+    harness.document.createdFindbars.length,
+    1,
+    "the command should begin lazy findbar creation",
+  );
+  const findbar = harness.document.createdFindbars[0];
+  harness.controller.destroy();
+  await settleFindbarCreation(harness.window);
+
+  assertEquals(
+    findbar.browser,
+    null,
+    "destroyed pending findbar should not bind",
+  );
+  assertEquals(
+    findbar.calls.length,
+    0,
+    "destroyed pending command should not run",
+  );
+  assertEquals(
+    findbar.destroyCount,
+    1,
+    "pending findbar cleanup should be idempotent",
+  );
+  assertEquals(
+    findbar.removeCount,
+    1,
+    "pending findbar should be removed once",
+  );
+}
+
+async function testPanelReopenUsesIndependentController(): Promise<void> {
+  const firstPanel = createHarness();
+  firstPanel.controller.init();
+  dispatchCommand(firstPanel.document.getCommand("cmd_find"));
+  await settleFindbarCreation(firstPanel.window);
+  firstPanel.window.dispatchEvent(new Event("unload"));
+
+  const reopenedPanel = createHarness();
+  reopenedPanel.controller.init();
+  dispatchCommand(reopenedPanel.document.getCommand("cmd_find"));
+  await settleFindbarCreation(reopenedPanel.window);
+
+  assertEquals(
+    reopenedPanel.document.createdFindbars.length,
+    1,
+    "a reopened panel should create its own findbar",
+  );
+  assertEquals(
+    reopenedPanel.document.createdFindbars[0].calls.join(","),
+    "find",
+    "find should work after reopening the panel",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "routes only find commands to one lazy findbar",
+      fn: testRoutesOnlyFindCommandsToOneLazyFindbar,
+    },
+    {
+      name: "leaves close and unrelated commands untouched",
+      fn: testLeavesCloseAndUnrelatedCommandsUntouched,
+    },
+    {
+      name: "leaves findbar Escape and close behavior untouched",
+      fn: testLeavesFindbarEscapeAndCloseBehaviorUntouched,
+    },
+    {
+      name: "unload destroys and detaches once",
+      fn: testUnloadDestroysAndDetachesOnce,
+    },
+    {
+      name: "destroy during lazy creation is safe",
+      fn: testDestroyDuringLazyCreationIsSafe,
+    },
+    {
+      name: "panel reopen uses an independent controller",
+      fn: testPanelReopenUsesIndependentController,
+    },
+  ];
+
+  await runTests("webPanelFindController.test.ts", tests);
+}

--- a/browser-features/chrome/common/panel-sidebar/utils/web-panel-find-controller.ts
+++ b/browser-features/chrome/common/panel-sidebar/utils/web-panel-find-controller.ts
@@ -1,0 +1,244 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { WebPanelBrowserElement } from "./web-panel-browser.ts";
+
+export const WEB_PANEL_FINDBAR_ID = "floorp-webpanel-findbar";
+
+const WEB_PANEL_FIND_COMMAND_IDS = [
+  "cmd_find",
+  "cmd_findAgain",
+  "cmd_findPrevious",
+  "cmd_findSelection",
+] as const;
+
+type WebPanelFindCommandId = (typeof WEB_PANEL_FIND_COMMAND_IDS)[number];
+
+type WebPanelFindbarElement = XULElement & {
+  browser: WebPanelBrowserElement | null;
+  destroy?: () => void;
+  onFindCommand: () => void;
+  onFindAgainCommand: (findPrevious: boolean) => void;
+  onFindSelectionCommand?: () => void;
+};
+
+export interface WebPanelFindDocument {
+  getElementById(id: string): Element | null;
+  createXULElement(name: string): Element;
+}
+
+export interface WebPanelFindWindow {
+  addEventListener(
+    type: string,
+    listener: EventListener,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListener,
+  ): void;
+  requestAnimationFrame(callback: FrameRequestCallback): number;
+}
+
+function isWebPanelFindCommandId(id: string): id is WebPanelFindCommandId {
+  return WEB_PANEL_FIND_COMMAND_IDS.includes(id as WebPanelFindCommandId);
+}
+
+/**
+ * Owns the findbar used by the browser.xhtml instance embedded in a web panel.
+ *
+ * The normal browser command handler asks gBrowser for a tab findbar. A web
+ * panel intentionally has no gBrowser, so these listeners route only the find
+ * commands to a findbar bound directly to the panel's content browser.
+ */
+export class WebPanelFindController {
+  private readonly commandElements = new Set<Element>();
+  private findbar: WebPanelFindbarElement | null = null;
+  private pendingFindbar: Promise<WebPanelFindbarElement | null> | null = null;
+  private pendingFindbarElement: WebPanelFindbarElement | null = null;
+  private readonly removedFindbars = new WeakSet<WebPanelFindbarElement>();
+  private initialized = false;
+  private destroyed = false;
+
+  constructor(
+    private readonly browser: WebPanelBrowserElement,
+    private readonly panelDocument: WebPanelFindDocument = document,
+    private readonly panelWindow: WebPanelFindWindow = window,
+  ) {}
+
+  private readonly handleCommand = (event: Event): void => {
+    const commandId = (event.currentTarget as Element | null)?.id ?? "";
+    if (!isWebPanelFindCommandId(commandId)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    void this.executeCommand(commandId);
+  };
+
+  private readonly handleUnload = (): void => {
+    this.destroy();
+  };
+
+  init(): void {
+    if (this.initialized || this.destroyed) {
+      return;
+    }
+
+    for (const commandId of WEB_PANEL_FIND_COMMAND_IDS) {
+      const commandElement = this.panelDocument.getElementById(commandId);
+      if (!commandElement) {
+        continue;
+      }
+
+      commandElement.addEventListener("command", this.handleCommand, true);
+      this.commandElements.add(commandElement);
+    }
+
+    this.panelWindow.addEventListener("unload", this.handleUnload);
+    this.initialized = true;
+  }
+
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+    this.initialized = false;
+
+    for (const commandElement of this.commandElements) {
+      commandElement.removeEventListener("command", this.handleCommand, true);
+    }
+    this.commandElements.clear();
+    this.panelWindow.removeEventListener("unload", this.handleUnload);
+
+    if (this.findbar) {
+      this.removeFindbar(this.findbar);
+    }
+    if (this.pendingFindbarElement) {
+      this.removeFindbar(this.pendingFindbarElement);
+    }
+
+    this.findbar = null;
+    this.pendingFindbarElement = null;
+  }
+
+  private async executeCommand(
+    commandId: WebPanelFindCommandId,
+  ): Promise<void> {
+    try {
+      const findbar = await this.getFindbar();
+      if (!findbar) {
+        return;
+      }
+
+      switch (commandId) {
+        case "cmd_find":
+          findbar.onFindCommand();
+          break;
+        case "cmd_findAgain":
+          findbar.onFindAgainCommand(false);
+          break;
+        case "cmd_findPrevious":
+          findbar.onFindAgainCommand(true);
+          break;
+        case "cmd_findSelection":
+          findbar.onFindSelectionCommand?.();
+          break;
+      }
+    } catch (error) {
+      console.error("[WebPanelFindController] Find command failed:", error);
+    }
+  }
+
+  private async getFindbar(): Promise<WebPanelFindbarElement | null> {
+    if (this.destroyed) {
+      return null;
+    }
+    if (this.findbar) {
+      return this.findbar;
+    }
+    if (this.pendingFindbar) {
+      return await this.pendingFindbar;
+    }
+
+    const pendingFindbar = this.createFindbar();
+    this.pendingFindbar = pendingFindbar;
+    try {
+      return await pendingFindbar;
+    } finally {
+      if (this.pendingFindbar === pendingFindbar) {
+        this.pendingFindbar = null;
+      }
+    }
+  }
+
+  private async createFindbar(): Promise<WebPanelFindbarElement | null> {
+    const existing = this.panelDocument.getElementById(WEB_PANEL_FINDBAR_ID) as
+      | WebPanelFindbarElement
+      | null;
+    if (existing) {
+      existing.browser = this.browser;
+      this.findbar = existing;
+      return existing;
+    }
+
+    const findbar = this.panelDocument.createXULElement(
+      "findbar",
+    ) as WebPanelFindbarElement;
+    findbar.id = WEB_PANEL_FINDBAR_ID;
+    this.pendingFindbarElement = findbar;
+
+    try {
+      const inserted = this.browser.insertAdjacentElement("afterend", findbar);
+      if (!inserted) {
+        throw new Error("Unable to insert the web panel findbar");
+      }
+
+      await new Promise<void>((resolve) => {
+        this.panelWindow.requestAnimationFrame(() => resolve());
+      });
+
+      if (this.destroyed || !this.browser.isConnected || !findbar.isConnected) {
+        this.removeFindbar(findbar);
+        return null;
+      }
+
+      findbar.browser = this.browser;
+      this.findbar = findbar;
+      this.pendingFindbarElement = null;
+      return findbar;
+    } catch (error) {
+      this.removeFindbar(findbar);
+      throw error;
+    } finally {
+      if (this.pendingFindbarElement === findbar && this.destroyed) {
+        this.pendingFindbarElement = null;
+      }
+    }
+  }
+
+  private removeFindbar(findbar: WebPanelFindbarElement): void {
+    if (this.removedFindbars.has(findbar)) {
+      return;
+    }
+    this.removedFindbars.add(findbar);
+
+    try {
+      findbar.destroy?.();
+    } catch (error) {
+      console.error("[WebPanelFindController] Findbar cleanup failed:", error);
+    }
+    findbar.remove();
+
+    if (this.findbar === findbar) {
+      this.findbar = null;
+    }
+    if (this.pendingFindbarElement === findbar) {
+      this.pendingFindbarElement = null;
+    }
+  }
+}

--- a/browser-features/chrome/common/panel-sidebar/website-panel-window-child.ts
+++ b/browser-features/chrome/common/panel-sidebar/website-panel-window-child.ts
@@ -14,11 +14,13 @@ import {
   WEB_PANEL_CONTENT_BROWSER_ID,
   type WebPanelBrowserElement,
 } from "./utils/web-panel-browser.ts";
+import { WebPanelFindController } from "./utils/web-panel-find-controller.ts";
 
 const PANEL_SIDEBAR_DATA_PREF_NAME = "floorp.panelSidebar.data";
 
 export class WebsitePanelWindowChild {
   private static instance: WebsitePanelWindowChild;
+  private findController: WebPanelFindController | null = null;
   static getInstance() {
     if (!WebsitePanelWindowChild.instance) {
       WebsitePanelWindowChild.instance = new WebsitePanelWindowChild();
@@ -274,6 +276,11 @@ export class WebsitePanelWindowChild {
     );
 
     const browser = this.createContentBrowser();
+    if (!this.findController) {
+      this.findController = new WebPanelFindController(browser);
+    }
+    this.findController.init();
+
     globalThis.requestAnimationFrame(() => {
       loadUriInWebPanelBrowser(browser, loadURL);
       this.setZoomLevel(browser);


### PR DESCRIPTION
## Summary

- create one lazy XUL findbar bound directly to the web-panel content browser
- intercept find/find-again/find-previous/find-selection in capture phase before browser.xhtml''s gBrowser-dependent handler
- clean up the local findbar and listeners with the child window lifecycle

## Verification

- `deno task test --near browser-features/chrome/common/panel-sidebar/test/webPanelFindController.test.ts` — 1 passed, 0 failed
- affected `bridge/loader-features` production bundle — passed
- live `navigator:webpanel` window: `cmd_find` was prevented, the findbar rendered and bound to `floorp-webpanel-content-browser`, and gBrowser/WebPanel console errors were 0

## Build note

The repository-wide before-mach build is blocked by the unchanged clean-base `pages-newtab` / `lucide-react@0.562.0` `MISSING_EXPORT` issue. The affected production bundle passes.

Closes #2538