### PR TITLE
fix(panel-sidebar): restore web and extension panel loading on Gecko 153

### DIFF
--- a/browser-features/chrome/@types/xul-window.d.ts
+++ b/browser-features/chrome/@types/xul-window.d.ts
@@ -233,10 +233,6 @@ declare namespace globalThis {
     DEFAULT_REMOTE_TYPE: string;
     EXTENSION_REMOTE_TYPE: string;
     deserializePrincipal(principal: unknown): unknown;
-    getRemoteTypeForURI(uri: string, ...args: unknown[]): string;
-    predictOriginAttributes(
-      options: Record<string, unknown>,
-    ): Record<string, unknown>;
   };
   var UrlbarUtils: { stripUnsafeProtocolOnPaste(text: string): string };
   var E: unknown;

--- a/browser-features/chrome/common/panel-sidebar/components/panel-sidebar.tsx
+++ b/browser-features/chrome/common/panel-sidebar/components/panel-sidebar.tsx
@@ -164,19 +164,6 @@ export class CPanelSidebar {
       const sidebarAction = getExtensionSidebarAction(panel.extensionId);
 
       browser.addEventListener("DOMContentLoaded", () => {
-        const oa = globalThis.E10SUtils.predictOriginAttributes({ browser });
-        browser.setAttribute(
-          "remoteType",
-          globalThis.E10SUtils.getRemoteTypeForURI(
-            panel.url ?? "",
-            true,
-            false,
-            globalThis.E10SUtils.EXTENSION_REMOTE_TYPE,
-            null,
-            oa,
-          ),
-        );
-
         browser.contentWindow.loadPanel(
           panel.extensionId,
           sidebarAction.default_panel,

--- a/browser-features/chrome/common/panel-sidebar/test/webPanelBrowserLoad.test.ts
+++ b/browser-features/chrome/common/panel-sidebar/test/webPanelBrowserLoad.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+} from "../../../test/utils/test_harness.ts";
+import {
+  loadUriInWebPanelBrowser,
+  type WebPanelBrowserElement,
+} from "../utils/web-panel-browser.ts";
+
+function testWebPanelLoadUsesSupportedOptions(): void {
+  const captured: { uri: nsIURI | null; options: object | null } = {
+    uri: null,
+    options: null,
+  };
+  const browser = {
+    loadURI(uri: nsIURI, options?: object): void {
+      captured.uri = uri;
+      captured.options = options ?? null;
+    },
+  } as unknown as WebPanelBrowserElement;
+
+  const targetURL = "https://example.com/panel-test";
+  loadUriInWebPanelBrowser(browser, targetURL);
+
+  assertEquals(
+    captured.uri?.spec,
+    targetURL,
+    "should load the requested URI",
+  );
+  assert(captured.options !== null, "should pass load options");
+
+  const options = captured.options as Record<string, unknown>;
+  assert(
+    options.triggeringPrincipal !== undefined,
+    "should pass a triggering principal",
+  );
+  assert(
+    !("remoteType" in options),
+    "should not pass the removed remoteType option",
+  );
+  assert(
+    !("remoteTypeOverride" in options),
+    "should not force a remote type override for a web URL",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  await runTests("webPanelBrowserLoad.test.ts", [
+    {
+      name: "web panel loads with Gecko-supported options",
+      fn: testWebPanelLoadUsesSupportedOptions,
+    },
+  ]);
+}

--- a/browser-features/chrome/common/panel-sidebar/utils/web-panel-browser.ts
+++ b/browser-features/chrome/common/panel-sidebar/utils/web-panel-browser.ts
@@ -81,17 +81,8 @@ export function loadUriInWebPanelBrowser(
   url: string,
 ): void {
   const principal = Services.scriptSecurityManager.getSystemPrincipal();
-  const oa = globalThis.E10SUtils.predictOriginAttributes({ browser });
   const loadURIOptions = {
     triggeringPrincipal: principal,
-    remoteType: globalThis.E10SUtils.getRemoteTypeForURI(
-      url,
-      true,
-      false,
-      globalThis.E10SUtils.DEFAULT_REMOTE_TYPE,
-      null,
-      oa,
-    ),
   };
 
   if (typeof browser.loadURI !== "function") {

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -13,9 +13,6 @@ import { waitForActor } from "./shared/waitForActor.sys.mts";
 import { CookieHelper } from "./shared/CookieHelper.sys.mts";
 import { NetworkIdleHelper } from "./shared/NetworkIdleHelper.sys.mts";
 
-const { E10SUtils } = ChromeUtils.importESModule(
-  "resource://gre/modules/E10SUtils.sys.mjs",
-);
 const { setTimeout, clearTimeout } = ChromeUtils.importESModule(
   "resource://gre/modules/Timer.sys.mjs",
 );
@@ -767,17 +764,8 @@ class TabManager {
     const { browser } = this._getInstance(instanceId);
     const principal = Services.scriptSecurityManager.getSystemPrincipal();
 
-    const oa = E10SUtils.predictOriginAttributes({ browser });
     const loadURIOptions = {
       triggeringPrincipal: principal,
-      remoteType: E10SUtils.getRemoteTypeForURI(
-        url,
-        true,
-        false,
-        E10SUtils.DEFAULT_REMOTE_TYPE,
-        null,
-        oa,
-      ),
     };
 
     // Check if browser.loadURI is defined before calling it

--- a/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
@@ -19,9 +19,6 @@ import { waitForActor } from "./shared/waitForActor.sys.mts";
 import { CookieHelper } from "./shared/CookieHelper.sys.mts";
 import { NetworkIdleHelper } from "./shared/NetworkIdleHelper.sys.mts";
 
-const { E10SUtils } = ChromeUtils.importESModule(
-  "resource://gre/modules/E10SUtils.sys.mjs",
-);
 const { HiddenFrame } = ChromeUtils.importESModule(
   "resource://gre/modules/HiddenFrame.sys.mjs",
 );
@@ -179,8 +176,8 @@ class webScraper {
    *
    * This method:
    * - Validates the browser instance exists
-   * - Sets up proper security principals and origin attributes
-   * - Loads the URL with appropriate remote type configuration
+   * - Sets up the triggering security principal
+   * - Loads the URL in the browser instance
    * - Monitors page load progress and resolves when navigation is complete
    * - Handles various edge cases like inner-frame events and same-document changes
    *
@@ -196,19 +193,8 @@ class webScraper {
     }
 
     const principal = Services.scriptSecurityManager.getSystemPrincipal();
-    const oa = E10SUtils.predictOriginAttributes({
-      browser,
-    });
     const loadURIOptions = {
       triggeringPrincipal: principal,
-      remoteType: E10SUtils.getRemoteTypeForURI(
-        url,
-        true,
-        false,
-        E10SUtils.DEFAULT_REMOTE_TYPE,
-        null,
-        oa,
-      ),
     };
 
     const uri = Services.io.newURI(url);


### PR DESCRIPTION
Fixes #2582

## What

- Stop predicting and forcing remote types before loading panel sidebar content.
- Let Gecko's supported `loadURI` and WebExtension `loadPanel` paths select the appropriate remoteness.
- Remove the same deleted Gecko API usage from the WebScraper and TabManager navigation paths, along with the stale TypeScript declarations.
- Add a regression test for the supported web-panel `loadURI` options.

## Why

Gecko 153 removed the `E10SUtils.predictOriginAttributes` and `getRemoteTypeForURI` APIs that these paths still called. The exception occurred before content could load, leaving web panels at `about:blank` and Floorp extension panels without their inner extension browser.

## Impact

Web panels and Floorp extension panels such as Sidebery load again on Gecko 153. This does not change panel data or require a migration.

The WebScraper and TabManager files are included because their navigation paths used the same removed Gecko APIs. Their cleanup keeps those paths compatible without changing their public API.

## Testing

- `deno fmt --check` for the new regression test
- `deno lint` for the changed logic and test files
- `deno check --sloppy-imports` for the panel source and regression test
- Panel-sidebar nearby browser tests: 7 passed, 0 failed
- Production loader-feature build
- Production loader-modules build
- `deno task feles-build build --phase before-mach`
- Repository search confirmed no remaining `predictOriginAttributes`, `getRemoteTypeForURI`, or `getRemoteTypeForURIObject` references under `browser-features` and `libs`
- Isolated Gecko 153 Floorp runtime with the built production assets:
  - Floorp Docs web panel loaded successfully
  - Sidebery 5.6.1 Floorp extension panel loaded its `moz-extension://` sidebar page
  - Reopen behavior, `autoUnload=false`, container identity, native Sidebery, and static Bookmarks passed
  - No deleted-API console errors remained
  - WebScraper HTTPS navigation passed

## Residual

The public TabManager OS API flow still encounters a separate `ownerGlobal` / instance lifecycle issue before reaching the changed `navigate()` path. This PR removes the deleted Gecko API usage from that path, but does not claim to fix or fully verify the separate TabManager lifecycle issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified web page and sidebar navigation loading.
  * Browser loading now relies on platform defaults while preserving the correct security context.
  * Removed unsupported process-routing options, improving compatibility with current browser behavior.

* **Tests**
  * Added coverage to verify web panels load requested pages with the appropriate loading options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->