### PR TITLE
fix(split-view): recover lost native tab-drag state safely

### DIFF
--- a/browser-features/chrome/common/split-view/components/native-tab-drag-recovery.ts
+++ b/browser-features/chrome/common/split-view/components/native-tab-drag-recovery.ts
@@ -1,0 +1,167 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { SplitViewTab } from "../data/types.js";
+
+const DRAG_SERVICE_CONTRACT_ID = "@mozilla.org/widget/dragservice;1";
+
+/** Gecko internals used only when the native dragend event was lost. */
+export interface NativeTabDragController {
+  finishMoveTogetherSelectedTabs?: (tab: RecoverableTab) => void;
+  finishAnimateTabMove?: () => void;
+  _resetTabsAfterDrop?: (ownerDocument: Document) => void;
+}
+
+export interface RecoverableTab extends SplitViewTab {
+  _dragData?: object;
+  closing?: boolean;
+  container?: {
+    tabDragAndDrop?: NativeTabDragController;
+  };
+  isConnected?: boolean;
+  ownerDocument?: Document;
+}
+
+/**
+ * Native identities captured for one Floorp drag transaction. These
+ * references must still be identical when recovery is attempted.
+ */
+export interface NativeTabDragRecovery {
+  readonly tab: RecoverableTab;
+  readonly dragData: object;
+  readonly controller: NativeTabDragController;
+  readonly ownerDocument: Document;
+  dragendObserved: boolean;
+  tabGoneObserved: boolean;
+  terminalGuardUsed: boolean;
+}
+
+export type DragSessionReader = () => nsIDragSession | null;
+
+export type NativeTabDragRecoveryResult =
+  | "full"
+  | "ui-only-tab-gone"
+  | "active-session"
+  | "blocked";
+
+/**
+ * Capture the native identities without mutating them. Missing state is not
+ * an error: normal bubbling dragend remains the primary finalization path.
+ */
+export function captureNativeTabDragRecovery(
+  tab: SplitViewTab,
+): NativeTabDragRecovery | null {
+  try {
+    const recoverableTab = tab as RecoverableTab;
+    const dragData = recoverableTab._dragData;
+    const controller = recoverableTab.container?.tabDragAndDrop;
+    const ownerDocument = recoverableTab.ownerDocument;
+
+    if (!dragData || !controller || !ownerDocument) {
+      return null;
+    }
+
+    return {
+      tab: recoverableTab,
+      dragData,
+      controller,
+      ownerDocument,
+      dragendObserved: false,
+      tabGoneObserved: false,
+      terminalGuardUsed: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Read the platform drag session through Gecko's supported drag service. */
+export function getCurrentNativeDragSession(): nsIDragSession | null {
+  const dragService = Cc[DRAG_SERVICE_CONTRACT_ID].getService(
+    Ci.nsIDragService,
+  );
+  return dragService.getCurrentSession() ?? null;
+}
+
+/**
+ * Recover a native tab drag only after Gecko failed to deliver dragend.
+ *
+ * Every prerequisite is checked before the first private finalizer is called.
+ * An active native drag session is retryable and does not consume the terminal
+ * guard. Once the session is gone, the guard is consumed before the first
+ * private call so a re-entrant or repeated attempt cannot invoke the sequence
+ * twice. Live tabs receive Gecko's full finalizer order. Closing or
+ * disconnected tabs receive controller-level UI cleanup through the captured
+ * controller even when Gecko has already removed or replaced `tab.container`.
+ */
+export function recoverLostNativeTabDrag(
+  captured: NativeTabDragRecovery,
+  current: NativeTabDragRecovery | null,
+  readSession: DragSessionReader = getCurrentNativeDragSession,
+): NativeTabDragRecoveryResult {
+  if (
+    current !== captured ||
+    captured.dragendObserved ||
+    captured.terminalGuardUsed
+  ) {
+    return "blocked";
+  }
+
+  try {
+    const { tab, dragData, controller, ownerDocument } = captured;
+    const tabIsGone = captured.tabGoneObserved || tab.closing === true ||
+      tab.linkedBrowser === null || tab.isConnected === false;
+
+    // The document and native drag payload identify the captured transaction
+    // on both paths. A live tab additionally has to retain the exact current
+    // controller; a gone tab may no longer have a container, so its captured
+    // controller is the only safe UI-cleanup target.
+    if (tab.ownerDocument !== ownerDocument || tab._dragData !== dragData) {
+      return "blocked";
+    }
+    if (!tabIsGone && tab.container?.tabDragAndDrop !== controller) {
+      return "blocked";
+    }
+
+    const finishAnimateTabMove = controller.finishAnimateTabMove;
+    const resetTabsAfterDrop = controller._resetTabsAfterDrop;
+    if (
+      typeof finishAnimateTabMove !== "function" ||
+      typeof resetTabsAfterDrop !== "function"
+    ) {
+      return "blocked";
+    }
+
+    let finishMoveTogetherSelectedTabs:
+      | ((recoveringTab: RecoverableTab) => void)
+      | null = null;
+    if (!tabIsGone) {
+      const candidate = controller.finishMoveTogetherSelectedTabs;
+      if (typeof candidate !== "function") {
+        return "blocked";
+      }
+      finishMoveTogetherSelectedTabs = candidate;
+    }
+
+    if (readSession() !== null) {
+      return "active-session";
+    }
+
+    captured.terminalGuardUsed = true;
+    if (finishMoveTogetherSelectedTabs) {
+      finishMoveTogetherSelectedTabs.call(controller, tab);
+    }
+    finishAnimateTabMove.call(controller);
+    resetTabsAfterDrop.call(controller, ownerDocument);
+    if (tab._dragData === dragData) {
+      delete tab._dragData;
+    }
+    return tabIsGone ? "ui-only-tab-gone" : "full";
+  } catch {
+    // Do not continue a partially failed private sequence. The caller will
+    // discard the pending split and perform Floorp-owned UI cleanup only.
+    return "blocked";
+  }
+}

--- a/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
+++ b/browser-features/chrome/common/split-view/components/split-view-tab-drop.ts
@@ -13,14 +13,14 @@ import { splitViewConfig } from "../data/config.js";
 import {
   computeDropZone,
   computeLayoutForExistingSplit,
+  type DropZone,
   zoneToLayout,
   zoneToTabOrder,
-  type DropZone,
 } from "../utils/zone-computation.js";
 import {
-  showDropOverlay,
   hideDropOverlay,
   removeDropOverlay,
+  showDropOverlay,
 } from "./split-view-drop-overlay.js";
 import {
   getActiveSplitViewGroupId,
@@ -28,6 +28,13 @@ import {
 } from "../patches/session-restore.js";
 import { applyLayout } from "../layout.js";
 import { forceCleanupDragState } from "../utils/force-cleanup.js";
+import {
+  captureNativeTabDragRecovery,
+  type DragSessionReader,
+  getCurrentNativeDragSession,
+  type NativeTabDragRecovery,
+  recoverLostNativeTabDrag,
+} from "./native-tab-drag-recovery.js";
 
 const TAB_DROP_TYPE = "application/x-moz-tabbrowser-tab";
 const NEW_WINDOW_ZONE_ID = "floorp-new-window-drop-zone";
@@ -36,10 +43,9 @@ const PREF_SPLIT_VIEW_DND_CREATION_ENABLED =
 
 let activeZone: DropZone = "right";
 let isTabDragging = false;
-/** Tab being dragged, captured at dragstart. */
-let draggedTabAtStart: SplitViewTab | null = null;
 let cleanupFns: (() => void)[] = [];
 let logger: ConsoleInstance | null = null;
+let nativeDragSessionReader: DragSessionReader = getCurrentNativeDragSession;
 /**
  * Heartbeat timer: dragover fires continuously during a drag (~60fps).
  * If this timer expires, the cursor has left the window — hide overlays.
@@ -59,26 +65,47 @@ let dragLeaveTimer: ReturnType<typeof setTimeout> | null = null;
  * layout (Issue: split view created after nudging a tab inside the tab
  * strip renders with a stale positional offset).
  */
+interface DragTransaction {
+  readonly tab: SplitViewTab;
+  readonly nativeRecovery: NativeTabDragRecovery | null;
+  dragendObserved: boolean;
+  recoveryDeadlineAt: number | null;
+  recoveryReason: LostTerminalReason | null;
+  recoveryTimer: ReturnType<typeof setTimeout> | null;
+}
+
 interface PendingSplitViewCreation {
+  transaction: DragTransaction;
   tab: SplitViewTab;
   zone: DropZone;
+  source: "content-drop";
 }
+let activeDragTransaction: DragTransaction | null = null;
 let pendingCreation: PendingSplitViewCreation | null = null;
+
 /**
- * Fallback timer that flushes `pendingCreation` if the native `dragend`
- * never arrives within the same drag gesture. `dragend` is the expected
- * flush path, but it can be dropped (Firefox Bugzilla #656164); without a
- * fallback the split view would silently never be created in that case.
+ * Give a late normal dragend time to reach Gecko's tab-container handler before
+ * attempting any private lost-terminal recovery. Floorp UI is cleared before
+ * this timer starts, so the grace period never leaves content input blocked.
  */
-const PENDING_CREATION_FALLBACK_MS = 100;
-let pendingCreationFlushTimer: ReturnType<typeof setTimeout> | null = null;
+const LOST_DRAGEND_RECOVERY_RETRY_MS = 100;
+const LOST_DRAGEND_RECOVERY_DEADLINE_MS = 1000;
+
+type LostTerminalReason =
+  | "content-drop"
+  | "mouseup"
+  | "window-blur"
+  | "document-hidden"
+  | "dragged-tab-close"
+  | "stuck-watchdog";
 
 /**
  * Watchdog: if `data-floorp-tab-dragging` (or any sibling drag attribute)
  * lingers on tabpanels for more than this duration without a fresh dragover,
- * we assume the drag's terminal events (dragend/drop) were lost and force a
- * cleanup. Keep this short enough that users don't notice a stuck state,
- * but long enough that legitimate pauses in dragover don't trigger it.
+ * we assume the drag's terminal events (dragend/drop) were lost, clear Floorp
+ * UI, and schedule guarded native recovery. Keep this short enough that users
+ * don't notice a stuck state, but long enough that legitimate pauses in
+ * dragover don't trigger it.
  */
 const STUCK_DRAG_WATCHDOG_MS = 2000;
 let stuckDragWatchdog: ReturnType<typeof setTimeout> | null = null;
@@ -92,84 +119,6 @@ export function isTabDragToSplitCreationEnabled(): boolean {
 
 function getTabpanels(): HTMLElement | null {
   return document?.getElementById("tabbrowser-tabpanels") as HTMLElement | null;
-}
-
-/**
- * Finish the visual side of Firefox's native tab-drag move that
- * `finishAnimateTabMove` would normally handle.
- *
- * Background: when a tab is nudged within the tab strip during a drag,
- * `_animateTabMove` (drag-and-drop.js) sets `style.transform` on the dragged
- * tab *and its neighbours*, and the drag-over-a-group path sets the
- * `movingtab-group` / `movingtab-addToGroup` attributes plus the
- * `--dragover-tab-group-color*` CSS variables (the blue "drop here to group"
- * indicator) and a `dragover-groupTarget` attribute on the hovered tab. All of
- * these are normally cleared by native `finishAnimateTabMove`, which is itself
- * gated on the `movingtab` attribute (`if (!this.#isMovingTab()) return;`).
- *
- * The split-view tab-drop path interferes with that cleanup:
- *   - `onDrop` runs `cleanup()` → `forceCleanupDragState()`, which removes the
- *     `movingtab` attribute as a safety net against leaked `pointer-events:none`;
- *   - later, native `dragend` → `handle_dragend` → `finishAnimateTabMove` sees
- *     `movingtab` already gone and returns early, so NONE of the visual state
- *     is cleared — per-tab `transform`s, the blue group indicator, etc.
- *   - when `addTabSplitView` then moves those tabs into the wrapper, the stale
- *     `transform` travels with them (positional offset bug) and the group
- *     indicator keeps painting over the tab strip.
- *
- * Calling this immediately before `addTabSplitView`/`addTabs` reproduces the
- * cleanup `finishAnimateTabMove` would have done (drag-and-drop.js: clearing
- * `transform` + `dragover-groupTarget` on every `dragAndDropElement`, removing
- * the `movingtab-group` / `movingtab-ungroup` / `movingtab-addToGroup`
- * attributes, and dropping the `--dragover-tab-group-color*` CSS variables), so
- * no drag visuals survive into the wrapper — regardless of whether the native
- * function actually ran.
- */
-function finishNativeTabMoveVisuals(): void {
-  const tabContainer = getGBrowser()?.tabContainer as
-    | (HTMLElement & {
-        tabDragAndDrop?: {
-          _tabbrowserTabs?: HTMLElement & {
-            dragAndDropElements?: Iterable<HTMLElement>;
-          };
-        };
-      })
-    | undefined;
-  const tbts = tabContainer?.tabDragAndDrop?._tabbrowserTabs;
-
-  // Prefer Firefox's own dragAndDropElements list — it is exactly the set
-  // `_animateTabMove` applied transforms to (tabs AND split-view wrappers).
-  const dde = tbts?.dragAndDropElements;
-  let items: HTMLElement[];
-  if (dde) {
-    items = Array.from(dde);
-  } else {
-    // Fallback: sweep all tabbrowser-tabs and split-view wrappers in the strip.
-    const all = document?.querySelectorAll(
-      ".tabbrowser-tab, tab-split-view-wrapper",
-    );
-    items = all ? (Array.from(all) as HTMLElement[]) : [];
-  }
-  for (const item of items) {
-    // _animateTabMove's translate; also clear dragover-groupTarget (native
-    // _resetGroupTarget) for any tab that was the hovered grouping target.
-    if (item.style.transform) {
-      item.style.transform = "";
-    }
-    item.removeAttribute("dragover-groupTarget");
-  }
-
-  if (tbts) {
-    // Native finishAnimateTabMove attribute cleanup.
-    tbts.removeAttribute("movingtab-group");
-    tbts.removeAttribute("movingtab-ungroup");
-    tbts.removeAttribute("movingtab-addToGroup");
-    // Native _setDragOverGroupColor(null): drop the blue group-indicator CSS
-    // variables, which otherwise keep painting over the tab strip.
-    tbts.style.removeProperty("--dragover-tab-group-color");
-    tbts.style.removeProperty("--dragover-tab-group-color-invert");
-    tbts.style.removeProperty("--dragover-tab-group-color-pale");
-  }
 }
 
 /**
@@ -334,14 +283,14 @@ function onNewWindowZoneDrop(event: DragEvent): void {
   if (zone) zone.removeAttribute("drag-hover");
 
   const gBrowser = getGBrowser();
-  const draggedTab = draggedTabAtStart;
+  const draggedTab = activeDragTransaction?.tab ?? null;
   if (!gBrowser || !draggedTab) {
-    cleanup();
+    abortDragTransaction();
     return;
   }
 
   // Move the dragged tab to a new window
-  cleanup();
+  abortDragTransaction();
   gBrowser.replaceTabWithWindow(draggedTab);
 }
 
@@ -357,9 +306,7 @@ function isEventInsideNewWindowZone(event: DragEvent): boolean {
 
 function onDragOver(event: DragEvent): void {
   if (!isTabDragToSplitCreationEnabled()) {
-    if (isTabDragging) {
-      cleanup();
-    }
+    abortDragTransaction();
     return;
   }
 
@@ -430,7 +377,7 @@ function onDragOver(event: DragEvent): void {
     showNewWindowZone();
   }
 
-  const draggedTab = draggedTabAtStart;
+  const draggedTab = activeDragTransaction?.tab ?? null;
   const activeSplitView = findExistingSplitView();
   const maxPanes = splitViewConfig().maxPanes;
 
@@ -447,9 +394,7 @@ function onDragOver(event: DragEvent): void {
 
 function onDrop(event: DragEvent): void {
   if (!isTabDragToSplitCreationEnabled()) {
-    if (isTabDragging) {
-      cleanup();
-    }
+    abortDragTransaction();
     return;
   }
 
@@ -470,24 +415,24 @@ function onDrop(event: DragEvent): void {
 
   const gBrowser = getGBrowser();
   if (!gBrowser) {
-    cleanup();
+    abortDragTransaction();
     return;
   }
 
-  const draggedTab = draggedTabAtStart;
-  if (!draggedTab) {
-    cleanup();
+  const transaction = activeDragTransaction;
+  const draggedTab = transaction?.tab ?? null;
+  if (!transaction || !draggedTab) {
+    abortDragTransaction();
     return;
   }
 
   if (draggedTab.splitview) {
-    cleanup();
+    abortDragTransaction();
     return;
   }
 
   // Save state before cleanup — split view creation is deferred until after
-  // Firefox's native `dragend` runs (see `pendingCreation` /
-  // `flushPendingCreationOnDragEnd`). The native `handle_dragend` calls
+  // Firefox's native bubbling `dragend` runs. The native `handle_dragend` calls
   // `finishAnimateTabMove` (clearing per-tab `transform`s set by
   // `_animateTabMove`) and `_resetTabsAfterDrop` (clearing per-tab inline
   // styles) and deletes `_dragData`. If we move tabs into the wrapper before
@@ -497,32 +442,22 @@ function onDrop(event: DragEvent): void {
   // offset. Deferring until the real `dragend` event guarantees native
   // cleanup has completed first.
   const zone = activeZone;
-  const tab = draggedTab;
-
-  cleanup();
-
-  pendingCreation = { tab, zone };
-  // Safety net: `dragend` is the primary flush path, but it can be dropped
-  // (Firefox Bugzilla #656164). If it never arrives, flush after a short
-  // grace period so the split view is still created. The timer is cleared on
-  // the normal `dragend` path.
-  if (pendingCreationFlushTimer) clearTimeout(pendingCreationFlushTimer);
-  pendingCreationFlushTimer = setTimeout(() => {
-    pendingCreationFlushTimer = null;
-    if (!pendingCreation) return;
-    logger?.warn(
-      "[tab-drop] dragend not received within grace period — flushing " +
-        "pending split view creation via fallback timer",
-    );
-    flushPendingCreationOnDragEnd();
-  }, PENDING_CREATION_FALLBACK_MS);
+  pendingCreation = {
+    transaction,
+    tab: draggedTab,
+    zone,
+    source: "content-drop",
+  };
+  scheduleLostTerminalRecovery(transaction, "content-drop");
 }
 
 /**
  * Actually create (or extend) the split view for the captured drop. Extracted
  * from `onDrop` so it can run from the `dragend` handler after native cleanup.
  */
-function runDeferredSplitViewCreation(creation: PendingSplitViewCreation): void {
+function runDeferredSplitViewCreation(
+  creation: PendingSplitViewCreation,
+): void {
   const { tab, zone } = creation;
   // Guard: if tab was closed or destroyed between cleanup and this deferred callback,
   // skip all operations to avoid acting on stale state.
@@ -531,15 +466,6 @@ function runDeferredSplitViewCreation(creation: PendingSplitViewCreation): void 
 
   const gBrowser = getGBrowser();
   if (!gBrowser) return;
-
-  // CRITICAL: finish the native tab-move visuals BEFORE moving tabs into the
-  // wrapper. This runs from the `dragend` handler, but native
-  // `finishAnimateTabMove` may have been skipped because `cleanup()` →
-  // `forceCleanupDragState()` already removed the `movingtab` attribute that
-  // gates it (`if (!this.#isMovingTab()) return;`). Without this sweep, stale
-  // `transform`s travel into the wrapper (positional offset) and the blue
-  // drag-over-group indicator keeps painting over the tab strip.
-  finishNativeTabMoveVisuals();
 
   // Re-query the current split view state rather than using the pre-cleanup
   // snapshot — the wrapper may have been destroyed or mutated by Firefox's
@@ -573,7 +499,8 @@ function runDeferredSplitViewCreation(creation: PendingSplitViewCreation): void 
         const partnerTab = findLastActivePartnerTab(gBrowser, tab);
         if (!partnerTab) return;
         if (partnerTab.splitview) {
-          const existingWrapper = partnerTab.splitview as unknown as SplitViewWrapper;
+          const existingWrapper = partnerTab
+            .splitview as unknown as SplitViewWrapper;
           if (existingWrapper.tabs.length < currentMaxPanes) {
             existingWrapper.addTabs([tab]);
             // Apply grid-3pane layout for 2→3 pane transition on center drop
@@ -602,10 +529,14 @@ function runDeferredSplitViewCreation(creation: PendingSplitViewCreation): void 
       const partnerTab = findLastActivePartnerTab(gBrowser, tab);
       if (!partnerTab) return;
       if (partnerTab.splitview) {
-        const existingWrapper = partnerTab.splitview as unknown as SplitViewWrapper;
+        const existingWrapper = partnerTab
+          .splitview as unknown as SplitViewWrapper;
         if (existingWrapper.tabs.length < currentMaxPanes) {
           existingWrapper.addTabs([tab]);
-          const layout = computeLayoutForExistingSplit(zone, existingWrapper.tabs.length - 1);
+          const layout = computeLayoutForExistingSplit(
+            zone,
+            existingWrapper.tabs.length - 1,
+          );
           if (layout) {
             const groupId = getActiveSplitViewGroupId();
             if (groupId) setPersistedGroupLayout(groupId, layout);
@@ -630,49 +561,241 @@ function runDeferredSplitViewCreation(creation: PendingSplitViewCreation): void 
   }
 }
 
-/**
- * Flush any pending split-view creation captured at drop time. Called from
- * the `dragend` handler so that Firefox's native post-drag cleanup
- * (`finishAnimateTabMove` / `_resetTabsAfterDrop`) has already run, which
- * prevents stale per-tab `transform`s from lingering on tabs as they are
- * moved into the wrapper.
- */
-function flushPendingCreationOnDragEnd(): void {
-  if (!pendingCreation) return;
-  if (pendingCreationFlushTimer) {
-    clearTimeout(pendingCreationFlushTimer);
-    pendingCreationFlushTimer = null;
+function cancelLostTerminalRecovery(transaction: DragTransaction): void {
+  if (transaction.recoveryTimer !== null) {
+    clearTimeout(transaction.recoveryTimer);
+    transaction.recoveryTimer = null;
+  }
+}
+
+function takePendingCreation(
+  transaction: DragTransaction,
+): PendingSplitViewCreation | null {
+  if (pendingCreation?.transaction !== transaction) {
+    return null;
   }
   const creation = pendingCreation;
   pendingCreation = null;
-  runDeferredSplitViewCreation(creation);
+  return creation;
 }
 
-function onDragEnd(): void {
-  if (!isTabDragToSplitCreationEnabled()) {
-    if (isTabDragging) {
-      cleanup();
+function eventBelongsToTransaction(
+  event: DragEvent,
+  transaction: DragTransaction,
+): boolean {
+  const target = event.target;
+  if ((target as unknown) === transaction.tab) {
+    return true;
+  }
+  if (
+    target &&
+    typeof target === "object" &&
+    "linkedTab" in target &&
+    target.linkedTab === transaction.tab
+  ) {
+    return true;
+  }
+
+  const dataTransfer = event.dataTransfer as unknown as {
+    mozGetDataAt?: (format: string, index: number) => unknown;
+  } | null;
+  try {
+    if (
+      dataTransfer?.mozGetDataAt?.(TAB_DROP_TYPE, 0) === transaction.tab
+    ) {
+      return true;
+    }
+  } catch {
+    // Fall through to Gecko's event-to-tab resolver.
+  }
+
+  const tabContainer = getGBrowser()?.tabContainer as unknown as {
+    _tabForDragEvent?: (dragEvent: DragEvent) => SplitViewTab | null;
+  } | null;
+  try {
+    return tabContainer?._tabForDragEvent?.(event) === transaction.tab;
+  } catch {
+    return false;
+  }
+}
+
+function finishLostTerminalRecovery(transaction: DragTransaction): void {
+  cancelLostTerminalRecovery(transaction);
+  if (activeDragTransaction === transaction) {
+    activeDragTransaction = null;
+  }
+  if (pendingCreation?.transaction === transaction) {
+    pendingCreation = null;
+  }
+  clearFloorpDragUi();
+}
+
+function expireLostTerminalRecovery(transaction: DragTransaction): void {
+  if (activeDragTransaction !== transaction) return;
+  const reason = transaction.recoveryReason ?? "stuck-watchdog";
+  logger?.warn(
+    `[tab-drop] ${reason}: native drag session remained active through the ` +
+      `${LOST_DRAGEND_RECOVERY_DEADLINE_MS}ms recovery deadline; ` +
+      "discarding the captured transaction and pending split creation",
+  );
+  finishLostTerminalRecovery(transaction);
+}
+
+function scheduleNextLostTerminalAttempt(transaction: DragTransaction): void {
+  if (transaction.recoveryTimer !== null) return;
+  const deadlineAt = transaction.recoveryDeadlineAt;
+  if (deadlineAt === null) return;
+
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    expireLostTerminalRecovery(transaction);
+    return;
+  }
+
+  transaction.recoveryTimer = setTimeout(
+    () => attemptLostTerminalRecovery(transaction),
+    Math.min(LOST_DRAGEND_RECOVERY_RETRY_MS, remainingMs),
+  );
+}
+
+function attemptLostTerminalRecovery(transaction: DragTransaction): void {
+  transaction.recoveryTimer = null;
+  if (activeDragTransaction !== transaction) {
+    return;
+  }
+  if (transaction.dragendObserved) {
+    abortDragTransaction();
+    return;
+  }
+
+  const deadlineAt = transaction.recoveryDeadlineAt;
+  if (deadlineAt === null || Date.now() >= deadlineAt) {
+    expireLostTerminalRecovery(transaction);
+    return;
+  }
+
+  const nativeRecovery = transaction.nativeRecovery;
+  const result = nativeRecovery === null ? "blocked" : recoverLostNativeTabDrag(
+    nativeRecovery,
+    activeDragTransaction.nativeRecovery,
+    nativeDragSessionReader,
+  );
+
+  if (result === "active-session") {
+    // This result is explicitly retryable: preserve both the captured native
+    // transaction and any accepted content drop. The helper has not consumed
+    // its terminal guard, so a later session-null attempt can finalize once.
+    if (Date.now() >= deadlineAt) {
+      expireLostTerminalRecovery(transaction);
+    } else {
+      scheduleNextLostTerminalAttempt(transaction);
     }
     return;
   }
 
-  // Run deferred split-view creation FIRST, before cleanup(), so that it
-  // executes in the same `dragend` task — after native `handle_dragend` has
-  // cleared transforms/inline-styles via `finishAnimateTabMove` and
-  // `_resetTabsAfterDrop`. `dragend` is the only reliable signal that the
-  // native drag is truly over and its cleanup has completed; using a plain
-  // `setTimeout(0)` instead races against that cleanup when the tab was
-  // nudged within the tab strip.
-  flushPendingCreationOnDragEnd();
+  const reason = transaction.recoveryReason ?? "stuck-watchdog";
+  const creation = result === "full" &&
+      pendingCreation?.source === "content-drop"
+    ? takePendingCreation(transaction)
+    : null;
 
-  cleanup();
-  // Belt-and-suspenders: ensure Firefox's "movingtab" attribute is cleared.
-  // handle_dragend normally does this, but if the dragged tab was consumed
-  // by our drop handler, the attribute may linger on gNavToolbox, which
-  // applies `pointer-events: none` to the nav-bar and blocks all clicks
-  // (including context menus).
-  document.getElementById("tabbrowser-tabs")?.removeAttribute("movingtab");
-  document.getElementById("navigator-toolbox")?.removeAttribute("movingtab");
+  if (result === "blocked") {
+    logger?.warn(
+      `[tab-drop] ${reason}: captured native identity or terminal state ` +
+        "changed; hard-aborting the transaction and pending split creation",
+    );
+    abortDragTransaction();
+    return;
+  }
+
+  finishLostTerminalRecovery(transaction);
+
+  if (result === "full" && creation) {
+    if (!isTabDragToSplitCreationEnabled()) {
+      logger?.warn(
+        `[tab-drop] ${reason}: native drag state recovered, but ` +
+          "drag-to-split creation is now disabled",
+      );
+      return;
+    }
+    logger?.warn(
+      `[tab-drop] ${reason}: native dragend was lost; ` +
+        "recovered the captured transaction",
+    );
+    runDeferredSplitViewCreation(creation);
+    return;
+  }
+
+  if (result === "ui-only-tab-gone") {
+    logger?.warn(
+      `[tab-drop] ${reason}: dragged tab is gone; recovered native UI only`,
+    );
+    return;
+  }
+
+  logger?.warn(
+    `[tab-drop] ${reason}: recovered native drag state; ` +
+      "no accepted content drop, so no split was created",
+  );
+}
+
+/**
+ * Clear Floorp-owned UI immediately, then retry identity-scoped recovery every
+ * 100ms while Gecko still reports an active native drag. The first safety
+ * signal fixes a one-second absolute deadline; later signals cannot extend it.
+ */
+function scheduleLostTerminalRecovery(
+  transaction: DragTransaction,
+  reason: LostTerminalReason,
+): void {
+  clearFloorpDragUi();
+  if (
+    activeDragTransaction !== transaction ||
+    transaction.dragendObserved
+  ) {
+    return;
+  }
+
+  if (transaction.recoveryDeadlineAt === null) {
+    transaction.recoveryDeadlineAt = Date.now() +
+      LOST_DRAGEND_RECOVERY_DEADLINE_MS;
+    transaction.recoveryReason = reason;
+  }
+  scheduleNextLostTerminalAttempt(transaction);
+}
+
+function onDragEnd(event: DragEvent): void {
+  const transaction = activeDragTransaction;
+  if (!transaction) {
+    clearFloorpDragUi();
+    return;
+  }
+
+  if (!eventBelongsToTransaction(event, transaction)) {
+    logger?.warn(
+      "[tab-drop] dragend identity did not match the captured transaction; " +
+        "discarding pending split creation",
+    );
+    abortDragTransaction();
+    return;
+  }
+
+  // This document listener is intentionally registered in the bubble phase.
+  // Gecko's tab-container dragend handler has therefore already finalized its
+  // multi-selected tabs, animation, styles, and _dragData. Do not repeat or
+  // approximate any of those private operations on the normal path.
+  transaction.dragendObserved = true;
+  if (transaction.nativeRecovery) {
+    transaction.nativeRecovery.dragendObserved = true;
+  }
+  cancelLostTerminalRecovery(transaction);
+  const creation = takePendingCreation(transaction);
+  activeDragTransaction = null;
+  clearFloorpDragUi();
+
+  if (creation && isTabDragToSplitCreationEnabled()) {
+    runDeferredSplitViewCreation(creation);
+  }
 }
 
 /**
@@ -687,30 +810,21 @@ function onDragLeave(event: DragEvent): void {
   // When moving between children of the same document, relatedTarget is
   // the element being entered.
   const related = event.relatedTarget;
-  if (related === null || !(related instanceof Node) || !document.contains(related)) {
+  if (
+    related === null || !(related instanceof Node) ||
+    !document.contains(related)
+  ) {
     hideDropOverlay();
     removeNewWindowZone();
   }
 }
 
-/** Capture split view state and dragged tab on dragstart. */
-function onDragStart(event: DragEvent): void {
-  if (!isTabDragToSplitCreationEnabled()) {
-    if (isTabDragging) {
-      cleanup();
-    }
-    return;
-  }
-
-  const types = event.dataTransfer?.types;
-  if (!types) return;
-  if (!Array.from(types).includes(TAB_DROP_TYPE)) return;
+function resolveDraggedTabAtStart(event: DragEvent): SplitViewTab | null {
   const gBrowser = getGBrowser();
-  if (!gBrowser) return;
-
+  if (!gBrowser) return null;
   // Try to identify the actual dragged tab:
-  // 1. event.target on tabContainer is the tab element, which has a
-  //    linkedTab property pointing to the SplitViewTab.
+  // 1. event.target is the tab itself, or a test/proxy element whose linkedTab
+  //    points to the SplitViewTab.
   // 2. Firefox's tabContainer exposes _tabForDragEvent(event) which
   //    resolves the tab element from the drag event source node.
   // 3. Fallback to selectedTab only when both above fail.
@@ -718,11 +832,17 @@ function onDragStart(event: DragEvent): void {
   if (
     target &&
     typeof target === "object" &&
+    gBrowser.tabs.includes(target as unknown as SplitViewTab)
+  ) {
+    return target as unknown as SplitViewTab;
+  }
+  if (
+    target &&
+    typeof target === "object" &&
     "linkedTab" in target &&
     target.linkedTab
   ) {
-    draggedTabAtStart = target.linkedTab as SplitViewTab;
-    return;
+    return target.linkedTab as SplitViewTab;
   }
 
   const tabContainer = gBrowser.tabContainer as unknown as HTMLElement & {
@@ -731,41 +851,70 @@ function onDragStart(event: DragEvent): void {
   if (tabContainer._tabForDragEvent) {
     const dragTab = tabContainer._tabForDragEvent(event);
     if (dragTab) {
-      draggedTabAtStart = dragTab;
-      return;
+      return dragTab;
     }
   }
 
-  draggedTabAtStart = gBrowser.selectedTab ?? null;
+  return gBrowser.selectedTab ?? null;
 }
 
-function cleanup(): void {
+/** Capture one identity-scoped drag transaction at dragstart. */
+function onDragStart(event: DragEvent): void {
+  if (!isTabDragToSplitCreationEnabled()) {
+    abortDragTransaction();
+    return;
+  }
+
+  const types = event.dataTransfer?.types;
+  if (!types || !Array.from(types).includes(TAB_DROP_TYPE)) return;
+
+  const draggedTab = resolveDraggedTabAtStart(event);
+  if (!draggedTab) {
+    abortDragTransaction();
+    return;
+  }
+
+  // A second dragstart makes any older pending transaction ambiguous.
+  abortDragTransaction();
+  activeDragTransaction = {
+    tab: draggedTab,
+    nativeRecovery: captureNativeTabDragRecovery(draggedTab),
+    dragendObserved: false,
+    recoveryDeadlineAt: null,
+    recoveryReason: null,
+    recoveryTimer: null,
+  };
+}
+
+/**
+ * Clear only attributes, elements, and UI timers owned by Floorp split view.
+ * The transaction-owned recovery timer is canceled separately by dragend or a
+ * hard abort so this helper can safely run when lost recovery is scheduled.
+ */
+function clearFloorpDragUi(): void {
   if (dragLeaveTimer) {
     clearTimeout(dragLeaveTimer);
     dragLeaveTimer = null;
   }
-  if (pendingCreationFlushTimer) {
-    clearTimeout(pendingCreationFlushTimer);
-    pendingCreationFlushTimer = null;
-  }
   clearStuckDragWatchdog();
   isTabDragging = false;
-  draggedTabAtStart = null;
   activeZone = "right";
-  // Drop the pending split-view creation. It is only flushed from `dragend`
-  // (see `onDragEnd`) or its fallback timer; if we reach `cleanup()` another
-  // way — e.g. the stuck-drag watchdog, a global mouseup/blur safety net, or
-  // detach-to-window where the tab is gone — the drag was abandoned and no
-  // split view should be created.
-  pendingCreation = null;
   removeDropOverlay();
   removeNewWindowZone();
-  // Belt-and-suspenders: clear every drag-related attribute and overlay
-  // element that could leak across event races. `dragend` may not fire
-  // reliably (Firefox Bugzilla #656164 — e.g. when the tab is detached to
-  // a new window), so every exit path must guarantee a full cleanup.
-  // `forceCleanupDragState` is idempotent and a no-op when nothing is leaked.
+  // This helper deliberately does not remove Gecko's `movingtab`, mutate
+  // `_dragData`, or invoke native finalizers.
   forceCleanupDragState(logger);
+}
+
+/** Fail closed: discard the transaction and pending split, then clear UI. */
+function abortDragTransaction(): void {
+  const transaction = activeDragTransaction;
+  if (transaction) {
+    cancelLostTerminalRecovery(transaction);
+  }
+  activeDragTransaction = null;
+  pendingCreation = null;
+  clearFloorpDragUi();
 }
 
 /**
@@ -773,8 +922,8 @@ function cleanup(): void {
  * `data-floorp-tab-dragging` is set. If `STUCK_DRAG_WATCHDOG_MS` elapses
  * without a fresh dragover, dragend, or drop, we treat the drag as lost
  * (the most common cause is detach-to-window, where Firefox never delivers
- * dragend/drop to this window) and force a cleanup so mouse input on the
- * content area is restored instead of staying blocked until restart.
+ * dragend/drop to this window), restore content input immediately, and give a
+ * late normal dragend a short chance to cancel guarded recovery.
  */
 function scheduleStuckDragWatchdog(): void {
   if (stuckDragWatchdog) clearTimeout(stuckDragWatchdog);
@@ -785,9 +934,14 @@ function scheduleStuckDragWatchdog(): void {
     if (stuck) {
       logger?.warn(
         "[tab-drop] stuck-drag watchdog fired — dragend/drop was lost, " +
-          "forcing cleanup to restore mouse input",
+          "scheduling guarded recovery",
       );
-      cleanup();
+      const transaction = activeDragTransaction;
+      if (transaction) {
+        scheduleLostTerminalRecovery(transaction, "stuck-watchdog");
+      } else {
+        clearFloorpDragUi();
+      }
     }
   }, STUCK_DRAG_WATCHDOG_MS);
 }
@@ -801,11 +955,15 @@ function clearStuckDragWatchdog(): void {
 
 // --- Public API ---
 
-export function initTabDrop(initLogger: ConsoleInstance): void {
+export function initTabDrop(
+  initLogger: ConsoleInstance,
+  readNativeDragSession: DragSessionReader = getCurrentNativeDragSession,
+): void {
   logger = initLogger;
+  nativeDragSessionReader = readNativeDragSession;
   const onOver = (e: Event) => onDragOver(e as DragEvent);
   const onDropFn = (e: Event) => onDrop(e as DragEvent);
-  const onEnd = () => onDragEnd();
+  const onEnd = (e: Event) => onDragEnd(e as DragEvent);
   const onStart = (e: Event) => onDragStart(e as DragEvent);
   const onLeave = (e: Event) => onDragLeave(e as DragEvent);
 
@@ -813,16 +971,34 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
   // #656164) and leave `data-floorp-tab-dragging` on tabpanels, which
   // permanently blocks mouse input on the content area. Reaching a mouseup,
   // a window blur, a visibility change, or a TabClose during an active drag
-  // is a strong signal that the drag is over — force a cleanup in those
-  // cases. `cleanup()` is idempotent and a no-op when nothing is active.
+  // is a strong signal that the drag is over. Clear Floorp UI immediately,
+  // then leave a short grace period for a normal Gecko-first dragend before
+  // attempting guarded lost-terminal recovery. Safety-only terminals never
+  // create a split view.
   const onGlobalMouseUp = (): void => {
-    if (isTabDragging) cleanup();
+    const transaction = activeDragTransaction;
+    if (transaction) {
+      scheduleLostTerminalRecovery(transaction, "mouseup");
+    } else if (isTabDragging) {
+      clearFloorpDragUi();
+    }
   };
   const onWindowBlur = (): void => {
-    if (isTabDragging) cleanup();
+    const transaction = activeDragTransaction;
+    if (transaction) {
+      scheduleLostTerminalRecovery(transaction, "window-blur");
+    } else if (isTabDragging) {
+      clearFloorpDragUi();
+    }
   };
   const onVisibilityChange = (): void => {
-    if (document.hidden && isTabDragging) cleanup();
+    if (!document.hidden) return;
+    const transaction = activeDragTransaction;
+    if (transaction) {
+      scheduleLostTerminalRecovery(transaction, "document-hidden");
+    } else if (isTabDragging) {
+      clearFloorpDragUi();
+    }
   };
   // Detach-to-window: when a tab is dragged out of the window, Firefox
   // closes the source tab (dispatching TabClose on it) and opens a new
@@ -832,14 +1008,18 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
   // only react when the closed tab is the one we captured at dragstart, so
   // an unrelated tab closing mid-drag does not abort the active drag.
   const onTabClose = (event: Event): void => {
-    if (!isTabDragging) return;
+    const transaction = activeDragTransaction;
+    if (!transaction) return;
     const closingTab = event.target as SplitViewTab | null;
-    if (closingTab && closingTab === draggedTabAtStart) {
+    if (closingTab && closingTab === transaction.tab) {
+      if (transaction.nativeRecovery) {
+        transaction.nativeRecovery.tabGoneObserved = true;
+      }
       logger?.warn(
         "[tab-drop] dragged tab closed mid-drag — assuming detach-to-window, " +
-          "forcing cleanup to restore mouse input",
+          "scheduling guarded recovery",
       );
-      cleanup();
+      scheduleLostTerminalRecovery(transaction, "dragged-tab-close");
     }
   };
 
@@ -874,15 +1054,15 @@ export function initTabDrop(initLogger: ConsoleInstance): void {
     () => globalThis.removeEventListener("TabClose", onTabClose),
   ];
 
-  logger.debug("[tab-drop] document-level listeners attached (capture phase)");
+  logger.debug(
+    "[tab-drop] document drag listeners attached (dragend in bubble phase)",
+  );
 }
 
 export function destroyTabDrop(): void {
   for (const fn of cleanupFns) fn();
   cleanupFns = [];
-  removeDropOverlay();
-  removeNewWindowZone();
-  clearStuckDragWatchdog();
-  cleanup();
+  abortDragTransaction();
   logger = null;
+  nativeDragSessionReader = getCurrentNativeDragSession;
 }

--- a/browser-features/chrome/common/split-view/components/test/split-view-tab-drop.test.ts
+++ b/browser-features/chrome/common/split-view/components/test/split-view-tab-drop.test.ts
@@ -12,24 +12,39 @@ import {
   initTabDrop,
   isTabDragToSplitCreationEnabled,
 } from "../split-view-tab-drop.ts";
-import type {
-  SplitViewGBrowser,
-  SplitViewTab,
-  SplitViewWrapper,
-} from "../../data/types.ts";
+import {
+  captureNativeTabDragRecovery,
+  type DragSessionReader,
+  type NativeTabDragController,
+  type NativeTabDragRecovery,
+  type RecoverableTab,
+  recoverLostNativeTabDrag,
+} from "../native-tab-drag-recovery.ts";
+import type { SplitViewGBrowser, SplitViewWrapper } from "../../data/types.ts";
 
 const TAB_DROP_TYPE = "application/x-moz-tabbrowser-tab";
 const NEW_WINDOW_ZONE_ID = "floorp-new-window-drop-zone";
 const PREF_SPLIT_VIEW_DND_CREATION_ENABLED =
   "floorp.splitView.dragToSplitCreate.enabled";
 
-type TestTab = SplitViewTab & { _lastAccessed?: number };
+type TestTab = RecoverableTab & { _lastAccessed?: number };
 
 interface DragScenario {
   addTabSplitViewCalls: () => number;
   cleanup: () => void;
+  dispatchDragEnd: () => void;
+  dispatchDragStartAndOver: () => void;
   dispatchDragToContent: () => { drop: Event };
+  dispatchDropToContent: () => Event;
+  draggedTab: TestTab;
+  eventOrder: () => string[];
+  nativeFinalizerCalls: () => string[];
   tabpanels: HTMLElement;
+}
+
+interface DragScenarioOptions {
+  multiSelected?: boolean;
+  readNativeDragSession?: DragSessionReader;
 }
 
 const testLogger = {
@@ -37,6 +52,22 @@ const testLogger = {
   warn() {},
   error() {},
 } as ConsoleInstance;
+
+function restoreDragToSplitPref(
+  hadUserValue: boolean,
+  originalValue: boolean,
+): void {
+  if (hadUserValue) {
+    Services.prefs.setBoolPref(
+      PREF_SPLIT_VIEW_DND_CREATION_ENABLED,
+      originalValue,
+    );
+  } else if (
+    Services.prefs.prefHasUserValue(PREF_SPLIT_VIEW_DND_CREATION_ENABLED)
+  ) {
+    Services.prefs.clearUserPref(PREF_SPLIT_VIEW_DND_CREATION_ENABLED);
+  }
+}
 
 function withRestoredPref(run: () => void): void {
   const hadUserValue = Services.prefs.prefHasUserValue(
@@ -50,16 +81,7 @@ function withRestoredPref(run: () => void): void {
   try {
     run();
   } finally {
-    if (hadUserValue) {
-      Services.prefs.setBoolPref(
-        PREF_SPLIT_VIEW_DND_CREATION_ENABLED,
-        originalValue,
-      );
-    } else if (
-      Services.prefs.prefHasUserValue(PREF_SPLIT_VIEW_DND_CREATION_ENABLED)
-    ) {
-      Services.prefs.clearUserPref(PREF_SPLIT_VIEW_DND_CREATION_ENABLED);
-    }
+    restoreDragToSplitPref(hadUserValue, originalValue);
   }
 }
 
@@ -78,11 +100,13 @@ function createTabDragEvent(
   type: string,
   clientX = 100,
   clientY = 50,
+  draggedTab: TestTab | null = null,
 ): Event {
   const event = new Event(type, { bubbles: true, cancelable: true });
   const dataTransfer = {
     types: [TAB_DROP_TYPE],
     dropEffect: "none",
+    mozGetDataAt: () => draggedTab,
   };
 
   Object.defineProperty(event, "dataTransfer", {
@@ -126,13 +150,15 @@ function ensureTabpanels(): {
   element: HTMLElement;
   cleanup: () => void;
 } {
-  const existing = document.getElementById("tabbrowser-tabpanels");
+  const existing = document.getElementById(
+    "tabbrowser-tabpanels",
+  ) as HTMLElement | null;
   const element = existing ?? document.createElement("div");
   const created = existing === null;
 
   if (created) {
     element.id = "tabbrowser-tabpanels";
-    document.documentElement.appendChild(element);
+    document.documentElement!.appendChild(element);
   }
 
   const originalRect = Object.getOwnPropertyDescriptor(
@@ -172,7 +198,36 @@ function ensureTabpanels(): {
   };
 }
 
-function setupDragScenario(): DragScenario {
+function markMovingTab(id: string): {
+  element: Element;
+  cleanup: () => void;
+} {
+  const existing = document.getElementById(id) as HTMLElement | null;
+  const element = existing ?? document.createElement("div");
+  const created = existing === null;
+  const originalValue = element.getAttribute("movingtab");
+
+  if (created) {
+    element.id = id;
+    document.documentElement!.appendChild(element);
+  }
+  element.setAttribute("movingtab", "true");
+
+  return {
+    element,
+    cleanup: () => {
+      if (created) {
+        element.remove();
+      } else if (originalValue === null) {
+        element.removeAttribute("movingtab");
+      } else {
+        element.setAttribute("movingtab", originalValue);
+      }
+    },
+  };
+}
+
+function setupDragScenario(options: DragScenarioOptions = {}): DragScenario {
   destroyTabDrop();
 
   const { element: tabpanels, cleanup: cleanupTabpanels } = ensureTabpanels();
@@ -181,9 +236,35 @@ function setupDragScenario(): DragScenario {
   };
   const draggedTab = createTestTab("dragged", 1);
   const partnerTab = createTestTab("partner", 10);
+  const selectedPeer = createTestTab("selected-peer", 5);
+  if (options.multiSelected) {
+    draggedTab.selected = true;
+    selectedPeer.selected = true;
+  }
   let addTabSplitViewCalls = 0;
+  const eventOrder: string[] = [];
+  const nativeFinalizerCalls: string[] = [];
+
+  const nativeController: NativeTabDragController = {
+    finishMoveTogetherSelectedTabs() {
+      nativeFinalizerCalls.push("finishMoveTogetherSelectedTabs");
+    },
+    finishAnimateTabMove() {
+      nativeFinalizerCalls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      nativeFinalizerCalls.push("_resetTabsAfterDrop");
+    },
+  };
+  draggedTab._dragData = {};
+  draggedTab.container = { tabDragAndDrop: nativeController };
+  draggedTab.ownerDocument = document;
 
   tabContainer.linkedTab = draggedTab;
+  document.documentElement!.appendChild(tabContainer);
+  tabContainer.addEventListener("dragend", () => {
+    eventOrder.push("gecko-dragend");
+  });
 
   const wrapper: SplitViewWrapper = {
     tabs: [partnerTab, draggedTab],
@@ -195,9 +276,9 @@ function setupDragScenario(): DragScenario {
   const mockGBrowser: SplitViewGBrowser = {
     tabpanels: tabpanels as unknown as SplitViewGBrowser["tabpanels"],
     tabContainer: tabContainer as unknown as XULElement,
-    tabs: [partnerTab, draggedTab],
+    tabs: [partnerTab, selectedPeer, draggedTab],
     selectedTab: partnerTab,
-    selectedTabs: [],
+    selectedTabs: options.multiSelected ? [draggedTab, selectedPeer] : [],
     activeSplitView: null,
     showSplitViewPanels() {},
     moveTabBefore() {},
@@ -207,32 +288,153 @@ function setupDragScenario(): DragScenario {
     },
     addTabSplitView() {
       addTabSplitViewCalls += 1;
+      eventOrder.push("split-created");
       return wrapper;
     },
     replaceTabWithWindow() {},
   };
 
   const cleanupGBrowser = setGlobalGBrowser(mockGBrowser);
-  initTabDrop(testLogger);
+  initTabDrop(testLogger, options.readNativeDragSession);
+
+  const dispatchDragStartAndOver = (): void => {
+    tabContainer.dispatchEvent(
+      createTabDragEvent("dragstart", 100, 50, draggedTab),
+    );
+    document.dispatchEvent(
+      createTabDragEvent("dragover", 100, 50, draggedTab),
+    );
+  };
+  const dispatchDropToContent = (): Event => {
+    const drop = createTabDragEvent("drop", 100, 50, draggedTab);
+    document.dispatchEvent(drop);
+    return drop;
+  };
+  const dispatchDragEnd = (): void => {
+    tabContainer.dispatchEvent(
+      createTabDragEvent("dragend", 100, 50, draggedTab),
+    );
+  };
 
   return {
     addTabSplitViewCalls: () => addTabSplitViewCalls,
+    draggedTab,
+    eventOrder: () => [...eventOrder],
+    nativeFinalizerCalls: () => [...nativeFinalizerCalls],
     tabpanels,
+    dispatchDragEnd,
+    dispatchDragStartAndOver,
+    dispatchDropToContent,
     dispatchDragToContent: () => {
-      tabContainer.dispatchEvent(createTabDragEvent("dragstart"));
-      document.dispatchEvent(createTabDragEvent("dragover"));
-      const drop = createTabDragEvent("drop");
-      document.dispatchEvent(drop);
-      document.dispatchEvent(new Event("dragend", { bubbles: true }));
+      dispatchDragStartAndOver();
+      const drop = dispatchDropToContent();
+      dispatchDragEnd();
       return { drop };
     },
     cleanup: () => {
       destroyTabDrop();
       cleanupGBrowser();
       cleanupTabpanels();
+      tabContainer.remove();
       document.getElementById(NEW_WINDOW_ZONE_ID)?.remove();
     },
   };
+}
+
+function createRecoveryFixture(
+  controller: NativeTabDragController,
+  calls: string[],
+): { tab: TestTab; recovery: NativeTabDragRecovery } {
+  const rawTab = createTestTab("recoverable", 1);
+  rawTab._dragData = {};
+  rawTab.container = { tabDragAndDrop: controller };
+  rawTab.ownerDocument = document;
+
+  const tab = new Proxy(rawTab, {
+    deleteProperty(target, property) {
+      if (property === "_dragData") {
+        calls.push("delete _dragData");
+      }
+      return Reflect.deleteProperty(target, property);
+    },
+  });
+  const recovery = captureNativeTabDragRecovery(tab);
+  assert(recovery !== null, "recovery fixture should capture native identity");
+  return { tab, recovery };
+}
+
+function waitForLostTerminalRecovery(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 150));
+}
+
+function waitForRecoveryRetry(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 350));
+}
+
+function waitForRecoveryDeadline(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 1250));
+}
+
+async function withEnabledDragScenario(
+  run: (scenario: DragScenario) => Promise<void> | void,
+  options: DragScenarioOptions = {},
+): Promise<void> {
+  const hadUserValue = Services.prefs.prefHasUserValue(
+    PREF_SPLIT_VIEW_DND_CREATION_ENABLED,
+  );
+  const originalValue = Services.prefs.getBoolPref(
+    PREF_SPLIT_VIEW_DND_CREATION_ENABLED,
+    true,
+  );
+  Services.prefs.setBoolPref(PREF_SPLIT_VIEW_DND_CREATION_ENABLED, true);
+  const scenario = setupDragScenario(options);
+
+  try {
+    await run(scenario);
+  } finally {
+    scenario.cleanup();
+    restoreDragToSplitPref(hadUserValue, originalValue);
+  }
+}
+
+type SafetyTerminal = "mouseup" | "blur" | "hidden" | "dragged-tab-close";
+
+function dispatchSafetyTerminal(
+  scenario: DragScenario,
+  terminal: SafetyTerminal,
+): void {
+  if (terminal === "hidden") {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      "hidden",
+    );
+    Object.defineProperty(document, "hidden", {
+      value: true,
+      configurable: true,
+    });
+    try {
+      document.dispatchEvent(new Event("visibilitychange"));
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(document, "hidden", originalDescriptor);
+      } else {
+        delete (document as unknown as Record<string, unknown>).hidden;
+      }
+    }
+    return;
+  }
+
+  if (terminal === "dragged-tab-close") {
+    const event = new Event("TabClose", { bubbles: true });
+    Object.defineProperty(event, "target", {
+      value: scenario.draggedTab,
+      configurable: true,
+    });
+    globalThis.dispatchEvent(event);
+    return;
+  }
+
+  globalThis.dispatchEvent(new Event(terminal));
 }
 
 function testTabDragToSplitCreationDefaultsToEnabled(): void {
@@ -332,6 +534,735 @@ function testEnabledPrefAllowsDragDropSplitCreation(): void {
   });
 }
 
+async function testNormalDragEndLetsGeckoFinishFirst(): Promise<void> {
+  const hadUserValue = Services.prefs.prefHasUserValue(
+    PREF_SPLIT_VIEW_DND_CREATION_ENABLED,
+  );
+  const originalValue = Services.prefs.getBoolPref(
+    PREF_SPLIT_VIEW_DND_CREATION_ENABLED,
+    true,
+  );
+  Services.prefs.setBoolPref(PREF_SPLIT_VIEW_DND_CREATION_ENABLED, true);
+
+  const scenario = setupDragScenario();
+  const tabstrip = markMovingTab("tabbrowser-tabs");
+  const toolbox = markMovingTab("navigator-toolbox");
+
+  try {
+    scenario.dispatchDragToContent();
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.eventOrder().join(" > "),
+      "gecko-dragend > split-created",
+      "bubbling dragend should reach Gecko before Floorp creates the split",
+    );
+    assertEquals(
+      scenario.nativeFinalizerCalls().length,
+      0,
+      "normal dragend must not invoke private native finalizers",
+    );
+    assert(
+      scenario.draggedTab._dragData !== undefined,
+      "normal Floorp cleanup must not delete Gecko _dragData",
+    );
+    assert(
+      tabstrip.element.hasAttribute("movingtab"),
+      "normal Floorp cleanup must not remove tabstrip movingtab",
+    );
+    assert(
+      toolbox.element.hasAttribute("movingtab"),
+      "normal Floorp cleanup must not remove toolbox movingtab",
+    );
+  } finally {
+    toolbox.cleanup();
+    tabstrip.cleanup();
+    scenario.cleanup();
+    restoreDragToSplitPref(hadUserValue, originalValue);
+  }
+}
+
+async function testNormalMultiSelectedDragEndDoesNotRecoverPrivately(): Promise<
+  void
+> {
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragToContent();
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.eventOrder().join(" > "),
+      "gecko-dragend > split-created",
+      "normal multi-selected dragend should remain Gecko-first",
+    );
+    assertEquals(
+      scenario.nativeFinalizerCalls().length,
+      0,
+      "Floorp must not repeat multi-selected finalization after normal dragend",
+    );
+  }, { multiSelected: true });
+}
+
+async function testLostContentDropRecoversThenCreatesSplit(): Promise<void> {
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+    const drop = scenario.dispatchDropToContent();
+
+    assertEquals(
+      drop.defaultPrevented,
+      true,
+      "the accepted content drop should be the split-creation source",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      0,
+      "a lost dragend path must wait for guarded native recovery",
+    );
+    assert(
+      !scenario.tabpanels.hasAttribute("data-floorp-tab-dragging"),
+      "Floorp UI should clear before the recovery grace period",
+    );
+
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.nativeFinalizerCalls().join(" > "),
+      "finishMoveTogetherSelectedTabs > finishAnimateTabMove > " +
+        "_resetTabsAfterDrop",
+      "a proven lost content drop should use the exact native order",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      1,
+      "only full recovery of an accepted content drop may create a split",
+    );
+  });
+}
+
+async function testActiveSessionRetriesThenCreatesOneSplit(): Promise<void> {
+  const activeSession = {} as nsIDragSession;
+  let sessionReads = 0;
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+    scenario.dispatchDropToContent();
+
+    await waitForRecoveryRetry();
+
+    assertEquals(
+      sessionReads,
+      2,
+      "recovery should retry after the first active native session",
+    );
+    assertEquals(
+      scenario.nativeFinalizerCalls().join(" > "),
+      "finishMoveTogetherSelectedTabs > finishAnimateTabMove > " +
+        "_resetTabsAfterDrop",
+      "the later session-null attempt should finalize the native drag once",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      1,
+      "the accepted content drop should survive one active-session retry",
+    );
+  }, {
+    readNativeDragSession: () => {
+      sessionReads += 1;
+      return sessionReads === 1 ? activeSession : null;
+    },
+  });
+}
+
+async function testActiveSessionDeadlineDiscardsWithoutResurrection(): Promise<
+  void
+> {
+  const activeSession = {} as nsIDragSession;
+  let sessionActive = true;
+  let sessionReads = 0;
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+    scenario.dispatchDropToContent();
+
+    await waitForRecoveryDeadline();
+
+    assert(
+      sessionReads > 1,
+      "an active session should be retried before the bounded deadline",
+    );
+    assertEquals(
+      scenario.nativeFinalizerCalls().length,
+      0,
+      "an active session through the deadline must not run native finalizers",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      0,
+      "deadline expiry must discard the accepted pending split",
+    );
+
+    sessionActive = false;
+    await waitForRecoveryRetry();
+    scenario.dispatchDragEnd();
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.nativeFinalizerCalls().length,
+      0,
+      "session-null after expiry must not resurrect the discarded transaction",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      0,
+      "a late dragend must not resurrect the discarded pending split",
+    );
+  }, {
+    readNativeDragSession: () => {
+      sessionReads += 1;
+      return sessionActive ? activeSession : null;
+    },
+  });
+}
+
+async function testLostContentDropWithClosingTabNeverCreatesSplit(): Promise<
+  void
+> {
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+    scenario.dispatchDropToContent();
+    dispatchSafetyTerminal(scenario, "dragged-tab-close");
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.nativeFinalizerCalls().join(" > "),
+      "finishAnimateTabMove > _resetTabsAfterDrop",
+      "a closing content-drop tab should receive controller-only UI recovery",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      0,
+      "UI-only recovery must discard even an accepted pending split",
+    );
+  });
+}
+
+async function testBlockedContentDropRecoveryNeverCreatesSplit(): Promise<
+  void
+> {
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+    scenario.dispatchDropToContent();
+    scenario.draggedTab.container = {
+      tabDragAndDrop: {
+        finishMoveTogetherSelectedTabs() {},
+        finishAnimateTabMove() {},
+        _resetTabsAfterDrop() {},
+      },
+    };
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.nativeFinalizerCalls().length,
+      0,
+      "changed native identity must block all captured-controller finalizers",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      0,
+      "blocked recovery must discard an accepted pending split",
+    );
+  });
+}
+
+async function testSafetyTerminalsRecoverWithoutCreatingSplit(): Promise<void> {
+  const terminals: SafetyTerminal[] = [
+    "mouseup",
+    "blur",
+    "hidden",
+    "dragged-tab-close",
+  ];
+
+  for (const terminal of terminals) {
+    await withEnabledDragScenario(async (scenario) => {
+      scenario.dispatchDragStartAndOver();
+      dispatchSafetyTerminal(scenario, terminal);
+
+      assert(
+        !scenario.tabpanels.hasAttribute("data-floorp-tab-dragging"),
+        `${terminal} should clear Floorp UI synchronously`,
+      );
+
+      await waitForLostTerminalRecovery();
+
+      const expectedFinalizers = terminal === "dragged-tab-close"
+        ? "finishAnimateTabMove > _resetTabsAfterDrop"
+        : "finishMoveTogetherSelectedTabs > finishAnimateTabMove > " +
+          "_resetTabsAfterDrop";
+      assertEquals(
+        scenario.nativeFinalizerCalls().join(" > "),
+        expectedFinalizers,
+        `${terminal} should use the guarded terminal-specific recovery path`,
+      );
+      assertEquals(
+        scenario.addTabSplitViewCalls(),
+        0,
+        `${terminal} without an accepted content drop must never create a split`,
+      );
+    });
+  }
+}
+
+async function testStuckWatchdogRecoversWithoutCreatingSplit(): Promise<void> {
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+
+    await new Promise((resolve) => setTimeout(resolve, 2250));
+
+    assert(
+      !scenario.tabpanels.hasAttribute("data-floorp-tab-dragging"),
+      "the watchdog should restore content input before recovery settles",
+    );
+    assertEquals(
+      scenario.nativeFinalizerCalls().join(" > "),
+      "finishMoveTogetherSelectedTabs > finishAnimateTabMove > " +
+        "_resetTabsAfterDrop",
+      "the watchdog should schedule the same guarded native recovery",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      0,
+      "watchdog-only recovery must never create a split",
+    );
+  });
+}
+
+async function testLostMultiSelectedDropFinalizesOnceBeforeSplit(): Promise<
+  void
+> {
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+    scenario.dispatchDropToContent();
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.nativeFinalizerCalls().join(" > "),
+      "finishMoveTogetherSelectedTabs > finishAnimateTabMove > " +
+        "_resetTabsAfterDrop",
+      "lost multi-selected recovery should finalize the group exactly once first",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      1,
+      "a fully recovered multi-selected content drop may create one split",
+    );
+  }, { multiSelected: true });
+}
+
+async function testMultiSelectedSafetyTerminalNeverCreatesSplit(): Promise<
+  void
+> {
+  await withEnabledDragScenario(async (scenario) => {
+    scenario.dispatchDragStartAndOver();
+    dispatchSafetyTerminal(scenario, "mouseup");
+    await waitForLostTerminalRecovery();
+
+    assertEquals(
+      scenario.nativeFinalizerCalls().filter((call) =>
+        call === "finishMoveTogetherSelectedTabs"
+      ).length,
+      1,
+      "multi-selected safety recovery should finalize the group once",
+    );
+    assertEquals(
+      scenario.addTabSplitViewCalls(),
+      0,
+      "multi-selected safety-only recovery must never create a split",
+    );
+  }, { multiSelected: true });
+}
+
+function testNullSessionRecoveryUsesExactOrderOnce(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    finishMoveTogetherSelectedTabs() {
+      calls.push("finishMoveTogetherSelectedTabs");
+    },
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      calls.push("readSession");
+      return null;
+    }),
+    "full",
+    "null native session should permit strict lost-dragend recovery",
+  );
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => null),
+    "blocked",
+    "terminal guard should reject a repeated recovery",
+  );
+  assertEquals(
+    calls.join(" > "),
+    "readSession > finishMoveTogetherSelectedTabs > finishAnimateTabMove > " +
+      "_resetTabsAfterDrop > delete _dragData",
+    "native recovery should prove session-null before the exact sequence",
+  );
+  assertEquals(
+    tab._dragData,
+    undefined,
+    "successful recovery should delete the captured _dragData last",
+  );
+}
+
+function testActiveSessionIsRetryableWithoutConsumingGuard(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    finishMoveTogetherSelectedTabs() {
+      calls.push("finishMoveTogetherSelectedTabs");
+    },
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+  const activeSession = {} as nsIDragSession;
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => activeSession),
+    "active-session",
+    "an active drag session should return the retryable result",
+  );
+  assertEquals(
+    calls.length,
+    0,
+    "active-session rejection must not partially touch Gecko state",
+  );
+  assert(
+    tab._dragData === recovery.dragData,
+    "active-session rejection should preserve captured _dragData",
+  );
+  assertEquals(
+    recovery.terminalGuardUsed,
+    false,
+    "an active-session result must not consume the terminal guard",
+  );
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => null),
+    "full",
+    "a later session-null attempt should still be allowed to recover",
+  );
+  assertEquals(
+    calls.join(" > "),
+    "finishMoveTogetherSelectedTabs > finishAnimateTabMove > " +
+      "_resetTabsAfterDrop > delete _dragData",
+    "the retryable attempt must leave the exact finalizer sequence untouched",
+  );
+}
+
+function testSessionReaderFailureBlocksBeforePrivateFinalizers(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    finishMoveTogetherSelectedTabs() {
+      calls.push("finishMoveTogetherSelectedTabs");
+    },
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      throw new Error("drag service unavailable");
+    }),
+    "blocked",
+    "a failed native-session read must block private recovery",
+  );
+  assertEquals(
+    calls.length,
+    0,
+    "a failed session read must happen before every private finalizer",
+  );
+  assert(
+    tab._dragData === recovery.dragData,
+    "a failed session read should preserve captured _dragData",
+  );
+}
+
+function testClosingTabWithMissingContainerUsesCapturedController(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    // A gone tab must not require or invoke finishMoveTogetherSelectedTabs.
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+  tab.closing = true;
+  tab.container = undefined;
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      calls.push("readSession");
+      return null;
+    }),
+    "ui-only-tab-gone",
+    "a closing tab may use its captured controller after container removal",
+  );
+  assertEquals(
+    calls.join(" > "),
+    "readSession > finishAnimateTabMove > _resetTabsAfterDrop > " +
+      "delete _dragData",
+    "gone-tab recovery must skip the tab-dependent native finalizer",
+  );
+  assertEquals(
+    tab._dragData,
+    undefined,
+    "gone-tab recovery should delete only the identical captured _dragData",
+  );
+}
+
+function testDisconnectedTabWithChangedContainerUsesCapturedController(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+  tab.isConnected = false;
+  tab.container = {
+    tabDragAndDrop: {
+      finishAnimateTabMove() {
+        calls.push("replacement finishAnimateTabMove");
+      },
+      _resetTabsAfterDrop() {
+        calls.push("replacement _resetTabsAfterDrop");
+      },
+    },
+  };
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => null),
+    "ui-only-tab-gone",
+    "a disconnected tab may use its captured controller after replacement",
+  );
+  assertEquals(
+    calls.join(" > "),
+    "finishAnimateTabMove > _resetTabsAfterDrop > delete _dragData",
+    "gone-tab recovery must invoke only the captured controller's exact calls",
+  );
+}
+
+function testGoneTabStillRequiresCapturedDragData(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+  const replacementDragData = {};
+  tab.closing = true;
+  tab.container = undefined;
+  tab._dragData = replacementDragData;
+  let sessionReads = 0;
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      sessionReads += 1;
+      return null;
+    }),
+    "blocked",
+    "gone-tab recovery must retain the captured native drag identity guard",
+  );
+  assertEquals(
+    sessionReads,
+    0,
+    "a changed drag payload should fail before reading native session state",
+  );
+  assertEquals(
+    calls.length,
+    0,
+    "a changed drag payload must not invoke the captured controller",
+  );
+  assert(
+    tab._dragData === replacementDragData,
+    "blocked recovery must preserve replacement drag data",
+  );
+}
+
+function testMissingNativeApiFailsClosedBeforeSessionRead(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    finishMoveTogetherSelectedTabs() {
+      calls.push("finishMoveTogetherSelectedTabs");
+    },
+    // finishAnimateTabMove is intentionally absent.
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+  let sessionReads = 0;
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      sessionReads += 1;
+      return null;
+    }),
+    "blocked",
+    "missing native API should make recovery ineligible",
+  );
+  assertEquals(
+    sessionReads,
+    0,
+    "all native APIs should be preflighted before reading terminal state",
+  );
+  assertEquals(
+    calls.length,
+    0,
+    "missing API rejection must not partially invoke available finalizers",
+  );
+  assert(
+    tab._dragData === recovery.dragData,
+    "missing API rejection should preserve captured _dragData",
+  );
+}
+
+function testRecoveryRejectsReentrancy(): void {
+  const calls: string[] = [];
+  let capturedRecovery: NativeTabDragRecovery | null = null;
+  const controller: NativeTabDragController = {
+    finishMoveTogetherSelectedTabs() {
+      calls.push("finishMoveTogetherSelectedTabs");
+      assert(capturedRecovery !== null, "fixture should assign recovery");
+      const nested = recoverLostNativeTabDrag(
+        capturedRecovery,
+        capturedRecovery,
+        () => null,
+      );
+      calls.push(`reentrant:${nested}`);
+    },
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const fixture = createRecoveryFixture(controller, calls);
+  capturedRecovery = fixture.recovery;
+
+  assertEquals(
+    recoverLostNativeTabDrag(
+      fixture.recovery,
+      fixture.recovery,
+      () => null,
+    ),
+    "full",
+    "outer recovery should complete",
+  );
+  assertEquals(
+    calls.join(" > "),
+    "finishMoveTogetherSelectedTabs > reentrant:blocked > " +
+      "finishAnimateTabMove > _resetTabsAfterDrop > delete _dragData",
+    "terminal guard should block re-entry before the first finalizer",
+  );
+}
+
+function testRecoveryRequiresCapturedIdentityAndUnobservedDragend(): void {
+  const calls: string[] = [];
+  const controller: NativeTabDragController = {
+    finishMoveTogetherSelectedTabs() {
+      calls.push("finishMoveTogetherSelectedTabs");
+    },
+    finishAnimateTabMove() {
+      calls.push("finishAnimateTabMove");
+    },
+    _resetTabsAfterDrop() {
+      calls.push("_resetTabsAfterDrop");
+    },
+  };
+  const { tab, recovery } = createRecoveryFixture(controller, calls);
+  const differentTransaction = { ...recovery };
+  let sessionReads = 0;
+
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, differentTransaction, () => {
+      sessionReads += 1;
+      return null;
+    }),
+    "blocked",
+    "a different transaction object must fail identity validation",
+  );
+  recovery.dragendObserved = true;
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      sessionReads += 1;
+      return null;
+    }),
+    "blocked",
+    "an observed dragend must make recovery ineligible",
+  );
+  recovery.dragendObserved = false;
+  tab._dragData = {};
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      sessionReads += 1;
+      return null;
+    }),
+    "blocked",
+    "a replaced native drag transaction must fail tab identity validation",
+  );
+  tab._dragData = recovery.dragData;
+  tab.container = {
+    tabDragAndDrop: {
+      finishMoveTogetherSelectedTabs() {},
+      finishAnimateTabMove() {},
+      _resetTabsAfterDrop() {},
+    },
+  };
+  assertEquals(
+    recoverLostNativeTabDrag(recovery, recovery, () => {
+      sessionReads += 1;
+      return null;
+    }),
+    "blocked",
+    "a changed native controller must fail captured identity validation",
+  );
+  assertEquals(
+    sessionReads,
+    0,
+    "identity mismatch should fail before querying the drag service",
+  );
+  assertEquals(
+    calls.length,
+    0,
+    "identity mismatch must not touch Gecko state",
+  );
+}
+
 export async function runAllTests(): Promise<void> {
   const tests: TestCase[] = [
     {
@@ -353,6 +1284,86 @@ export async function runAllTests(): Promise<void> {
     {
       name: "enabled pref allows drag-and-drop split view creation",
       fn: testEnabledPrefAllowsDragDropSplitCreation,
+    },
+    {
+      name: "normal bubbling dragend lets Gecko finish before Floorp",
+      fn: testNormalDragEndLetsGeckoFinishFirst,
+    },
+    {
+      name: "normal multi-selected dragend does not use private recovery",
+      fn: testNormalMultiSelectedDragEndDoesNotRecoverPrivately,
+    },
+    {
+      name: "lost content drop recovers before creating split",
+      fn: testLostContentDropRecoversThenCreatesSplit,
+    },
+    {
+      name: "active session retries then creates one split",
+      fn: testActiveSessionRetriesThenCreatesOneSplit,
+    },
+    {
+      name: "active session deadline discards without resurrection",
+      fn: testActiveSessionDeadlineDiscardsWithoutResurrection,
+    },
+    {
+      name: "lost content drop with closing tab never creates split",
+      fn: testLostContentDropWithClosingTabNeverCreatesSplit,
+    },
+    {
+      name: "blocked content-drop recovery never creates split",
+      fn: testBlockedContentDropRecoveryNeverCreatesSplit,
+    },
+    {
+      name: "safety terminals recover without creating split",
+      fn: testSafetyTerminalsRecoverWithoutCreatingSplit,
+    },
+    {
+      name: "stuck watchdog recovers without creating split",
+      fn: testStuckWatchdogRecoversWithoutCreatingSplit,
+    },
+    {
+      name: "lost multi-selected drop finalizes once before split",
+      fn: testLostMultiSelectedDropFinalizesOnceBeforeSplit,
+    },
+    {
+      name: "multi-selected safety terminal never creates split",
+      fn: testMultiSelectedSafetyTerminalNeverCreatesSplit,
+    },
+    {
+      name: "null-session recovery uses exact native order once",
+      fn: testNullSessionRecoveryUsesExactOrderOnce,
+    },
+    {
+      name: "active native session is retryable without consuming guard",
+      fn: testActiveSessionIsRetryableWithoutConsumingGuard,
+    },
+    {
+      name: "session read failure blocks before private finalizers",
+      fn: testSessionReaderFailureBlocksBeforePrivateFinalizers,
+    },
+    {
+      name: "closing tab with missing container uses captured controller",
+      fn: testClosingTabWithMissingContainerUsesCapturedController,
+    },
+    {
+      name: "disconnected tab with changed container uses captured controller",
+      fn: testDisconnectedTabWithChangedContainerUsesCapturedController,
+    },
+    {
+      name: "gone tab still requires captured drag data",
+      fn: testGoneTabStillRequiresCapturedDragData,
+    },
+    {
+      name: "missing native API fails closed before session read",
+      fn: testMissingNativeApiFailsClosedBeforeSessionRead,
+    },
+    {
+      name: "native recovery rejects reentrancy",
+      fn: testRecoveryRejectsReentrancy,
+    },
+    {
+      name: "native recovery requires captured identity and lost dragend",
+      fn: testRecoveryRequiresCapturedIdentityAndUnobservedDragend,
     },
   ];
 

--- a/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
+++ b/browser-features/chrome/common/split-view/patches/tabpanels-patch.ts
@@ -296,10 +296,10 @@ export function patchTabpanels(
         clearSplitHandles();
         clearGridStyles(this);
         // Safety net: leaving split view is a definitive teardown moment.
-        // Sweep every drag-related attribute (`data-floorp-dragging`,
-        // `data-floorp-tab-dragging`, Firefox's `movingtab`) and any
-        // lingering drop overlay so web content always regains mouse input.
-        // Idempotent; no-op when nothing is leaked.
+        // Sweep Floorp drag attributes (`data-floorp-dragging` and
+        // `data-floorp-tab-dragging`) plus lingering overlays so web content
+        // regains mouse input. Gecko-owned `movingtab` is left for native
+        // drag finalization. Idempotent; no-op when nothing is leaked.
         forceCleanupDragState(logger);
         // When leaving split view, Gecko can keep `.split-view-panel`
         // / `.deck-selected` on old panes until the next native refresh.
@@ -565,8 +565,8 @@ export function patchTabpanels(
       if (tabsToolbar) {
         tabsToolbar.removeAttribute("splitview-multibar");
       }
-      // Final teardown: sweep all drag-related attributes and overlays so
-      // unpatching can never leave mouse input blocked on content.
+      // Final teardown: sweep Floorp-owned drag attributes and overlays so
+      // unpatching cannot leave Floorp UI blocking mouse input on content.
       forceCleanupDragState(logger);
       const splitMarkerTabs = document?.querySelectorAll<HTMLElement>(
         "#tabbrowser-tabs .tabbrowser-tab[data-floorp-split-tab]",

--- a/browser-features/chrome/common/split-view/utils/force-cleanup.ts
+++ b/browser-features/chrome/common/split-view/utils/force-cleanup.ts
@@ -4,13 +4,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * Belt-and-suspenders cleanup of all split-view drag-related state that can
+ * Belt-and-suspenders cleanup of Floorp-owned split-view drag UI that can
  * leak across event races (e.g. Firefox Bugzilla #656164 where `dragend`
  * doesn't fire when a tab is consumed by a drop handler, or when a tab is
- * detached to a new window). When any of these attributes or overlay
- * elements lingers, it applies `pointer-events: none` to web content (via
- * `split-view.css` and Firefox's own `browser.css`) and blocks all mouse
- * input on the page until the browser is restarted.
+ * detached to a new window). Lingering Floorp drag attributes apply
+ * `pointer-events: none` to web content via `split-view.css` and can block
+ * mouse input until the browser is restarted.
  *
  * This helper is intentionally idempotent and side-effect-free when nothing
  * is leaked — safe to call on every drag/drop/mouseup/blur event.
@@ -18,11 +17,14 @@
  * Coverage:
  * - `#tabbrowser-tabpanels[data-floorp-dragging]` (splitter / pane reorder)
  * - `#tabbrowser-tabpanels[data-floorp-tab-dragging]` (tab drop)
- * - `#tabbrowser-tabs[movingtab]` and `#navigator-toolbox[movingtab]`
- *   (Firefox-native leftover; `browser.css` applies `pointer-events: none`
- *   to `#navigator-toolbox[movingtab]`)
  * - `#floorp-split-drop-overlay` element appended to `documentElement`
  * - `#floorp-new-window-drop-zone` element appended to `documentElement`
+ *
+ * Gecko-owned state such as `movingtab`, `_dragData`, and native tab-move
+ * transforms is deliberately out of scope. Clearing it before Gecko's normal
+ * bubbling `dragend` handler runs can prevent native multi-tab finalization.
+ * Lost native dragend recovery, when provably safe, is handled separately by
+ * the tab-drop transaction guard.
  *
  * See: Floorp PR #2492, Firefox Bugzilla #656164.
  */
@@ -44,19 +46,6 @@ export function forceCleanupDragState(
           "[force-cleanup] removed lingering data-floorp-tab-dragging",
         );
       }
-    }
-
-    // Firefox's `browser.css` targets `#tabbrowser-tabs[movingtab]` and
-    // `#navigator-toolbox[movingtab]` (NOT tabpanels), so sweep those.
-    const tabbrowserTabs = document?.getElementById("tabbrowser-tabs");
-    if (tabbrowserTabs?.hasAttribute("movingtab")) {
-      tabbrowserTabs.removeAttribute("movingtab");
-      logger?.debug("[force-cleanup] removed lingering movingtab on tabs");
-    }
-    const navigatorToolbox = document?.getElementById("navigator-toolbox");
-    if (navigatorToolbox?.hasAttribute("movingtab")) {
-      navigatorToolbox.removeAttribute("movingtab");
-      logger?.debug("[force-cleanup] removed lingering movingtab on toolbox");
     }
 
     const overlay = document?.getElementById("floorp-split-drop-overlay");


### PR DESCRIPTION
## Summary

- let Gecko''s normal bubble-phase `dragend` finalize first
- recover only after identity/API checks and a null native drag session
- retry transient active sessions for up to one second, then fail closed without creating a split
- handle closing/detached tabs with a UI-only finalizer and remove unconditional Gecko-owned `movingtab` cleanup
- cover content drop, mouseup, blur, hidden visibility, TabClose, watchdog, multi-selected tabs, and no-resurrection behavior

## Verification

- `deno task test --near browser-features/chrome/common/split-view/components/test/split-view-tab-drop.test.ts` — 1 passed, 0 failed (6.733 s)
- affected `bridge/loader-features` production bundle — passed
- `deno fmt --check`, `deno lint`, `deno check --sloppy-imports`, and independent final audit — passed

Physical multi-tab drag hardware input was not available; Gecko lifecycle/finalizer behavior is exercised inside the real Floorp test browser.

## Build note

The repository-wide before-mach build is blocked by the unchanged clean-base `pages-newtab` / `lucide-react@0.562.0` `MISSING_EXPORT` issue. The affected production bundle passes.

Closes #2508