### PR TITLE
fix(pwa): bind install and launch to the invoking browser container

### DIFF
--- a/browser-features/chrome/common/pwa/ssbManager.ts
+++ b/browser-features/chrome/common/pwa/ssbManager.ts
@@ -8,6 +8,10 @@ import type { DataManager } from "./dataStore.ts";
 import { DataManager as DataManagerClass } from "./dataStore.ts";
 import type { Browser, Manifest } from "./type.ts";
 import { SsbRunner } from "./ssbRunner.ts";
+import {
+  getUserContextIdForBrowser,
+  isContainerExperimentEnabled,
+} from "./containerUtils.ts";
 
 const { AppConstants } = ChromeUtils.importESModule(
   "resource://gre/modules/AppConstants.sys.mjs",
@@ -28,6 +32,32 @@ if (AppConstants.platform === "win") {
     "resource://noraneko/modules/pwa/supports/Linux.sys.mjs",
   );
   SupportClass = LinuxSupport;
+}
+
+export function resolveEffectiveUserContextId(
+  browser: Browser,
+  explicitUserContextId: number | undefined,
+  containerExperimentEnabled: boolean,
+  browserUserContextIdResolver: (browser: Browser) => number =
+    getUserContextIdForBrowser,
+): number {
+  if (!containerExperimentEnabled) {
+    return 0;
+  }
+
+  if (explicitUserContextId !== undefined) {
+    return explicitUserContextId;
+  }
+
+  return browserUserContextIdResolver(browser);
+}
+
+function browserStillShowsUrl(browser: Browser, expectedUrl: string): boolean {
+  try {
+    return browser.currentURI.spec === expectedUrl;
+  } catch {
+    return false;
+  }
 }
 
 export class SiteSpecificBrowserManager {
@@ -101,36 +131,36 @@ export class SiteSpecificBrowserManager {
     asPwa = true,
     installUserContextId?: number,
   ) {
-    // Normalize: when experiment is disabled, ignore container ID
-    let effectiveUserContextId = installUserContextId;
-    try {
-      const { PwaContainerExperiment } = ChromeUtils.importESModule(
-        "resource://noraneko/modules/pwa/PwaContainerExperiment.sys.mjs",
-      );
-      if (!PwaContainerExperiment.isEnabled()) {
-        effectiveUserContextId = undefined;
-      }
-    } catch {
-      effectiveUserContextId = undefined;
-    }
+    const effectiveUserContextId = this.getEffectiveUserContextId(
+      browser,
+      installUserContextId,
+    );
+    const currentPageUrl = browser.currentURI.spec;
 
-    const isInstalled = await this.checkCurrentPageIsInstalled(browser);
+    const isInstalled = await this.checkPageIsInstalledForContainer(
+      browser,
+      effectiveUserContextId,
+    );
+
+    if (!browserStillShowsUrl(browser, currentPageUrl)) {
+      return;
+    }
 
     if (isInstalled) {
       const currentTabSsb = await this.getCurrentTabSsb(browser);
 
-      if (!currentTabSsb) {
+      if (!currentTabSsb || !browserStillShowsUrl(browser, currentPageUrl)) {
         return;
       }
 
       const ssbObj = await this.getIdByUrl(
         currentTabSsb.start_url,
-        effectiveUserContextId ?? 0,
+        effectiveUserContextId,
       );
 
-      if (ssbObj && globalThis.gBrowser.selectedBrowser.currentURI) {
+      if (ssbObj && browserStillShowsUrl(browser, currentPageUrl)) {
         await this.runSsbByUrl(
-          globalThis.gBrowser.selectedBrowser.currentURI.spec,
+          currentPageUrl,
           effectiveUserContextId,
         );
       }
@@ -139,21 +169,36 @@ export class SiteSpecificBrowserManager {
         useWebManifest: asPwa,
       });
 
-      if (!manifest) {
+      if (!manifest || !browserStillShowsUrl(browser, currentPageUrl)) {
         return;
       }
 
-      if (effectiveUserContextId && effectiveUserContextId > 0) {
-        manifest.userContextId = effectiveUserContextId;
-      }
+      manifest.userContextId = effectiveUserContextId;
 
       await this.install(manifest);
 
-      // Installing needs some time to finish
-      globalThis.setTimeout(() => {
-        this.runSsbByUrl(manifest.start_url, effectiveUserContextId);
-      }, 3000);
+      if (browserStillShowsUrl(browser, currentPageUrl)) {
+        this.scheduleRunSsbByUrl(manifest.start_url, effectiveUserContextId);
+      }
     }
+  }
+
+  private getEffectiveUserContextId(
+    browser: Browser,
+    explicitUserContextId: number | undefined,
+  ): number {
+    return resolveEffectiveUserContextId(
+      browser,
+      explicitUserContextId,
+      isContainerExperimentEnabled(),
+    );
+  }
+
+  private scheduleRunSsbByUrl(url: string, userContextId: number): void {
+    // Installing needs some time to finish.
+    globalThis.setTimeout(() => {
+      void this.runSsbByUrl(url, userContextId);
+    }, 3000);
   }
 
   public async checkCurrentPageIsInstalled(browser: Browser): Promise<boolean> {
@@ -196,8 +241,8 @@ export class SiteSpecificBrowserManager {
     }
 
     for (const key in ssbData) {
-      const { startUrl, userContextId: storedCtxId } =
-        DataManagerClass.parseKey(key);
+      const { startUrl, userContextId: storedCtxId } = DataManagerClass
+        .parseKey(key);
       if (
         (startUrl === currentTabSsb.start_url ||
           currentTabSsb.start_url.startsWith(startUrl)) &&
@@ -329,10 +374,11 @@ export class SiteSpecificBrowserManager {
     const currentPageCanBeInstalled = this.checkSiteCanBeInstall(
       browser.currentURI,
     );
-    const currentPageHasSsbManifest =
-      await this.manifestProcesser.getManifestFromBrowser(browser, true);
-    const currentPageIsInstalled =
-      await this.checkCurrentPageIsInstalled(browser);
+    const currentPageHasSsbManifest = await this.manifestProcesser
+      .getManifestFromBrowser(browser, true);
+    const currentPageIsInstalled = await this.checkCurrentPageIsInstalled(
+      browser,
+    );
 
     if (
       (!currentPageCanBeInstalled || !currentPageHasSsbManifest) &&

--- a/browser-features/chrome/common/pwa/test/ssbManager.test.ts
+++ b/browser-features/chrome/common/pwa/test/ssbManager.test.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // @colocated-env browser
 
-import { SiteSpecificBrowserManager } from "../ssbManager.ts";
+import {
+  resolveEffectiveUserContextId,
+  SiteSpecificBrowserManager,
+} from "../ssbManager.ts";
 import { DataManager } from "../dataStore.ts";
-import type { Manifest } from "../type.ts";
+import type { Browser, Manifest } from "../type.ts";
 import {
   assert,
   assertEquals,
@@ -27,9 +30,63 @@ const checkSiteCanBeInstall = (
   }
 ).checkSiteCanBeInstall;
 
+const getIdByUrl = (
+  SiteSpecificBrowserManager.prototype as unknown as {
+    getIdByUrl: (
+      url: string,
+      userContextId?: number,
+    ) => Promise<Manifest | undefined>;
+  }
+).getIdByUrl;
+
 /** Convenience wrapper around `Services.io.newURI` for terse test bodies. */
 function makeURI(spec: string): nsIURI {
   return Services.io.newURI(spec);
+}
+
+function makeBrowser(spec: string): Browser {
+  return {
+    currentURI: makeURI(spec),
+  } as unknown as Browser;
+}
+
+function makeManifest(
+  startUrl = "https://example.com/",
+  userContextId?: number,
+): Manifest {
+  return {
+    id: `${startUrl}:${userContextId ?? 0}`,
+    name: "Example",
+    start_url: startUrl,
+    icon: "",
+    userContextId,
+  };
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolvePromise!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+function installOrRunWithManagerLike(
+  managerLike: object,
+  browser: Browser,
+  asPwa = true,
+  userContextId?: number,
+): Promise<void> {
+  return SiteSpecificBrowserManager.prototype.installOrRunCurrentPageAsSsb
+    .call(
+      managerLike as unknown as SiteSpecificBrowserManager,
+      browser,
+      asPwa,
+      userContextId,
+    );
 }
 
 const tests: TestCase[] = [
@@ -114,6 +171,457 @@ const tests: TestCase[] = [
         assertEquals(threw, undefined, `${spec} must not throw`);
         assertEquals(result, false, `${spec} must return false`);
       }
+    },
+  },
+  {
+    name: "explicit userContextId 0 and positive values win when enabled",
+    fn() {
+      const browser = makeBrowser("https://passed.example/");
+      let resolverCalls = 0;
+      const resolveFromBrowser = (_browser: Browser): number => {
+        resolverCalls += 1;
+        return 9;
+      };
+
+      assertEquals(
+        resolveEffectiveUserContextId(browser, 0, true, resolveFromBrowser),
+        0,
+        "explicit default-container id must be preserved",
+      );
+      assertEquals(
+        resolveEffectiveUserContextId(browser, 6, true, resolveFromBrowser),
+        6,
+        "explicit positive container id must be preserved",
+      );
+      assertEquals(
+        resolverCalls,
+        0,
+        "explicit ids must not be replaced by the browser container",
+      );
+    },
+  },
+  {
+    name: "disabled container experiment always resolves to 0",
+    fn() {
+      const browser = makeBrowser("https://passed.example/");
+      let resolverCalls = 0;
+      const result = resolveEffectiveUserContextId(
+        browser,
+        8,
+        false,
+        () => {
+          resolverCalls += 1;
+          return 9;
+        },
+      );
+
+      assertEquals(
+        result,
+        0,
+        "disabled experiment must use the default context",
+      );
+      assertEquals(
+        resolverCalls,
+        0,
+        "disabled experiment must not derive a browser container",
+      );
+    },
+  },
+  {
+    name: "omitted userContextId derives from the passed browser",
+    fn() {
+      const passedBrowser = makeBrowser("https://passed.example/");
+      const selectedBrowser = makeBrowser("https://selected.example/");
+      let resolvedBrowser: Browser | null = null;
+      const result = resolveEffectiveUserContextId(
+        passedBrowser,
+        undefined,
+        true,
+        (browser) => {
+          resolvedBrowser = browser;
+          return browser === passedBrowser ? 4 : 9;
+        },
+      );
+
+      assertEquals(result, 4, "passed browser container must be derived");
+      assert(
+        resolvedBrowser === passedBrowser,
+        "resolver must receive the passed browser",
+      );
+      assert(
+        resolvedBrowser !== selectedBrowser,
+        "an unrelated selected browser must not be consulted",
+      );
+    },
+  },
+  {
+    name: "install flow preserves explicit 0 and positive contexts end to end",
+    async fn() {
+      for (const explicitUserContextId of [0, 6]) {
+        const browser = makeBrowser("https://example.com/account");
+        const createdManifest = makeManifest("https://example.com/");
+        const predicateContextIds: number[] = [];
+        const installedManifests: Manifest[] = [];
+        const scheduledLaunches: Array<{
+          url: string;
+          userContextId: number;
+        }> = [];
+        const managerLike = {
+          getEffectiveUserContextId(
+            receivedBrowser: Browser,
+            receivedExplicitUserContextId: number | undefined,
+          ): number {
+            return resolveEffectiveUserContextId(
+              receivedBrowser,
+              receivedExplicitUserContextId,
+              true,
+              () => 11,
+            );
+          },
+          checkPageIsInstalledForContainer(
+            _browser: Browser,
+            userContextId: number,
+          ): Promise<boolean> {
+            predicateContextIds.push(userContextId);
+            return Promise.resolve(false);
+          },
+          createFromBrowser(
+            _browser: Browser,
+            _options: { useWebManifest: boolean },
+          ): Promise<Manifest> {
+            return Promise.resolve(createdManifest);
+          },
+          install(manifest: Manifest): Promise<void> {
+            installedManifests.push(manifest);
+            return Promise.resolve();
+          },
+          scheduleRunSsbByUrl(url: string, userContextId: number): void {
+            scheduledLaunches.push({ url, userContextId });
+          },
+        };
+
+        await installOrRunWithManagerLike(
+          managerLike,
+          browser,
+          true,
+          explicitUserContextId,
+        );
+
+        assertEquals(
+          predicateContextIds[0],
+          explicitUserContextId,
+          "installed predicate must receive the effective context",
+        );
+        assertEquals(
+          installedManifests[0].userContextId,
+          explicitUserContextId,
+          "stored manifest must retain the effective context, including 0",
+        );
+        assertEquals(
+          scheduledLaunches[0].url,
+          createdManifest.start_url,
+          "post-install launch must use the installed start URL",
+        );
+        assertEquals(
+          scheduledLaunches[0].userContextId,
+          explicitUserContextId,
+          "post-install launch must retain the effective context",
+        );
+      }
+    },
+  },
+  {
+    name: "disabled install flow uses context 0 throughout",
+    async fn() {
+      const browser = makeBrowser("https://example.com/account");
+      const createdManifest = makeManifest("https://example.com/");
+      let predicateUserContextId = -1;
+      const installedManifests: Manifest[] = [];
+      let scheduledUserContextId = -1;
+      const managerLike = {
+        getEffectiveUserContextId(
+          receivedBrowser: Browser,
+          receivedExplicitUserContextId: number | undefined,
+        ): number {
+          return resolveEffectiveUserContextId(
+            receivedBrowser,
+            receivedExplicitUserContextId,
+            false,
+            () => 11,
+          );
+        },
+        checkPageIsInstalledForContainer(
+          _browser: Browser,
+          userContextId: number,
+        ): Promise<boolean> {
+          predicateUserContextId = userContextId;
+          return Promise.resolve(false);
+        },
+        createFromBrowser(): Promise<Manifest> {
+          return Promise.resolve(createdManifest);
+        },
+        install(manifest: Manifest): Promise<void> {
+          installedManifests.push(manifest);
+          return Promise.resolve();
+        },
+        scheduleRunSsbByUrl(_url: string, userContextId: number): void {
+          scheduledUserContextId = userContextId;
+        },
+      };
+
+      await installOrRunWithManagerLike(managerLike, browser, true, 8);
+
+      assertEquals(
+        predicateUserContextId,
+        0,
+        "disabled predicate must use the default context",
+      );
+      assertEquals(
+        installedManifests.length,
+        1,
+        "disabled install must save one manifest",
+      );
+      assertEquals(
+        installedManifests[0].userContextId,
+        0,
+        "disabled install must store the default context",
+      );
+      assertEquals(
+        scheduledUserContextId,
+        0,
+        "disabled post-install launch must use the default context",
+      );
+    },
+  },
+  {
+    name: "selected-browser switch during await cannot change lookup or launch",
+    async fn() {
+      const originalGBrowser = globalThis.gBrowser;
+      const passedBrowser = makeBrowser("https://passed.example/account");
+      const unrelatedBrowser = makeBrowser(
+        "https://unrelated.example/selected",
+      );
+      const passedManifest = makeManifest("https://passed.example/", 7);
+      const installedDeferred = createDeferred<boolean>();
+      const lookupCalls: Array<{ url: string; userContextId: number }> = [];
+      const launchCalls: Array<{ url: string; userContextId: number }> = [];
+      let resolverCalls = 0;
+      const managerLike = {
+        getEffectiveUserContextId(
+          receivedBrowser: Browser,
+          explicitUserContextId: number | undefined,
+        ): number {
+          resolverCalls += 1;
+          return resolveEffectiveUserContextId(
+            receivedBrowser,
+            explicitUserContextId,
+            true,
+            (browser) => browser === passedBrowser ? 7 : 12,
+          );
+        },
+        checkPageIsInstalledForContainer(
+          _browser: Browser,
+          userContextId: number,
+        ): Promise<boolean> {
+          assertEquals(
+            userContextId,
+            7,
+            "predicate must receive the pre-await passed-browser context",
+          );
+          return installedDeferred.promise;
+        },
+        getCurrentTabSsb(): Promise<Manifest> {
+          return Promise.resolve(passedManifest);
+        },
+        getIdByUrl(
+          url: string,
+          userContextId: number,
+        ): Promise<Manifest> {
+          lookupCalls.push({ url, userContextId });
+          return Promise.resolve(passedManifest);
+        },
+        runSsbByUrl(url: string, userContextId: number): Promise<void> {
+          launchCalls.push({ url, userContextId });
+          return Promise.resolve();
+        },
+      };
+
+      try {
+        const operation = installOrRunWithManagerLike(
+          managerLike,
+          passedBrowser,
+        );
+        (globalThis as Record<string, unknown>).gBrowser = {
+          selectedBrowser: unrelatedBrowser,
+          selectedTab: { linkedBrowser: unrelatedBrowser },
+        };
+        installedDeferred.resolve(true);
+        await operation;
+
+        assertEquals(
+          resolverCalls,
+          1,
+          "effective context must be captured exactly once before awaiting",
+        );
+        assertEquals(
+          lookupCalls[0].userContextId,
+          7,
+          "exact-container lookup must retain the captured context",
+        );
+        assertEquals(
+          launchCalls[0].userContextId,
+          7,
+          "launch must retain the captured context",
+        );
+        assertEquals(
+          launchCalls[0].url,
+          "https://passed.example/account",
+          "launch URL must remain bound to the passed browser invocation",
+        );
+      } finally {
+        globalThis.gBrowser = originalGBrowser;
+      }
+    },
+  },
+  {
+    name: "same-browser navigation during installed lookup aborts launch",
+    async fn() {
+      const browser = makeBrowser("https://original.example/account");
+      const installedDeferred = createDeferred<boolean>();
+      let manifestReads = 0;
+      let lookupCalls = 0;
+      let launchCalls = 0;
+      const managerLike = {
+        getEffectiveUserContextId(): number {
+          return 7;
+        },
+        checkPageIsInstalledForContainer(): Promise<boolean> {
+          return installedDeferred.promise;
+        },
+        getCurrentTabSsb(): Promise<Manifest> {
+          manifestReads += 1;
+          return Promise.resolve(makeManifest("https://original.example/", 7));
+        },
+        getIdByUrl(): Promise<Manifest> {
+          lookupCalls += 1;
+          return Promise.resolve(makeManifest("https://original.example/", 7));
+        },
+        runSsbByUrl(): Promise<void> {
+          launchCalls += 1;
+          return Promise.resolve();
+        },
+      };
+
+      const operation = installOrRunWithManagerLike(managerLike, browser);
+      browser.currentURI = makeURI("https://changed.example/");
+      installedDeferred.resolve(true);
+      await operation;
+
+      assertEquals(
+        manifestReads,
+        0,
+        "a changed page must abort before reading a later manifest",
+      );
+      assertEquals(lookupCalls, 0, "a changed page must skip installed lookup");
+      assertEquals(launchCalls, 0, "a changed page must not launch an app");
+    },
+  },
+  {
+    name: "same-browser navigation during manifest creation aborts install",
+    async fn() {
+      const browser = makeBrowser("https://original.example/account");
+      const manifestDeferred = createDeferred<Manifest | null>();
+      let installCalls = 0;
+      let scheduledLaunches = 0;
+      const managerLike = {
+        getEffectiveUserContextId(): number {
+          return 7;
+        },
+        checkPageIsInstalledForContainer(): Promise<boolean> {
+          return Promise.resolve(false);
+        },
+        createFromBrowser(): Promise<Manifest | null> {
+          return manifestDeferred.promise;
+        },
+        install(): Promise<void> {
+          installCalls += 1;
+          return Promise.resolve();
+        },
+        scheduleRunSsbByUrl(): void {
+          scheduledLaunches += 1;
+        },
+      };
+
+      const operation = installOrRunWithManagerLike(managerLike, browser);
+      await Promise.resolve();
+      browser.currentURI = makeURI("https://changed.example/");
+      manifestDeferred.resolve(makeManifest("https://original.example/", 7));
+      await operation;
+
+      assertEquals(installCalls, 0, "a changed page must not be installed");
+      assertEquals(
+        scheduledLaunches,
+        0,
+        "a changed page must not schedule an app launch",
+      );
+    },
+  },
+  {
+    name:
+      "duplicate URLs are matched by exact container for predicate and lookup",
+    async fn() {
+      const startUrl = "https://duplicate.example/";
+      const defaultManifest = makeManifest(startUrl, 0);
+      const containerManifest = makeManifest(startUrl, 7);
+      const ssbData = {
+        [DataManager.buildKey(startUrl, 0)]: defaultManifest,
+        [DataManager.buildKey(startUrl, 7)]: containerManifest,
+      };
+      const browser = makeBrowser(`${startUrl}account`);
+      const managerLike = {
+        checkSiteCanBeInstall,
+        getCurrentTabSsb: () => Promise.resolve(containerManifest),
+        dataManager: {
+          getCurrentSsbData: () => Promise.resolve(ssbData),
+        },
+      };
+
+      assertEquals(
+        await SiteSpecificBrowserManager.prototype
+          .checkPageIsInstalledForContainer.call(
+            managerLike as unknown as SiteSpecificBrowserManager,
+            browser,
+            7,
+          ),
+        true,
+        "matching URL and container must be installed",
+      );
+      assertEquals(
+        await SiteSpecificBrowserManager.prototype
+          .checkPageIsInstalledForContainer.call(
+            managerLike as unknown as SiteSpecificBrowserManager,
+            browser,
+            8,
+          ),
+        false,
+        "same URL in other containers must not satisfy the predicate",
+      );
+      assert(
+        await getIdByUrl.call(
+          managerLike as unknown as SiteSpecificBrowserManager,
+          startUrl,
+          0,
+        ) === defaultManifest,
+        "default-container lookup must return the default entry",
+      );
+      assert(
+        await getIdByUrl.call(
+          managerLike as unknown as SiteSpecificBrowserManager,
+          startUrl,
+          7,
+        ) === containerManifest,
+        "container lookup must return the matching container entry",
+      );
     },
   },
   {


### PR DESCRIPTION
## Summary

- resolve the effective container from the browser passed to the command
- preserve explicit container 0 and use exact-container installed-app lookup
- keep URL/container stable across awaits and abort if the invoking browser navigates
- prevent a later selected-tab switch from changing install/launch behavior

## Verification

- `deno task test --near browser-features/chrome/common/pwa/test/ssbManager.test.ts` — 1 passed, 0 failed
- regression test swaps `globalThis.gBrowser.selectedBrowser` during the await and confirms lookup/launch stay on the passed browser and container
- affected `bridge/loader-features` production bundle — passed
- static format/lint/type checks and independent audit — passed

## Build note

The repository-wide before-mach build is blocked by the unchanged clean-base `pages-newtab` / `lucide-react@0.562.0` `MISSING_EXPORT` issue. The affected production bundle passes.

Closes #2518