### PR TITLE
fix(workspaces): validate Firefox replacement-tab containers

### DIFF
--- a/browser-features/chrome/common/workspaces/test/tabReplacementLifecycle.test.ts
+++ b/browser-features/chrome/common/workspaces/test/tabReplacementLifecycle.test.ts
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  excludeTrackedReplacement,
+  FirefoxTabReplacementTracker,
+  getOriginUserContextId,
+  hasFirefoxReplacementSignal,
+  hasOriginUserContextId,
+} from "../utils/tab-replacement-lifecycle.ts";
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+
+type FakeTab = {
+  id: string;
+  closing?: unknown;
+  _endRemoveArgs?: unknown;
+  url?: string;
+  userContextId?: number;
+  getAttribute?: (name: string) => string;
+};
+
+type FakeBrowser = {
+  getAttribute?: (name: string) => string;
+  browsingContext?: {
+    originAttributes?: {
+      userContextId?: unknown;
+    } | null;
+  } | null;
+};
+
+function makeReplacementSource(id = "closing"): FakeTab {
+  return {
+    id,
+    closing: true,
+    _endRemoveArgs: [false, true],
+  };
+}
+
+function testFirefoxReplacementSignalIsCapabilityChecked(): void {
+  assertEquals(hasFirefoxReplacementSignal(null), false, "null is not a tab");
+  assertEquals(
+    hasFirefoxReplacementSignal({ closing: true }),
+    false,
+    "missing private removal args must fail safe",
+  );
+  assertEquals(
+    hasFirefoxReplacementSignal({
+      closing: true,
+      _endRemoveArgs: { 1: true },
+    }),
+    false,
+    "non-array private removal args must fail safe",
+  );
+  assertEquals(
+    hasFirefoxReplacementSignal({
+      closing: true,
+      _endRemoveArgs: [false, false],
+    }),
+    false,
+    "a close without Firefox's new-tab signal is not a replacement source",
+  );
+  assertEquals(
+    hasFirefoxReplacementSignal({
+      closing: false,
+      _endRemoveArgs: [false, true],
+    }),
+    false,
+    "the tab must also be actively closing",
+  );
+  assertEquals(
+    hasFirefoxReplacementSignal(makeReplacementSource()),
+    true,
+    "closing plus _endRemoveArgs[1] === true is the required signal",
+  );
+}
+
+function testLinkedBrowserOriginAttributesAreAuthoritative(): void {
+  const replacementTab: FakeTab = {
+    id: "native-replacement",
+    getAttribute: (name) => name === "usercontextid" ? "7" : "",
+  };
+  const replacementBrowser: FakeBrowser = {
+    getAttribute: (name) => name === "usercontextid" ? "7" : "",
+    browsingContext: {
+      originAttributes: { userContextId: 0 },
+    },
+  };
+
+  assertEquals(
+    replacementTab.getAttribute?.("usercontextid"),
+    "7",
+    "the tab attribute models WorkspacesService's mirrored container value",
+  );
+  assertEquals(
+    replacementBrowser.getAttribute?.("usercontextid"),
+    "7",
+    "the browser attribute can mirror the same non-authoritative value",
+  );
+  assertEquals(
+    getOriginUserContextId(replacementBrowser),
+    0,
+    "the browsing-context origin wins over tab and browser attributes",
+  );
+  assertEquals(
+    hasOriginUserContextId(replacementBrowser, 7),
+    false,
+    "mirrored usercontextid=7 attributes cannot authorize container reuse",
+  );
+  assertEquals(
+    hasOriginUserContextId(replacementBrowser, 0),
+    true,
+    "the authoritative default-container origin remains reusable for context 0",
+  );
+
+  const containerBrowser: FakeBrowser = {
+    browsingContext: {
+      originAttributes: { userContextId: 7 },
+    },
+  };
+  assertEquals(
+    hasOriginUserContextId(containerBrowser, 7),
+    true,
+    "an exact positive browsing-context match is reusable",
+  );
+  assertEquals(
+    hasOriginUserContextId(containerBrowser, 0),
+    false,
+    "a container origin cannot be reused for the default context",
+  );
+}
+
+function testLinkedBrowserOriginLookupFailsClosed(): void {
+  const missingCases: unknown[] = [
+    null,
+    {},
+    { browsingContext: null },
+    { browsingContext: {} },
+    {
+      browsingContext: { originAttributes: null },
+    },
+    {
+      browsingContext: { originAttributes: {} },
+    },
+    {
+      browsingContext: {
+        originAttributes: { userContextId: "7" },
+      },
+    },
+    {
+      browsingContext: {
+        originAttributes: { userContextId: -1 },
+      },
+    },
+    {
+      browsingContext: {
+        originAttributes: { userContextId: 1.5 },
+      },
+    },
+  ];
+
+  for (const browser of missingCases) {
+    assertEquals(
+      getOriginUserContextId(browser),
+      null,
+      "missing or malformed authoritative context must be unknown",
+    );
+    assertEquals(
+      hasOriginUserContextId(browser, 0),
+      false,
+      "unknown authoritative context must not authorize replacement reuse",
+    );
+  }
+
+  const throwingBrowser: Record<string, unknown> = {};
+  Object.defineProperty(throwingBrowser, "browsingContext", {
+    get(): never {
+      throw new Error("browsing context unavailable");
+    },
+  });
+  assertEquals(
+    getOriginUserContextId(throwingBrowser),
+    null,
+    "a throwing browsing-context getter must fail closed",
+  );
+  assertEquals(
+    hasOriginUserContextId(
+      {
+        browsingContext: {
+          originAttributes: { userContextId: 7 },
+        },
+      },
+      Number.NaN,
+    ),
+    false,
+    "an invalid expected context must also fail closed",
+  );
+}
+
+function testNativeReplacementIsCapturedByExactIdentity(): void {
+  const tracker = new FirefoxTabReplacementTracker<FakeTab>();
+  const closing = makeReplacementSource();
+  const replacement = { id: "native-replacement", url: "about:newtab" };
+
+  tracker.observeTabOpen(replacement, [closing, replacement]);
+
+  assertEquals(
+    tracker.finishTabClose(closing),
+    replacement,
+    "TabClose should consume the exact TabOpen object",
+  );
+}
+
+function testAmbiguousClosingSourcesFailSafe(): void {
+  const tracker = new FirefoxTabReplacementTracker<FakeTab>();
+  const closingA = makeReplacementSource("closing-a");
+  const closingB = makeReplacementSource("closing-b");
+  const opened = { id: "opened", url: "about:newtab" };
+
+  tracker.observeTabOpen(opened, [closingA, closingB, opened]);
+
+  assertEquals(
+    tracker.finishTabClose(closingA),
+    null,
+    "ambiguous lifecycle must not classify the opened tab",
+  );
+  assertEquals(
+    tracker.finishTabClose(closingB),
+    null,
+    "neither ambiguous source may claim the opened tab",
+  );
+}
+
+function testOpenedTabCannotBeItsOwnClosingSource(): void {
+  const tracker = new FirefoxTabReplacementTracker<FakeTab>();
+  const opened = makeReplacementSource("opened");
+
+  tracker.observeTabOpen(opened, [opened]);
+
+  assertEquals(
+    tracker.finishTabClose(opened),
+    null,
+    "the qualifying closing tab must be another tab",
+  );
+}
+
+function testFirstCapturedTabCannotBeOverwritten(): void {
+  const tracker = new FirefoxTabReplacementTracker<FakeTab>();
+  const closing = makeReplacementSource();
+  const replacement = { id: "native-replacement" };
+  const laterOpened = { id: "later-opened" };
+
+  tracker.observeTabOpen(replacement, [closing, replacement]);
+  tracker.observeTabOpen(laterOpened, [closing, replacement, laterOpened]);
+
+  assertEquals(
+    tracker.finishTabClose(closing),
+    replacement,
+    "the first TabOpen object remains authoritative for the transaction",
+  );
+}
+
+function testOnlyCurrentReplacementIsExcluded(): void {
+  const nativeReplacement: FakeTab = {
+    id: "native-replacement",
+    url: "about:newtab",
+    userContextId: 0,
+  };
+  const floorpStart: FakeTab = {
+    id: "floorp-start",
+    url: "about:newtab",
+    userContextId: 0,
+  };
+  const userNewtab: FakeTab = {
+    id: "user-newtab",
+    url: "about:newtab",
+    userContextId: 0,
+  };
+  const leftoverReplacement: FakeTab = {
+    id: "leftover-replacement",
+    url: "about:newtab",
+    userContextId: 0,
+  };
+  const containerWorkspaceTab: FakeTab = {
+    id: "container-workspace",
+    url: "about:newtab",
+    userContextId: 7,
+  };
+
+  const remaining = excludeTrackedReplacement(
+    [
+      nativeReplacement,
+      floorpStart,
+      userNewtab,
+      leftoverReplacement,
+      containerWorkspaceTab,
+    ],
+    nativeReplacement,
+  );
+
+  assert(
+    !remaining.includes(nativeReplacement),
+    "exact replacement is removed",
+  );
+  assert(
+    remaining.includes(floorpStart),
+    "Floorp Start must remain a user tab",
+  );
+  assert(remaining.includes(userNewtab), "user-created newtab must remain");
+  assert(
+    remaining.includes(leftoverReplacement),
+    "a replacement left from an earlier close must remain",
+  );
+  assert(
+    remaining.includes(containerWorkspaceTab),
+    "container workspace tab must remain",
+  );
+}
+
+function testMissingSignalPreservesEveryTab(): void {
+  const floorpStart: FakeTab = { id: "floorp-start", url: "about:newtab" };
+  const userNewtab: FakeTab = { id: "user-newtab", url: "about:newtab" };
+  const remaining = excludeTrackedReplacement(
+    [floorpStart, userNewtab],
+    null,
+  );
+
+  assertEquals(remaining.length, 2, "missing signal must preserve all tabs");
+  assert(remaining.includes(floorpStart), "Floorp Start is preserved");
+  assert(remaining.includes(userNewtab), "user newtab is preserved");
+}
+
+function testSuppressedCloseStillConsumesTransaction(): void {
+  const tracker = new FirefoxTabReplacementTracker<FakeTab>();
+  const closing = makeReplacementSource();
+  const replacement = { id: "native-replacement" };
+  tracker.observeTabOpen(replacement, [closing, replacement]);
+
+  assertEquals(
+    tracker.finishTabClose(closing),
+    replacement,
+    "the transaction is consumed before a suppressed handler returns",
+  );
+  assertEquals(
+    tracker.finishTabClose(closing),
+    null,
+    "a consumed transaction cannot be reused",
+  );
+}
+
+function testTerminalGuardRejectsManagerCreatedReentrancy(): void {
+  const tracker = new FirefoxTabReplacementTracker<FakeTab>();
+  const closing = makeReplacementSource();
+  const replacement = { id: "native-replacement" };
+  tracker.observeTabOpen(replacement, [closing, replacement]);
+  tracker.finishTabClose(closing);
+
+  const managerCreated = {
+    id: "manager-created",
+    url: "about:newtab",
+    userContextId: 7,
+  };
+  tracker.observeTabOpen(managerCreated, [closing, managerCreated]);
+
+  assertEquals(
+    tracker.finishTabClose(closing),
+    null,
+    "tabs opened reentrantly during TabClose cannot revive the transaction",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "Firefox replacement signal is capability checked",
+      fn: testFirefoxReplacementSignalIsCapabilityChecked,
+    },
+    {
+      name: "linked-browser origin attributes are authoritative",
+      fn: testLinkedBrowserOriginAttributesAreAuthoritative,
+    },
+    {
+      name: "linked-browser origin lookup fails closed",
+      fn: testLinkedBrowserOriginLookupFailsClosed,
+    },
+    {
+      name: "native replacement is captured by exact identity",
+      fn: testNativeReplacementIsCapturedByExactIdentity,
+    },
+    {
+      name: "ambiguous closing sources fail safe",
+      fn: testAmbiguousClosingSourcesFailSafe,
+    },
+    {
+      name: "opened tab cannot be its own closing source",
+      fn: testOpenedTabCannotBeItsOwnClosingSource,
+    },
+    {
+      name: "first captured tab cannot be overwritten",
+      fn: testFirstCapturedTabCannotBeOverwritten,
+    },
+    {
+      name: "only current replacement is excluded",
+      fn: testOnlyCurrentReplacementIsExcluded,
+    },
+    {
+      name: "missing signal preserves every tab",
+      fn: testMissingSignalPreservesEveryTab,
+    },
+    {
+      name: "suppressed close consumes transaction",
+      fn: testSuppressedCloseStillConsumesTransaction,
+    },
+    {
+      name: "terminal guard rejects manager-created reentrancy",
+      fn: testTerminalGuardRejectsManagerCreatedReentrancy,
+    },
+  ];
+
+  await runTests("tabReplacementLifecycle.test.ts", tests);
+}
+
+await runAllTests();

--- a/browser-features/chrome/common/workspaces/utils/tab-replacement-lifecycle.ts
+++ b/browser-features/chrome/common/workspaces/utils/tab-replacement-lifecycle.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MPL-2.0
+
+type FirefoxTabRemovalState = {
+  closing?: unknown;
+  _endRemoveArgs?: unknown;
+};
+
+type BrowserWithBrowsingContext = {
+  browsingContext?: unknown;
+};
+
+type BrowsingContextWithOriginAttributes = {
+  originAttributes?: unknown;
+};
+
+type OriginAttributesWithUserContextId = {
+  userContextId?: unknown;
+};
+
+/**
+ * Read the container identity from the authoritative browsing context.
+ *
+ * The `usercontextid` attributes on the tab and browser elements can be
+ * present before Firefox has created the replacement browser in that origin
+ * context. Never use those mirrored DOM attributes as proof that a native
+ * replacement is safe to reuse.
+ */
+export function getOriginUserContextId(browser: unknown): number | null {
+  try {
+    if (typeof browser !== "object" || browser === null) {
+      return null;
+    }
+
+    const browsingContext = (browser as BrowserWithBrowsingContext)
+      .browsingContext;
+    if (typeof browsingContext !== "object" || browsingContext === null) {
+      return null;
+    }
+
+    const originAttributes = (
+      browsingContext as BrowsingContextWithOriginAttributes
+    ).originAttributes;
+    if (typeof originAttributes !== "object" || originAttributes === null) {
+      return null;
+    }
+
+    const userContextId = (
+      originAttributes as OriginAttributesWithUserContextId
+    ).userContextId;
+    return typeof userContextId === "number" &&
+        Number.isSafeInteger(userContextId) &&
+        userContextId >= 0
+      ? userContextId
+      : null;
+  } catch {
+    // Access to linked browser state can fail while Firefox is tearing down a
+    // tab. Unknown identity must never authorize replacement reuse.
+    return null;
+  }
+}
+
+/**
+ * Fail-closed check for reusing a tracked Firefox replacement in a workspace.
+ */
+export function hasOriginUserContextId(
+  browser: unknown,
+  expectedUserContextId: number,
+): boolean {
+  if (
+    !Number.isSafeInteger(expectedUserContextId) ||
+    expectedUserContextId < 0
+  ) {
+    return false;
+  }
+
+  return getOriginUserContextId(browser) === expectedUserContextId;
+}
+
+/**
+ * Firefox sets `_endRemoveArgs[1]` to true before synchronously opening the
+ * keep-alive tab that replaces the last visible tab in a window. Treat the
+ * private field as a capability: if its shape or value is unavailable, fail
+ * safe and do not classify any opened tab as a replacement.
+ */
+export function hasFirefoxReplacementSignal(tab: unknown): boolean {
+  if (typeof tab !== "object" || tab === null) {
+    return false;
+  }
+
+  const removalState = tab as FirefoxTabRemovalState;
+  return removalState.closing === true &&
+    Array.isArray(removalState._endRemoveArgs) &&
+    removalState._endRemoveArgs[1] === true;
+}
+
+/** Remove only the exact Firefox replacement object captured for this close. */
+export function excludeTrackedReplacement<T extends object>(
+  tabs: readonly T[],
+  replacement: T | null,
+): T[] {
+  return tabs.filter((tab) => tab !== replacement);
+}
+
+/**
+ * Correlates Firefox's synchronous TabOpen -> TabClose replacement lifecycle.
+ * A WeakMap keeps identity authoritative; a WeakSet prevents tabs opened
+ * reentrantly by the workspace manager during TabClose from being associated
+ * with the closing transaction after it has become terminal.
+ */
+export class FirefoxTabReplacementTracker<T extends object> {
+  private readonly replacementByClosingTab = new WeakMap<T, T>();
+  private readonly terminalClosingTabs = new WeakSet<T>();
+
+  observeTabOpen(openedTab: T, tabs: readonly T[]): void {
+    const closingCandidates = tabs.filter((candidate) =>
+      candidate !== openedTab &&
+      !this.terminalClosingTabs.has(candidate) &&
+      hasFirefoxReplacementSignal(candidate)
+    );
+
+    if (closingCandidates.length !== 1) {
+      return;
+    }
+
+    const closingTab = closingCandidates[0];
+    if (!this.replacementByClosingTab.has(closingTab)) {
+      this.replacementByClosingTab.set(closingTab, openedTab);
+    }
+  }
+
+  /**
+   * Make the transaction terminal before its TabClose handler can create tabs,
+   * then consume and return the exact TabOpen object captured for it.
+   */
+  finishTabClose(closingTab: T): T | null {
+    this.terminalClosingTabs.add(closingTab);
+    const replacement = this.replacementByClosingTab.get(closingTab) ?? null;
+    this.replacementByClosingTab.delete(closingTab);
+    return replacement;
+  }
+}

--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -25,6 +25,11 @@ import { configStore, enabled } from "./data/config.ts";
 import type { WorkspaceIcons } from "./utils/workspace-icons.ts";
 import type { WorkspacesDataManager } from "./workspacesDataManagerBase.tsx";
 import { isRight } from "fp-ts/Either";
+import {
+  excludeTrackedReplacement,
+  FirefoxTabReplacementTracker,
+  hasOriginUserContextId,
+} from "./utils/tab-replacement-lifecycle.ts";
 
 interface TabEvent extends Event {
   target: XULElement;
@@ -38,6 +43,9 @@ export class WorkspacesTabManager {
   // bulk tab removal (workspace deletion) so that closing tabs one-by-one
   // does not interfere with the deletion flow (fixes #2247).
   private suppressTabCloseHandling = false;
+  private readonly firefoxReplacementTracker = new FirefoxTabReplacementTracker<
+    XULElement
+  >();
   constructor(iconCtx: WorkspaceIcons, dataManagerCtx: WorkspacesDataManager) {
     this.iconCtx = iconCtx;
     this.dataManagerCtx = dataManagerCtx;
@@ -52,13 +60,19 @@ export class WorkspacesTabManager {
       ).SessionStore.promiseAllWindowsRestored
         .then(() => {
           this.initializeWorkspace();
-          globalThis.addEventListener("TabClose", this.boundHandleTabClose as EventListener);
+          globalThis.addEventListener(
+            "TabClose",
+            this.boundHandleTabClose as EventListener,
+          );
           globalThis.addEventListener("TabOpen", this.boundHandleTabOpen);
         })
         .catch((error: Error) => {
           console.error("Error waiting for windows restore:", error);
           this.initializeWorkspace();
-          globalThis.addEventListener("TabClose", this.boundHandleTabClose as EventListener);
+          globalThis.addEventListener(
+            "TabClose",
+            this.boundHandleTabClose as EventListener,
+          );
           globalThis.addEventListener("TabOpen", this.boundHandleTabOpen);
         });
     };
@@ -196,15 +210,25 @@ export class WorkspacesTabManager {
   private boundHandleTabOpen: (event: Event) => void;
 
   public cleanup() {
-    globalThis.removeEventListener("TabClose", this.boundHandleTabClose as EventListener);
+    globalThis.removeEventListener(
+      "TabClose",
+      this.boundHandleTabClose as EventListener,
+    );
     globalThis.removeEventListener("TabOpen", this.boundHandleTabOpen);
   }
 
   private handleTabClose = (event: TabEvent) => {
+    const tab = event.target as XULElement;
+    // Consume the transaction before any close logic can synchronously create
+    // another tab. This also runs for suppressed closes so their transaction
+    // cannot be revived by a reentrant TabOpen.
+    const trackedReplacement = this.firefoxReplacementTracker.finishTabClose(
+      tab,
+    );
+
     // Skip workspace-empty logic when bulk-removing tabs (e.g. workspace deletion)
     if (this.suppressTabCloseHandling) return;
 
-    const tab = event.target as XULElement;
     let workspaceId = this.getWorkspaceIdFromAttribute(tab);
 
     // If the tab has no workspace attribute, assign it to the current workspace
@@ -217,43 +241,37 @@ export class WorkspacesTabManager {
         return;
       }
     }
+    if (!workspaceId) return;
+    const closingWorkspaceId = workspaceId;
 
     const currentWorkspaceId = this.dataManagerCtx.getSelectedWorkspaceID();
-    const isCurrentWorkspace = workspaceId === currentWorkspaceId;
+    const isCurrentWorkspace = closingWorkspaceId === currentWorkspaceId;
     const allTabs = globalThis.gBrowser.tabs as XULElement[];
+    const remainingTabs = allTabs.filter((t) => t !== tab);
+    const replacementTab = trackedReplacement !== null &&
+        remainingTabs.includes(trackedReplacement)
+      ? trackedReplacement
+      : null;
+    const remainingUserTabs = excludeTrackedReplacement(
+      remainingTabs,
+      replacementTab,
+    );
 
     const resolveWorkspaceIdForClose = (
       targetTab: XULElement,
     ): TWorkspaceID => {
       return this.getWorkspaceIdFromAttribute(targetTab) ?? currentWorkspaceId;
     };
-    const workspaceTabs = allTabs.filter((t) => {
-      return t !== tab && resolveWorkspaceIdForClose(t) === workspaceId;
+    const workspaceTabs = remainingUserTabs.filter((t) => {
+      return resolveWorkspaceIdForClose(t) === closingWorkspaceId;
     });
 
-    const validWorkspaceTabs = workspaceTabs.filter((t) => {
-      // Firefox auto-creates a "replacement" tab (blank page in the default
-      // container) right before firing TabClose when
-      // browser.tabs.closeWindowWithLastTab=false. Such tabs have no user
-      // value and must not prevent the "workspace becoming empty" detection.
-      // Earlier code tried to identify them by creation timestamp, but that is
-      // unreliable: Firefox creates the replacement *before* TabClose fires,
-      // and a replacement left over from a previous close also looks "old".
-      // Instead, identify replacements by their stable intrinsic features:
-      // blank/newtab URL + default container + not pinned.
-      // Container-switch / reopen tabs (fixes #2193) are created in the
-      // workspace's *target* container, so they keep userContextId > 0 and are
-      // never misclassified here.
-      return !this.isAutoReplacementTab(t as unknown as XULElement);
-    });
-
-    if (isCurrentWorkspace && validWorkspaceTabs.length === 0) {
+    if (isCurrentWorkspace && workspaceTabs.length === 0) {
       // Current workspace is becoming empty.
       // Check if there are tabs in OTHER workspaces.
-      const otherWorkspaceTabs = allTabs.filter((t) => {
-        if (t === tab) return false;
+      const otherWorkspaceTabs = remainingUserTabs.filter((t) => {
         const wsId = resolveWorkspaceIdForClose(t);
-        return wsId !== workspaceId;
+        return wsId !== closingWorkspaceId;
       });
 
       if (otherWorkspaceTabs.length > 0) {
@@ -261,6 +279,14 @@ export class WorkspacesTabManager {
         // Check if exitOnLastTabClose is enabled - if not, just create a new tab
         // and switch to another workspace instead of closing the window.
         if (!configStore.exitOnLastTabClose) {
+          if (replacementTab) {
+            this.reuseOrReplaceTrackedReplacement(
+              replacementTab,
+              closingWorkspaceId,
+              false,
+            );
+          }
+
           // Find the first workspace with tabs and switch to it
           const firstOtherTab = otherWorkspaceTabs[0];
           const targetWorkspaceId = this.getWorkspaceIdFromAttribute(
@@ -272,25 +298,16 @@ export class WorkspacesTabManager {
           return;
         }
 
-        // Search for an existing tab (e.g. auto-created by Firefox) to use as replacement
-        // to avoid duplicating tabs on session restore.
-        const remainingTabs = allTabs.filter((t) => t !== tab);
-        let replacement = remainingTabs.find((t) => {
-          const tWsId = this.getWorkspaceIdFromAttribute(t);
-          // Use if it belongs to current workspace (but was filtered as 'recent')
-          // or if it has no workspace assigned yet.
-          return tWsId === workspaceId || !tWsId;
-        });
+        // Reuse only the exact TabOpen object Firefox created for this close,
+        // and only when its browsing context is in the workspace container.
+        const replacement = this.reuseOrReplaceTrackedReplacement(
+          replacementTab,
+          closingWorkspaceId,
+          true,
+        );
 
-        if (!replacement) {
-          replacement = this.createTabForWorkspace(workspaceId, true);
-        } else {
-          this.setWorkspaceIdToAttribute(replacement, workspaceId);
-          globalThis.gBrowser.selectedTab = replacement;
-        }
-
-        replacement.setAttribute(WORKSPACE_LAST_SHOW_ID, workspaceId);
-        this.dataManagerCtx.setCurrentWorkspaceID(workspaceId);
+        replacement.setAttribute(WORKSPACE_LAST_SHOW_ID, closingWorkspaceId);
+        this.dataManagerCtx.setCurrentWorkspaceID(closingWorkspaceId);
         this.updateTabsVisibility();
 
         // Set pending exit pref to collapse duplicates on restart
@@ -308,75 +325,67 @@ export class WorkspacesTabManager {
         // Check if exitOnLastTabClose is enabled - if not, create a new tab
         // instead of closing the window.
         if (!configStore.exitOnLastTabClose) {
-          // Firefox already created a replacement tab due to closeWindowWithLastTab=false,
-          // so we just need to assign it to the current workspace.
-          const remainingTabs = (globalThis.gBrowser.tabs as XULElement[])
-            .filter((t) => t !== tab);
-          if (remainingTabs.length > 0) {
-            const newTab = remainingTabs[0];
-
-            // Check if the replacement tab's container matches the workspace's container.
-            // Firefox creates replacement tabs in the default container (userContextId=0),
-            // which is wrong for workspaces that have a specific container configured.
-            const workspace = this.dataManagerCtx.getRawWorkspace(workspaceId);
-            const workspaceUserContextId = workspace?.userContextId ?? 0;
-            const tabActualUserContextId = Number.parseInt(
-              newTab.getAttribute("usercontextid") || "0",
-              10,
-            );
-
-            if (
-              workspaceUserContextId > 0 &&
-              tabActualUserContextId !== workspaceUserContextId
-            ) {
-              // Firefox's replacement tab is in the wrong container. Remove it and
-              // create a proper one in the correct container (#2193).
-              this.suppressTabCloseHandling = true;
-              try {
-                globalThis.gBrowser.removeTab(newTab);
-              } finally {
-                this.suppressTabCloseHandling = false;
-              }
-              this.createTabForWorkspace(workspaceId, true);
-            } else {
-              this.setWorkspaceIdToAttribute(newTab, workspaceId);
-              globalThis.gBrowser.selectedTab = newTab;
-            }
-          } else {
-            this.createTabForWorkspace(workspaceId, true);
-          }
+          this.reuseOrReplaceTrackedReplacement(
+            replacementTab,
+            closingWorkspaceId,
+            true,
+          );
           this.updateTabsVisibility();
           return;
         }
 
-        // exitOnLastTabClose is true. Before closing, verify there truly are no
-        // remaining USER tabs. Firefox's auto-replacement tab (blank page in the
-        // default container) does not count — it should not prevent the quit.
-        // Real user tabs (e.g. one the user just opened) must keep the window
-        // alive, which is what prevents a premature close (#2152).
-        const remainingTabs = (globalThis.gBrowser.tabs as XULElement[])
-          .filter((t) => t !== tab)
-          .filter((t) => !this.isAutoReplacementTab(t));
-        if (remainingTabs.length === 0) {
+        // exitOnLastTabClose is true. Only the exact replacement for this
+        // transaction is disposable; Floorp Start, user newtabs, and stale
+        // blank tabs all keep the window alive (#2509).
+        if (remainingUserTabs.length === 0) {
+          if (replacementTab) {
+            this.reuseOrReplaceTrackedReplacement(
+              replacementTab,
+              closingWorkspaceId,
+              true,
+            );
+          }
           Services.prefs.setBoolPref(WORKSPACE_PENDING_EXIT_PREF_NAME, true);
           setTimeout(() => {
             globalThis.close();
           }, 0);
         } else {
           // Remaining user tabs exist (e.g., user just opened a new tab).
-          // Assign the first one to the workspace instead of closing.
-          const newTab = remainingTabs[0];
-          this.setWorkspaceIdToAttribute(newTab, workspaceId);
+          // Keep any tracked native replacement only after validating its
+          // origin context, then assign the first user tab to the workspace.
+          if (replacementTab) {
+            this.reuseOrReplaceTrackedReplacement(
+              replacementTab,
+              closingWorkspaceId,
+              false,
+            );
+          }
+          const newTab = remainingUserTabs[0];
+          this.setWorkspaceIdToAttribute(newTab, closingWorkspaceId);
           globalThis.gBrowser.selectedTab = newTab;
           this.updateTabsVisibility();
         }
       }
+    } else if (replacementTab) {
+      // A Firefox replacement should normally imply the current workspace is
+      // becoming empty. If visibility or attribution state says otherwise,
+      // still fail closed rather than leaving an unvalidated native tab alive.
+      this.reuseOrReplaceTrackedReplacement(
+        replacementTab,
+        closingWorkspaceId,
+        false,
+      );
+      this.updateTabsVisibility();
     }
   };
 
   private handleTabOpen = (event: Event) => {
     try {
       const tab = (event as CustomEvent).target as XULElement;
+      this.firefoxReplacementTracker.observeTabOpen(
+        tab,
+        globalThis.gBrowser.tabs as XULElement[],
+      );
       const wsId = this.getWorkspaceIdFromAttribute(tab) ??
         this.dataManagerCtx.getSelectedWorkspaceID();
       if (!this.getWorkspaceIdFromAttribute(tab)) {
@@ -394,7 +403,7 @@ export class WorkspacesTabManager {
       selectedTab &&
       !selectedTab.hasAttribute(WORKSPACE_LAST_SHOW_ID) &&
       selectedTab.getAttribute(WORKSPACE_TAB_ATTRIBUTION_ID) ===
-      currentWorkspaceId
+        currentWorkspaceId
     ) {
       const lastShowWorkspaceTabs = document?.querySelectorAll(
         `[${WORKSPACE_LAST_SHOW_ID}="${currentWorkspaceId}"]`,
@@ -433,7 +442,9 @@ export class WorkspacesTabManager {
     const tabGroups = globalThis.gBrowser.tabGroups;
     for (const group of tabGroups) {
       const hasVisibleTabInGroup = (group.tabs as Array<XULElement>)
-        .some((tab) => this.getWorkspaceIdFromAttribute(tab) === currentWorkspaceId);
+        .some((tab) =>
+          this.getWorkspaceIdFromAttribute(tab) === currentWorkspaceId
+        );
       group.style.display = hasVisibleTabInGroup ? "" : "none";
     }
 
@@ -448,7 +459,7 @@ export class WorkspacesTabManager {
           if (child.tagName !== "tab") return false;
           return (
             this.getWorkspaceIdFromAttribute(child as XULElement) ===
-            currentWorkspaceId
+              currentWorkspaceId
           );
         },
       );
@@ -495,53 +506,64 @@ export class WorkspacesTabManager {
   }
 
   /**
-   * Detect whether a tab is an auto-created Firefox "replacement" tab.
-   *
-   * When `browser.tabs.closeWindowWithLastTab` is forced to false (which this
-   * feature does), Firefox spawns a blank replacement tab *before* firing
-   * TabClose to keep the window from going empty. Such tabs have no user value
-   * and must not block the "workspace becoming empty" detection.
-   *
-   * Replacements are identified by stable intrinsic features rather than by
-   * creation timestamp (which proved unreliable — Firefox creates the
-   * replacement before TabClose fires, and one left over from a previous close
-   * looks old). Specifically: blank/newtab URL + default container (no
-   * userContextId) + not pinned.
-   *
-   * Tabs created by container-switch / reopen logic (#2193) and "Open Link in
-   * New Tab" always carry a real userContextId or a non-blank URL, so they are
-   * never misclassified as replacements here.
+   * Reuse a tracked native replacement only when its authoritative browsing
+   * context matches the workspace. A replacement with missing or mismatched
+   * origin attributes is replaced before it is removed, so Firefox never sees
+   * an empty window and creates another keep-alive tab during this handler.
    */
-  private isAutoReplacementTab(tab: XULElement): boolean {
-    try {
-      // Pinned tabs are never auto-replacements.
-      if (tab.getAttribute("pinned") === "true") return false;
+  private reuseOrReplaceTrackedReplacement(
+    replacement: XULElement | null,
+    workspaceId: TWorkspaceID,
+    select: boolean,
+  ): XULElement {
+    const expectedUserContextId = this.dataManagerCtx.getRawWorkspace(
+      workspaceId,
+    )?.userContextId ?? 0;
 
-      // Replacement tabs are always created in the default container.
-      // Any non-zero userContextId means it is a user/container tab.
-      const userContextId = Number.parseInt(
-        tab.getAttribute("usercontextid") || "0",
-        10,
-      );
-      if (userContextId > 0) return false;
+    if (
+      replacement &&
+      this.tabHasOriginUserContextId(replacement, expectedUserContextId)
+    ) {
+      this.setWorkspaceIdToAttribute(replacement, workspaceId);
+      if (select) {
+        globalThis.gBrowser.selectedTab = replacement;
+      }
+      return replacement;
+    }
 
-      const browser = globalThis.gBrowser.getBrowserForTab(
-        tab as unknown as XULElement,
-      );
-      const url = browser?.currentURI?.spec || "";
-      // Replacement tabs are blank / newtab / home pages.
-      const isBlankOrNewTab = !url ||
-        url === "about:blank" ||
-        url === "about:newtab" ||
-        url === "about:home";
-      return isBlankOrNewTab;
-    } catch (e) {
+    const workspaceTab = this.createTabForWorkspace(workspaceId, select);
+    if (!this.tabHasOriginUserContextId(workspaceTab, expectedUserContextId)) {
       console.error(
-        "WorkspacesTabManager: error checking if tab is auto-replacement",
-        e,
+        "[WorkspacesTabManager] Failed to create a tab in the workspace container",
       );
-      // On error, assume NOT a replacement so we never accidentally treat a
-      // real user tab as disposable.
+      throw new Error("Workspace tab browsing context mismatch");
+    }
+    if (!replacement) {
+      return workspaceTab;
+    }
+
+    const wasSuppressingTabClose = this.suppressTabCloseHandling;
+    this.suppressTabCloseHandling = true;
+    try {
+      globalThis.gBrowser.removeTab(replacement);
+    } finally {
+      this.suppressTabCloseHandling = wasSuppressingTabClose;
+    }
+    return workspaceTab;
+  }
+
+  private tabHasOriginUserContextId(
+    tab: XULElement,
+    expectedUserContextId: number,
+  ): boolean {
+    try {
+      const browser = globalThis.gBrowser.getBrowserForTab(tab);
+      return hasOriginUserContextId(browser, expectedUserContextId);
+    } catch (error) {
+      console.error(
+        "[WorkspacesTabManager] Failed to inspect tab origin attributes",
+        error,
+      );
       return false;
     }
   }
@@ -579,8 +601,8 @@ export class WorkspacesTabManager {
         const targetWorkspaceId = defaultId !== workspaceId
           ? defaultId
           : fallbackWorkspaceId && fallbackWorkspaceId !== workspaceId
-            ? fallbackWorkspaceId
-            : null;
+          ? fallbackWorkspaceId
+          : null;
 
         if (targetWorkspaceId) {
           const defaultTabs = document?.querySelectorAll(
@@ -672,7 +694,7 @@ export class WorkspacesTabManager {
       if (
         currentlySelectedTab &&
         this.getWorkspaceIdFromAttribute(currentlySelectedTab) ===
-        prevWorkspaceId
+          prevWorkspaceId
       ) {
         currentlySelectedTab.setAttribute(
           WORKSPACE_LAST_SHOW_ID,


### PR DESCRIPTION
## Summary

- track Firefox''s keep-alive replacement tab by exact object identity
- validate container identity from `browsingContext.originAttributes.userContextId` instead of mutable DOM attributes
- fail closed on malformed origin state
- create and verify the correct workspace-container tab before removing a mismatched native replacement

## Verification

- `deno task test --near browser-features/chrome/common/workspaces/test/tabReplacementLifecycle.test.ts` — 1 passed, 0 failed
- tests cover attribute spoofing, ambiguity, reentrancy, default/positive contexts, malformed/throwing origin state, and preserved user tabs
- affected `bridge/loader-features` production bundle — passed
- static format/lint/type checks and independent Firefox-lifecycle audit — passed

## Build note

The repository-wide before-mach build is blocked by the unchanged clean-base `pages-newtab` / `lucide-react@0.562.0` `MISSING_EXPORT` issue. The affected production bundle passes.

Closes #2509