### PR TITLE
fix(release): bind stable updates to immutable provenance

### DIFF
--- a/.github/workflows/assemble-release-bundle.yml
+++ b/.github/workflows/assemble-release-bundle.yml
@@ -1,0 +1,841 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+name: "(P) Assemble immutable release bundle v2"
+
+on:
+  workflow_call:
+    inputs:
+      source_workflow_run_id:
+        description: "Current Floorp workflow run containing every source artifact"
+        type: string
+        required: true
+      floorp_head_sha:
+        description: "Exact lowercase Floorp commit SHA used by every package"
+        type: string
+        required: true
+      validation_only:
+        description: "Assemble an unsigned bundle that cannot be published"
+        type: boolean
+        required: false
+        default: false
+      runtime_context_artifact:
+        description: 'Exact JSON identity: {"name":string,"id":positive integer,"digest":"sha256:<64 lowercase hex>"}'
+        type: string
+        required: true
+      windows_installer_artifact:
+        description: "Exact JSON identity for the Windows installer artifact"
+        type: string
+        required: true
+      windows_mar_artifact:
+        description: "Exact JSON identity for the Windows MAR artifact"
+        type: string
+        required: true
+      linux_installer_artifact:
+        description: "Exact JSON identity for the Linux x86_64 installer artifact"
+        type: string
+        required: true
+      linux_mar_artifact:
+        description: "Exact JSON identity for the Linux x86_64 MAR artifact"
+        type: string
+        required: true
+      linux_deb_artifact:
+        description: "Exact JSON identity for the Linux x86_64 DEB artifact"
+        type: string
+        required: true
+      linux_aarch64_installer_artifact:
+        description: "Exact JSON identity for the Linux aarch64 installer artifact"
+        type: string
+        required: true
+      linux_aarch64_mar_artifact:
+        description: "Exact JSON identity for the Linux aarch64 MAR artifact"
+        type: string
+        required: true
+      mac_installer_artifact:
+        description: "Exact JSON identity for the macOS universal installer artifact"
+        type: string
+        required: true
+      mac_mar_artifact:
+        description: "Exact JSON identity for the macOS universal MAR artifact"
+        type: string
+        required: true
+      verification_windows_x86_64_artifact:
+        description: "Exact JSON identity for the Windows x86_64 verification record"
+        type: string
+        required: true
+      verification_linux_x86_64_artifact:
+        description: "Exact JSON identity for the Linux x86_64 verification record"
+        type: string
+        required: true
+      verification_linux_aarch64_artifact:
+        description: "Exact JSON identity for the Linux aarch64 verification record"
+        type: string
+        required: true
+      verification_mac_x86_64_artifact:
+        description: "Exact JSON identity for the macOS x86_64 verification record"
+        type: string
+        required: true
+      verification_mac_aarch64_artifact:
+        description: "Exact JSON identity for the macOS aarch64 verification record"
+        type: string
+        required: true
+    outputs:
+      artifact_name:
+        description: "Canonical release bundle artifact name"
+        value: ${{ jobs.assemble.outputs.artifact_name }}
+      artifact_id:
+        description: "Immutable release bundle artifact ID"
+        value: ${{ jobs.assemble.outputs.artifact_id }}
+      artifact_digest:
+        description: "Immutable release bundle artifact digest"
+        value: ${{ jobs.assemble.outputs.artifact_digest }}
+      manifest_set_id:
+        description: "Release manifest set identity"
+        value: ${{ jobs.assemble.outputs.manifest_set_id }}
+      firefox_version:
+        description: "Firefox version proven by all native records"
+        value: ${{ jobs.assemble.outputs.firefox_version }}
+      floorp_version:
+        description: "Floorp release version"
+        value: ${{ jobs.assemble.outputs.floorp_version }}
+      release_tag:
+        description: "Canonical Floorp release tag"
+        value: ${{ jobs.assemble.outputs.release_tag }}
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  assemble:
+    name: Validate provenance and assemble the flat release bundle
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      artifact_name: ${{ steps.contract.outputs.artifact-name }}
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      artifact_digest: >-
+        ${{ format('sha256:{0}', steps.upload.outputs.artifact-digest) }}
+      manifest_set_id: ${{ steps.assemble.outputs.manifest-set-id }}
+      firefox_version: ${{ steps.assemble.outputs.firefox-version }}
+      floorp_version: ${{ steps.assemble.outputs.floorp-version }}
+      release_tag: ${{ steps.assemble.outputs.release-tag }}
+    steps:
+      - name: Validate every immutable artifact identity through REST
+        id: contract
+        uses: actions/github-script@v7
+        env:
+          SOURCE_WORKFLOW_RUN_ID: ${{ inputs.source_workflow_run_id }}
+          FLOORP_HEAD_SHA: ${{ inputs.floorp_head_sha }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+          RUNTIME_CONTEXT_ARTIFACT: ${{ inputs.runtime_context_artifact }}
+          WINDOWS_INSTALLER_ARTIFACT: ${{ inputs.windows_installer_artifact }}
+          WINDOWS_MAR_ARTIFACT: ${{ inputs.windows_mar_artifact }}
+          LINUX_INSTALLER_ARTIFACT: ${{ inputs.linux_installer_artifact }}
+          LINUX_MAR_ARTIFACT: ${{ inputs.linux_mar_artifact }}
+          LINUX_DEB_ARTIFACT: ${{ inputs.linux_deb_artifact }}
+          LINUX_AARCH64_INSTALLER_ARTIFACT: ${{ inputs.linux_aarch64_installer_artifact }}
+          LINUX_AARCH64_MAR_ARTIFACT: ${{ inputs.linux_aarch64_mar_artifact }}
+          MAC_INSTALLER_ARTIFACT: ${{ inputs.mac_installer_artifact }}
+          MAC_MAR_ARTIFACT: ${{ inputs.mac_mar_artifact }}
+          VERIFICATION_WINDOWS_X86_64_ARTIFACT: ${{ inputs.verification_windows_x86_64_artifact }}
+          VERIFICATION_LINUX_X86_64_ARTIFACT: ${{ inputs.verification_linux_x86_64_artifact }}
+          VERIFICATION_LINUX_AARCH64_ARTIFACT: ${{ inputs.verification_linux_aarch64_artifact }}
+          VERIFICATION_MAC_X86_64_ARTIFACT: ${{ inputs.verification_mac_x86_64_artifact }}
+          VERIFICATION_MAC_AARCH64_ARTIFACT: ${{ inputs.verification_mac_aarch64_artifact }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fail = (message) => {
+              core.setFailed(message);
+              throw new Error(message);
+            };
+            const parsePositiveId = (name, value) => {
+              if (!/^[1-9][0-9]*$/.test(value || "")) {
+                fail(`${name} must be a positive decimal integer`);
+              }
+              const result = Number(value);
+              if (!Number.isSafeInteger(result)) {
+                fail(`${name} exceeds JavaScript's safe integer range`);
+              }
+              return result;
+            };
+            const parseIdentity = (environmentName, expectedName) => {
+              let value;
+              try {
+                value = JSON.parse(process.env[environmentName]);
+              } catch (error) {
+                fail(`${environmentName} is not valid JSON: ${error.message}`);
+              }
+              if (
+                value === null || Array.isArray(value) || typeof value !== "object" ||
+                Object.keys(value).sort().join(",") !== "digest,id,name"
+              ) {
+                fail(`${environmentName} must contain exactly name, id, and digest`);
+              }
+              if (value.name !== expectedName) {
+                fail(`${environmentName}.name must be ${expectedName}`);
+              }
+              if (!Number.isSafeInteger(value.id) || value.id < 1) {
+                fail(`${environmentName}.id must be a positive safe integer`);
+              }
+              if (!/^sha256:[0-9a-f]{64}$/.test(value.digest || "")) {
+                fail(`${environmentName}.digest must be a lowercase sha256 digest`);
+              }
+              return value;
+            };
+
+            const sourceRunId = parsePositiveId(
+              "source_workflow_run_id",
+              process.env.SOURCE_WORKFLOW_RUN_ID,
+            );
+            if (sourceRunId !== context.runId) {
+              fail(
+                `Assembly accepts only artifacts from the current run ` +
+                `(${context.runId}), not ${sourceRunId}`,
+              );
+            }
+            const floorpHeadSha = process.env.FLOORP_HEAD_SHA;
+            if (!/^[0-9a-f]{40}$/.test(floorpHeadSha || "")) {
+              fail("floorp_head_sha must be a lowercase 40-character commit SHA");
+            }
+            const validationOnly = process.env.VALIDATION_ONLY === "true";
+            const unsignedSuffix = validationOnly ? "-unsigned" : "";
+            const identities = new Map([
+              ["runtime-context", parseIdentity(
+                "RUNTIME_CONTEXT_ARTIFACT",
+                "floorp-runtime-provenance-v2",
+              )],
+              ["windows-installer", parseIdentity(
+                "WINDOWS_INSTALLER_ARTIFACT",
+                `noraneko-windows-x86_64-installer${unsignedSuffix}`,
+              )],
+              ["windows-mar", parseIdentity(
+                "WINDOWS_MAR_ARTIFACT",
+                `floorp-windows-x86_64-mar-full${unsignedSuffix}`,
+              )],
+              ["linux-installer", parseIdentity(
+                "LINUX_INSTALLER_ARTIFACT",
+                `noraneko-linux-x86_64-installer${unsignedSuffix}`,
+              )],
+              ["linux-mar", parseIdentity(
+                "LINUX_MAR_ARTIFACT",
+                `floorp-linux-x86_64-mar-full${unsignedSuffix}`,
+              )],
+              ["linux-deb", parseIdentity(
+                "LINUX_DEB_ARTIFACT",
+                `floorp-Linux-x64-deb${unsignedSuffix}`,
+              )],
+              ["linux-aarch64-installer", parseIdentity(
+                "LINUX_AARCH64_INSTALLER_ARTIFACT",
+                `noraneko-linux-aarch64-installer${unsignedSuffix}`,
+              )],
+              ["linux-aarch64-mar", parseIdentity(
+                "LINUX_AARCH64_MAR_ARTIFACT",
+                `floorp-linux-aarch64-mar-full${unsignedSuffix}`,
+              )],
+              ["mac-installer", parseIdentity(
+                "MAC_INSTALLER_ARTIFACT",
+                `noraneko-mac-universal-installer${unsignedSuffix}`,
+              )],
+              ["mac-mar", parseIdentity(
+                "MAC_MAR_ARTIFACT",
+                `floorp-mac-universal-mar-full${unsignedSuffix}`,
+              )],
+              ["verification-windows-x86_64", parseIdentity(
+                "VERIFICATION_WINDOWS_X86_64_ARTIFACT",
+                "floorp-native-verification-windows-x86_64-v2",
+              )],
+              ["verification-linux-x86_64", parseIdentity(
+                "VERIFICATION_LINUX_X86_64_ARTIFACT",
+                "floorp-native-verification-linux-x86_64-v2",
+              )],
+              ["verification-linux-aarch64", parseIdentity(
+                "VERIFICATION_LINUX_AARCH64_ARTIFACT",
+                "floorp-native-verification-linux-aarch64-v2",
+              )],
+              ["verification-mac-x86_64", parseIdentity(
+                "VERIFICATION_MAC_X86_64_ARTIFACT",
+                "floorp-native-verification-mac-x86_64-v2",
+              )],
+              ["verification-mac-aarch64", parseIdentity(
+                "VERIFICATION_MAC_AARCH64_ARTIFACT",
+                "floorp-native-verification-mac-aarch64-v2",
+              )],
+            ]);
+            const inputIds = [...identities.values()].map((identity) => identity.id);
+            if (new Set(inputIds).size !== inputIds.length) {
+              fail("Each release input must reference a different artifact ID");
+            }
+
+            const {data: run} = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: sourceRunId,
+            });
+            if (run.id !== sourceRunId || run.repository?.full_name !== context.repo.owner + "/" + context.repo.repo) {
+              fail("Source workflow run repository or ID mismatch");
+            }
+            if (run.head_sha !== floorpHeadSha) {
+              fail(`Source workflow head ${run.head_sha} != ${floorpHeadSha}`);
+            }
+            if (!["queued", "in_progress", "completed"].includes(run.status)) {
+              fail(`Source workflow has an invalid status: ${run.status}`);
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: sourceRunId,
+                per_page: 100,
+              },
+            );
+            for (const [key, expected] of identities) {
+              const idMatches = artifacts.filter((artifact) => artifact.id === expected.id);
+              if (idMatches.length !== 1) {
+                fail(`${key} artifact ID is not unique in source run ${sourceRunId}`);
+              }
+              const nameMatches = artifacts.filter(
+                (artifact) => artifact.name === expected.name && !artifact.expired,
+              );
+              if (nameMatches.length !== 1 || nameMatches[0].id !== expected.id) {
+                fail(`${key} does not uniquely bind its canonical name to its ID`);
+              }
+              const artifact = idMatches[0];
+              if (artifact.name !== expected.name || artifact.digest !== expected.digest) {
+                fail(`${key} REST name or digest does not match its input identity`);
+              }
+              if (artifact.expired || !Number.isInteger(artifact.size_in_bytes) || artifact.size_in_bytes < 1) {
+                fail(`${key} is expired or empty`);
+              }
+              core.setOutput(`${key}-artifact-id`, String(expected.id));
+            }
+            core.setOutput(
+              "artifact-name",
+              validationOnly
+                ? "floorp-release-bundle-v2-validation"
+                : "floorp-release-bundle-v2",
+            );
+
+      - name: Download exact normalized Runtime context
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.runtime-context-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/runtime-context
+          merge-multiple: true
+
+      - name: Download exact Windows installer
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.windows-installer-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/windows-installer
+          merge-multiple: true
+
+      - name: Download exact Windows MAR
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.windows-mar-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/windows-mar
+          merge-multiple: true
+
+      - name: Download exact Linux x86_64 installer
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.linux-installer-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/linux-installer
+          merge-multiple: true
+
+      - name: Download exact Linux x86_64 MAR
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.linux-mar-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/linux-mar
+          merge-multiple: true
+
+      - name: Download exact Linux x86_64 DEB
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.linux-deb-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/linux-deb
+          merge-multiple: true
+
+      - name: Download exact Linux aarch64 installer
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.linux-aarch64-installer-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/linux-aarch64-installer
+          merge-multiple: true
+
+      - name: Download exact Linux aarch64 MAR
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.linux-aarch64-mar-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/linux-aarch64-mar
+          merge-multiple: true
+
+      - name: Download exact macOS installer
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.mac-installer-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/mac-installer
+          merge-multiple: true
+
+      - name: Download exact macOS MAR
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.mac-mar-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/mac-mar
+          merge-multiple: true
+
+      - name: Download exact Windows x86_64 verification record
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.verification-windows-x86_64-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/verification-windows-x86_64
+          merge-multiple: true
+
+      - name: Download exact Linux x86_64 verification record
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.verification-linux-x86_64-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/verification-linux-x86_64
+          merge-multiple: true
+
+      - name: Download exact Linux aarch64 verification record
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.verification-linux-aarch64-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/verification-linux-aarch64
+          merge-multiple: true
+
+      - name: Download exact macOS x86_64 verification record
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.verification-mac-x86_64-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/verification-mac-x86_64
+          merge-multiple: true
+
+      - name: Download exact macOS aarch64 verification record
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.contract.outputs.verification-mac-aarch64-artifact-id }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/release-inputs/verification-mac-aarch64
+          merge-multiple: true
+
+      - name: Checkout the exact Floorp source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.floorp_head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve the exact inherited Windows stub asset
+        id: stub
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fail = (message) => {
+              core.setFailed(message);
+              throw new Error(message);
+            };
+            const { data: release } = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              headers: { "X-GitHub-Api-Version": "2026-03-10" },
+            });
+            if (
+              !Number.isSafeInteger(release.id) || release.id < 1 ||
+              !/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(release.tag_name || "") ||
+              release.draft || release.prerelease
+            ) {
+              fail("Latest public Floorp release identity is not canonical");
+            }
+            const matches = release.assets.filter(
+              (asset) => asset.name === "floorp-stub.installer.exe",
+            );
+            if (matches.length !== 1) {
+              fail("Latest public Floorp release must contain exactly one stub installer");
+            }
+            const asset = matches[0];
+            if (
+              !Number.isSafeInteger(asset.id) || asset.id < 1 ||
+              !Number.isSafeInteger(asset.size) || asset.size < 1 ||
+              !/^sha256:[0-9a-f]{64}$/.test(asset.digest || "")
+            ) {
+              fail("Latest Floorp stub asset has no immutable digest identity");
+            }
+            core.setOutput("release-id", String(release.id));
+            core.setOutput("release-tag", release.tag_name);
+            core.setOutput("asset-id", String(asset.id));
+            core.setOutput("asset-digest", asset.digest);
+            core.setOutput("asset-size", String(asset.size));
+
+      - name: Download and verify the exact inherited Windows stub asset
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STUB_RELEASE_ID: ${{ steps.stub.outputs.release-id }}
+          STUB_RELEASE_TAG: ${{ steps.stub.outputs.release-tag }}
+          STUB_ASSET_ID: ${{ steps.stub.outputs.asset-id }}
+          STUB_ASSET_DIGEST: ${{ steps.stub.outputs.asset-digest }}
+          STUB_ASSET_SIZE: ${{ steps.stub.outputs.asset-size }}
+          STUB_DIR: ${{ runner.temp }}/release-inputs/windows-stub
+          STUB_SOURCE_PATH: ${{ runner.temp }}/stub-source-v2.json
+        run: |
+          set -euo pipefail
+          mkdir "$STUB_DIR"
+          stub="$STUB_DIR/floorp-stub.installer.exe"
+          curl --fail --location --silent --show-error \
+            --retry 3 --retry-all-errors \
+            --header "Accept: application/octet-stream" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2026-03-10" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/assets/$STUB_ASSET_ID" \
+            --output "$stub"
+
+          actual_size="$(stat -c%s "$stub")"
+          actual_digest="sha256:$(sha256sum "$stub" | cut -d' ' -f1)"
+          if [[ "$actual_size" != "$STUB_ASSET_SIZE" || "$actual_digest" != "$STUB_ASSET_DIGEST" ]]; then
+            echo "Inherited stub bytes differ from release asset $STUB_ASSET_ID" >&2
+            exit 1
+          fi
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg release_tag "$STUB_RELEASE_TAG" \
+            --argjson release_id "$STUB_RELEASE_ID" \
+            --argjson asset_id "$STUB_ASSET_ID" \
+            --arg asset_name "floorp-stub.installer.exe" \
+            --arg asset_digest "$STUB_ASSET_DIGEST" \
+            --argjson size "$STUB_ASSET_SIZE" \
+            '{
+              repository: $repository,
+              release_tag: $release_tag,
+              release_id: $release_id,
+              asset_id: $asset_id,
+              asset_name: $asset_name,
+              asset_digest: $asset_digest,
+              size: $size
+            }' > "$STUB_SOURCE_PATH"
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Extract fixed release files and assemble metadata
+        id: assemble
+        shell: bash
+        env:
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+          SOURCE_WORKFLOW_RUN_ID: ${{ inputs.source_workflow_run_id }}
+          FLOORP_HEAD_SHA: ${{ inputs.floorp_head_sha }}
+          INPUT_ROOT: ${{ runner.temp }}/release-inputs
+          BUNDLE_DIR: ${{ runner.temp }}/floorp-release-bundle-v2
+          DESCRIPTOR_PATH: ${{ runner.temp }}/assemble-release-v2.json
+          STUB_SOURCE_PATH: ${{ runner.temp }}/stub-source-v2.json
+          WINDOWS_INSTALLER_IDENTITY: ${{ inputs.windows_installer_artifact }}
+          LINUX_INSTALLER_IDENTITY: ${{ inputs.linux_installer_artifact }}
+          LINUX_AARCH64_INSTALLER_IDENTITY: ${{ inputs.linux_aarch64_installer_artifact }}
+          MAC_INSTALLER_IDENTITY: ${{ inputs.mac_installer_artifact }}
+        run: |
+          set -euo pipefail
+
+          require_only_root_file() {
+            local directory="$1"
+            local filename="$2"
+            local expected="$directory/$filename"
+            mapfile -d '' -t files < <(find "$directory" -type f -print0)
+            if (( ${#files[@]} != 1 )) || [[ "${files[0]}" != "$expected" ]]; then
+              echo "Expected exactly the root file $expected" >&2
+              find "$directory" -maxdepth 3 -type f -print >&2 || true
+              exit 1
+            fi
+          }
+
+          require_root_file() {
+            local directory="$1"
+            local filename="$2"
+            if [[ ! -f "$directory/$filename" ]]; then
+              echo "Expected root file $directory/$filename" >&2
+              find "$directory" -maxdepth 2 -type f -print >&2 || true
+              exit 1
+            fi
+          }
+
+          mkdir "$BUNDLE_DIR"
+          floorp_version="$(jq -er '.version | select(type == "string")' package.json)"
+          if [[ ! "$floorp_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Stable release version is not canonical: $floorp_version" >&2
+            exit 1
+          fi
+          release_tag="v$floorp_version"
+          mode=production
+          if [[ "$VALIDATION_ONLY" == true ]]; then
+            mode=validation
+          fi
+
+          require_only_root_file \
+            "$INPUT_ROOT/runtime-context" normalized-runtime-provenance-v2.json
+          for record in \
+            verification-windows-x86_64 \
+            verification-linux-x86_64 \
+            verification-linux-aarch64 \
+            verification-mac-x86_64 \
+            verification-mac-aarch64; do
+            require_only_root_file "$INPUT_ROOT/$record" native-verification.json
+          done
+
+          validate_record_binding() {
+            local record_path="$1"
+            local target_key="$2"
+            local native_arch="$3"
+            local installer_identity="$4"
+            jq -e \
+              --arg target_key "$target_key" \
+              --arg native_arch "$native_arch" \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg head_sha "$FLOORP_HEAD_SHA" \
+              --argjson workflow_run_id "$SOURCE_WORKFLOW_RUN_ID" \
+              --argjson installer "$installer_identity" \
+              --argjson unsigned "$VALIDATION_ONLY" '
+                .schema_version == 2 and
+                .target_key == $target_key and
+                .native_arch == $native_arch and
+                .floorp == {
+                  repository: $repository,
+                  head_sha: $head_sha,
+                  workflow_run_id: $workflow_run_id
+                } and
+                .floorp_package == {
+                  artifact_name: $installer.name,
+                  artifact_id: $installer.id,
+                  artifact_digest: $installer.digest,
+                  unsigned: $unsigned
+                }
+              ' "$record_path" >/dev/null
+          }
+
+          validate_record_binding \
+            "$INPUT_ROOT/verification-windows-x86_64/native-verification.json" \
+            windows x86_64 "$WINDOWS_INSTALLER_IDENTITY"
+          validate_record_binding \
+            "$INPUT_ROOT/verification-linux-x86_64/native-verification.json" \
+            linux x86_64 "$LINUX_INSTALLER_IDENTITY"
+          validate_record_binding \
+            "$INPUT_ROOT/verification-linux-aarch64/native-verification.json" \
+            linuxAarch64 aarch64 "$LINUX_AARCH64_INSTALLER_IDENTITY"
+          validate_record_binding \
+            "$INPUT_ROOT/verification-mac-x86_64/native-verification.json" \
+            mac x86_64 "$MAC_INSTALLER_IDENTITY"
+          validate_record_binding \
+            "$INPUT_ROOT/verification-mac-aarch64/native-verification.json" \
+            mac aarch64 "$MAC_INSTALLER_IDENTITY"
+
+          require_root_file \
+            "$INPUT_ROOT/windows-installer" floorp-windows-x86_64.installer.exe
+          require_root_file \
+            "$INPUT_ROOT/windows-mar" floorp-windows-x86_64-full.mar
+          require_root_file \
+            "$INPUT_ROOT/linux-installer" floorp-linux-x86_64.tar.xz
+          require_root_file \
+            "$INPUT_ROOT/linux-mar" floorp-linux-x86_64-full.mar
+          require_root_file \
+            "$INPUT_ROOT/linux-aarch64-installer" floorp-linux-aarch64.tar.xz
+          require_root_file \
+            "$INPUT_ROOT/linux-aarch64-mar" floorp-linux-aarch64-full.mar
+          require_root_file \
+            "$INPUT_ROOT/mac-installer" floorp-macOS-universal.dmg
+          require_root_file \
+            "$INPUT_ROOT/mac-mar" floorp-mac-universal-full.mar
+          require_root_file \
+            "$INPUT_ROOT/linux-deb" "floorp-${floorp_version}.deb"
+          require_only_root_file \
+            "$INPUT_ROOT/windows-stub" floorp-stub.installer.exe
+
+          cp -- "$INPUT_ROOT/windows-installer/floorp-windows-x86_64.installer.exe" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/windows-mar/floorp-windows-x86_64-full.mar" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/linux-installer/floorp-linux-x86_64.tar.xz" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/linux-mar/floorp-linux-x86_64-full.mar" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/linux-aarch64-installer/floorp-linux-aarch64.tar.xz" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/linux-aarch64-mar/floorp-linux-aarch64-full.mar" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/mac-installer/floorp-macOS-universal.dmg" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/mac-mar/floorp-mac-universal-full.mar" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/linux-deb/floorp-${floorp_version}.deb" "$BUNDLE_DIR/"
+          cp -- "$INPUT_ROOT/windows-stub/floorp-stub.installer.exe" "$BUNDLE_DIR/"
+
+          release_base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${release_tag}"
+          mar_entry() {
+            local filename="$1"
+            local path="$BUNDLE_DIR/$filename"
+            jq -n \
+              --arg path "$path" \
+              --arg url "$release_base/$filename" \
+              --arg sha512 "$(sha512sum "$path" | cut -d' ' -f1)" \
+              --argjson size "$(stat -c%s "$path")" \
+              '{path: $path, url: $url, size: $size, sha512: $sha512}'
+          }
+
+          release_file_entry() {
+            local filename="$1"
+            local path="$BUNDLE_DIR/$filename"
+            jq -n \
+              --arg path "$path" \
+              --arg name "$filename" \
+              --arg sha512 "$(sha512sum "$path" | cut -d' ' -f1)" \
+              --argjson size "$(stat -c%s "$path")" \
+              '{path: $path, name: $name, size: $size, sha512: $sha512}'
+          }
+
+          jq -n \
+            --arg mode "$mode" \
+            --arg floorp_version "$floorp_version" \
+            --arg release_tag "$release_tag" \
+            --argjson stub_source "$(cat "$STUB_SOURCE_PATH")" \
+            --arg runtime "$INPUT_ROOT/runtime-context/normalized-runtime-provenance-v2.json" \
+            --arg win_record "$INPUT_ROOT/verification-windows-x86_64/native-verification.json" \
+            --arg linux_record "$INPUT_ROOT/verification-linux-x86_64/native-verification.json" \
+            --arg linux_arm_record "$INPUT_ROOT/verification-linux-aarch64/native-verification.json" \
+            --arg mac_x64_record "$INPUT_ROOT/verification-mac-x86_64/native-verification.json" \
+            --arg mac_arm_record "$INPUT_ROOT/verification-mac-aarch64/native-verification.json" \
+            --argjson windows "$(mar_entry floorp-windows-x86_64-full.mar)" \
+            --argjson linux "$(mar_entry floorp-linux-x86_64-full.mar)" \
+            --argjson linux_arm "$(mar_entry floorp-linux-aarch64-full.mar)" \
+            --argjson mac "$(mar_entry floorp-mac-universal-full.mar)" \
+            --argjson windows_installer "$(release_file_entry floorp-windows-x86_64.installer.exe)" \
+            --argjson windows_stub "$(release_file_entry floorp-stub.installer.exe)" \
+            --argjson linux_installer "$(release_file_entry floorp-linux-x86_64.tar.xz)" \
+            --argjson linux_arm_installer "$(release_file_entry floorp-linux-aarch64.tar.xz)" \
+            --argjson mac_installer "$(release_file_entry floorp-macOS-universal.dmg)" \
+            --argjson linux_deb "$(release_file_entry "floorp-${floorp_version}.deb")" \
+            '{
+              schema_version: 2,
+              mode: $mode,
+              floorp_version: $floorp_version,
+              release_tag: $release_tag,
+              stub_source: $stub_source,
+              runtime_provenance_path: $runtime,
+              native_verification_paths: [
+                $win_record,
+                $linux_record,
+                $linux_arm_record,
+                $mac_x64_record,
+                $mac_arm_record
+              ],
+              mars: {
+                windows: $windows,
+                linux: $linux,
+                linuxAarch64: $linux_arm,
+                mac: $mac
+              },
+              release_files: {
+                windows: $windows_installer,
+                windowsStub: $windows_stub,
+                linux: $linux_installer,
+                linuxAarch64: $linux_arm_installer,
+                mac: $mac_installer,
+                linuxDeb: $linux_deb
+              }
+            }' > "$DESCRIPTOR_PATH"
+
+          deno run --allow-read --allow-write \
+            tools/src/release_provenance.ts \
+            assemble-release \
+            --descriptor "$DESCRIPTOR_PATH" \
+            --output-dir "$BUNDLE_DIR" \
+            --github-output "$GITHUB_OUTPUT"
+
+          jq -e \
+            --arg mode "$mode" \
+            --arg version "$floorp_version" \
+            --arg release_tag "$release_tag" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg head_sha "$FLOORP_HEAD_SHA" \
+            --argjson workflow_run_id "$SOURCE_WORKFLOW_RUN_ID" '
+              .schema_version == 2 and
+              .mode == $mode and
+              .noraneko_version == $version and
+              .floorp == {
+                repository: $repository,
+                head_sha: $head_sha,
+                workflow_run_id: $workflow_run_id,
+                release_tag: $release_tag
+              }
+            ' "$BUNDLE_DIR/release-manifest-set-v2.json" >/dev/null
+
+          expected_files="$RUNNER_TEMP/expected-release-files.txt"
+          actual_files="$RUNNER_TEMP/actual-release-files.txt"
+          cat > "$expected_files" <<EOF
+          floorp-${floorp_version}.deb
+          floorp-linux-aarch64-full.mar
+          floorp-linux-aarch64.tar.xz
+          floorp-linux-x86_64-full.mar
+          floorp-linux-x86_64.tar.xz
+          floorp-mac-universal-full.mar
+          floorp-macOS-universal.dmg
+          floorp-windows-x86_64-full.mar
+          floorp-windows-x86_64.installer.exe
+          floorp-stub.installer.exe
+          hashes.txt
+          linux-aarch64-meta.json
+          linux-meta.json
+          mac-meta.json
+          release-manifest-set-v2.json
+          win-meta.json
+          EOF
+          find "$BUNDLE_DIR" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort > "$actual_files"
+          sort -o "$expected_files" "$expected_files"
+          if ! diff -u "$expected_files" "$actual_files"; then
+            echo "Release bundle is not the exact flat file set" >&2
+            exit 1
+          fi
+          if find "$BUNDLE_DIR" -mindepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Release bundle must contain only root files" >&2
+            exit 1
+          fi
+
+          echo "floorp-version=$floorp_version" >> "$GITHUB_OUTPUT"
+          echo "release-tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable release bundle
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.contract.outputs.artifact-name }}
+          path: ${{ runner.temp }}/floorp-release-bundle-v2/*
+          if-no-files-found: error
+          overwrite: true
+          compression-level: 0

--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -93,6 +93,16 @@ jobs:
           $tag = $release.tag_name
           Write-Host "Latest tag: $tag"
 
+          # Release provenance v2 makes the public asset set immutable. Keep a
+          # newly signed stub as a workflow artifact for a future explicit
+          # bundle-input path; never replace bytes after publication was verified.
+          $immutableManifest = $release.assets | Where-Object {
+            $_.name -eq 'release-manifest-set-v2.json'
+          }
+          if ($immutableManifest) {
+            throw "Refusing to mutate provenance-v2 release $tag"
+          }
+
           # Find asset id for the stub installer if present
           $asset = $release.assets | Where-Object { $_.name -eq $fileName }
           if ($asset) {

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,6 +21,54 @@ on:
         type: string
         default: ""
         required: false
+      provenance_mode:
+        type: choice
+        required: true
+        default: legacy
+        options:
+          - legacy
+          - stable-v2
+          - stable-v2-validation
+      runtime_repository:
+        type: string
+        default: ""
+        required: false
+      runtime_workflow_run_id:
+        type: string
+        default: ""
+        required: false
+      runtime_manifest_artifact_id:
+        type: string
+        default: ""
+        required: false
+      runtime_manifest_artifact_digest:
+        type: string
+        default: ""
+        required: false
+      runtime_head_sha:
+        type: string
+        default: ""
+        required: false
+      expected_build_id:
+        type: string
+        default: ""
+        required: false
+      runtime_artifact_name:
+        type: string
+        default: ""
+        required: false
+      runtime_artifact_id:
+        type: string
+        default: ""
+        required: false
+      runtime_artifact_digest:
+        type: string
+        default: ""
+        required: false
+      floorp_head_sha:
+        type: string
+        default: ""
+        required: false
       skip_signing:
         type: boolean
         required: false
@@ -31,7 +79,6 @@ on:
     inputs:
       platform:
         type: string
-        default: Windows-x64
         required: true
       beta:
         type: boolean
@@ -41,50 +88,553 @@ on:
         type: string
         default: ""
         required: false
+      provenance_mode:
+        type: string
+        required: false
+        default: legacy
+      runtime_repository:
+        type: string
+        default: ""
+        required: false
+      runtime_workflow_run_id:
+        type: string
+        default: ""
+        required: false
+      runtime_manifest_artifact_id:
+        type: string
+        default: ""
+        required: false
+      runtime_manifest_artifact_digest:
+        type: string
+        default: ""
+        required: false
+      runtime_head_sha:
+        type: string
+        default: ""
+        required: false
+      expected_build_id:
+        type: string
+        default: ""
+        required: false
+      runtime_artifact_name:
+        type: string
+        default: ""
+        required: false
+      runtime_artifact_id:
+        type: string
+        default: ""
+        required: false
+      runtime_artifact_digest:
+        type: string
+        default: ""
+        required: false
+      floorp_head_sha:
+        type: string
+        default: ""
+        required: false
       skip_signing:
         type: boolean
         required: false
         default: false
         description: "Skip code signing process"
+    secrets:
+      runtime_artifact_token:
+        required: false
+      SIGNPATH_API_TOKEN:
+        required: false
+      APPLE_DEVELOPER_P12_BASE64:
+        required: false
+      APPLE_DEVELOPER_P12_PASSWORD:
+        required: false
+      APPLE_PROVISIONING_PROFILE_BASE64:
+        required: false
+      APPLE_DEVELOPER_API_KEY_JSON:
+        required: false
+      APPLE_DEVELOPER_TEAM_ID:
+        required: false
     outputs:
       run_id:
         description: "Workflow run ID for downstream artifact downloads"
         value: ${{ jobs.main.outputs.run_id }}
+      platform_key:
+        description: "Canonical release platform key"
+        value: ${{ jobs.main.outputs.platform_key }}
+      runtime_artifact_name:
+        description: "Runtime artifact name used by this package job"
+        value: ${{ jobs.main.outputs.runtime_artifact_name }}
+      runtime_artifact_id:
+        description: "Immutable Runtime artifact ID (v2 only)"
+        value: ${{ jobs.main.outputs.runtime_artifact_id }}
+      runtime_artifact_digest:
+        description: "Runtime artifact digest (v2 only)"
+        value: ${{ jobs.main.outputs.runtime_artifact_digest }}
+      expected_build_id:
+        description: "Authoritative Runtime BuildID (v2 only)"
+        value: ${{ jobs.main.outputs.expected_build_id }}
+      installer_artifact_name:
+        description: "Final installer/package artifact name"
+        value: ${{ jobs.main.outputs.installer_artifact_name }}
+      installer_artifact_id:
+        description: "Final installer/package artifact ID"
+        value: ${{ jobs.main.outputs.installer_artifact_id }}
+      installer_artifact_digest:
+        description: "Final installer/package artifact digest"
+        value: ${{ jobs.main.outputs.installer_artifact_digest }}
+      mar_artifact_name:
+        description: "Full MAR artifact name"
+        value: ${{ jobs.main.outputs.mar_artifact_name }}
+      mar_artifact_id:
+        description: "Full MAR artifact ID"
+        value: ${{ jobs.main.outputs.mar_artifact_id }}
+      mar_artifact_digest:
+        description: "Full MAR artifact digest"
+        value: ${{ jobs.main.outputs.mar_artifact_digest }}
+      deb_artifact_name:
+        description: "Linux x64 DEB artifact name, otherwise empty"
+        value: ${{ jobs.main.outputs.deb_artifact_name }}
+      deb_artifact_id:
+        description: "Linux x64 DEB artifact ID, otherwise empty"
+        value: ${{ jobs.main.outputs.deb_artifact_id }}
+      deb_artifact_digest:
+        description: "Linux x64 DEB artifact digest, otherwise empty"
+        value: ${{ jobs.main.outputs.deb_artifact_digest }}
 
 run-name: 📦️ Package ${{ inputs.platform }}${{ inputs.skip_signing && ' (Unsigned)' || '' }}
+
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-22.04
     outputs:
       run_id: ${{ github.run_id }}
+      platform_key: ${{ steps.provenance.outputs.platform_key }}
+      runtime_artifact_name: ${{ steps.provenance.outputs.runtime_artifact_name }}
+      runtime_artifact_id: ${{ steps.provenance.outputs.runtime_artifact_id }}
+      runtime_artifact_digest: ${{ steps.provenance.outputs.runtime_artifact_digest }}
+      expected_build_id: ${{ steps.provenance.outputs.expected_build_id }}
+      installer_artifact_name: ${{ steps.artifact-contract.outputs.installer_artifact_name }}
+      installer_artifact_id: ${{ steps.upload-installer.outputs.artifact-id }}
+      installer_artifact_digest: >-
+        ${{ format('sha256:{0}', steps.upload-installer.outputs.artifact-digest) }}
+      mar_artifact_name: ${{ steps.artifact-contract.outputs.mar_artifact_name }}
+      mar_artifact_id: ${{ steps.upload-mar.outputs.artifact-id }}
+      mar_artifact_digest: >-
+        ${{ format('sha256:{0}', steps.upload-mar.outputs.artifact-digest) }}
+      deb_artifact_name: ${{ steps.artifact-contract.outputs.deb_artifact_name }}
+      deb_artifact_id: ${{ steps.upload-deb.outputs.artifact-id }}
+      deb_artifact_digest: >-
+        ${{ steps.upload-deb.outputs.artifact-digest &&
+            format('sha256:{0}', steps.upload-deb.outputs.artifact-digest) || '' }}
     steps:
-      - name: Get commit hash from runtime_artifact_workflow_run_id
-        if: ${{ inputs.runtime_artifact_workflow_run_id != '' }}
-        id: get-commit
+      - name: Require dedicated Runtime artifact token
+        if: ${{ inputs.provenance_mode != 'legacy' }}
+        shell: bash
+        env:
+          RUNTIME_ARTIFACT_TOKEN: ${{ secrets.runtime_artifact_token }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RUNTIME_ARTIFACT_TOKEN" ]]; then
+            echo "stable v2 requires the dedicated runtime_artifact_token secret" >&2
+            exit 1
+          fi
+
+      - name: Validate provenance contract
+        id: provenance
         uses: actions/github-script@v7
+        env:
+          PROVENANCE_MODE: ${{ inputs.provenance_mode }}
+          TARGET_PLATFORM: ${{ inputs.platform }}
+          IS_BETA: ${{ inputs.beta }}
+          SKIP_SIGNING: ${{ inputs.skip_signing }}
+          LEGACY_RUNTIME_RUN_ID: ${{ inputs.runtime_artifact_workflow_run_id }}
+          RUNTIME_REPOSITORY: ${{ inputs.runtime_repository }}
+          RUNTIME_WORKFLOW_RUN_ID: ${{ inputs.runtime_workflow_run_id }}
+          RUNTIME_MANIFEST_ARTIFACT_ID: ${{ inputs.runtime_manifest_artifact_id }}
+          RUNTIME_MANIFEST_ARTIFACT_DIGEST: ${{ inputs.runtime_manifest_artifact_digest }}
+          RUNTIME_HEAD_SHA: ${{ inputs.runtime_head_sha }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected_build_id }}
+          RUNTIME_ARTIFACT_NAME: ${{ inputs.runtime_artifact_name }}
+          RUNTIME_ARTIFACT_ID: ${{ inputs.runtime_artifact_id }}
+          RUNTIME_ARTIFACT_DIGEST: ${{ inputs.runtime_artifact_digest }}
+          FLOORP_HEAD_SHA: ${{ inputs.floorp_head_sha }}
+          FLOORP_REPOSITORY: ${{ github.repository }}
+          CURRENT_FLOORP_SHA: ${{ github.sha }}
+          CURRENT_FLOORP_REF: ${{ github.ref }}
+          FLOORP_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ inputs.provenance_mode == 'legacy' && github.token || secrets.runtime_artifact_token }}
           script: |
-            const runId = '${{ inputs.runtime_artifact_workflow_run_id }}';
-            const targetRepo = '${{ github.repository }}-runtime';
-            const [owner, repo] = targetRepo.split('/');
+            const fail = (message) => {
+              core.setFailed(message);
+              throw new Error(message);
+            };
+            const required = (name, value) => {
+              if (!value) fail(`${name} is required for stable v2 provenance`);
+              return value;
+            };
+            const parsePositiveId = (name, value) => {
+              if (!/^[1-9][0-9]*$/.test(value)) {
+                fail(`${name} must be a positive decimal integer`);
+              }
+              const parsed = Number(value);
+              if (!Number.isSafeInteger(parsed)) {
+                fail(`${name} exceeds JavaScript's safe integer range`);
+              }
+              return parsed;
+            };
+            const validateSha = (name, value) => {
+              if (!/^[0-9a-f]{40}$/.test(value)) {
+                fail(`${name} must be a lowercase 40-character commit SHA`);
+              }
+            };
+            const validateDigest = (name, value) => {
+              if (!/^sha256:[0-9a-f]{64}$/.test(value)) {
+                fail(`${name} must be a lowercase sha256 artifact digest`);
+              }
+            };
+            const validateBuildId = (value) => {
+              if (!/^[0-9]{14}$/.test(value)) {
+                fail("expected_build_id must be 14 decimal UTC digits");
+              }
+              const parts = [
+                Number(value.slice(0, 4)),
+                Number(value.slice(4, 6)),
+                Number(value.slice(6, 8)),
+                Number(value.slice(8, 10)),
+                Number(value.slice(10, 12)),
+                Number(value.slice(12, 14)),
+              ];
+              const date = new Date(Date.UTC(
+                parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5],
+              ));
+              const actual = [
+                date.getUTCFullYear(), date.getUTCMonth() + 1,
+                date.getUTCDate(), date.getUTCHours(),
+                date.getUTCMinutes(), date.getUTCSeconds(),
+              ];
+              if (actual.some((part, index) => part !== parts[index])) {
+                fail("expected_build_id is not a valid UTC calendar timestamp");
+              }
+            };
+            const buildIdFromCreatedAt = (value) => {
+              const match = value?.match(
+                /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?Z$/,
+              );
+              if (!match) fail(`Runtime run has an invalid created_at: ${value}`);
+              return match.slice(1).join("");
+            };
+
+            const contracts = new Map([
+              ["Windows-x64", {
+                key: "windows",
+                artifact: "floorp-windows-x86_64-moz-artifact",
+              }],
+              ["Windows-x86_64", {
+                key: "windows",
+                artifact: "floorp-windows-x86_64-moz-artifact",
+              }],
+              ["Linux-x64", {
+                key: "linux",
+                artifact: "floorp-linux-x86_64-moz-artifact",
+              }],
+              ["Linux-x86_64", {
+                key: "linux",
+                artifact: "floorp-linux-x86_64-moz-artifact",
+              }],
+              ["Linux-aarch64", {
+                key: "linuxAarch64",
+                artifact: "floorp-linux-aarch64-moz-artifact",
+              }],
+              ["macOS-x64", {
+                key: "mac",
+                artifact: "floorp-mac-universal-moz-artifact",
+              }],
+              ["macOS-x86_64", {
+                key: "mac",
+                artifact: "floorp-mac-universal-moz-artifact",
+              }],
+            ]);
+            const contract = contracts.get(process.env.TARGET_PLATFORM);
+            if (!contract) {
+              fail(`Unsupported platform: ${process.env.TARGET_PLATFORM}`);
+            }
+
+            const mode = process.env.PROVENANCE_MODE;
+            if (!["legacy", "stable-v2", "stable-v2-validation"].includes(mode)) {
+              fail(`Unsupported provenance_mode: ${mode}`);
+            }
+            const productionV2 = mode === "stable-v2";
+            const isV2 = mode !== "legacy";
+            const floorpRepository = process.env.FLOORP_REPOSITORY;
+            const [floorpOwner, floorpRepo] = floorpRepository.split("/");
+            if (!floorpOwner || !floorpRepo) {
+              fail(`Invalid Floorp repository: ${floorpRepository}`);
+            }
+
+            if (productionV2) {
+              if (floorpRepository !== "Floorp-Projects/Floorp") {
+                fail(
+                  `stable-v2 requires Floorp-Projects/Floorp, got ${floorpRepository}`,
+                );
+              }
+              const floorpDefaultBranch = required(
+                "Floorp default branch",
+                process.env.FLOORP_DEFAULT_BRANCH,
+              );
+              const expectedFloorpRef = `refs/heads/${floorpDefaultBranch}`;
+              if (process.env.CURRENT_FLOORP_REF !== expectedFloorpRef) {
+                fail(
+                  `stable-v2 must run from Floorp default ref ${expectedFloorpRef}, ` +
+                    `got ${process.env.CURRENT_FLOORP_REF}`,
+                );
+              }
+            }
+
+            if (!isV2) {
+              const v2Inputs = [
+                "RUNTIME_REPOSITORY", "RUNTIME_WORKFLOW_RUN_ID",
+                "RUNTIME_MANIFEST_ARTIFACT_ID",
+                "RUNTIME_MANIFEST_ARTIFACT_DIGEST", "RUNTIME_HEAD_SHA",
+                "EXPECTED_BUILD_ID", "RUNTIME_ARTIFACT_NAME",
+                "RUNTIME_ARTIFACT_ID", "RUNTIME_ARTIFACT_DIGEST",
+                "FLOORP_HEAD_SHA",
+              ];
+              for (const name of v2Inputs) {
+                if (process.env[name]) {
+                  fail(`${name.toLowerCase()} cannot be used in legacy mode`);
+                }
+              }
+
+              const runtimeRepository = `${floorpRepository}-runtime`;
+              let runtimeRef = "";
+              const legacyRunId = process.env.LEGACY_RUNTIME_RUN_ID;
+              if (legacyRunId) {
+                const runId = parsePositiveId(
+                  "runtime_artifact_workflow_run_id", legacyRunId,
+                );
+                const [owner, repo] = runtimeRepository.split("/");
+                const { data: run } = await github.rest.actions.getWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: runId,
+                });
+                runtimeRef = run.head_sha;
+                if (!/^[0-9a-fA-F]{40}$/.test(runtimeRef || "")) {
+                  fail(`Legacy Runtime run has an invalid head SHA: ${runtimeRef}`);
+                }
+              }
+
+              core.setOutput("is_v2", "false");
+              core.setOutput("platform_key", contract.key);
+              core.setOutput("runtime_repository", runtimeRepository);
+              core.setOutput("runtime_workflow_run_id", legacyRunId);
+              core.setOutput("runtime_ref", runtimeRef);
+              core.setOutput("floorp_ref", process.env.CURRENT_FLOORP_SHA);
+              core.setOutput("runtime_artifact_name", contract.artifact);
+              core.setOutput("runtime_artifact_id", "");
+              core.setOutput("runtime_artifact_digest", "");
+              core.setOutput("expected_build_id", "");
+              return;
+            }
+
+            if (process.env.LEGACY_RUNTIME_RUN_ID) {
+              fail("runtime_artifact_workflow_run_id cannot coexist with stable v2 inputs");
+            }
+            if (process.env.IS_BETA !== "false") {
+              fail(`${mode} cannot package a beta release`);
+            }
+            if (mode === "stable-v2" && process.env.SKIP_SIGNING !== "false") {
+              fail("stable-v2 requires skip_signing=false");
+            }
+            if (
+              mode === "stable-v2-validation" &&
+              process.env.SKIP_SIGNING !== "true"
+            ) {
+              fail("stable-v2-validation requires skip_signing=true");
+            }
+
+            const runtimeRepository = required(
+              "runtime_repository", process.env.RUNTIME_REPOSITORY,
+            );
+            if (runtimeRepository !== "Floorp-Projects/Floorp-Runtime") {
+              fail(`stable v2 requires Floorp-Projects/Floorp-Runtime, got ${runtimeRepository}`);
+            }
+            const runtimeHeadSha = required(
+              "runtime_head_sha", process.env.RUNTIME_HEAD_SHA,
+            );
+            const floorpHeadSha = required(
+              "floorp_head_sha", process.env.FLOORP_HEAD_SHA,
+            );
+            const expectedBuildId = required(
+              "expected_build_id", process.env.EXPECTED_BUILD_ID,
+            );
+            validateSha("runtime_head_sha", runtimeHeadSha);
+            validateSha("floorp_head_sha", floorpHeadSha);
+            validateBuildId(expectedBuildId);
+            if (floorpHeadSha !== process.env.CURRENT_FLOORP_SHA) {
+              fail(
+                `floorp_head_sha ${floorpHeadSha} must equal caller SHA ` +
+                `${process.env.CURRENT_FLOORP_SHA}`,
+              );
+            }
+
+            const runId = parsePositiveId(
+              "runtime_workflow_run_id",
+              required(
+                "runtime_workflow_run_id", process.env.RUNTIME_WORKFLOW_RUN_ID,
+              ),
+            );
+            const manifestArtifactId = parsePositiveId(
+              "runtime_manifest_artifact_id",
+              required(
+                "runtime_manifest_artifact_id",
+                process.env.RUNTIME_MANIFEST_ARTIFACT_ID,
+              ),
+            );
+            const targetArtifactId = parsePositiveId(
+              "runtime_artifact_id",
+              required("runtime_artifact_id", process.env.RUNTIME_ARTIFACT_ID),
+            );
+            if (manifestArtifactId === targetArtifactId) {
+              fail("Runtime manifest and target artifact IDs must be different");
+            }
+
+            const manifestDigest = required(
+              "runtime_manifest_artifact_digest",
+              process.env.RUNTIME_MANIFEST_ARTIFACT_DIGEST,
+            );
+            const targetDigest = required(
+              "runtime_artifact_digest", process.env.RUNTIME_ARTIFACT_DIGEST,
+            );
+            validateDigest("runtime_manifest_artifact_digest", manifestDigest);
+            validateDigest("runtime_artifact_digest", targetDigest);
+
+            const targetArtifactName = required(
+              "runtime_artifact_name", process.env.RUNTIME_ARTIFACT_NAME,
+            );
+            if (targetArtifactName !== contract.artifact) {
+              fail(
+                `Runtime artifact ${targetArtifactName} does not match ` +
+                `${process.env.TARGET_PLATFORM} (${contract.artifact})`,
+              );
+            }
+
+            const [owner, repo] = runtimeRepository.split("/");
             const { data: run } = await github.rest.actions.getWorkflowRun({
               owner,
               repo,
-              run_id: runId
+              run_id: runId,
             });
-            const commitHash = run.head_sha;
-            if (!commitHash || !/^[0-9a-fA-F]{40}$/.test(commitHash)) {
-              core.setFailed('Commit hash is missing or not a valid SHA-1: ' + commitHash);
-              throw new Error('Commit hash is missing or not a valid SHA-1: ' + commitHash);
+            if (run.id !== runId) fail("Runtime run ID changed during lookup");
+            if (run.path !== ".github/workflows/daily-build.yml") {
+              fail(`Runtime run used unexpected workflow path: ${run.path}`);
             }
-            core.setOutput('commit_hash', commitHash);
+            if (run.status !== "completed" || run.conclusion !== "success") {
+              fail(
+                `Runtime run ${runId} must be completed/success, got ` +
+                `${run.status}/${run.conclusion}`,
+              );
+            }
+            if (run.head_sha !== runtimeHeadSha) {
+              fail(`Runtime run head SHA ${run.head_sha} != ${runtimeHeadSha}`);
+            }
+            const headRepository = run.head_repository?.full_name;
+            if (headRepository !== runtimeRepository) {
+              fail(
+                `Runtime run head repository ${headRepository} != ${runtimeRepository}`,
+              );
+            }
+            if (productionV2) {
+              const { data: runtimeRepoData } = await github.rest.repos.get({
+                owner,
+                repo,
+              });
+              const runtimeDefaultBranch = required(
+                "Runtime default branch",
+                runtimeRepoData.default_branch,
+              );
+              if (run.head_branch !== runtimeDefaultBranch) {
+                fail(
+                  `stable-v2 requires Runtime default branch ${runtimeDefaultBranch}, ` +
+                    `got ${run.head_branch}`,
+                );
+              }
+              const allowedRuntimeEvents = new Set([
+                "workflow_dispatch",
+                "schedule",
+              ]);
+              if (!allowedRuntimeEvents.has(run.event)) {
+                fail(`stable-v2 rejects Runtime event ${run.event}`);
+              }
+            }
+            const runBuildId = buildIdFromCreatedAt(run.created_at);
+            if (runBuildId !== expectedBuildId) {
+              fail(
+                `Runtime run created_at BuildID ${runBuildId} != ${expectedBuildId}`,
+              );
+            }
+
+            const validateArtifact = async (
+              label, artifactId, expectedName, expectedDigest,
+            ) => {
+              const { data: artifact } = await github.rest.actions.getArtifact({
+                owner,
+                repo,
+                artifact_id: artifactId,
+              });
+              if (artifact.id !== artifactId) {
+                fail(`${label} artifact ID changed during lookup`);
+              }
+              if (artifact.name !== expectedName) {
+                fail(`${label} artifact name ${artifact.name} != ${expectedName}`);
+              }
+              if (artifact.digest !== expectedDigest) {
+                fail(
+                  `${label} artifact digest ${artifact.digest} != ${expectedDigest}`,
+                );
+              }
+              if (artifact.expired) fail(`${label} artifact is expired`);
+              if (!Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes <= 0) {
+                fail(`${label} artifact is empty or has an invalid size`);
+              }
+              if (artifact.workflow_run?.id !== runId) {
+                fail(`${label} artifact does not belong to Runtime run ${runId}`);
+              }
+              if (artifact.workflow_run?.head_sha !== runtimeHeadSha) {
+                fail(`${label} artifact head SHA does not match Runtime run`);
+              }
+            };
+
+            await validateArtifact(
+              "Runtime manifest", manifestArtifactId,
+              "floorp-runtime-build-manifest-v2", manifestDigest,
+            );
+            await validateArtifact(
+              "Runtime target", targetArtifactId,
+              targetArtifactName, targetDigest,
+            );
+
+            core.setOutput("is_v2", "true");
+            core.setOutput("platform_key", contract.key);
+            core.setOutput("runtime_repository", runtimeRepository);
+            core.setOutput("runtime_workflow_run_id", String(runId));
+            core.setOutput("runtime_ref", runtimeHeadSha);
+            core.setOutput("floorp_ref", floorpHeadSha);
+            core.setOutput("runtime_artifact_name", targetArtifactName);
+            core.setOutput("runtime_artifact_id", String(targetArtifactId));
+            core.setOutput("runtime_artifact_digest", targetDigest);
+            core.setOutput("expected_build_id", expectedBuildId);
 
       - name: Checkout ${{ github.repository }}-runtime
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.repository }}-runtime
-          ref: ${{ steps.get-commit.outputs.commit_hash }}
+          repository: ${{ steps.provenance.outputs.runtime_repository }}
+          ref: ${{ steps.provenance.outputs.runtime_ref }}
+          token: ${{ inputs.provenance_mode == 'legacy' && github.token || secrets.runtime_artifact_token }}
+          persist-credentials: false
           submodules: "recursive"
 
       - name: Apply upstream patches
@@ -103,7 +653,115 @@ jobs:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.repository }}
+          ref: ${{ steps.provenance.outputs.floorp_ref }}
           path: "noraneko"
+          persist-credentials: false
+
+      - name: Download verified Runtime artifact by ID
+        if: ${{ steps.provenance.outputs.is_v2 == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.provenance.outputs.runtime_artifact_id }}
+          run-id: ${{ steps.provenance.outputs.runtime_workflow_run_id }}
+          github-token: ${{ inputs.provenance_mode == 'legacy' && github.token || secrets.runtime_artifact_token }}
+          repository: ${{ steps.provenance.outputs.runtime_repository }}
+          path: ${{ runner.temp }}/floorp-runtime-v2
+          merge-multiple: true
+
+      - name: Stage exact Runtime v2 bundle
+        if: ${{ steps.provenance.outputs.is_v2 == 'true' }}
+        shell: bash
+        env:
+          PLATFORM_KEY: ${{ steps.provenance.outputs.platform_key }}
+          RUNTIME_ARTIFACT_NAME: ${{ steps.provenance.outputs.runtime_artifact_name }}
+          EXPECTED_BUILD_ID: ${{ steps.provenance.outputs.expected_build_id }}
+          RUNTIME_DOWNLOAD_DIR: ${{ runner.temp }}/floorp-runtime-v2
+          RUNTIME_SUPPORT_DIR: ${{ runner.temp }}/floorp-runtime-v2-support
+        run: |
+          set -euo pipefail
+
+          root="$RUNTIME_DOWNLOAD_DIR"
+          support="$RUNTIME_SUPPORT_DIR"
+          test -d "$root"
+          test ! -L "$root"
+
+          case "$PLATFORM_KEY" in
+            windows)
+              primary_files=("${RUNTIME_ARTIFACT_NAME}.zip")
+              ;;
+            linux|linuxAarch64)
+              primary_files=("${RUNTIME_ARTIFACT_NAME}.tar.xz")
+              ;;
+            mac)
+              primary_files=(
+                "floorp-macOS-universal-moz-artifact.dmg"
+                "floorp-macOS.update_framework_artifacts.zip"
+              )
+              ;;
+            *)
+              echo "Unsupported v2 platform key: $PLATFORM_KEY" >&2
+              exit 1
+              ;;
+          esac
+
+          expected_entries=("${primary_files[@]}" "dist-host" "floorp-application.ini")
+          entry_count=0
+          while IFS= read -r -d '' entry; do
+            entry_count=$((entry_count + 1))
+            name="$(basename "$entry")"
+            allowed=false
+            for expected in "${expected_entries[@]}"; do
+              if [[ "$name" == "$expected" ]]; then
+                allowed=true
+                break
+              fi
+            done
+            if [[ "$allowed" != true ]]; then
+              echo "Unexpected top-level Runtime artifact entry: $name" >&2
+              exit 1
+            fi
+          done < <(find "$root" -mindepth 1 -maxdepth 1 -print0)
+          if (( entry_count != ${#expected_entries[@]} )); then
+            echo "Runtime artifact has $entry_count top-level entries; expected ${#expected_entries[@]}" >&2
+            exit 1
+          fi
+
+          for file in "${primary_files[@]}"; do
+            if [[ ! -f "$root/$file" || -L "$root/$file" || ! -s "$root/$file" ]]; then
+              echo "Required Runtime package is missing, linked, or empty: $file" >&2
+              exit 1
+            fi
+          done
+          if [[ ! -d "$root/dist-host" || -L "$root/dist-host" ]]; then
+            echo "Runtime dist-host is missing or is a symbolic link" >&2
+            exit 1
+          fi
+          if [[ -z "$(find "$root/dist-host" -type f -print -quit)" ]]; then
+            echo "Runtime dist-host is empty" >&2
+            exit 1
+          fi
+          if [[ ! -f "$root/floorp-application.ini" || -L "$root/floorp-application.ini" ]]; then
+            echo "Runtime floorp-application.ini is missing or is a symbolic link" >&2
+            exit 1
+          fi
+
+          mapfile -t build_ids < <(
+            sed -n 's/^BuildID=//p' "$root/floorp-application.ini" | tr -d '\r'
+          )
+          if (( ${#build_ids[@]} != 1 )) || [[ "${build_ids[0]}" != "$EXPECTED_BUILD_ID" ]]; then
+            echo "Runtime application.ini BuildID does not exactly match $EXPECTED_BUILD_ID" >&2
+            exit 1
+          fi
+
+          rm -rf -- "$support"
+          mkdir -p "$support" "$HOME/artifacts"
+          cp -a -- "$root/dist-host" "$support/dist-host"
+          cp -- "$root/floorp-application.ini" "$support/floorp-application.ini"
+          for file in "${primary_files[@]}"; do
+            cp -- "$root/$file" "$HOME/artifacts/$file"
+          done
+          echo "Staged immutable Runtime artifact $RUNTIME_ARTIFACT_NAME"
 
       - uses: actions/setup-node@v4
         with:
@@ -379,23 +1037,31 @@ jobs:
           ./mach configure
           git apply --ignore-space-change --ignore-whitespace .github/patches/packaging/*.patch
 
-      - name: Possibly retrieve run ID if not provided
+      - name: Set legacy Runtime run ID
+        env:
+          PROVENANCE_MODE: ${{ inputs.provenance_mode }}
+          LEGACY_RUNTIME_RUN_ID: ${{ inputs.runtime_artifact_workflow_run_id }}
         run: |
-          if [ -z "${{ inputs.runtime_artifact_workflow_run_id }}" ]; then
-            echo "RUNTIME_ARTIFACT_WORKFLOW_RUN_ID=false" >> $GITHUB_ENV
+          set -euo pipefail
+          if [[ "$PROVENANCE_MODE" != "legacy" || -z "$LEGACY_RUNTIME_RUN_ID" ]]; then
+            echo "RUNTIME_ARTIFACT_WORKFLOW_RUN_ID=false" >> "$GITHUB_ENV"
           else
-            echo "RUNTIME_ARTIFACT_WORKFLOW_RUN_ID=${{ inputs.runtime_artifact_workflow_run_id }}" >> $GITHUB_ENV
+            echo "RUNTIME_ARTIFACT_WORKFLOW_RUN_ID=$LEGACY_RUNTIME_RUN_ID" >> "$GITHUB_ENV"
           fi
 
       - name: Get Artifact Name
+        id: artifact-contract
         shell: bash
         env:
           FORCE_COLOR: 3
+          PROVENANCE_MODE: ${{ inputs.provenance_mode }}
+          RAW_INPUT_PLATFORM: ${{ inputs.platform }}
+          SKIP_SIGNING: ${{ inputs.skip_signing }}
         run: |
           #!/bin/bash
-          set -e
+          set -euo pipefail
 
-          RAW_PLATFORM="${INPUT_PLATFORM:-${{ inputs.platform }}}"
+          RAW_PLATFORM="${INPUT_PLATFORM:-$RAW_INPUT_PLATFORM}"
           CANON_PLATFORM="${CANON_PLATFORM:-$RAW_PLATFORM}"
           if [[ "$CANON_PLATFORM" == *-x64 ]]; then
             CANON_PLATFORM="${CANON_PLATFORM%-x64}-x86_64"
@@ -403,34 +1069,42 @@ jobs:
 
           case "$CANON_PLATFORM" in
             "Windows-x86_64")
+              output_name="windows-x86_64"
+              output_installer_name="floorp-windows-x86_64.installer.exe"
               echo "ARTIFACT_NAME=floorp-windows-x86_64-moz-artifact" >> $GITHUB_ENV
               echo "ARTIFACT_FROM_RELEASE_NAME=floorp-windows-x86_64-moz-artifact.zip" >> $GITHUB_ENV
-              echo "OUTPUT_NAME=windows-x86_64" >> $GITHUB_ENV
+              echo "OUTPUT_NAME=$output_name" >> $GITHUB_ENV
               echo "INSTALLER_PATH=*installer.exe" >> $GITHUB_ENV
-              echo "OUTPUT_INSTALLER_NAME=floorp-windows-x86_64.installer.exe" >> $GITHUB_ENV
+              echo "OUTPUT_INSTALLER_NAME=$output_installer_name" >> $GITHUB_ENV
               echo "WORKSPACE_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
               ;;
             "Linux-x86_64")
+              output_name="linux-x86_64"
+              output_installer_name="floorp-linux-x86_64.tar.xz"
               echo "ARTIFACT_NAME=floorp-linux-x86_64-moz-artifact" >> $GITHUB_ENV
               echo "ARTIFACT_FROM_RELEASE_NAME=floorp-linux-x86_64-moz-artifact.tar.xz" >> $GITHUB_ENV
-              echo "OUTPUT_NAME=linux-x86_64" >> $GITHUB_ENV
+              echo "OUTPUT_NAME=$output_name" >> $GITHUB_ENV
               echo "INSTALLER_PATH=floorp*tar.xz" >> $GITHUB_ENV
-              echo "OUTPUT_INSTALLER_NAME=floorp-linux-x86_64.tar.xz" >> $GITHUB_ENV
+              echo "OUTPUT_INSTALLER_NAME=$output_installer_name" >> $GITHUB_ENV
               ;;
             "Linux-aarch64")
+              output_name="linux-aarch64"
+              output_installer_name="floorp-linux-aarch64.tar.xz"
               echo "ARTIFACT_NAME=floorp-linux-aarch64-moz-artifact" >> $GITHUB_ENV
               echo "ARTIFACT_FROM_RELEASE_NAME=floorp-linux-aarch64-moz-artifact.tar.xz" >> $GITHUB_ENV
-              echo "OUTPUT_NAME=linux-aarch64" >> $GITHUB_ENV
+              echo "OUTPUT_NAME=$output_name" >> $GITHUB_ENV
               echo "INSTALLER_PATH=floorp*tar.xz" >> $GITHUB_ENV
-              echo "OUTPUT_INSTALLER_NAME=floorp-linux-aarch64.tar.xz" >> $GITHUB_ENV
+              echo "OUTPUT_INSTALLER_NAME=$output_installer_name" >> $GITHUB_ENV
               ;;
             "macOS-x86_64")
+              output_name="mac-universal"
+              output_installer_name="floorp-macOS-universal.dmg"
               echo "ARTIFACT_NAME=floorp-mac-universal-moz-artifact" >> $GITHUB_ENV
               echo "ARTIFACT_FROM_RELEASE_NAME=floorp-macOS-universal-moz-artifact.dmg" >> $GITHUB_ENV
               echo "ARTIFACT_FROM_RELEASE_NAME_FRAMEWORK=floorp-macOS.update_framework_artifacts.zip" >> $GITHUB_ENV
-              echo "OUTPUT_NAME=mac-universal" >> $GITHUB_ENV
+              echo "OUTPUT_NAME=$output_name" >> $GITHUB_ENV
               echo "INSTALLER_PATH=floorp-*dmg" >> $GITHUB_ENV
-              echo "OUTPUT_INSTALLER_NAME=floorp-macOS-universal.dmg" >> $GITHUB_ENV
+              echo "OUTPUT_INSTALLER_NAME=$output_installer_name" >> $GITHUB_ENV
               ;;
             *)
               echo "Unknown canonical platform: $CANON_PLATFORM"
@@ -438,10 +1112,30 @@ jobs:
               ;;
           esac
 
+          suffix=""
+          if [[ "$SKIP_SIGNING" == "true" ]]; then
+            suffix="-unsigned"
+          fi
+          deb_artifact_name=""
+          if [[ "$CANON_PLATFORM" == "Linux-x86_64" ]]; then
+            deb_artifact_name="floorp-Linux-x64-deb${suffix}"
+          fi
+          if [[ "$PROVENANCE_MODE" == "legacy" ]]; then
+            installer_upload_path="$HOME/noraneko-installer/*"
+          else
+            installer_upload_path="$HOME/noraneko-installer/$output_installer_name"
+          fi
+          echo "INSTALLER_UPLOAD_PATH=$installer_upload_path" >> "$GITHUB_ENV"
+          {
+            echo "installer_artifact_name=noraneko-${output_name}-installer${suffix}"
+            echo "mar_artifact_name=floorp-${output_name}-mar-full${suffix}"
+            echo "deb_artifact_name=${deb_artifact_name}"
+          } >> "$GITHUB_OUTPUT"
+
           echo "Environment variables set for platform: $RAW_PLATFORM (canonical: $CANON_PLATFORM)"
 
       - name: Download mozilla artifact from Actions
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -451,7 +1145,7 @@ jobs:
           path: ~/downloads
 
       - name: Download Mozilla Artifact from GitHub Releases
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
         run: |
           mkdir -p ~/downloads
           CANON_PLATFORM="${CANON_PLATFORM:-${{ inputs.platform }}}"
@@ -469,7 +1163,7 @@ jobs:
           esac
 
       - name: Make Downloaded Artifact to Mozilla Artifact (Actions)
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
         run: |
           mkdir -p ~/artifacts
           cd ~/downloads
@@ -489,7 +1183,7 @@ jobs:
           cd "$GITHUB_WORKSPACE"
 
       - name: Make Download Artifact to Mozilla Artifact (GitHub Releases)
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
         run: |
           mkdir -p ~/artifacts
           cd ~/downloads
@@ -556,6 +1250,10 @@ jobs:
           cd ..
 
       - name: Build
+        env:
+          PROVENANCE_MODE: ${{ inputs.provenance_mode }}
+          RAW_INPUT_PLATFORM: ${{ inputs.platform }}
+          VERIFIED_RUNTIME_ARTIFACT_NAME: ${{ steps.provenance.outputs.runtime_artifact_name }}
         run: |
           #!/bin/bash
           set -euo pipefail
@@ -573,7 +1271,16 @@ jobs:
             return 1
           }
 
-          PLATFORM="${INPUT_PLATFORM:-${{ inputs.platform }}}"
+          exact_artifact() {
+            local path="$1"
+            if [[ ! -f "$path" || -L "$path" || ! -s "$path" ]]; then
+              echo "Verified Runtime artifact is missing, linked, or empty: $path" >&2
+              return 1
+            fi
+            printf '%s\n' "$path"
+          }
+
+          PLATFORM="${INPUT_PLATFORM:-$RAW_INPUT_PLATFORM}"
           CANON_PLATFORM="${CANON_PLATFORM:-$PLATFORM}"
           if [[ "$CANON_PLATFORM" == *-x64 ]]; then
             CANON_PLATFORM="${CANON_PLATFORM%-x64}-x86_64"
@@ -581,7 +1288,11 @@ jobs:
 
           case "$CANON_PLATFORM" in
             "Windows-x86_64")
-              ARTIFACT=$(find_first "floorp-win*-moz-artifact*.zip" "noraneko-win*-moz-artifact*.zip" "*win*-moz-artifact*.zip")
+              if [[ "$PROVENANCE_MODE" == "legacy" ]]; then
+                ARTIFACT=$(find_first "floorp-win*-moz-artifact*.zip" "noraneko-win*-moz-artifact*.zip" "*win*-moz-artifact*.zip")
+              else
+                ARTIFACT=$(exact_artifact "$HOME/artifacts/${VERIFIED_RUNTIME_ARTIFACT_NAME}.zip")
+              fi
               if [ -z "$ARTIFACT" ]; then
                 echo "Windows artifact not found in ~/artifacts" >&2
                 exit 1
@@ -589,7 +1300,11 @@ jobs:
               MOZ_ARTIFACT_FILE="$ARTIFACT" ./mach build
               ;;
             "Linux-x86_64")
-              ARTIFACT=$(find_first "floorp-linux-x86_64-moz-artifact*.tar.xz" "noraneko-linux-x86_64-moz-artifact*.tar.xz" "*linux*x86_64*moz-artifact*.tar.xz")
+              if [[ "$PROVENANCE_MODE" == "legacy" ]]; then
+                ARTIFACT=$(find_first "floorp-linux-x86_64-moz-artifact*.tar.xz" "noraneko-linux-x86_64-moz-artifact*.tar.xz" "*linux*x86_64*moz-artifact*.tar.xz")
+              else
+                ARTIFACT=$(exact_artifact "$HOME/artifacts/${VERIFIED_RUNTIME_ARTIFACT_NAME}.tar.xz")
+              fi
               if [ -z "$ARTIFACT" ]; then
                 echo "Linux x86_64 artifact not found in ~/artifacts" >&2
                 exit 1
@@ -597,7 +1312,11 @@ jobs:
               MOZ_ARTIFACT_FILE="$ARTIFACT" ./mach build
               ;;
             "Linux-aarch64")
-              ARTIFACT=$(find_first "floorp-linux-aarch64-moz-artifact*.tar.xz" "noraneko-linux-aarch64-moz-artifact*.tar.xz" "*linux*aarch64*moz-artifact*.tar.xz")
+              if [[ "$PROVENANCE_MODE" == "legacy" ]]; then
+                ARTIFACT=$(find_first "floorp-linux-aarch64-moz-artifact*.tar.xz" "noraneko-linux-aarch64-moz-artifact*.tar.xz" "*linux*aarch64*moz-artifact*.tar.xz")
+              else
+                ARTIFACT=$(exact_artifact "$HOME/artifacts/${VERIFIED_RUNTIME_ARTIFACT_NAME}.tar.xz")
+              fi
               if [ -z "$ARTIFACT" ]; then
                 echo "Linux aarch64 artifact not found in ~/artifacts" >&2
                 exit 1
@@ -605,8 +1324,13 @@ jobs:
               MOZ_ARTIFACT_FILE="$ARTIFACT" ./mach build
               ;;
             "macOS-x86_64")
-              DMG=$(find_first "floorp-mac*-moz-artifact*.dmg" "noraneko-mac*-moz-artifact*.dmg" "*mac*moz-artifact*.dmg")
-              FRAMEWORK=$(find_first "floorp-mac*.update_framework_artifacts.zip" "noraneko-mac*.update_framework_artifacts.zip" "*mac*.update_framework_artifacts.zip")
+              if [[ "$PROVENANCE_MODE" == "legacy" ]]; then
+                DMG=$(find_first "floorp-mac*-moz-artifact*.dmg" "noraneko-mac*-moz-artifact*.dmg" "*mac*moz-artifact*.dmg")
+                FRAMEWORK=$(find_first "floorp-mac*.update_framework_artifacts.zip" "noraneko-mac*.update_framework_artifacts.zip" "*mac*.update_framework_artifacts.zip")
+              else
+                DMG=$(exact_artifact "$HOME/artifacts/floorp-macOS-universal-moz-artifact.dmg")
+                FRAMEWORK=$(exact_artifact "$HOME/artifacts/floorp-macOS.update_framework_artifacts.zip")
+              fi
               if [ -z "$DMG" ] || [ -z "$FRAMEWORK" ]; then
                 echo "macOS artifacts not found in ~/artifacts" >&2
                 exit 1
@@ -614,7 +1338,7 @@ jobs:
               MOZ_ARTIFACT_FILE="${DMG}:${FRAMEWORK}" ./mach build
               ;;
             *)
-              echo "Unsupported platform ${{ inputs.platform }}" >&2
+              echo "Unsupported platform $RAW_INPUT_PLATFORM" >&2
               exit 1
               ;;
           esac
@@ -937,13 +1661,16 @@ jobs:
           EOF
 
       - name: Upload Linux DEB artifact
+        id: upload-deb
         if: ${{ inputs.platform == 'Linux-x86_64' || inputs.platform == 'Linux-x64' }}
         uses: actions/upload-artifact@v4
         with:
-          name: floorp-Linux-x64-deb
+          name: ${{ steps.artifact-contract.outputs.deb_artifact_name }}
           path: |
             /home/runner/ppa-deb/*
           compression-level: 9
+          if-no-files-found: error
+          overwrite: true
 
       - name: Upload Noraneko Artifact
         uses: actions/upload-artifact@v4
@@ -1264,8 +1991,47 @@ jobs:
               ;;
           esac
 
+      - name: Stage verified Runtime v2 MAR inputs
+        if: ${{ inputs.provenance_mode != 'legacy' }}
+        shell: bash
+        env:
+          EXPECTED_BUILD_ID: ${{ steps.provenance.outputs.expected_build_id }}
+          RUNTIME_SUPPORT_DIR: ${{ runner.temp }}/floorp-runtime-v2-support
+        run: |
+          set -euo pipefail
+
+          support="$RUNTIME_SUPPORT_DIR"
+          host_dest="$GITHUB_WORKSPACE/obj-artifact-build-output/dist/host"
+          ini_dest="$HOME/noraneko-dev/floorp-application.ini"
+
+          if [[ ! -d "$support/dist-host" || -L "$support/dist-host" ]]; then
+            echo "Verified Runtime dist-host staging directory is missing" >&2
+            exit 1
+          fi
+          if [[ ! -f "$support/floorp-application.ini" || -L "$support/floorp-application.ini" ]]; then
+            echo "Verified Runtime application.ini staging file is missing" >&2
+            exit 1
+          fi
+
+          rm -rf -- "$host_dest"
+          mkdir -p "$(dirname "$host_dest")" "$(dirname "$ini_dest")"
+          cp -a -- "$support/dist-host" "$host_dest"
+          cp -- "$support/floorp-application.ini" "$ini_dest"
+
+          actual_build_id="$(
+            sed -n 's/^BuildID=//p' "$ini_dest" | tr -d '\r'
+          )"
+          if [[ "$actual_build_id" != "$EXPECTED_BUILD_ID" ]]; then
+            echo "Staged Runtime BuildID $actual_build_id != $EXPECTED_BUILD_ID" >&2
+            exit 1
+          fi
+          if [[ -z "$(find "$host_dest" -type f -print -quit)" ]]; then
+            echo "Staged Runtime dist-host is empty" >&2
+            exit 1
+          fi
+
       - name: Download artifact of MAR tools (Actions)
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
         uses: actions/download-artifact@v4
         with:
           pattern: "*dist-host"
@@ -1276,7 +2042,7 @@ jobs:
           merge-multiple: true
 
       - name: Download artifact of MAR tools (GitHub Releases)
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
         run: |
           set -euo pipefail
           mkdir -p ~/downloads
@@ -1307,7 +2073,7 @@ jobs:
           fi
 
       - name: Download artifact of binary for getting build information (Actions)
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID != 'false' }}
         uses: actions/download-artifact@v4
         with:
           pattern: "*application-ini"
@@ -1318,7 +2084,7 @@ jobs:
           merge-multiple: true
 
       - name: Download artifact of binary for getting build information (GiHub Releases)
-        if: ${{ env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
+        if: ${{ inputs.provenance_mode == 'legacy' && env.RUNTIME_ARTIFACT_WORKFLOW_RUN_ID == 'false' }}
         run: |
           set -euo pipefail
           mkdir -p ~/downloads ~/noraneko-dev
@@ -1453,9 +2219,21 @@ jobs:
           echo "MAR package created successfully!"
 
       - name: Verify installer workspace
+        env:
+          PROVENANCE_MODE: ${{ inputs.provenance_mode }}
         run: |
           set -euo pipefail
           mkdir -p ~/noraneko-installer
+
+          if [[ "$PROVENANCE_MODE" != "legacy" ]]; then
+            expected_installer="$HOME/noraneko-installer/$OUTPUT_INSTALLER_NAME"
+            if [[ ! -f "$expected_installer" || -L "$expected_installer" || ! -s "$expected_installer" ]]; then
+              echo "Stable v2 expected exactly $expected_installer; broad fallback is disabled" >&2
+              exit 1
+            fi
+            echo "Verified exact stable v2 installer/package: $expected_installer"
+            exit 0
+          fi
 
           # If already populated, show contents and continue
           if [ -n "$(find ~/noraneko-installer -mindepth 1 -print -quit 2>/dev/null)" ]; then
@@ -1499,7 +2277,7 @@ jobs:
               echo "Failed to locate installer files. Diagnostics:" >&2
               echo "Listing possible locations:" >&2
               for d in "${CANDIDATES[@]}"; do
-                eval expanded="$d"
+                expanded="$d"
                 echo "== $expanded ==" >&2
                 ls -la "$expanded" 2>/dev/null || echo " (not found)" >&2
               done
@@ -1512,14 +2290,20 @@ jobs:
           fi
 
       - name: Publish dist
+        id: upload-installer
         uses: actions/upload-artifact@v4
         with:
-          name: noraneko-${{ env.OUTPUT_NAME }}-installer${{ inputs.skip_signing && '-unsigned' || '' }}
-          path: ~/noraneko-installer/*
+          name: ${{ steps.artifact-contract.outputs.installer_artifact_name }}
+          path: ${{ env.INSTALLER_UPLOAD_PATH }}
           compression-level: 9
+          if-no-files-found: error
+          overwrite: true
 
       - name: Publish MAR
+        id: upload-mar
         uses: actions/upload-artifact@v4
         with:
-          name: floorp-${{ env.OUTPUT_NAME }}-mar-full${{ inputs.skip_signing && '-unsigned' || '' }}
+          name: ${{ steps.artifact-contract.outputs.mar_artifact_name }}
           path: ~/noraneko-publish/*
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/package_and_publish_release.yml
+++ b/.github/workflows/package_and_publish_release.yml
@@ -1,79 +1,574 @@
+# SPDX-License-Identifier: MPL-2.0
+
 name: "(P) ⚠️ Package and Publish Release"
 
-on:
+'on':
   workflow_dispatch:
     inputs:
-      runtime_windows_artifact_workflow_run_id:
-        description: "The workflow run ID for the Windows runtime artifact"
-        required: false
+      runtime_workflow_run_id:
+        description: Successful Floorp-Runtime daily-build workflow run ID
+        required: true
         type: string
-      runtime_linux_artifact_workflow_run_id:
-        description: "The workflow run ID for the Linux runtime artifact"
-        required: false
+      runtime_manifest_artifact_id:
+        description: Immutable floorp-runtime-build-manifest-v2 artifact ID
+        required: true
         type: string
-      runtime_mac_artifact_workflow_run_id:
-        description: "The workflow run ID for the macOS runtime artifact"
+      validation_only:
+        description: Build, verify, and assemble without signing or publishing
         required: false
-        type: string
-      runtime_linux_aarch64_artifact_workflow_run_id:
-        description: "The workflow run ID for the Linux aarch64 runtime artifact"
-        required: false
-        type: string
+        type: boolean
+        default: false
+
 permissions:
-  contents: write
+  actions: read
+  contents: read
+
+run-name: >-
+  Package release from Runtime run ${{ inputs.runtime_workflow_run_id }}
+  ${{ inputs.validation_only && ' (validation only)' || '' }}
 
 jobs:
   check-version:
+    name: Check release version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check if version already exists
+        with:
+          persist-credentials: false
+
+      - name: Require the production Floorp default branch
+        if: ${{ inputs.validation_only != true }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {data: repository} = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const expectedRef = `refs/heads/${repository.default_branch}`;
+            if (context.ref !== expectedRef) {
+              throw new Error(
+                `Production releases require ${expectedRef}, got ${context.ref}`,
+              );
+            }
+
+      - name: Reject an existing production release
+        if: ${{ inputs.validation_only != true }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           VERSION=$(jq -r .version package.json)
           if gh release view "v$VERSION"; then
-            echo "Version v$VERSION already exists. Exiting..."
+            echo "Version v$VERSION already exists. Exiting..." >&2
             exit 1
           fi
 
-  package-windows:
+      - name: Reject a production tag bound to another commit
+        if: ${{ inputs.validation_only != true }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("node:fs");
+            const version = JSON.parse(
+              fs.readFileSync("package.json", "utf8"),
+            ).version;
+            if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.test(version || "")) {
+              throw new Error("package.json contains a non-canonical release version");
+            }
+            const tag = `v${version}`;
+            let object;
+            try {
+              const response = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tag}`,
+              });
+              object = response.data.object;
+            } catch (error) {
+              if (error.status === 404) return;
+              throw error;
+            }
+            for (let depth = 0; object.type === "tag"; depth += 1) {
+              if (depth >= 8) {
+                throw new Error(`Tag ${tag} exceeds the annotated-tag depth limit`);
+              }
+              const response = await github.rest.git.getTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_sha: object.sha,
+              });
+              object = response.data.object;
+            }
+            if (object.type !== "commit" || object.sha !== context.sha) {
+              throw new Error(
+                `Existing tag ${tag} is not bound to Floorp head ${context.sha}`,
+              );
+            }
+
+  validate-runtime-provenance:
+    name: Validate Runtime provenance
     needs: check-version
+    uses: ./.github/workflows/validate-runtime-provenance.yml
+    with:
+      runtime_workflow_run_id: ${{ inputs.runtime_workflow_run_id }}
+      runtime_manifest_artifact_id: ${{ inputs.runtime_manifest_artifact_id }}
+      validation_only: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+
+  package-windows:
+    name: Package Windows x86_64
+    needs: validate-runtime-provenance
     uses: ./.github/workflows/package.yml
     with:
       platform: Windows-x64
-      runtime_artifact_workflow_run_id: ${{ inputs.runtime_windows_artifact_workflow_run_id }}
-    secrets: inherit
+      provenance_mode: >-
+        ${{ inputs.validation_only && 'stable-v2-validation' || 'stable-v2' }}
+      runtime_repository: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_repository }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.windows_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.windows_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.windows_artifact_digest }}
+      floorp_head_sha: ${{ github.sha }}
+      skip_signing: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+      SIGNPATH_API_TOKEN: >-
+        ${{ ! inputs.validation_only && secrets.SIGNPATH_API_TOKEN || '' }}
 
   package-linux:
-    needs: check-version
+    name: Package Linux x86_64
+    needs: validate-runtime-provenance
     uses: ./.github/workflows/package.yml
     with:
       platform: Linux-x64
-      runtime_artifact_workflow_run_id: ${{ inputs.runtime_linux_artifact_workflow_run_id }}
-    secrets: inherit
-
-  package-macos:
-    needs: check-version
-    uses: ./.github/workflows/package.yml
-    with:
-      platform: macOS-x64
-      runtime_artifact_workflow_run_id: ${{ inputs.runtime_mac_artifact_workflow_run_id }}
-    secrets: inherit
+      provenance_mode: >-
+        ${{ inputs.validation_only && 'stable-v2-validation' || 'stable-v2' }}
+      runtime_repository: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_repository }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_artifact_digest }}
+      floorp_head_sha: ${{ github.sha }}
+      skip_signing: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
 
   package-linux-aarch64:
-    needs: check-version
+    name: Package Linux aarch64
+    needs: validate-runtime-provenance
     uses: ./.github/workflows/package.yml
     with:
       platform: Linux-aarch64
-      runtime_artifact_workflow_run_id: ${{ inputs.runtime_linux_aarch64_artifact_workflow_run_id }}
-    secrets: inherit
+      provenance_mode: >-
+        ${{ inputs.validation_only && 'stable-v2-validation' || 'stable-v2' }}
+      runtime_repository: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_repository }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_aarch64_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_aarch64_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_aarch64_artifact_digest }}
+      floorp_head_sha: ${{ github.sha }}
+      skip_signing: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
 
-  publishs:
+  package-macos:
+    name: Package macOS universal
+    needs: validate-runtime-provenance
+    uses: ./.github/workflows/package.yml
+    with:
+      platform: macOS-x64
+      provenance_mode: >-
+        ${{ inputs.validation_only && 'stable-v2-validation' || 'stable-v2' }}
+      runtime_repository: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_repository }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_digest }}
+      floorp_head_sha: ${{ github.sha }}
+      skip_signing: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+      APPLE_DEVELOPER_P12_BASE64: >-
+        ${{ ! inputs.validation_only && secrets.APPLE_DEVELOPER_P12_BASE64 || '' }}
+      APPLE_DEVELOPER_P12_PASSWORD: >-
+        ${{ ! inputs.validation_only && secrets.APPLE_DEVELOPER_P12_PASSWORD || '' }}
+      APPLE_PROVISIONING_PROFILE_BASE64: >-
+        ${{ ! inputs.validation_only && secrets.APPLE_PROVISIONING_PROFILE_BASE64 || '' }}
+      APPLE_DEVELOPER_API_KEY_JSON: >-
+        ${{ ! inputs.validation_only && secrets.APPLE_DEVELOPER_API_KEY_JSON || '' }}
+      APPLE_DEVELOPER_TEAM_ID: >-
+        ${{ ! inputs.validation_only && secrets.APPLE_DEVELOPER_TEAM_ID || '' }}
+
+  verify-windows-x86_64:
+    name: Verify Windows x86_64 package
+    needs: [validate-runtime-provenance, package-windows]
+    uses: ./.github/workflows/verify-release-artifact.yml
+    with:
+      source_workflow_run_id: ${{ github.run_id }}
+      package_artifact_name: ${{ needs.package-windows.outputs.installer_artifact_name }}
+      package_artifact_id: ${{ needs.package-windows.outputs.installer_artifact_id }}
+      package_artifact_digest: ${{ needs.package-windows.outputs.installer_artifact_digest }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.windows_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.windows_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.windows_artifact_digest }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      floorp_head_sha: ${{ github.sha }}
+      platform_key: windows
+      native_arch: x86_64
+      runner: windows-2025
+      validation_only: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+
+  verify-linux-x86_64:
+    name: Verify Linux x86_64 package
+    needs: [validate-runtime-provenance, package-linux]
+    uses: ./.github/workflows/verify-release-artifact.yml
+    with:
+      source_workflow_run_id: ${{ github.run_id }}
+      package_artifact_name: ${{ needs.package-linux.outputs.installer_artifact_name }}
+      package_artifact_id: ${{ needs.package-linux.outputs.installer_artifact_id }}
+      package_artifact_digest: ${{ needs.package-linux.outputs.installer_artifact_digest }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_artifact_digest }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      floorp_head_sha: ${{ github.sha }}
+      platform_key: linux
+      native_arch: x86_64
+      runner: ubuntu-24.04
+      validation_only: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+
+  verify-linux-aarch64:
+    name: Verify Linux aarch64 package
+    needs: [validate-runtime-provenance, package-linux-aarch64]
+    uses: ./.github/workflows/verify-release-artifact.yml
+    with:
+      source_workflow_run_id: ${{ github.run_id }}
+      package_artifact_name: >-
+        ${{ needs.package-linux-aarch64.outputs.installer_artifact_name }}
+      package_artifact_id: >-
+        ${{ needs.package-linux-aarch64.outputs.installer_artifact_id }}
+      package_artifact_digest: >-
+        ${{ needs.package-linux-aarch64.outputs.installer_artifact_digest }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_aarch64_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_aarch64_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.linux_aarch64_artifact_digest }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      floorp_head_sha: ${{ github.sha }}
+      platform_key: linuxAarch64
+      native_arch: aarch64
+      runner: ubuntu-24.04-arm
+      validation_only: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+
+  verify-mac-x86_64:
+    name: Verify macOS x86_64 package
+    needs: [validate-runtime-provenance, package-macos]
+    uses: ./.github/workflows/verify-release-artifact.yml
+    with:
+      source_workflow_run_id: ${{ github.run_id }}
+      package_artifact_name: ${{ needs.package-macos.outputs.installer_artifact_name }}
+      package_artifact_id: ${{ needs.package-macos.outputs.installer_artifact_id }}
+      package_artifact_digest: ${{ needs.package-macos.outputs.installer_artifact_digest }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_digest }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      floorp_head_sha: ${{ github.sha }}
+      platform_key: mac
+      native_arch: x86_64
+      runner: macos-15-intel
+      validation_only: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+
+  verify-mac-aarch64:
+    name: Verify macOS aarch64 package
+    needs: [validate-runtime-provenance, package-macos]
+    uses: ./.github/workflows/verify-release-artifact.yml
+    with:
+      source_workflow_run_id: ${{ github.run_id }}
+      package_artifact_name: ${{ needs.package-macos.outputs.installer_artifact_name }}
+      package_artifact_id: ${{ needs.package-macos.outputs.installer_artifact_id }}
+      package_artifact_digest: ${{ needs.package-macos.outputs.installer_artifact_digest }}
+      runtime_workflow_run_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_workflow_run_id }}
+      runtime_head_sha: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_head_sha }}
+      runtime_manifest_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.runtime_manifest_artifact_digest }}
+      runtime_artifact_name: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_name }}
+      runtime_artifact_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_id }}
+      runtime_artifact_digest: >-
+        ${{ needs.validate-runtime-provenance.outputs.mac_artifact_digest }}
+      expected_build_id: >-
+        ${{ needs.validate-runtime-provenance.outputs.expected_build_id }}
+      floorp_head_sha: ${{ github.sha }}
+      platform_key: mac
+      native_arch: aarch64
+      runner: macos-14
+      validation_only: ${{ inputs.validation_only }}
+    secrets:
+      runtime_artifact_token: ${{ secrets.PAT }}
+
+  assemble-release-bundle:
+    name: Assemble verified release bundle
     needs:
-      [package-windows, package-linux, package-macos, package-linux-aarch64]
+      - validate-runtime-provenance
+      - package-windows
+      - package-linux
+      - package-linux-aarch64
+      - package-macos
+      - verify-windows-x86_64
+      - verify-linux-x86_64
+      - verify-linux-aarch64
+      - verify-mac-x86_64
+      - verify-mac-aarch64
+    uses: ./.github/workflows/assemble-release-bundle.yml
+    with:
+      source_workflow_run_id: ${{ github.run_id }}
+      floorp_head_sha: ${{ github.sha }}
+      validation_only: ${{ inputs.validation_only }}
+      runtime_context_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.validate-runtime-provenance.outputs.provenance_artifact_name,
+        needs.validate-runtime-provenance.outputs.provenance_artifact_id,
+        needs.validate-runtime-provenance.outputs.provenance_artifact_digest) }}
+      windows_installer_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-windows.outputs.installer_artifact_name,
+        needs.package-windows.outputs.installer_artifact_id,
+        needs.package-windows.outputs.installer_artifact_digest) }}
+      windows_mar_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-windows.outputs.mar_artifact_name,
+        needs.package-windows.outputs.mar_artifact_id,
+        needs.package-windows.outputs.mar_artifact_digest) }}
+      linux_installer_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-linux.outputs.installer_artifact_name,
+        needs.package-linux.outputs.installer_artifact_id,
+        needs.package-linux.outputs.installer_artifact_digest) }}
+      linux_mar_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-linux.outputs.mar_artifact_name,
+        needs.package-linux.outputs.mar_artifact_id,
+        needs.package-linux.outputs.mar_artifact_digest) }}
+      linux_deb_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-linux.outputs.deb_artifact_name,
+        needs.package-linux.outputs.deb_artifact_id,
+        needs.package-linux.outputs.deb_artifact_digest) }}
+      linux_aarch64_installer_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-linux-aarch64.outputs.installer_artifact_name,
+        needs.package-linux-aarch64.outputs.installer_artifact_id,
+        needs.package-linux-aarch64.outputs.installer_artifact_digest) }}
+      linux_aarch64_mar_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-linux-aarch64.outputs.mar_artifact_name,
+        needs.package-linux-aarch64.outputs.mar_artifact_id,
+        needs.package-linux-aarch64.outputs.mar_artifact_digest) }}
+      mac_installer_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-macos.outputs.installer_artifact_name,
+        needs.package-macos.outputs.installer_artifact_id,
+        needs.package-macos.outputs.installer_artifact_digest) }}
+      mac_mar_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.package-macos.outputs.mar_artifact_name,
+        needs.package-macos.outputs.mar_artifact_id,
+        needs.package-macos.outputs.mar_artifact_digest) }}
+      verification_windows_x86_64_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.verify-windows-x86_64.outputs.record_artifact_name,
+        needs.verify-windows-x86_64.outputs.record_artifact_id,
+        needs.verify-windows-x86_64.outputs.record_artifact_digest) }}
+      verification_linux_x86_64_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.verify-linux-x86_64.outputs.record_artifact_name,
+        needs.verify-linux-x86_64.outputs.record_artifact_id,
+        needs.verify-linux-x86_64.outputs.record_artifact_digest) }}
+      verification_linux_aarch64_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.verify-linux-aarch64.outputs.record_artifact_name,
+        needs.verify-linux-aarch64.outputs.record_artifact_id,
+        needs.verify-linux-aarch64.outputs.record_artifact_digest) }}
+      verification_mac_x86_64_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.verify-mac-x86_64.outputs.record_artifact_name,
+        needs.verify-mac-x86_64.outputs.record_artifact_id,
+        needs.verify-mac-x86_64.outputs.record_artifact_digest) }}
+      verification_mac_aarch64_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.verify-mac-aarch64.outputs.record_artifact_name,
+        needs.verify-mac-aarch64.outputs.record_artifact_id,
+        needs.verify-mac-aarch64.outputs.record_artifact_digest) }}
+
+  publish:
+    name: Publish verified release
+    needs: assemble-release-bundle
+    if: ${{ inputs.validation_only != true }}
+    permissions:
+      actions: read
+      contents: write
     uses: ./.github/workflows/publish_release.yml
     with:
+      source_workflow_run_id: ${{ github.run_id }}
+      bundle_artifact: >-
+        ${{ format('{{"name":"{0}","id":{1},"digest":"{2}"}}',
+        needs.assemble-release-bundle.outputs.artifact_name,
+        needs.assemble-release-bundle.outputs.artifact_id,
+        needs.assemble-release-bundle.outputs.artifact_digest) }}
       publish_ppa: true
-      linux_deb_run_id: ${{ needs.package-linux.outputs.run_id }}
-    secrets: inherit
+    secrets:
+      UPDATES_ACTIONS_TOKEN: ${{ secrets.UPDATE_SERVER_TOKEN }}
+      PORTABLE_ACTIONS_TOKEN: ${{ secrets.UPDATE_SERVER_TOKEN }}
+      KEYMASK: ${{ secrets.KEYMASK }}
+      GPG_SEC: ${{ secrets.GPG_SEC }}
+      GPG_SSB: ${{ secrets.GPG_SSB }}
+      PPA_FTP_URL: ${{ secrets.PPA_FTP_URL }}
+      PPA_FTP_USER: ${{ secrets.PPA_FTP_USER }}
+      PPA_FTP_PASS: ${{ secrets.PPA_FTP_PASS }}
+      CLOUDFLARE_API_TOKEN_FOR_PURGE: >-
+        ${{ secrets.CLOUDFLARE_API_TOKEN_FOR_PURGE }}
+      CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+
+  validation-complete:
+    name: Validation-only release bundle complete
+    needs: assemble-release-bundle
+    if: ${{ inputs.validation_only == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize validation result
+        env:
+          BUNDLE_ARTIFACT_NAME: >-
+            ${{ needs.assemble-release-bundle.outputs.artifact_name }}
+          BUNDLE_ARTIFACT_ID: >-
+            ${{ needs.assemble-release-bundle.outputs.artifact_id }}
+          BUNDLE_ARTIFACT_DIGEST: >-
+            ${{ needs.assemble-release-bundle.outputs.artifact_digest }}
+          MANIFEST_SET_ID: >-
+            ${{ needs.assemble-release-bundle.outputs.manifest_set_id }}
+          RELEASE_TAG: ${{ needs.assemble-release-bundle.outputs.release_tag }}
+        run: |
+          {
+            echo "### Validation-only release bundle completed"
+            echo ""
+            echo "- Bundle: \`${BUNDLE_ARTIFACT_NAME}\`"
+            echo "- Artifact ID: \`${BUNDLE_ARTIFACT_ID}\`"
+            echo "- Artifact digest: \`${BUNDLE_ARTIFACT_DIGEST}\`"
+            echo "- Manifest set: \`${MANIFEST_SET_ID}\`"
+            echo "- Candidate release tag: \`${RELEASE_TAG}\`"
+            echo "- Publication: skipped"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -2,327 +2,932 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-name: "(P) |α| Publish Release"
+name: "(P) Publish immutable release bundle v2"
 
 on:
   workflow_call:
     inputs:
+      source_workflow_run_id:
+        description: "Floorp workflow run containing the immutable bundle artifact"
+        type: string
+        required: true
+      bundle_artifact:
+        description: 'Exact JSON identity: {"name":string,"id":positive integer,"digest":"sha256:<64 lowercase hex>"}'
+        type: string
+        required: true
       publish_ppa:
+        description: "Publish the release DEB through the existing PPA workflow"
         type: boolean
         required: false
         default: false
-      linux_deb_run_id:
-        type: string
+    secrets:
+      UPDATES_ACTIONS_TOKEN:
+        description: "Token scoped only to dispatching and reading Floorp-Updates Actions"
+        required: true
+      PORTABLE_ACTIONS_TOKEN:
+        description: "Token scoped only to dispatching and reading Floorp-Portable-v2 Actions"
+        required: true
+      KEYMASK:
         required: false
+      GPG_SEC:
+        required: false
+      GPG_SSB:
+        required: false
+      PPA_FTP_URL:
+        required: false
+      PPA_FTP_USER:
+        required: false
+      PPA_FTP_PASS:
+        required: false
+      CLOUDFLARE_API_TOKEN_FOR_PURGE:
+        required: false
+      CLOUDFLARE_ZONE_ID:
+        required: false
+    outputs:
+      manifest_set_id:
+        description: "Published release manifest set identity"
+        value: ${{ jobs.prepare_release.outputs.manifest_set_id }}
+      firefox_version:
+        description: "Published Firefox version"
+        value: ${{ jobs.prepare_release.outputs.firefox_version }}
+      floorp_version:
+        description: "Published Floorp version"
+        value: ${{ jobs.prepare_release.outputs.floorp_version }}
+      release_tag:
+        description: "Published release tag"
+        value: ${{ jobs.prepare_release.outputs.release_tag }}
 
 permissions:
-  contents: write
+  actions: read
+  contents: read
 
-run-name: "|α| Publish Release"
+concurrency:
+  group: publish-release-v2-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
-  main:
-    runs-on: ubuntu-latest
+  prepare_release:
+    name: Validate immutable bundle and create draft release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: write
     outputs:
-      VERSION: ${{ steps.setup.outputs.VERSION }}
-      NR_VERSION: ${{ steps.setup.outputs.NR_VERSION }}
+      manifest_set_id: ${{ steps.validate.outputs.manifest-set-id }}
+      firefox_version: ${{ steps.validate.outputs.firefox-version }}
+      floorp_version: ${{ steps.validate.outputs.floorp-version }}
+      release_tag: ${{ steps.manifest.outputs.release-tag }}
+      floorp_head_sha: ${{ steps.manifest.outputs.floorp-head-sha }}
+      bundle_artifact_id: ${{ steps.bundle.outputs.artifact-id }}
     steps:
-      - uses: actions/setup-node@v4
+      - name: Revalidate the exact bundle identity through REST
+        id: bundle
+        uses: actions/github-script@v7
+        env:
+          SOURCE_WORKFLOW_RUN_ID: ${{ inputs.source_workflow_run_id }}
+          BUNDLE_ARTIFACT: ${{ inputs.bundle_artifact }}
+          PUBLISH_PPA: ${{ inputs.publish_ppa }}
         with:
-          node-version: 22
+          github-token: ${{ github.token }}
+          script: |
+            const fail = (message) => {
+              core.setFailed(message);
+              throw new Error(message);
+            };
+            if (!/^[1-9][0-9]*$/.test(process.env.SOURCE_WORKFLOW_RUN_ID || "")) {
+              fail("source_workflow_run_id must be a positive decimal integer");
+            }
+            const runId = Number(process.env.SOURCE_WORKFLOW_RUN_ID);
+            if (!Number.isSafeInteger(runId)) {
+              fail("source_workflow_run_id exceeds JavaScript's safe integer range");
+            }
+            if (process.env.PUBLISH_PPA === "true" && runId !== context.runId) {
+              fail("PPA publication requires the exact current source workflow run");
+            }
+            let expected;
+            try {
+              expected = JSON.parse(process.env.BUNDLE_ARTIFACT);
+            } catch (error) {
+              fail(`bundle_artifact is not valid JSON: ${error.message}`);
+            }
+            if (
+              expected === null || Array.isArray(expected) ||
+              typeof expected !== "object" ||
+              Object.keys(expected).sort().join(",") !== "digest,id,name"
+            ) {
+              fail("bundle_artifact must contain exactly name, id, and digest");
+            }
+            if (expected.name !== "floorp-release-bundle-v2") {
+              fail("Only the production floorp-release-bundle-v2 artifact can be published");
+            }
+            if (!Number.isSafeInteger(expected.id) || expected.id < 1) {
+              fail("bundle_artifact.id must be a positive safe integer");
+            }
+            if (!/^sha256:[0-9a-f]{64}$/.test(expected.digest || "")) {
+              fail("bundle_artifact.digest must be a lowercase sha256 digest");
+            }
 
-      - uses: denoland/setup-deno@v2
+            const {data: run} = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            if (run.id !== runId || run.repository?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              fail("Bundle source workflow repository or ID mismatch");
+            }
+            if (runId === context.runId) {
+              if (!["queued", "in_progress", "completed"].includes(run.status)) {
+                fail(`Current source workflow has an invalid status: ${run.status}`);
+              }
+            } else if (run.status !== "completed" || run.conclusion !== "success") {
+              fail("A prior bundle source workflow must be completed successfully");
+            }
+            if (!/^[0-9a-f]{40}$/.test(run.head_sha || "")) {
+              fail("Bundle source workflow has a non-canonical head SHA");
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100,
+              },
+            );
+            const idMatches = artifacts.filter((artifact) => artifact.id === expected.id);
+            const nameMatches = artifacts.filter(
+              (artifact) => artifact.name === expected.name && !artifact.expired,
+            );
+            if (idMatches.length !== 1 || nameMatches.length !== 1 || nameMatches[0].id !== expected.id) {
+              fail("Bundle name and ID do not identify one unexpired source-run artifact");
+            }
+            const artifact = idMatches[0];
+            if (
+              artifact.name !== expected.name || artifact.digest !== expected.digest ||
+              artifact.expired || !Number.isInteger(artifact.size_in_bytes) ||
+              artifact.size_in_bytes < 1
+            ) {
+              fail("Bundle REST identity, expiry, or size does not match the input identity");
+            }
+            core.setOutput("artifact-id", String(expected.id));
+            core.setOutput("source-head-sha", run.head_sha);
+
+      - name: Download only the exact bundle artifact ID
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ steps.bundle.outputs.artifact-id }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/floorp-release-bundle-v2
+          merge-multiple: true
+
+      - name: Read the manifest-bound Floorp commit
+        id: manifest
+        uses: actions/github-script@v7
+        env:
+          BUNDLE_DIR: ${{ runner.temp }}/floorp-release-bundle-v2
+          SOURCE_WORKFLOW_RUN_ID: ${{ inputs.source_workflow_run_id }}
+          SOURCE_HEAD_SHA: ${{ steps.bundle.outputs.source-head-sha }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const manifestPath = path.join(
+              process.env.BUNDLE_DIR,
+              "release-manifest-set-v2.json",
+            );
+            if (!fs.statSync(manifestPath, {throwIfNoEntry: false})?.isFile()) {
+              throw new Error("Bundle lacks root release-manifest-set-v2.json");
+            }
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+            if (manifest.schema_version !== 2 || manifest.mode !== "production") {
+              throw new Error("Bundle manifest is not a production v2 manifest");
+            }
+            if (
+              !manifest.floorp || manifest.floorp.repository !== `${context.repo.owner}/${context.repo.repo}` ||
+              !/^[0-9a-f]{40}$/.test(manifest.floorp.head_sha || "")
+            ) {
+              throw new Error("Bundle manifest has invalid Floorp provenance");
+            }
+            if (manifest.floorp.head_sha !== process.env.SOURCE_HEAD_SHA) {
+              throw new Error("Bundle manifest Floorp head differs from its source workflow run");
+            }
+            if (String(manifest.floorp.workflow_run_id) !== process.env.SOURCE_WORKFLOW_RUN_ID) {
+              throw new Error("Bundle manifest source workflow run does not match the requested run");
+            }
+            if (
+              typeof manifest.floorp.release_tag !== "string" ||
+              !/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(manifest.floorp.release_tag)
+            ) {
+              throw new Error("Bundle manifest has a non-canonical release tag");
+            }
+            core.setOutput("floorp-head-sha", manifest.floorp.head_sha);
+            core.setOutput("release-tag", manifest.floorp.release_tag);
+
+      - name: Checkout the manifest-bound Floorp commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.manifest.outputs.floorp-head-sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
-      - name: init zx
+      - name: Reject unsigned, validation, or inconsistent release bundles
+        id: validate
+        shell: bash
+        env:
+          BUNDLE_DIR: ${{ runner.temp }}/floorp-release-bundle-v2
         run: |
-          deno install -g -A npm:zx
+          set -euo pipefail
+          deno run --allow-read --allow-write \
+            tools/src/release_provenance.ts \
+            validate-release-bundle \
+            --bundle-dir "$BUNDLE_DIR" \
+            --production \
+            --github-output "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - name: Refuse to mutate an existing public or unrelated draft release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ steps.manifest.outputs.release-tag }}
+          FLOORP_HEAD_SHA: ${{ steps.manifest.outputs.floorp-head-sha }}
+          FLOORP_VERSION: ${{ steps.validate.outputs.floorp-version }}
         with:
-          fetch-depth: 1
-          ref: main
-
-      - name: Download Windows artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: floorp-windows-x86_64-mar-full
-          path: ~/noraneko-publish/win
           github-token: ${{ github.token }}
+          script: |
+            async function resolveTagCommit(tag, allowMissing) {
+              let object;
+              try {
+                const response = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `tags/${tag}`,
+                });
+                object = response.data.object;
+              } catch (error) {
+                if (allowMissing && error.status === 404) return null;
+                throw error;
+              }
+              for (let depth = 0; object.type === "tag"; depth += 1) {
+                if (depth >= 8) {
+                  throw new Error(`Tag ${tag} exceeds the annotated-tag depth limit`);
+                }
+                const response = await github.rest.git.getTag({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_sha: object.sha,
+                });
+                object = response.data.object;
+              }
+              if (object.type !== "commit" || !/^[0-9a-f]{40}$/.test(object.sha)) {
+                throw new Error(`Tag ${tag} does not resolve to a canonical commit`);
+              }
+              return object.sha;
+            }
+            const existingTagCommit = await resolveTagCommit(
+              process.env.RELEASE_TAG,
+              true,
+            );
+            if (
+              existingTagCommit !== null &&
+              existingTagCommit !== process.env.FLOORP_HEAD_SHA
+            ) {
+              throw new Error(
+                `Existing tag ${process.env.RELEASE_TAG} resolves to ` +
+                `${existingTagCommit}, not ${process.env.FLOORP_HEAD_SHA}`,
+              );
+            }
 
-      - name: Download Linux artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: floorp-linux-x86_64-mar-full
-          path: ~/noraneko-publish/linux
-          github-token: ${{ github.token }}
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              {owner: context.repo.owner, repo: context.repo.repo, per_page: 100},
+            );
+            const matches = releases.filter(
+              (release) => release.tag_name === process.env.RELEASE_TAG,
+            );
+            if (matches.length > 1) {
+              throw new Error("Multiple releases use the requested immutable tag");
+            }
+            if (matches.length === 0) {
+              return;
+            }
+            const release = matches[0];
+            if (!release.draft) {
+              throw new Error(
+                `Refusing to replace assets on public release ${process.env.RELEASE_TAG}`,
+              );
+            }
+            if (release.target_commitish !== process.env.FLOORP_HEAD_SHA) {
+              throw new Error("Existing draft is bound to a different Floorp commit");
+            }
+            const allowedAssets = new Set([
+              `floorp-${process.env.FLOORP_VERSION}.deb`,
+              "floorp-stub.installer.exe",
+              "floorp-linux-aarch64-full.mar",
+              "floorp-linux-aarch64.tar.xz",
+              "floorp-linux-x86_64-full.mar",
+              "floorp-linux-x86_64.tar.xz",
+              "floorp-mac-universal-full.mar",
+              "floorp-macOS-universal.dmg",
+              "floorp-windows-x86_64-full.mar",
+              "floorp-windows-x86_64.installer.exe",
+              "hashes.txt",
+              "linux-aarch64-meta.json",
+              "linux-meta.json",
+              "mac-meta.json",
+              "release-manifest-set-v2.json",
+              "win-meta.json",
+            ]);
+            if (release.assets.some((asset) => !allowedAssets.has(asset.name))) {
+              throw new Error("Existing draft contains an asset outside the v2 bundle");
+            }
+            if (new Set(release.assets.map((asset) => asset.name)).size !== release.assets.length) {
+              throw new Error("Existing draft contains duplicate asset names");
+            }
 
-      - name: Download macOS artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: floorp-mac-universal-mar-full
-          path: ~/noraneko-publish/mac
-          github-token: ${{ github.token }}
-
-      - name: Download Windows installer
-        uses: actions/download-artifact@v4
-        with:
-          name: noraneko-windows-x86_64-installer
-          path: ~/noraneko-publish/win-dist
-          github-token: ${{ github.token }}
-
-      - name: Download Linux installer
-        uses: actions/download-artifact@v4
-        with:
-          name: noraneko-linux-x86_64-installer
-          path: ~/noraneko-publish/linux-dist
-          github-token: ${{ github.token }}
-
-      - name: Download Linux PPA DEB
-        uses: actions/download-artifact@v4
-        with:
-          name: floorp-Linux-x64-deb
-          path: ~/noraneko-publish/linux-deb
-          github-token: ${{ github.token }}
-
-      - name: Download macOS installer
-        uses: actions/download-artifact@v4
-        with:
-          name: noraneko-mac-universal-installer
-          path: ~/noraneko-publish/mac-dist
-          github-token: ${{ github.token }}
-
-      - name: Download Linux aarch64 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: floorp-linux-aarch64-mar-full
-          path: ~/noraneko-publish/linux-aarch64
-          github-token: ${{ github.token }}
-
-      - name: Download Linux aarch64 installer
-        uses: actions/download-artifact@v4
-        with:
-          name: noraneko-linux-aarch64-installer
-          path: ~/noraneko-publish/linux-aarch64-dist
-          github-token: ${{ github.token }}
-
-      # PPA-related setup and artifact download were moved to a
-      # reusable workflow (`.github/workflows/publish_ppa.yml`) which is
-      # called after the updater dispatch. See the `publish_ppa` job.
-
-      - name: Download Stub Installers from latest release
-        run: |
-          set -eux
-          mkdir -p ~/noraneko-publish/stub-installers
-
-          # Download the known stub installer directly. No token required.
-          URL="https://github.com/Floorp-Projects/Floorp/releases/latest/download/floorp-stub.installer.exe"
-          OUT="$HOME/noraneko-publish/stub-installers/$(basename "$URL")"
-
-          echo "Downloading stub installer from $URL to $OUT"
-          curl -L --fail -o "$OUT" "$URL"
-
-          echo "Downloaded contents of ~/noraneko-publish/stub-installers:"
-          ls -la ~/noraneko-publish/stub-installers || true
-
-      - name: Setup
-        id: setup
-        run: |
-          deno install --allow-scripts
-          sudo apt install jq
-
-          VERSION=$(cat ~/noraneko-publish/win/meta.json | jq '.version' | sed 's/"//g')
-          NR_VERSION=$(cat ~/noraneko-publish/win/meta.json | jq '.noraneko_version' | sed 's/"//g')
-
-          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
-          echo "NR_VERSION=${NR_VERSION}" >> "$GITHUB_ENV"
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "NR_VERSION=${NR_VERSION}" >> "$GITHUB_OUTPUT"
-
-          echo "BUILDID=$(cat ~/noraneko-publish/mac/meta.json | jq '.buildid' | sed 's/"//g')" >> "$GITHUB_ENV"
-          echo "BUILDID2=$(cat ~/noraneko-publish/mac/meta.json | jq '.noraneko_buildid' | sed 's/"//g')" >> "$GITHUB_ENV"
-          echo "ROOT_DIR=$(echo ~)" >> "$GITHUB_ENV"
-
-      - name: Check Files
-        run: |
-          echo "Windows Files:"
-          ls -la ~/noraneko-publish/win
-          echo "Linux Files:"
-          ls -la ~/noraneko-publish/linux
-          echo "Linux DEB Files:"
-          ls -la ~/noraneko-publish/linux-deb
-          echo "Linux aarch64 Files:"
-          ls -la ~/noraneko-publish/linux-aarch64
-          echo "macOS Files:"
-          ls -la ~/noraneko-publish/mac
-          echo "Windows Installer Files:"
-          ls -la ~/noraneko-publish/win-dist
-          echo "Linux Installer Files:"
-          ls -la ~/noraneko-publish/linux-dist
-          echo "Linux aarch64 Installer Files:"
-          ls -la ~/noraneko-publish/linux-aarch64-dist
-          echo "macOS Installer Files:"
-          ls -la ~/noraneko-publish/mac-dist
-
-      - name: Prepare meta.json files with platform-specific names
-        run: |
-          cp ~/noraneko-publish/win/meta.json ~/noraneko-publish/win-meta.json
-          cp ~/noraneko-publish/linux/meta.json ~/noraneko-publish/linux-meta.json
-          cp ~/noraneko-publish/linux-aarch64/meta.json ~/noraneko-publish/linux-aarch64-meta.json
-          cp ~/noraneko-publish/mac/meta.json ~/noraneko-publish/mac-meta.json
-
-      - name: Generate hashes.txt
-        run: |
-          cd ~/noraneko-publish
-          echo "# Floorp ${{ env.NR_VERSION }} - File Hashes" > hashes.txt
-          echo "Generated on: $(date -u)" >> hashes.txt
-          echo "" >> hashes.txt
-
-          echo "## Windows Files" >> hashes.txt
-          find win -name "*.mar" -o -name "*.exe" | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          find win-dist -name "*.exe" | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          echo "" >> hashes.txt
-
-          echo "## Linux Files" >> hashes.txt
-          find linux -name "*.mar" | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          find linux-dist -type f | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          echo "" >> hashes.txt
-
-          echo "## Linux aarch64 Files" >> hashes.txt
-          find linux-aarch64 -name "*.mar" | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          find linux-aarch64-dist -type f | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          echo "" >> hashes.txt
-
-          echo "## macOS Files" >> hashes.txt
-          find mac -name "*.mar" | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          find mac-dist -name "*.dmg" | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-          echo "" >> hashes.txt
-
-          echo "## Stub Installers" >> hashes.txt
-          find stub-installers -name "*.exe" | while read file; do
-            echo "SHA256: $(sha256sum "$file" | cut -d' ' -f1) - $file" >> hashes.txt
-          done
-
-      # NOTE: The PPA publishing step was moved out of the `main` job and
-      # implemented as a separate job `publish_ppa` that runs after the
-      # updater dispatch. See the `publish_ppa` job defined below.
-      - name: Deploy to GitHub Releases 🚀
+      - name: Create or update the draft GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            ${{ env.ROOT_DIR }}/noraneko-publish/win/*.mar
-            ${{ env.ROOT_DIR }}/noraneko-publish/win-dist/*.exe
-            ${{ env.ROOT_DIR }}/noraneko-publish/win-meta.json
-            ${{ env.ROOT_DIR }}/noraneko-publish/linux/*.mar
-            ${{ env.ROOT_DIR }}/noraneko-publish/linux-dist/**
-            ${{ env.ROOT_DIR }}/noraneko-publish/linux-deb/*.deb
-            ${{ env.ROOT_DIR }}/noraneko-publish/linux-meta.json
-            ${{ env.ROOT_DIR }}/noraneko-publish/linux-aarch64/*.mar
-            ${{ env.ROOT_DIR }}/noraneko-publish/linux-aarch64-dist/**
-            ${{ env.ROOT_DIR }}/noraneko-publish/linux-aarch64-meta.json
-            ${{ env.ROOT_DIR }}/noraneko-publish/mac/*.mar
-            ${{ env.ROOT_DIR }}/noraneko-publish/mac-dist/*.dmg
-            ${{ env.ROOT_DIR }}/noraneko-publish/mac-meta.json
-            ${{ env.ROOT_DIR }}/noraneko-publish/stub-installers/**
-            ${{ env.ROOT_DIR }}/noraneko-publish/hashes.txt
-          tag_name: "v${{ env.NR_VERSION }}"
-          name: "Floorp ${{ env.NR_VERSION }}"
+          tag_name: ${{ steps.manifest.outputs.release-tag }}
+          target_commitish: ${{ steps.manifest.outputs.floorp-head-sha }}
+          name: Floorp ${{ steps.validate.outputs.floorp-version }}
           body: |
-            Release Note: https://blog.floorp.app/release/${{ env.NR_VERSION }}
+            Release Note: https://blog.floorp.app/release/${{ steps.validate.outputs.floorp-version }}
 
-            ## What's Changed
-
-            ${{ steps.release_notes.outputs.body }}
+            This draft was assembled from an immutable, natively verified release manifest set.
           generate_release_notes: true
           draft: true
+          prerelease: false
           make_latest: true
+          fail_on_unmatched_files: true
+          files: ${{ runner.temp }}/floorp-release-bundle-v2/*
           token: ${{ github.token }}
 
   release_check:
-    needs: [main]
-    runs-on: ubuntu-latest
+    name: Manual approval and public release gate
+    needs: prepare_release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     environment: Deploy-to-installer-release
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - name: Check Release is Published
+      - name: Download the immutable expected bundle again by artifact ID
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.prepare_release.outputs.bundle_artifact_id }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/expected-release-bundle
+          merge-multiple: true
+
+      - name: Require the exact draft to have been published manually
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+          FLOORP_HEAD_SHA: ${{ needs.prepare_release.outputs.floorp_head_sha }}
+          FLOORP_VERSION: ${{ needs.prepare_release.outputs.floorp_version }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const {data: release} = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: process.env.RELEASE_TAG,
+            });
+            let object = (await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${process.env.RELEASE_TAG}`,
+            })).data.object;
+            for (let depth = 0; object.type === "tag"; depth += 1) {
+              if (depth >= 8) {
+                throw new Error("Release tag exceeds the annotated-tag depth limit");
+              }
+              object = (await github.rest.git.getTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_sha: object.sha,
+              })).data.object;
+            }
+            if (
+              object.type !== "commit" ||
+              object.sha !== process.env.FLOORP_HEAD_SHA
+            ) {
+              throw new Error(
+                `Release tag resolves to ${object.type}:${object.sha}, not ` +
+                process.env.FLOORP_HEAD_SHA,
+              );
+            }
+            if (release.draft || release.prerelease) {
+              throw new Error(
+                `Release ${process.env.RELEASE_TAG} must be public and stable before updater deployment`,
+              );
+            }
+            if (release.tag_name !== process.env.RELEASE_TAG) {
+              throw new Error("Published release tag changed after validation");
+            }
+            if (release.target_commitish !== process.env.FLOORP_HEAD_SHA) {
+              throw new Error(
+                `Release target ${release.target_commitish} is not the manifest head ` +
+                process.env.FLOORP_HEAD_SHA,
+              );
+            }
+            const expectedAssets = [
+              `floorp-${process.env.FLOORP_VERSION}.deb`,
+              "floorp-stub.installer.exe",
+              "floorp-linux-aarch64-full.mar",
+              "floorp-linux-aarch64.tar.xz",
+              "floorp-linux-x86_64-full.mar",
+              "floorp-linux-x86_64.tar.xz",
+              "floorp-mac-universal-full.mar",
+              "floorp-macOS-universal.dmg",
+              "floorp-windows-x86_64-full.mar",
+              "floorp-windows-x86_64.installer.exe",
+              "hashes.txt",
+              "linux-aarch64-meta.json",
+              "linux-meta.json",
+              "mac-meta.json",
+              "release-manifest-set-v2.json",
+              "win-meta.json",
+            ].sort();
+            const actualAssets = release.assets.map((asset) => asset.name).sort();
+            if (JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) {
+              throw new Error(
+                `Published assets differ from the exact release bundle: ${actualAssets.join(", ")}`,
+              );
+            }
+            if (release.assets.some((asset) => !Number.isInteger(asset.size) || asset.size < 1)) {
+              throw new Error("Published release contains an empty asset");
+            }
+
+      - name: Prove every public release asset is byte-identical to the bundle
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          NR_VERSION: ${{ needs.main.outputs.NR_VERSION }}
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+          EXPECTED_DIR: ${{ runner.temp }}/expected-release-bundle
+          PUBLIC_DIR: ${{ runner.temp }}/public-release-assets
         run: |
-          IS_DRAFT=$(gh release view "v$NR_VERSION" --json isDraft --jq '.isDraft')
-          if [ "$IS_DRAFT" == "true" ]; then
-            echo "Error: Release v$NR_VERSION is still a draft!"
-            echo "Please manually publish the release before approving this deployment."
+          set -euo pipefail
+          mkdir "$PUBLIC_DIR"
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir "$PUBLIC_DIR"
+
+          expected_names="$RUNNER_TEMP/expected-public-asset-names.txt"
+          public_names="$RUNNER_TEMP/actual-public-asset-names.txt"
+          find "$EXPECTED_DIR" -mindepth 1 -maxdepth 1 -type f \
+            -printf '%f\n' | sort > "$expected_names"
+          find "$PUBLIC_DIR" -mindepth 1 -maxdepth 1 -type f \
+            -printf '%f\n' | sort > "$public_names"
+          if ! diff -u "$expected_names" "$public_names"; then
+            echo "Public release asset names differ from the immutable bundle" >&2
             exit 1
           fi
-          echo "Release v$NR_VERSION is public. Proceeding with deployment."
+          if [[ "$(wc -l < "$expected_names" | tr -d ' ')" != 16 ]]; then
+            echo "Immutable release bundle does not contain exactly 16 assets" >&2
+            exit 1
+          fi
 
-  publish:
-    needs: [release_check, main]
-    runs-on: ubuntu-latest
-    environment:
-      name: Deploy-to-updater-release
-    outputs:
-      NR_VERSION: ${{ needs.main.outputs.NR_VERSION }}
-      VERSION: ${{ needs.main.outputs.VERSION }}
+          while IFS= read -r filename; do
+            if ! cmp --silent \
+              "$EXPECTED_DIR/$filename" \
+              "$PUBLIC_DIR/$filename"; then
+              echo "Public release asset differs from immutable bundle: $filename" >&2
+              exit 1
+            fi
+          done < "$expected_names"
+          echo "All 16 public release assets are byte-identical to the bundle."
+
+  publish_updates:
+    name: Publish and verify stable updater metadata v2
+    needs: [prepare_release, release_check]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: Deploy-to-updater-release
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - name: Deploy to Floorp Update Server 🚀
+      - name: Dispatch the exact Updates v2 request and capture its run ID
+        id: dispatch
+        uses: actions/github-script@v7
         env:
-          NR_VERSION: ${{ needs.main.outputs.NR_VERSION }}
-          VERSION: ${{ needs.main.outputs.VERSION }}
-          GH_TOKEN: ${{ secrets.UPDATE_SERVER_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+          FLOORP_VERSION: ${{ needs.prepare_release.outputs.floorp_version }}
+          FIREFOX_VERSION: ${{ needs.prepare_release.outputs.firefox_version }}
+          MANIFEST_SET_ID: ${{ needs.prepare_release.outputs.manifest_set_id }}
+        with:
+          github-token: ${{ secrets.UPDATES_ACTIONS_TOKEN }}
+          script: |
+            const requestId =
+              `floorp-${context.runId}-${process.env.GITHUB_RUN_ATTEMPT}`;
+            if (!/^[A-Za-z0-9._-]{1,64}$/.test(requestId)) {
+              throw new Error("Generated Updates request ID is not canonical");
+            }
+            const releaseBase =
+              `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/` +
+              process.env.RELEASE_TAG;
+            const response = await github.request(
+              "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+              {
+                owner: "Floorp-Projects",
+                repo: "Floorp-Updates",
+                workflow_id: "update-stable-updatexml-files-v2.yml",
+                ref: "main",
+                return_run_details: true,
+                inputs: {
+                  "win-mar-url": `${releaseBase}/floorp-windows-x86_64-full.mar`,
+                  "linux-mar-url": `${releaseBase}/floorp-linux-x86_64-full.mar`,
+                  "linux-aarch64-mar-url": `${releaseBase}/floorp-linux-aarch64-full.mar`,
+                  "mac-mar-url": `${releaseBase}/floorp-mac-universal-full.mar`,
+                  "win-meta-url": `${releaseBase}/win-meta.json`,
+                  "linux-meta-url": `${releaseBase}/linux-meta.json`,
+                  "linux-aarch64-meta-url": `${releaseBase}/linux-aarch64-meta.json`,
+                  "mac-meta-url": `${releaseBase}/mac-meta.json`,
+                  "firefox-version": process.env.FIREFOX_VERSION,
+                  "app-version2": process.env.FLOORP_VERSION,
+                  "request-id": requestId,
+                  "dry-run": false,
+                },
+                headers: {"X-GitHub-Api-Version": "2026-03-10"},
+              },
+            );
+            const runId = response.data?.workflow_run_id;
+            if (response.status !== 200 || !Number.isSafeInteger(runId) || runId < 1) {
+              throw new Error("Updates dispatch did not return a positive workflow_run_id");
+            }
+            core.setOutput("request-id", requestId);
+            core.setOutput("workflow-run-id", String(runId));
+
+      - name: Poll only the returned Updates run and bind its result artifact
+        id: updates_result
+        uses: actions/github-script@v7
+        env:
+          UPDATES_RUN_ID: ${{ steps.dispatch.outputs.workflow-run-id }}
+          REQUEST_ID: ${{ steps.dispatch.outputs.request-id }}
+          FLOORP_VERSION: ${{ needs.prepare_release.outputs.floorp_version }}
+        with:
+          github-token: ${{ secrets.UPDATES_ACTIONS_TOKEN }}
+          script: |
+            const runId = Number(process.env.UPDATES_RUN_ID);
+            const expectedTitle =
+              `Stable v2 ${process.env.FLOORP_VERSION} (${process.env.REQUEST_ID})`;
+            let completedRun;
+            for (let attempt = 1; attempt <= 180; attempt += 1) {
+              const {data: run} = await github.rest.actions.getWorkflowRun({
+                owner: "Floorp-Projects",
+                repo: "Floorp-Updates",
+                run_id: runId,
+              });
+              if (
+                run.id !== runId || run.event !== "workflow_dispatch" ||
+                run.head_branch !== "main" ||
+                run.path !== ".github/workflows/update-stable-updatexml-files-v2.yml" ||
+                run.display_title !== expectedTitle
+              ) {
+                throw new Error("Returned Updates run does not match the dispatched request");
+              }
+              if (run.status === "completed") {
+                if (run.conclusion !== "success") {
+                  throw new Error(`Updates run concluded ${run.conclusion}`);
+                }
+                completedRun = run;
+                break;
+              }
+              if (
+                !["requested", "queued", "in_progress", "waiting", "pending"]
+                  .includes(run.status)
+              ) {
+                throw new Error(`Updates run entered unexpected status ${run.status}`);
+              }
+              await new Promise((resolve) => setTimeout(resolve, 10000));
+            }
+            if (!completedRun) {
+              throw new Error("Timed out waiting 30 minutes for the exact Updates run");
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: "Floorp-Projects",
+                repo: "Floorp-Updates",
+                run_id: runId,
+                per_page: 100,
+              },
+            );
+            const expectedName = `stable-update-result-${process.env.REQUEST_ID}`;
+            const matches = artifacts.filter(
+              (artifact) => artifact.name === expectedName && !artifact.expired,
+            );
+            if (matches.length !== 1) {
+              throw new Error(`Expected exactly one unexpired ${expectedName} artifact`);
+            }
+            const artifact = matches[0];
+            if (
+              !Number.isSafeInteger(artifact.id) || artifact.id < 1 ||
+              !/^sha256:[0-9a-f]{64}$/.test(artifact.digest || "") ||
+              !Number.isInteger(artifact.size_in_bytes) || artifact.size_in_bytes < 1
+            ) {
+              throw new Error("Updates result artifact has an invalid immutable identity");
+            }
+            core.setOutput("artifact-id", String(artifact.id));
+            core.setOutput("artifact-name", artifact.name);
+            core.setOutput("artifact-digest", artifact.digest);
+
+      - name: Download only the exact Updates result artifact ID
+        uses: actions/download-artifact@v4
+        with:
+          repository: Floorp-Projects/Floorp-Updates
+          run-id: ${{ steps.dispatch.outputs.workflow-run-id }}
+          artifact-ids: ${{ steps.updates_result.outputs.artifact-id }}
+          github-token: ${{ secrets.UPDATES_ACTIONS_TOKEN }}
+          path: ${{ runner.temp }}/stable-update-result
+          merge-multiple: true
+
+      - name: Validate Updates request, manifest, status, and commit result
+        id: result
+        shell: bash
+        env:
+          RESULT_DIR: ${{ runner.temp }}/stable-update-result
+          REQUEST_ID: ${{ steps.dispatch.outputs.request-id }}
+          MANIFEST_SET_ID: ${{ needs.prepare_release.outputs.manifest_set_id }}
         run: |
-          gh workflow run update-stable-updatexml-files.yml \
-            --repo Floorp-Projects/Floorp-Updates \
-            --ref main \
-            -f win-mar-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/floorp-windows-x86_64-full.mar" \
-            -f linux-mar-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/floorp-linux-x86_64-full.mar" \
-            -f linux-aarch64-mar-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/floorp-linux-aarch64-full.mar" \
-            -f mac-mar-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/floorp-mac-universal-full.mar" \
-            -f win-meta-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/win-meta.json" \
-            -f linux-meta-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/linux-meta.json" \
-            -f linux-aarch64-meta-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/linux-aarch64-meta.json" \
-            -f mac-meta-url="https://github.com/Floorp-Projects/Floorp/releases/download/v${NR_VERSION}/mac-meta.json" \
-            -f firefox-version="${VERSION}" \
-            -f app-version2="${NR_VERSION}"
+          set -euo pipefail
+          result="$RESULT_DIR/stable-update-result.json"
+          mapfile -d '' -t files < <(find "$RESULT_DIR" -type f -print0)
+          if (( ${#files[@]} != 1 )) || [[ "${files[0]}" != "$result" ]]; then
+            echo "Expected exactly root stable-update-result.json" >&2
+            exit 1
+          fi
+          jq -e \
+            --arg request "$REQUEST_ID" \
+            --arg manifest "$MANIFEST_SET_ID" '
+              type == "object" and
+              (keys | sort) == [
+                "base_sha", "deploy_required", "endpoint_sha256",
+                "manifest_set_id", "request_id", "schema_version", "status",
+                "transition", "updates_commit_sha"
+              ] and
+              .schema_version == 1 and
+              .request_id == $request and
+              .manifest_set_id == $manifest and
+              (.status == "updated" or .status == "noop") and
+              .transition == .status and
+              (.deploy_required | type) == "boolean" and
+              (.base_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+              (.endpoint_sha256 | type) == "object" and
+              (.endpoint_sha256 | keys | sort) == [
+                "browser/stable/Darwin/aarch64/update.xml",
+                "browser/stable/Darwin/x86_64/update.xml",
+                "browser/stable/Linux/aarch64/update.xml",
+                "browser/stable/Linux/x86_64/update.xml",
+                "browser/stable/WINNT/x86_64/update.xml"
+              ] and
+              ([.endpoint_sha256[] |
+                type == "string" and test("^sha256:[0-9a-f]{64}$")
+              ] | all) and
+              (
+                if .deploy_required then
+                  .status == "updated" and
+                  (.updates_commit_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+                  .updates_commit_sha != .base_sha
+                else
+                  .status == "noop" and
+                  (.updates_commit_sha == null or
+                    .updates_commit_sha == .base_sha)
+                end
+              )
+            ' "$result" >/dev/null
+
+          deploy_required="$(jq -r '.deploy_required' "$result")"
+          updates_commit_sha="$(jq -r '.updates_commit_sha // ""' "$result")"
+          echo "deploy-required=$deploy_required" >> "$GITHUB_OUTPUT"
+          echo "updates-commit-sha=$updates_commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Poll the exact Cloudflare deployment run without accepting stale main
+        if: steps.result.outputs.deploy-required == 'true'
+        uses: actions/github-script@v7
+        env:
+          UPDATES_COMMIT_SHA: ${{ steps.result.outputs.updates-commit-sha }}
+        with:
+          github-token: ${{ secrets.UPDATES_ACTIONS_TOKEN }}
+          script: |
+            const expectedSha = process.env.UPDATES_COMMIT_SHA;
+            const owner = "Floorp-Projects";
+            const repo = "Floorp-Updates";
+            const assertMain = async () => {
+              const {data: ref} = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: "heads/main",
+              });
+              if (ref.object.sha !== expectedSha) {
+                throw new Error(
+                  `Floorp-Updates main advanced to ${ref.object.sha}; refusing stale ${expectedSha}`,
+                );
+              }
+            };
+            await assertMain();
+            const {data: workflow} = await github.rest.actions.getWorkflow({
+              owner,
+              repo,
+              workflow_id: "upload-cfp.yml",
+            });
+            if (
+              workflow.path !== ".github/workflows/upload-cfp.yml" ||
+              workflow.name !== "Deploy Floorp Updates to Cloudflare Pages"
+            ) {
+              throw new Error("Cloudflare deployment workflow identity changed");
+            }
+
+            let exactRunId;
+            for (let attempt = 1; attempt <= 120; attempt += 1) {
+              await assertMain();
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner,
+                  repo,
+                  workflow_id: workflow.id,
+                  branch: "main",
+                  event: "push",
+                  per_page: 100,
+                },
+              );
+              const matches = runs.filter((run) => run.head_sha === expectedSha);
+              const ids = [...new Set(matches.map((run) => run.id))];
+              if (ids.length > 1) {
+                throw new Error("Multiple Cloudflare workflow runs matched the exact update commit");
+              }
+              if (ids.length === 1) {
+                exactRunId = ids[0];
+                break;
+              }
+              await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+            if (!exactRunId) {
+              throw new Error("Timed out waiting for the exact Cloudflare push run");
+            }
+
+            for (let attempt = 1; attempt <= 180; attempt += 1) {
+              await assertMain();
+              const {data: run} = await github.rest.actions.getWorkflowRun({
+                owner,
+                repo,
+                run_id: exactRunId,
+              });
+              if (
+                run.workflow_id !== workflow.id || run.head_sha !== expectedSha ||
+                run.head_branch !== "main" || run.event !== "push" ||
+                run.path !== ".github/workflows/upload-cfp.yml"
+              ) {
+                throw new Error("Cloudflare run no longer matches its exact commit and workflow");
+              }
+              if (run.status === "completed") {
+                if (run.conclusion !== "success") {
+                  throw new Error(`Cloudflare deployment concluded ${run.conclusion}`);
+                }
+                await assertMain();
+                return;
+              }
+              await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+            throw new Error("Timed out waiting for the exact Cloudflare deployment run");
+
+      - name: Verify all five public updater endpoint byte hashes
+        shell: bash
+        env:
+          RESULT_FILE: ${{ runner.temp }}/stable-update-result/stable-update-result.json
+          REQUEST_ID: ${{ steps.dispatch.outputs.request-id }}
+        run: |
+          set -euo pipefail
+          declare -A endpoints=(
+            ["browser/stable/WINNT/x86_64/update.xml"]="https://updates.floorp.app/browser/stable/WINNT/x86_64/update.xml"
+            ["browser/stable/Linux/x86_64/update.xml"]="https://updates.floorp.app/browser/stable/Linux/x86_64/update.xml"
+            ["browser/stable/Linux/aarch64/update.xml"]="https://updates.floorp.app/browser/stable/Linux/aarch64/update.xml"
+            ["browser/stable/Darwin/x86_64/update.xml"]="https://updates.floorp.app/browser/stable/Darwin/x86_64/update.xml"
+            ["browser/stable/Darwin/aarch64/update.xml"]="https://updates.floorp.app/browser/stable/Darwin/aarch64/update.xml"
+          )
+
+          for attempt in $(seq 1 120); do
+            all_match=true
+            for repository_path in "${!endpoints[@]}"; do
+              expected="$(jq -er --arg path "$repository_path" '.endpoint_sha256[$path]' "$RESULT_FILE")"
+              output="$RUNNER_TEMP/public-$(printf '%s' "$repository_path" | sha256sum | cut -d' ' -f1).xml"
+              http_code="$(
+                curl --silent --show-error --location \
+                  --connect-timeout 10 --max-time 30 \
+                  --output "$output" --write-out '%{http_code}' \
+                  "${endpoints[$repository_path]}?force=1&request=$REQUEST_ID" || true
+              )"
+              if [[ "$http_code" != 200 ]]; then
+                all_match=false
+                continue
+              fi
+              if ! python3 - "$output" <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse(sys.argv[1]).getroot()
+          if root.tag.rsplit("}", 1)[-1] != "updates":
+              raise SystemExit("public updater response root is not <updates>")
+          PY
+              then
+                all_match=false
+                continue
+              fi
+              actual="sha256:$(sha256sum "$output" | cut -d' ' -f1)"
+              if [[ "$actual" != "$expected" ]]; then
+                all_match=false
+              fi
+            done
+            if [[ "$all_match" == true ]]; then
+              echo "All five public updater endpoints match the committed result hashes."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Public updater endpoints did not converge within ten minutes" >&2
+          exit 1
 
   trigger_portable:
-    needs: [publish]
-    runs-on: ubuntu-latest
+    name: Build the exact public Floorp Portable release
+    needs: [prepare_release, publish_updates]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - name: Trigger Floorp Portable Build
+      - name: Dispatch and wait for only the returned Portable run
+        uses: actions/github-script@v7
         env:
-          GH_TOKEN: ${{ secrets.UPDATE_SERVER_TOKEN }}
-          NR_VERSION: ${{ needs.publish.outputs.NR_VERSION }}
-        run: |
-          gh workflow run build.yml \
-            --repo Floorp-Projects/Floorp-Portable-v2 \
-            --ref master \
-            -f version="$NR_VERSION"
+          FLOORP_VERSION: ${{ needs.prepare_release.outputs.floorp_version }}
+        with:
+          github-token: ${{ secrets.PORTABLE_ACTIONS_TOKEN }}
+          script: |
+            const owner = "Floorp-Projects";
+            const repo = "Floorp-Portable-v2";
+            const response = await github.request(
+              "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+              {
+                owner,
+                repo,
+                workflow_id: "build.yml",
+                ref: "master",
+                return_run_details: true,
+                inputs: {version: process.env.FLOORP_VERSION},
+                headers: {"X-GitHub-Api-Version": "2026-03-10"},
+              },
+            );
+            const runId = response.data?.workflow_run_id;
+            if (response.status !== 200 || !Number.isSafeInteger(runId) || runId < 1) {
+              throw new Error("Portable dispatch did not return a positive workflow_run_id");
+            }
+            for (let attempt = 1; attempt <= 180; attempt += 1) {
+              const {data: run} = await github.rest.actions.getWorkflowRun({
+                owner,
+                repo,
+                run_id: runId,
+              });
+              if (
+                run.id !== runId || run.event !== "workflow_dispatch" ||
+                run.head_branch !== "master" || run.path !== ".github/workflows/build.yml"
+              ) {
+                throw new Error("Returned Portable run does not match the dispatched workflow");
+              }
+              if (run.status === "completed") {
+                if (run.conclusion !== "success") {
+                  throw new Error(`Portable build concluded ${run.conclusion}`);
+                }
+                return;
+              }
+              await new Promise((resolve) => setTimeout(resolve, 10000));
+            }
+            throw new Error("Timed out waiting for the exact Portable build run");
 
   publish_ppa:
-    needs: [trigger_portable, publish]
+    name: Publish the exact source-run DEB to PPA
+    needs: [prepare_release, trigger_portable]
     if: ${{ inputs.publish_ppa }}
+    permissions:
+      actions: read
+      contents: read
     uses: ./.github/workflows/publish_ppa.yml
     with:
-      nr_version: ${{ needs.publish.outputs.NR_VERSION }}
-      artifact_run_id: ${{ inputs.linux_deb_run_id }}
+      nr_version: ${{ needs.prepare_release.outputs.floorp_version }}
+      artifact_run_id: ${{ inputs.source_workflow_run_id }}
     secrets:
       KEYMASK: ${{ secrets.KEYMASK }}
       GPG_SEC: ${{ secrets.GPG_SEC }}
@@ -330,5 +935,5 @@ jobs:
       PPA_FTP_URL: ${{ secrets.PPA_FTP_URL }}
       PPA_FTP_USER: ${{ secrets.PPA_FTP_USER }}
       PPA_FTP_PASS: ${{ secrets.PPA_FTP_PASS }}
-      CLOUDFLARE_API_TOKEN_FOR_PURGE: ${{ secrets.CLOULDFLARE_API_TOKEN_FOR_PURGE }}
-      CLOUDFLARE_ZONE_ID: ${{ secrets.CLOULDFLARE_ZONE_ID }}
+      CLOUDFLARE_API_TOKEN_FOR_PURGE: ${{ secrets.CLOUDFLARE_API_TOKEN_FOR_PURGE }}
+      CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}

--- a/.github/workflows/validate-runtime-provenance.yml
+++ b/.github/workflows/validate-runtime-provenance.yml
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: MPL-2.0
+
+name: Validate Runtime Provenance v2
+
+'on':
+  workflow_call:
+    inputs:
+      runtime_workflow_run_id:
+        description: Successful Floorp-Runtime daily-build workflow run ID
+        type: string
+        required: true
+      runtime_manifest_artifact_id:
+        description: Immutable floorp-runtime-build-manifest-v2 artifact ID
+        type: string
+        required: true
+      validation_only:
+        description: Allow an exact non-default-branch Runtime run for validation only
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      runtime_artifact_token:
+        description: Token with Actions read access to Floorp-Runtime
+        required: true
+    outputs:
+      provenance_artifact_name:
+        value: ${{ jobs.validate.outputs.provenance_artifact_name }}
+      provenance_artifact_id:
+        value: ${{ jobs.validate.outputs.provenance_artifact_id }}
+      provenance_artifact_digest:
+        value: ${{ jobs.validate.outputs.provenance_artifact_digest }}
+      runtime_repository:
+        value: ${{ jobs.validate.outputs.runtime_repository }}
+      runtime_workflow_run_id:
+        value: ${{ jobs.validate.outputs.runtime_workflow_run_id }}
+      runtime_manifest_artifact_name:
+        value: ${{ jobs.validate.outputs.runtime_manifest_artifact_name }}
+      runtime_manifest_artifact_id:
+        value: ${{ jobs.validate.outputs.runtime_manifest_artifact_id }}
+      runtime_manifest_artifact_digest:
+        value: ${{ jobs.validate.outputs.runtime_manifest_artifact_digest }}
+      runtime_head_sha:
+        value: ${{ jobs.validate.outputs.runtime_head_sha }}
+      expected_build_id:
+        value: ${{ jobs.validate.outputs.expected_build_id }}
+      windows_artifact_name:
+        value: ${{ jobs.validate.outputs.windows_artifact_name }}
+      windows_artifact_id:
+        value: ${{ jobs.validate.outputs.windows_artifact_id }}
+      windows_artifact_digest:
+        value: ${{ jobs.validate.outputs.windows_artifact_digest }}
+      linux_artifact_name:
+        value: ${{ jobs.validate.outputs.linux_artifact_name }}
+      linux_artifact_id:
+        value: ${{ jobs.validate.outputs.linux_artifact_id }}
+      linux_artifact_digest:
+        value: ${{ jobs.validate.outputs.linux_artifact_digest }}
+      linux_aarch64_artifact_name:
+        value: ${{ jobs.validate.outputs.linux_aarch64_artifact_name }}
+      linux_aarch64_artifact_id:
+        value: ${{ jobs.validate.outputs.linux_aarch64_artifact_id }}
+      linux_aarch64_artifact_digest:
+        value: ${{ jobs.validate.outputs.linux_aarch64_artifact_digest }}
+      mac_artifact_name:
+        value: ${{ jobs.validate.outputs.mac_artifact_name }}
+      mac_artifact_id:
+        value: ${{ jobs.validate.outputs.mac_artifact_id }}
+      mac_artifact_digest:
+        value: ${{ jobs.validate.outputs.mac_artifact_digest }}
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  validate:
+    name: Validate immutable Floorp-Runtime provenance
+    runs-on: ubuntu-24.04
+    outputs:
+      provenance_artifact_name: floorp-runtime-provenance-v2
+      provenance_artifact_id: ${{ steps.upload-provenance.outputs.artifact-id }}
+      provenance_artifact_digest: >-
+        ${{ format('sha256:{0}', steps.upload-provenance.outputs.artifact-digest) }}
+      runtime_repository: Floorp-Projects/Floorp-Runtime
+      runtime_workflow_run_id: ${{ steps.validate-runtime.outputs.runtime-run-id }}
+      runtime_manifest_artifact_name: floorp-runtime-build-manifest-v2
+      runtime_manifest_artifact_id: ${{ steps.validate-runtime.outputs.runtime-manifest-artifact-id }}
+      runtime_manifest_artifact_digest: ${{ steps.validate-runtime.outputs.runtime-manifest-artifact-digest }}
+      runtime_head_sha: ${{ steps.validate-runtime.outputs.runtime-head-sha }}
+      expected_build_id: ${{ steps.validate-runtime.outputs.runtime-build-id }}
+      windows_artifact_name: floorp-windows-x86_64-moz-artifact
+      windows_artifact_id: ${{ steps.validate-runtime.outputs.windows-artifact-id }}
+      windows_artifact_digest: ${{ steps.validate-runtime.outputs.windows-artifact-digest }}
+      linux_artifact_name: floorp-linux-x86_64-moz-artifact
+      linux_artifact_id: ${{ steps.validate-runtime.outputs.linux-artifact-id }}
+      linux_artifact_digest: ${{ steps.validate-runtime.outputs.linux-artifact-digest }}
+      linux_aarch64_artifact_name: floorp-linux-aarch64-moz-artifact
+      linux_aarch64_artifact_id: ${{ steps.validate-runtime.outputs.linuxAarch64-artifact-id }}
+      linux_aarch64_artifact_digest: ${{ steps.validate-runtime.outputs.linuxAarch64-artifact-digest }}
+      mac_artifact_name: floorp-mac-universal-moz-artifact
+      mac_artifact_id: ${{ steps.validate-runtime.outputs.mac-artifact-id }}
+      mac_artifact_digest: ${{ steps.validate-runtime.outputs.mac-artifact-digest }}
+    steps:
+      - name: Checkout current Floorp source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Validate Runtime run and manifest artifact through REST
+        uses: actions/github-script@v7
+        env:
+          RUNTIME_WORKFLOW_RUN_ID: ${{ inputs.runtime_workflow_run_id }}
+          RUNTIME_MANIFEST_ARTIFACT_ID: ${{ inputs.runtime_manifest_artifact_id }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+        with:
+          github-token: ${{ secrets.runtime_artifact_token }}
+          script: |
+            const fs = require("fs");
+            const owner = "Floorp-Projects";
+            const repo = "Floorp-Runtime";
+            const repository = `${owner}/${repo}`;
+            const expectedWorkflowPath = ".github/workflows/daily-build.yml";
+            const expectedManifestName = "floorp-runtime-build-manifest-v2";
+            const apiHeaders = {
+              "X-GitHub-Api-Version": "2026-03-10",
+            };
+
+            function positiveId(label, raw) {
+              if (!/^[1-9][0-9]*$/.test(raw || "")) {
+                throw new Error(`${label} must be a positive decimal integer`);
+              }
+              const value = Number(raw);
+              if (!Number.isSafeInteger(value)) {
+                throw new Error(`${label} exceeds JavaScript's safe integer range`);
+              }
+              return value;
+            }
+
+            const runId = positiveId(
+              "Runtime workflow run ID",
+              process.env.RUNTIME_WORKFLOW_RUN_ID,
+            );
+            const manifestArtifactId = positiveId(
+              "Runtime manifest artifact ID",
+              process.env.RUNTIME_MANIFEST_ARTIFACT_ID,
+            );
+            if (!["true", "false"].includes(process.env.VALIDATION_ONLY)) {
+              throw new Error("validation_only must be an Actions boolean");
+            }
+            const validationOnly = process.env.VALIDATION_ONLY === "true";
+
+            const { data: run } = await github.rest.actions.getWorkflowRun({
+              owner,
+              repo,
+              run_id: runId,
+              headers: apiHeaders,
+            });
+            if (run.id !== runId) {
+              throw new Error(`Runtime API returned unexpected run ID ${run.id}`);
+            }
+            if (run.repository?.full_name !== repository) {
+              throw new Error(`Runtime run belongs to ${run.repository?.full_name}`);
+            }
+            if (run.status !== "completed" || run.conclusion !== "success") {
+              throw new Error(
+                `Runtime run must be completed/success, got ${run.status}/${run.conclusion}`,
+              );
+            }
+            if (!/^[0-9a-f]{40}$/.test(run.head_sha || "")) {
+              throw new Error("Runtime run head SHA must be 40 lowercase hex digits");
+            }
+            if (!Number.isSafeInteger(run.run_attempt) || run.run_attempt < 1) {
+              throw new Error("Runtime run attempt must be a positive integer");
+            }
+            if (!validationOnly) {
+              const { data: runtimeRepository } = await github.rest.repos.get({
+                owner,
+                repo,
+                headers: apiHeaders,
+              });
+              if (
+                run.head_branch !== runtimeRepository.default_branch ||
+                run.head_repository?.full_name !== repository
+              ) {
+                throw new Error(
+                  "Production requires a Runtime run from its exact default branch",
+                );
+              }
+              if (!["workflow_dispatch", "schedule"].includes(run.event)) {
+                throw new Error(
+                  `Production rejects untrusted Runtime event ${run.event}`,
+                );
+              }
+            }
+
+            const { data: workflow } = await github.rest.actions.getWorkflow({
+              owner,
+              repo,
+              workflow_id: run.workflow_id,
+              headers: apiHeaders,
+            });
+            if (workflow.path !== expectedWorkflowPath) {
+              throw new Error(
+                `Runtime run must use ${expectedWorkflowPath}, got ${workflow.path}`,
+              );
+            }
+
+            const { data: manifestArtifact } =
+              await github.rest.actions.getArtifact({
+                owner,
+                repo,
+                artifact_id: manifestArtifactId,
+                headers: apiHeaders,
+              });
+            if (manifestArtifact.id !== manifestArtifactId) {
+              throw new Error("Runtime manifest artifact ID changed during lookup");
+            }
+            if (manifestArtifact.name !== expectedManifestName) {
+              throw new Error(
+                `Expected ${expectedManifestName}, got ${manifestArtifact.name}`,
+              );
+            }
+            if (manifestArtifact.expired !== false) {
+              throw new Error("Runtime manifest artifact is expired");
+            }
+            if (!/^sha256:[0-9a-f]{64}$/.test(manifestArtifact.digest || "")) {
+              throw new Error("Runtime manifest artifact digest is invalid");
+            }
+            if (manifestArtifact.workflow_run?.id !== runId) {
+              throw new Error("Runtime manifest artifact belongs to another run");
+            }
+            if (manifestArtifact.workflow_run?.head_sha !== run.head_sha) {
+              throw new Error("Runtime manifest artifact head SHA differs from its run");
+            }
+
+            const preflight = {
+              schema_version: 2,
+              repository,
+              workflow_path: expectedWorkflowPath,
+              run: {
+                id: run.id,
+                status: run.status,
+                conclusion: run.conclusion,
+                head_sha: run.head_sha,
+                run_attempt: run.run_attempt,
+                created_at: run.created_at,
+              },
+              manifest_artifact: {
+                id: manifestArtifact.id,
+                name: manifestArtifact.name,
+                digest: manifestArtifact.digest,
+                expired: manifestArtifact.expired,
+                workflow_run_id: manifestArtifact.workflow_run.id,
+                workflow_run_head_sha: manifestArtifact.workflow_run.head_sha,
+              },
+            };
+            fs.mkdirSync("runtime-validation", { recursive: true });
+            fs.writeFileSync(
+              "runtime-validation/runtime-rest-preflight-v2.json",
+              `${JSON.stringify(preflight, null, 2)}\n`,
+              "utf8",
+            );
+
+      - name: Download exact Runtime manifest artifact
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.runtime_artifact_token }}
+          script: |
+            const fs = require("fs");
+            const preflight = JSON.parse(fs.readFileSync(
+              "runtime-validation/runtime-rest-preflight-v2.json",
+              "utf8",
+            ));
+            const response = await github.rest.actions.downloadArtifact({
+              owner: "Floorp-Projects",
+              repo: "Floorp-Runtime",
+              artifact_id: preflight.manifest_artifact.id,
+              archive_format: "zip",
+              headers: {
+                "X-GitHub-Api-Version": "2026-03-10",
+              },
+            });
+            fs.writeFileSync(
+              "runtime-validation/runtime-manifest-artifact.zip",
+              Buffer.from(response.data),
+            );
+
+      - name: Extract exact Runtime manifest artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARCHIVE=runtime-validation/runtime-manifest-artifact.zip
+          if [[ "$(unzip -Z1 "$ARCHIVE")" != "runtime-build-manifest-v2.json" ]]; then
+            echo "Runtime manifest archive must contain exactly runtime-build-manifest-v2.json" >&2
+            unzip -Z1 "$ARCHIVE" >&2
+            exit 1
+          fi
+          mkdir -p runtime-validation/manifest
+          unzip -q "$ARCHIVE" -d runtime-validation/manifest
+
+      - name: Validate Runtime manifest artifact layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          MANIFEST=runtime-validation/manifest/runtime-build-manifest-v2.json
+          FILE_COUNT=$(find runtime-validation/manifest -type f -print | wc -l | tr -d ' ')
+          if [[ "$FILE_COUNT" != "1" || ! -f "$MANIFEST" ]]; then
+            echo "Runtime manifest artifact must contain exactly runtime-build-manifest-v2.json" >&2
+            find runtime-validation/manifest -type f -print >&2
+            exit 1
+          fi
+
+      - name: Build strict Runtime REST snapshot
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.runtime_artifact_token }}
+          script: |
+            const fs = require("fs");
+            const owner = "Floorp-Projects";
+            const repo = "Floorp-Runtime";
+            const apiHeaders = {
+              "X-GitHub-Api-Version": "2026-03-10",
+            };
+            const preflight = JSON.parse(fs.readFileSync(
+              "runtime-validation/runtime-rest-preflight-v2.json",
+              "utf8",
+            ));
+            const manifest = JSON.parse(fs.readFileSync(
+              "runtime-validation/manifest/runtime-build-manifest-v2.json",
+              "utf8",
+            ));
+            const expectedTargets = [
+              ["Windows", "x86_64", "floorp-windows-x86_64-moz-artifact"],
+              ["Linux", "x86_64", "floorp-linux-x86_64-moz-artifact"],
+              ["Linux", "aarch64", "floorp-linux-aarch64-moz-artifact"],
+              ["Darwin", "universal", "floorp-mac-universal-moz-artifact"],
+            ];
+            if (!Array.isArray(manifest.targets) ||
+                manifest.targets.length !== expectedTargets.length) {
+              throw new Error("Runtime manifest must contain exactly four targets");
+            }
+
+            const artifactIds = new Set([preflight.manifest_artifact.id]);
+            const targetArtifacts = [];
+            for (let index = 0; index < expectedTargets.length; index += 1) {
+              const target = manifest.targets[index];
+              const [platform, arch, artifactName] = expectedTargets[index];
+              if (target?.platform !== platform || target?.arch !== arch ||
+                  target?.artifact_name !== artifactName) {
+                throw new Error(
+                  `Runtime manifest target ${index} does not match ${platform}/${arch}`,
+                );
+              }
+              const rawArtifactId = String(target.artifact_id ?? "");
+              if (!/^[1-9][0-9]*$/.test(rawArtifactId)) {
+                throw new Error(`Runtime target ${index} artifact ID is invalid`);
+              }
+              const artifactId = Number(rawArtifactId);
+              if (!Number.isSafeInteger(artifactId) || artifactIds.has(artifactId)) {
+                throw new Error(`Runtime target ${index} artifact ID is not unique`);
+              }
+              artifactIds.add(artifactId);
+
+              const { data: artifact } = await github.rest.actions.getArtifact({
+                owner,
+                repo,
+                artifact_id: artifactId,
+                headers: apiHeaders,
+              });
+              targetArtifacts.push({
+                id: artifact.id,
+                name: artifact.name,
+                digest: artifact.digest,
+                expired: artifact.expired,
+                workflow_run_id: artifact.workflow_run?.id,
+                workflow_run_head_sha: artifact.workflow_run?.head_sha,
+              });
+            }
+
+            const snapshot = {
+              ...preflight,
+              target_artifacts: targetArtifacts,
+            };
+            fs.writeFileSync(
+              "runtime-validation/runtime-rest-snapshot-v2.json",
+              `${JSON.stringify(snapshot, null, 2)}\n`,
+              "utf8",
+            );
+
+      - name: Validate and normalize Runtime provenance
+        id: validate-runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          deno run --allow-read --allow-write \
+            tools/src/release_provenance.ts validate-runtime \
+            --manifest runtime-validation/manifest/runtime-build-manifest-v2.json \
+            --rest-snapshot runtime-validation/runtime-rest-snapshot-v2.json \
+            --output runtime-validation/normalized-runtime-provenance-v2.json \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload normalized Runtime provenance
+        id: upload-provenance
+        uses: actions/upload-artifact@v4
+        with:
+          name: floorp-runtime-provenance-v2
+          path: runtime-validation/normalized-runtime-provenance-v2.json
+          if-no-files-found: error
+          overwrite: true
+
+      - name: Summarize validated Runtime provenance
+        shell: bash
+        env:
+          PROVENANCE_ARTIFACT_ID: ${{ steps.upload-provenance.outputs.artifact-id }}
+          PROVENANCE_ARTIFACT_DIGEST: ${{ steps.upload-provenance.outputs.artifact-digest }}
+          RUNTIME_RUN_ID: ${{ steps.validate-runtime.outputs.runtime-run-id }}
+          RUNTIME_HEAD_SHA: ${{ steps.validate-runtime.outputs.runtime-head-sha }}
+          EXPECTED_BUILD_ID: ${{ steps.validate-runtime.outputs.runtime-build-id }}
+        run: |
+          {
+            echo "### Validated Runtime provenance v2"
+            echo ""
+            echo "- Runtime run: \`${RUNTIME_RUN_ID}\`"
+            echo "- Runtime head: \`${RUNTIME_HEAD_SHA}\`"
+            echo "- Expected BuildID: \`${EXPECTED_BUILD_ID}\`"
+            echo "- Normalized artifact ID: \`${PROVENANCE_ARTIFACT_ID}\`"
+            echo "- Normalized artifact digest: \`${PROVENANCE_ARTIFACT_DIGEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-release-artifact.yml
+++ b/.github/workflows/verify-release-artifact.yml
@@ -1,0 +1,1009 @@
+# SPDX-License-Identifier: MPL-2.0
+
+name: Verify Final Floorp Release Artifact
+
+"on":
+  workflow_call:
+    inputs:
+      source_workflow_run_id:
+        description: Floorp workflow run containing the final package artifact
+        type: string
+        required: true
+      package_artifact_name:
+        description: Expected final Floorp package artifact name
+        type: string
+        required: true
+      package_artifact_id:
+        description: Immutable final Floorp package artifact ID
+        type: string
+        required: true
+      package_artifact_digest:
+        description: SHA-256 digest reported by upload-artifact
+        type: string
+        required: true
+      runtime_workflow_run_id:
+        description: Successful Floorp-Runtime workflow run ID
+        type: string
+        required: true
+      runtime_head_sha:
+        description: Exact Floorp-Runtime source commit
+        type: string
+        required: true
+      runtime_artifact_name:
+        description: Expected selected Runtime target artifact name
+        type: string
+        required: true
+      runtime_artifact_id:
+        description: Immutable selected Runtime target artifact ID
+        type: string
+        required: true
+      runtime_artifact_digest:
+        description: Selected Runtime target artifact SHA-256 digest
+        type: string
+        required: true
+      runtime_manifest_artifact_id:
+        description: Immutable Runtime manifest artifact ID
+        type: string
+        required: true
+      runtime_manifest_artifact_digest:
+        description: Runtime manifest artifact SHA-256 digest
+        type: string
+        required: true
+      expected_build_id:
+        description: Expected 14-digit application and platform BuildID
+        type: string
+        required: true
+      floorp_head_sha:
+        description: Exact Floorp source commit used by the package jobs
+        type: string
+        required: true
+      platform_key:
+        description: Stable release target key
+        type: string
+        required: true
+      native_arch:
+        description: Architecture of the native verification runner
+        type: string
+        required: true
+      runner:
+        description: Exact GitHub-hosted native runner label
+        type: string
+        required: true
+      validation_only:
+        description: Accept the exact unsigned package artifact contract
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      runtime_artifact_token:
+        description: Token with Actions read access to Floorp-Runtime
+        required: true
+    outputs:
+      record_artifact_name:
+        description: Native verification record artifact name
+        value: ${{ jobs.verify.outputs.record_artifact_name }}
+      record_artifact_id:
+        description: Immutable native verification record artifact ID
+        value: ${{ jobs.verify.outputs.record_artifact_id }}
+      record_artifact_digest:
+        description: Native verification record artifact SHA-256 digest
+        value: ${{ jobs.verify.outputs.record_artifact_digest }}
+      firefox_version:
+        description: Firefox version observed from the packaged executable
+        value: ${{ jobs.verify.outputs.firefox_version }}
+      app_build_id:
+        description: Application BuildID observed from the packaged executable
+        value: ${{ jobs.verify.outputs.app_build_id }}
+      platform_build_id:
+        description: Platform BuildID observed from the packaged executable
+        value: ${{ jobs.verify.outputs.platform_build_id }}
+      build_id2:
+        description: Floorp UUIDv7 identity read from the final package
+        value: ${{ jobs.verify.outputs.build_id2 }}
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  verify:
+    name: Verify ${{ inputs.platform_key }}/${{ inputs.native_arch }} package
+    # Route only to fixed GitHub-hosted labels. Invalid input still lands on a
+    # hosted Linux runner and is rejected by the first step; it can never select
+    # an arbitrary self-hosted runner before the contract check executes.
+    runs-on: >-
+      ${{
+        inputs.platform_key == 'windows' &&
+          inputs.native_arch == 'x86_64' && 'windows-2025' ||
+        inputs.platform_key == 'linux' &&
+          inputs.native_arch == 'x86_64' && 'ubuntu-24.04' ||
+        inputs.platform_key == 'linuxAarch64' &&
+          inputs.native_arch == 'aarch64' && 'ubuntu-24.04-arm' ||
+        inputs.platform_key == 'mac' &&
+          inputs.native_arch == 'x86_64' && 'macos-15-intel' ||
+        inputs.platform_key == 'mac' &&
+          inputs.native_arch == 'aarch64' && 'macos-14' ||
+        'ubuntu-24.04'
+      }}
+    timeout-minutes: 30
+    outputs:
+      record_artifact_name: ${{ steps.contract.outputs.record-artifact-name }}
+      record_artifact_id: ${{ steps.upload-record.outputs.artifact-id }}
+      record_artifact_digest: >-
+        ${{ format('sha256:{0}', steps.upload-record.outputs.artifact-digest) }}
+      firefox_version: ${{ steps.record.outputs.firefox-version }}
+      app_build_id: ${{ steps.record.outputs.app-build-id }}
+      platform_build_id: ${{ steps.record.outputs.platform-build-id }}
+      build_id2: ${{ steps.record.outputs.build-id2 }}
+    steps:
+      - name: Validate immutable native verifier contract
+        id: contract
+        uses: actions/github-script@v7
+        env:
+          SOURCE_RUN_ID: ${{ inputs.source_workflow_run_id }}
+          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          PACKAGE_ARTIFACT_ID: ${{ inputs.package_artifact_id }}
+          PACKAGE_ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
+          RUNTIME_RUN_ID: ${{ inputs.runtime_workflow_run_id }}
+          RUNTIME_HEAD_SHA: ${{ inputs.runtime_head_sha }}
+          RUNTIME_ARTIFACT_NAME: ${{ inputs.runtime_artifact_name }}
+          RUNTIME_ARTIFACT_ID: ${{ inputs.runtime_artifact_id }}
+          RUNTIME_ARTIFACT_DIGEST: ${{ inputs.runtime_artifact_digest }}
+          RUNTIME_MANIFEST_ARTIFACT_ID: >-
+            ${{ inputs.runtime_manifest_artifact_id }}
+          RUNTIME_MANIFEST_ARTIFACT_DIGEST: >-
+            ${{ inputs.runtime_manifest_artifact_digest }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected_build_id }}
+          FLOORP_HEAD_SHA: ${{ inputs.floorp_head_sha }}
+          PLATFORM_KEY: ${{ inputs.platform_key }}
+          NATIVE_ARCH: ${{ inputs.native_arch }}
+          TARGET_RUNNER: ${{ inputs.runner }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+        with:
+          script: |
+            const contracts = new Map([
+              ["windows/x86_64", {
+                runner: "windows-2025",
+                artifact: "noraneko-windows-x86_64-installer",
+                file: "floorp-windows-x86_64.installer.exe",
+                record: "floorp-native-verification-windows-x86_64-v2",
+                runtimePlatform: "Windows",
+                runtimeArch: "x86_64",
+                runtimeArtifact: "floorp-windows-x86_64-moz-artifact",
+              }],
+              ["linux/x86_64", {
+                runner: "ubuntu-24.04",
+                artifact: "noraneko-linux-x86_64-installer",
+                file: "floorp-linux-x86_64.tar.xz",
+                record: "floorp-native-verification-linux-x86_64-v2",
+                runtimePlatform: "Linux",
+                runtimeArch: "x86_64",
+                runtimeArtifact: "floorp-linux-x86_64-moz-artifact",
+              }],
+              ["linuxAarch64/aarch64", {
+                runner: "ubuntu-24.04-arm",
+                artifact: "noraneko-linux-aarch64-installer",
+                file: "floorp-linux-aarch64.tar.xz",
+                record: "floorp-native-verification-linux-aarch64-v2",
+                runtimePlatform: "Linux",
+                runtimeArch: "aarch64",
+                runtimeArtifact: "floorp-linux-aarch64-moz-artifact",
+              }],
+              ["mac/x86_64", {
+                runner: "macos-15-intel",
+                artifact: "noraneko-mac-universal-installer",
+                file: "floorp-macOS-universal.dmg",
+                record: "floorp-native-verification-mac-x86_64-v2",
+                runtimePlatform: "Darwin",
+                runtimeArch: "universal",
+                runtimeArtifact: "floorp-mac-universal-moz-artifact",
+              }],
+              ["mac/aarch64", {
+                runner: "macos-14",
+                artifact: "noraneko-mac-universal-installer",
+                file: "floorp-macOS-universal.dmg",
+                record: "floorp-native-verification-mac-aarch64-v2",
+                runtimePlatform: "Darwin",
+                runtimeArch: "universal",
+                runtimeArtifact: "floorp-mac-universal-moz-artifact",
+              }],
+            ]);
+
+            const positiveInteger = /^[1-9][0-9]*$/;
+            for (const [label, value] of [
+              ["source workflow run ID", process.env.SOURCE_RUN_ID],
+              ["package artifact ID", process.env.PACKAGE_ARTIFACT_ID],
+              ["Runtime workflow run ID", process.env.RUNTIME_RUN_ID],
+              ["Runtime artifact ID", process.env.RUNTIME_ARTIFACT_ID],
+              ["Runtime manifest artifact ID", process.env.RUNTIME_MANIFEST_ARTIFACT_ID],
+            ]) {
+              if (!positiveInteger.test(value || "")) {
+                throw new Error(`${label} must be a positive decimal integer`);
+              }
+              if (!Number.isSafeInteger(Number(value))) {
+                throw new Error(`${label} exceeds JavaScript's safe integer range`);
+              }
+            }
+
+            const digestPattern = /^sha256:[0-9a-f]{64}$/;
+            for (const [label, value] of [
+              ["package artifact digest", process.env.PACKAGE_ARTIFACT_DIGEST],
+              ["Runtime artifact digest", process.env.RUNTIME_ARTIFACT_DIGEST],
+              [
+                "Runtime manifest artifact digest",
+                process.env.RUNTIME_MANIFEST_ARTIFACT_DIGEST,
+              ],
+            ]) {
+              if (!digestPattern.test(value || "")) {
+                throw new Error(`${label} must be a lowercase SHA-256 digest`);
+              }
+            }
+
+            const shaPattern = /^[0-9a-f]{40}$/;
+            if (!shaPattern.test(process.env.FLOORP_HEAD_SHA || "")) {
+              throw new Error("Floorp head SHA must be exactly 40 lowercase hex digits");
+            }
+            if (!shaPattern.test(process.env.RUNTIME_HEAD_SHA || "")) {
+              throw new Error("Runtime head SHA must be exactly 40 lowercase hex digits");
+            }
+            if (!/^[0-9]{14}$/.test(process.env.EXPECTED_BUILD_ID || "")) {
+              throw new Error("expected BuildID must be exactly 14 ASCII digits");
+            }
+            if (process.env.SOURCE_RUN_ID !== String(context.runId)) {
+              throw new Error("Floorp package must belong to the current caller run");
+            }
+            if (process.env.FLOORP_HEAD_SHA !== context.sha) {
+              throw new Error("Floorp head SHA does not match the current caller SHA");
+            }
+
+            const key = `${process.env.PLATFORM_KEY}/${process.env.NATIVE_ARCH}`;
+            const contract = contracts.get(key);
+            if (!contract) {
+              throw new Error(`unsupported native verifier target: ${key}`);
+            }
+            if (process.env.TARGET_RUNNER !== contract.runner) {
+              throw new Error(
+                `${key} requires ${contract.runner}, got ${process.env.TARGET_RUNNER}`
+              );
+            }
+            if (process.env.RUNTIME_ARTIFACT_NAME !== contract.runtimeArtifact) {
+              throw new Error(
+                `${key} requires Runtime artifact ${contract.runtimeArtifact}, got ` +
+                  process.env.RUNTIME_ARTIFACT_NAME
+              );
+            }
+            if (process.env.RUNTIME_ARTIFACT_ID ===
+                process.env.RUNTIME_MANIFEST_ARTIFACT_ID) {
+              throw new Error("Runtime target and manifest artifact IDs must differ");
+            }
+            if (process.env.RUNTIME_ARTIFACT_DIGEST ===
+                process.env.RUNTIME_MANIFEST_ARTIFACT_DIGEST) {
+              throw new Error("Runtime target and manifest artifact digests must differ");
+            }
+            if (!["true", "false"].includes(process.env.VALIDATION_ONLY)) {
+              throw new Error("validation_only must be an Actions boolean");
+            }
+            const expectedArtifact = contract.artifact +
+              (process.env.VALIDATION_ONLY === "true" ? "-unsigned" : "");
+            if (process.env.PACKAGE_ARTIFACT_NAME !== expectedArtifact) {
+              throw new Error(
+                `${key} requires package artifact ${expectedArtifact}, got ` +
+                  process.env.PACKAGE_ARTIFACT_NAME
+              );
+            }
+            if (process.env.VALIDATION_ONLY !== "true" &&
+                process.env.PACKAGE_ARTIFACT_NAME.endsWith("-unsigned")) {
+              throw new Error("production verification cannot consume unsigned packages");
+            }
+
+            core.setOutput("package-file-name", contract.file);
+            core.setOutput("record-artifact-name", contract.record);
+            core.setOutput("record-file-name", "native-verification.json");
+            core.setOutput("runtime-platform", contract.runtimePlatform);
+            core.setOutput("runtime-arch", contract.runtimeArch);
+            core.setOutput("runtime-target-artifact", contract.runtimeArtifact);
+
+      - name: Validate Floorp source run and package artifact through REST
+        uses: actions/github-script@v7
+        env:
+          SOURCE_RUN_ID: ${{ inputs.source_workflow_run_id }}
+          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          PACKAGE_ARTIFACT_ID: ${{ inputs.package_artifact_id }}
+          PACKAGE_ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
+          FLOORP_HEAD_SHA: ${{ inputs.floorp_head_sha }}
+        with:
+          script: |
+            const floorpRunId = Number(process.env.SOURCE_RUN_ID);
+            const packageArtifactId = Number(process.env.PACKAGE_ARTIFACT_ID);
+            const {data: floorpRun} = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: floorpRunId,
+            });
+            if (floorpRun.id !== floorpRunId ||
+                floorpRun.repository?.full_name !==
+                  `${context.repo.owner}/${context.repo.repo}`) {
+              throw new Error("Floorp REST workflow provenance mismatch");
+            }
+            if (floorpRun.head_sha !== process.env.FLOORP_HEAD_SHA) {
+              throw new Error("Floorp workflow head SHA mismatch");
+            }
+            if (!['queued', 'in_progress', 'completed'].includes(floorpRun.status)) {
+              throw new Error(`unexpected Floorp workflow status: ${floorpRun.status}`);
+            }
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: floorpRunId,
+                per_page: 100,
+              }
+            );
+            const idMatches = artifacts.filter(
+              artifact => artifact.id === packageArtifactId
+            );
+            const nameMatches = artifacts.filter(
+              artifact => artifact.name === process.env.PACKAGE_ARTIFACT_NAME &&
+                !artifact.expired
+            );
+            if (idMatches.length !== 1 || nameMatches.length !== 1 ||
+                nameMatches[0].id !== packageArtifactId) {
+              throw new Error("Floorp package artifact is missing or ambiguous");
+            }
+            const artifact = idMatches[0];
+            if (artifact.expired ||
+                artifact.digest !== process.env.PACKAGE_ARTIFACT_DIGEST ||
+                !Number.isInteger(artifact.size_in_bytes) ||
+                artifact.size_in_bytes < 1) {
+              throw new Error("Floorp package artifact REST provenance mismatch");
+            }
+
+      - name: Validate Runtime run and artifacts through REST
+        id: provenance
+        uses: actions/github-script@v7
+        env:
+          RUNTIME_RUN_ID: ${{ inputs.runtime_workflow_run_id }}
+          RUNTIME_HEAD_SHA: ${{ inputs.runtime_head_sha }}
+          RUNTIME_ARTIFACT_NAME: ${{ inputs.runtime_artifact_name }}
+          RUNTIME_ARTIFACT_ID: ${{ inputs.runtime_artifact_id }}
+          RUNTIME_ARTIFACT_DIGEST: ${{ inputs.runtime_artifact_digest }}
+          RUNTIME_MANIFEST_ARTIFACT_ID: >-
+            ${{ inputs.runtime_manifest_artifact_id }}
+          RUNTIME_MANIFEST_ARTIFACT_DIGEST: >-
+            ${{ inputs.runtime_manifest_artifact_digest }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected_build_id }}
+        with:
+          github-token: ${{ secrets.runtime_artifact_token }}
+          script: |
+            const runtimeRunId = Number(process.env.RUNTIME_RUN_ID);
+            const runtimeArtifactId = Number(process.env.RUNTIME_ARTIFACT_ID);
+            const runtimeManifestArtifactId = Number(
+              process.env.RUNTIME_MANIFEST_ARTIFACT_ID
+            );
+            const runtimeOwner = "Floorp-Projects";
+            const runtimeRepo = "Floorp-Runtime";
+            const {data: runtimeRun} = await github.rest.actions.getWorkflowRun({
+              owner: runtimeOwner,
+              repo: runtimeRepo,
+              run_id: runtimeRunId,
+            });
+            if (runtimeRun.id !== runtimeRunId ||
+                runtimeRun.repository?.full_name !== `${runtimeOwner}/${runtimeRepo}`) {
+              throw new Error("Runtime REST workflow provenance mismatch");
+            }
+            if (!Number.isSafeInteger(runtimeRun.workflow_id) ||
+                runtimeRun.workflow_id < 1) {
+              throw new Error("Runtime workflow ID is malformed");
+            }
+            const {data: runtimeWorkflow} = await github.rest.actions.getWorkflow({
+              owner: runtimeOwner,
+              repo: runtimeRepo,
+              workflow_id: runtimeRun.workflow_id,
+            });
+            if (runtimeWorkflow.path !== ".github/workflows/daily-build.yml") {
+              throw new Error("Runtime run did not use the trusted daily-build workflow");
+            }
+            if (!Number.isInteger(runtimeRun.run_attempt) || runtimeRun.run_attempt < 1 ||
+                !/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/.test(
+                  runtimeRun.created_at || ""
+                )) {
+              throw new Error("Runtime workflow attempt or created_at is malformed");
+            }
+            if (runtimeRun.status !== "completed" || runtimeRun.conclusion !== "success") {
+              throw new Error("Runtime workflow must be completed successfully");
+            }
+            if (runtimeRun.head_sha !== process.env.RUNTIME_HEAD_SHA) {
+              throw new Error("Runtime workflow head SHA mismatch");
+            }
+            const derivedBuildId = runtimeRun.created_at.replace(/[-:TZ]/g, "");
+            if (derivedBuildId !== process.env.EXPECTED_BUILD_ID) {
+              throw new Error(
+                `Runtime run BuildID ${derivedBuildId} does not match ` +
+                  process.env.EXPECTED_BUILD_ID
+              );
+            }
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: runtimeOwner,
+                repo: runtimeRepo,
+                run_id: runtimeRunId,
+                per_page: 100,
+              }
+            );
+            function validateArtifact(id, name, digest) {
+              const idMatches = artifacts.filter(artifact => artifact.id === id);
+              const nameMatches = artifacts.filter(
+                artifact => artifact.name === name && !artifact.expired
+              );
+              if (idMatches.length !== 1 || nameMatches.length !== 1 ||
+                  nameMatches[0].id !== id) {
+                throw new Error(`Runtime artifact ${name} is missing or ambiguous`);
+              }
+              const artifact = idMatches[0];
+              if (artifact.expired || artifact.digest !== digest ||
+                  !Number.isInteger(artifact.size_in_bytes) ||
+                  artifact.size_in_bytes < 1) {
+                throw new Error(`Runtime artifact ${name} REST provenance mismatch`);
+              }
+            }
+            validateArtifact(
+              runtimeArtifactId,
+              process.env.RUNTIME_ARTIFACT_NAME,
+              process.env.RUNTIME_ARTIFACT_DIGEST
+            );
+            validateArtifact(
+              runtimeManifestArtifactId,
+              "floorp-runtime-build-manifest-v2",
+              process.env.RUNTIME_MANIFEST_ARTIFACT_DIGEST
+            );
+            core.setOutput("runtime-created-at", runtimeRun.created_at);
+            core.setOutput("runtime-run-attempt", String(runtimeRun.run_attempt));
+
+      - name: Checkout exact Floorp source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.floorp_head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Download exact Runtime manifest artifact by ID
+        uses: actions/download-artifact@v4
+        with:
+          repository: Floorp-Projects/Floorp-Runtime
+          run-id: ${{ inputs.runtime_workflow_run_id }}
+          artifact-ids: ${{ inputs.runtime_manifest_artifact_id }}
+          path: ${{ runner.temp }}/runtime-manifest
+          merge-multiple: true
+          github-token: ${{ secrets.runtime_artifact_token }}
+
+      - name: Locate exact Runtime manifest
+        id: runtime-manifest
+        shell: pwsh
+        env:
+          MANIFEST_DIR: ${{ runner.temp }}/runtime-manifest
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $expected = Join-Path $env:MANIFEST_DIR 'runtime-build-manifest-v2.json'
+          $files = @(Get-ChildItem -LiteralPath $env:MANIFEST_DIR -Recurse -File)
+          if ($files.Count -ne 1 -or $files[0].FullName -ne $expected) {
+            throw "Expected exactly the root Runtime manifest $expected"
+          }
+          "path=$expected" >> $env:GITHUB_OUTPUT
+
+      - name: Validate selected Runtime target artifact through REST
+        uses: actions/github-script@v7
+        env:
+          RUNTIME_MANIFEST_PATH: ${{ steps.runtime-manifest.outputs.path }}
+          RUNTIME_RUN_ID: ${{ inputs.runtime_workflow_run_id }}
+          RUNTIME_HEAD_SHA: ${{ inputs.runtime_head_sha }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected_build_id }}
+          RUNTIME_CREATED_AT: ${{ steps.provenance.outputs.runtime-created-at }}
+          RUNTIME_RUN_ATTEMPT: ${{ steps.provenance.outputs.runtime-run-attempt }}
+          RUNTIME_TARGET_PLATFORM: ${{ steps.contract.outputs.runtime-platform }}
+          RUNTIME_TARGET_ARCH: ${{ steps.contract.outputs.runtime-arch }}
+          RUNTIME_TARGET_ARTIFACT: >-
+            ${{ steps.contract.outputs.runtime-target-artifact }}
+          RUNTIME_TARGET_ARTIFACT_ID: ${{ inputs.runtime_artifact_id }}
+          RUNTIME_TARGET_ARTIFACT_DIGEST: ${{ inputs.runtime_artifact_digest }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const manifest = JSON.parse(
+              fs.readFileSync(process.env.RUNTIME_MANIFEST_PATH, "utf8")
+            );
+            if (manifest.schema_version !== 2 ||
+                manifest.repository !== "Floorp-Projects/Floorp-Runtime" ||
+                manifest.head_sha !== process.env.RUNTIME_HEAD_SHA ||
+                manifest.workflow_run_id !== Number(process.env.RUNTIME_RUN_ID) ||
+                manifest.expected_build_id !== process.env.EXPECTED_BUILD_ID) {
+              throw new Error("Runtime manifest top-level provenance mismatch");
+            }
+            if (!Array.isArray(manifest.targets)) {
+              throw new Error("Runtime manifest targets must be an array");
+            }
+            const matches = manifest.targets.filter(target =>
+              target?.platform === process.env.RUNTIME_TARGET_PLATFORM &&
+              target?.arch === process.env.RUNTIME_TARGET_ARCH
+            );
+            if (matches.length !== 1) {
+              throw new Error("Runtime manifest must contain exactly one selected target");
+            }
+            const selected = matches[0];
+            if (selected.artifact_name !== process.env.RUNTIME_TARGET_ARTIFACT ||
+                selected.artifact_id !== Number(process.env.RUNTIME_TARGET_ARTIFACT_ID) ||
+                selected.artifact_digest !== process.env.RUNTIME_TARGET_ARTIFACT_DIGEST ||
+                selected.expected_build_id !== process.env.EXPECTED_BUILD_ID ||
+                !Number.isSafeInteger(selected.artifact_id) || selected.artifact_id < 1 ||
+                !/^sha256:[0-9a-f]{64}$/.test(selected.artifact_digest || "")) {
+              throw new Error("Runtime manifest selected target is malformed");
+            }
+            if (manifest.run_created_at !== process.env.RUNTIME_CREATED_AT ||
+                manifest.run_attempt !== Number(process.env.RUNTIME_RUN_ATTEMPT)) {
+              throw new Error("Runtime manifest run creation/attempt mismatch");
+            }
+
+      - name: Download exact final Floorp package artifact by ID
+        uses: actions/download-artifact@v4
+        with:
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_workflow_run_id }}
+          artifact-ids: ${{ inputs.package_artifact_id }}
+          path: ${{ runner.temp }}/floorp-package
+          merge-multiple: true
+          github-token: ${{ github.token }}
+
+      - name: Verify Windows final package natively
+        if: inputs.platform_key == 'windows'
+        shell: pwsh
+        env:
+          PACKAGE_DIR: ${{ runner.temp }}/floorp-package
+          PACKAGE_FILE_NAME: ${{ steps.contract.outputs.package-file-name }}
+          FULL_VERSION_FILE: ${{ runner.temp }}/floorp-full-version.txt
+          BUILD_ID2_FILE: ${{ runner.temp }}/floorp-buildid2
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:RUNNER_ARCH -ne 'X64') {
+            throw "Expected a native X64 runner, got $env:RUNNER_ARCH"
+          }
+
+          $package = Join-Path $env:PACKAGE_DIR $env:PACKAGE_FILE_NAME
+          $files = @(Get-ChildItem -LiteralPath $env:PACKAGE_DIR -Recurse -File)
+          if ($files.Count -ne 1 -or $files[0].FullName -ne $package) {
+            throw "Expected exactly the root final package $package"
+          }
+
+          function Assert-ExpectedAuthenticodeState {
+            param(
+              [Parameter(Mandatory = $true)][string]$Path,
+              [Parameter(Mandatory = $true)][string]$Label
+            )
+            $signature = Get-AuthenticodeSignature -FilePath $Path
+            if ($env:VALIDATION_ONLY -eq 'true') {
+              if ($signature.Status -eq
+                  [System.Management.Automation.SignatureStatus]::Valid) {
+                throw "Validation-only $Label unexpectedly has a valid signature"
+              }
+              if ($signature.Status -ne
+                  [System.Management.Automation.SignatureStatus]::NotSigned) {
+                throw "Validation-only $Label has an invalid signature state: $($signature.Status)"
+              }
+              Write-Host "Observed expected unsigned $Label (NotSigned)"
+            } else {
+              if ($signature.Status -ne
+                  [System.Management.Automation.SignatureStatus]::Valid) {
+                throw "Production $Label Authenticode is not valid: $($signature.Status)"
+              }
+              Write-Host "Verified production $Label Authenticode signature"
+            }
+          }
+          Assert-ExpectedAuthenticodeState -Path $package -Label 'Windows installer'
+
+          $extractDirectory = Join-Path $env:RUNNER_TEMP 'floorp-native-package'
+          New-Item -ItemType Directory -Path $extractDirectory -Force | Out-Null
+          & 7z x -y "-o$extractDirectory" $package
+          if ($LASTEXITCODE -ne 0) {
+            throw "7z failed to extract the final Floorp SFX package"
+          }
+          $binaries = @(
+            Get-ChildItem -LiteralPath $extractDirectory -Recurse -File -Filter 'floorp.exe'
+          )
+          if ($binaries.Count -ne 1) {
+            throw "Expected exactly one final floorp.exe; found $($binaries.Count)"
+          }
+          Assert-ExpectedAuthenticodeState `
+            -Path $binaries[0].FullName `
+            -Label 'floorp.exe'
+
+          $buildId2 = Join-Path $binaries[0].DirectoryName 'browser/buildid2'
+          if (-not (Test-Path -LiteralPath $buildId2 -PathType Leaf)) {
+            throw "Final Floorp package is missing browser/buildid2"
+          }
+          Copy-Item -LiteralPath $buildId2 -Destination $env:BUILD_ID2_FILE
+
+          $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+          $startInfo.FileName = $binaries[0].FullName
+          $startInfo.Arguments = '--full-version'
+          $startInfo.WorkingDirectory = $binaries[0].DirectoryName
+          $startInfo.UseShellExecute = $false
+          $startInfo.RedirectStandardOutput = $true
+          $startInfo.RedirectStandardError = $true
+          $startInfo.CreateNoWindow = $true
+          [void]$startInfo.Environment.Remove('XUL_APP_FILE')
+
+          $process = [System.Diagnostics.Process]::new()
+          $process.StartInfo = $startInfo
+          try {
+            if (-not $process.Start()) {
+              throw 'Failed to start final floorp.exe'
+            }
+            $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+            $stderrTask = $process.StandardError.ReadToEndAsync()
+            if (-not $process.WaitForExit(30000)) {
+              $process.Kill($true)
+              $process.WaitForExit()
+              throw 'Final floorp.exe --full-version timed out after 30 seconds'
+            }
+            $stdout = $stdoutTask.GetAwaiter().GetResult()
+            $stderr = $stderrTask.GetAwaiter().GetResult()
+            if ($process.ExitCode -ne 0) {
+              throw "Final floorp.exe exited with code $($process.ExitCode): $stderr"
+            }
+          } finally {
+            $process.Dispose()
+          }
+
+          Write-Host $stdout
+          if ($stderr) { Write-Host "stderr: $stderr" }
+          [System.IO.File]::WriteAllText(
+            $env:FULL_VERSION_FILE,
+            $stdout,
+            [System.Text.UTF8Encoding]::new($false)
+          )
+
+      - name: Verify Linux final package natively
+        if: inputs.platform_key == 'linux' || inputs.platform_key == 'linuxAarch64'
+        shell: bash
+        env:
+          PACKAGE_DIR: ${{ runner.temp }}/floorp-package
+          PACKAGE_FILE_NAME: ${{ steps.contract.outputs.package-file-name }}
+          FULL_VERSION_FILE: ${{ runner.temp }}/floorp-full-version.txt
+          BUILD_ID2_FILE: ${{ runner.temp }}/floorp-buildid2
+          TARGET_ARCH: ${{ inputs.native_arch }}
+        run: |
+          set -euo pipefail
+          case "$TARGET_ARCH" in
+            x86_64) expected_runner_arch=x86_64 ;;
+            aarch64) expected_runner_arch=aarch64 ;;
+            *) echo "Unsupported Linux architecture: $TARGET_ARCH" >&2; exit 1 ;;
+          esac
+          if [[ "$(uname -m)" != "$expected_runner_arch" ]]; then
+            echo "Expected native $expected_runner_arch runner, got $(uname -m)" >&2
+            exit 1
+          fi
+
+          package="$PACKAGE_DIR/$PACKAGE_FILE_NAME"
+          shopt -s nullglob dotglob
+          package_entries=("$PACKAGE_DIR"/*)
+          if (( ${#package_entries[@]} != 1 )) ||
+             [[ ! -f "${package_entries[0]}" ]] ||
+             [[ "${package_entries[0]}" != "$package" ]]; then
+            echo "Expected exactly the root final package $package" >&2
+            exit 1
+          fi
+
+          extract_dir="$RUNNER_TEMP/floorp-native-package"
+          mkdir -p "$extract_dir"
+          tar -xf "$package" -C "$extract_dir"
+          mapfile -d '' -t binaries < <(
+            find "$extract_dir" -type f -name floorp -perm /111 -print0
+          )
+          if (( ${#binaries[@]} != 1 )); then
+            echo "Expected exactly one final Floorp executable; found ${#binaries[@]}" >&2
+            exit 1
+          fi
+
+          build_id2="$(dirname "${binaries[0]}")/browser/buildid2"
+          if [[ ! -f "$build_id2" ]]; then
+            echo "Final Floorp package is missing browser/buildid2" >&2
+            exit 1
+          fi
+          cp "$build_id2" "$BUILD_ID2_FILE"
+
+          unset XUL_APP_FILE
+          set +e
+          full_version="$(
+            cd "$(dirname "${binaries[0]}")" &&
+              timeout --signal=KILL 30s ./floorp --full-version 2>&1
+          )"
+          status=$?
+          set -e
+          printf '%s\n' "$full_version"
+          if (( status != 0 )); then
+            echo "Final Floorp --full-version failed with exit code $status" >&2
+            exit "$status"
+          fi
+          printf '%s\n' "$full_version" > "$FULL_VERSION_FILE"
+
+      - name: Verify macOS final package natively
+        if: inputs.platform_key == 'mac'
+        shell: bash
+        env:
+          PACKAGE_DIR: ${{ runner.temp }}/floorp-package
+          PACKAGE_FILE_NAME: ${{ steps.contract.outputs.package-file-name }}
+          FULL_VERSION_FILE: ${{ runner.temp }}/floorp-full-version.txt
+          BUILD_ID2_FILE: ${{ runner.temp }}/floorp-buildid2
+          TARGET_ARCH: ${{ inputs.native_arch }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+        run: |
+          set -euo pipefail
+          case "$TARGET_ARCH" in
+            x86_64) expected_runner_arch=x86_64; expected_slice=x86_64 ;;
+            aarch64) expected_runner_arch=arm64; expected_slice=arm64 ;;
+            *) echo "Unsupported macOS architecture: $TARGET_ARCH" >&2; exit 1 ;;
+          esac
+          if [[ "$(uname -m)" != "$expected_runner_arch" ]]; then
+            echo "Expected native $expected_runner_arch runner, got $(uname -m)" >&2
+            exit 1
+          fi
+
+          package="$PACKAGE_DIR/$PACKAGE_FILE_NAME"
+          shopt -s nullglob dotglob
+          package_entries=("$PACKAGE_DIR"/*)
+          if (( ${#package_entries[@]} != 1 )) ||
+             [[ ! -f "${package_entries[0]}" ]] ||
+             [[ "${package_entries[0]}" != "$package" ]]; then
+            echo "Expected exactly the root final package $package" >&2
+            exit 1
+          fi
+
+          mount_plist="$RUNNER_TEMP/floorp-mount.plist"
+          cleanup() {
+            if [[ -s "$mount_plist" ]]; then
+              python3 - "$mount_plist" <<'PY' | while IFS= read -r mount_point; do
+          import plistlib
+          import sys
+
+          try:
+              with open(sys.argv[1], "rb") as source:
+                  payload = plistlib.load(source)
+          except Exception:
+              raise SystemExit(0)
+          for entity in payload.get("system-entities", []):
+              if isinstance(entity, dict) and entity.get("mount-point"):
+                  print(entity["mount-point"])
+          PY
+                hdiutil detach "$mount_point" >/dev/null 2>&1 ||
+                  hdiutil detach -force "$mount_point" >/dev/null 2>&1 || true
+              done
+            fi
+          }
+          trap cleanup EXIT
+          hdiutil attach -readonly -nobrowse -plist "$package" > "$mount_plist"
+
+          mount_point="$(python3 - "$mount_plist" <<'PY'
+          import plistlib
+          import sys
+
+          with open(sys.argv[1], "rb") as source:
+              payload = plistlib.load(source)
+          points = [
+              entity["mount-point"]
+              for entity in payload.get("system-entities", [])
+              if isinstance(entity, dict) and entity.get("mount-point")
+          ]
+          if len(points) != 1:
+              raise SystemExit(f"expected one mounted DMG volume, found {len(points)}")
+          print(points[0])
+          PY
+          )"
+
+          app_bundle="$(python3 - "$mount_point" <<'PY'
+          import pathlib
+          import sys
+
+          matches = [
+              path
+              for path in pathlib.Path(sys.argv[1]).glob("*.app")
+              if path.is_dir()
+          ]
+          if len(matches) != 1:
+              raise SystemExit(f"expected one final Floorp app, found {len(matches)}")
+          print(matches[0])
+          PY
+          )"
+          app_binary="$app_bundle/Contents/MacOS/floorp"
+          if [[ ! -x "$app_binary" ]]; then
+            echo "Final Floorp app is missing its executable" >&2
+            exit 1
+          fi
+          slices="$(lipo -archs "$app_binary")"
+          case " $slices " in
+            *" $expected_slice "*) ;;
+            *) echo "Universal binary lacks $expected_slice slice: $slices" >&2; exit 1 ;;
+          esac
+
+          codesign_log="$RUNNER_TEMP/floorp-codesign-verification.txt"
+          if [[ "$VALIDATION_ONLY" == "true" ]]; then
+            if codesign --verify --deep --strict --verbose=2 \
+              "$app_bundle" > "$codesign_log" 2>&1; then
+              cat "$codesign_log"
+              echo "Validation-only Floorp app unexpectedly has a valid code signature" >&2
+              exit 1
+            fi
+            signature_metadata="$(
+              find "$app_bundle" -type d -name _CodeSignature -print -quit
+            )"
+            if [[ -n "$signature_metadata" ]]; then
+              echo "Validation-only Floorp app contains signature metadata: $signature_metadata" >&2
+              exit 1
+            fi
+            while IFS= read -r -d '' code_path; do
+              if codesign --display --verbose=2 \
+                "$code_path" > "$codesign_log" 2>&1; then
+                cat "$codesign_log"
+                echo "Validation-only Floorp package contains signed code: $code_path" >&2
+                exit 1
+              fi
+            done < <(APP_BUNDLE="$app_bundle" python3 - <<'PY'
+          import os
+          import pathlib
+          import sys
+
+          app = pathlib.Path(os.environ["APP_BUNDLE"])
+          candidates = {app}
+          directory_suffixes = (".app", ".framework", ".xpc", ".appex", ".plugin", ".bundle")
+          file_suffixes = (".dylib", ".so")
+          for root, directories, files in os.walk(app / "Contents", followlinks=False):
+              root_path = pathlib.Path(root)
+              for name in directories:
+                  candidate = root_path / name
+                  if name.endswith(directory_suffixes):
+                      candidates.add(candidate)
+              for name in files:
+                  candidate = root_path / name
+                  if candidate.is_symlink():
+                      continue
+                  if name.endswith(file_suffixes) or os.access(candidate, os.X_OK):
+                      candidates.add(candidate)
+          for candidate in sorted(candidates, key=lambda path: os.fsencode(path)):
+              sys.stdout.buffer.write(os.fsencode(candidate) + b"\0")
+          PY
+            )
+            echo "Observed expected unsigned validation-only Floorp app"
+          else
+            if ! codesign --verify --deep --strict --verbose=2 \
+              "$app_bundle" > "$codesign_log" 2>&1; then
+              cat "$codesign_log" >&2
+              echo "Production Floorp app code signature verification failed" >&2
+              exit 1
+            fi
+            cat "$codesign_log"
+            echo "Verified production Floorp app code signature"
+          fi
+
+          build_id2="$app_bundle/Contents/Resources/browser/buildid2"
+          if [[ ! -f "$build_id2" ]]; then
+            echo "Final Floorp app is missing browser/buildid2" >&2
+            exit 1
+          fi
+          cp "$build_id2" "$BUILD_ID2_FILE"
+
+          unset XUL_APP_FILE
+          APP_BINARY="$app_binary" python3 - <<'PY'
+          import os
+          import pathlib
+          import subprocess
+          import sys
+
+          environment = os.environ.copy()
+          environment.pop("XUL_APP_FILE", None)
+          try:
+              result = subprocess.run(
+                  [os.environ["APP_BINARY"], "--full-version"],
+                  cwd=pathlib.Path(os.environ["APP_BINARY"]).parent,
+                  env=environment,
+                  stdout=subprocess.PIPE,
+                  stderr=subprocess.STDOUT,
+                  timeout=30,
+                  check=False,
+              )
+          except subprocess.TimeoutExpired as error:
+              if error.stdout:
+                  sys.stderr.buffer.write(error.stdout)
+              raise SystemExit(
+                  "final Floorp --full-version timed out after 30 seconds"
+              ) from error
+
+          sys.stdout.buffer.write(result.stdout)
+          if result.returncode != 0:
+              raise SystemExit(
+                  f"final Floorp exited with code {result.returncode}"
+              )
+          pathlib.Path(os.environ["FULL_VERSION_FILE"]).write_bytes(result.stdout)
+          PY
+
+      - name: Create strict native verification descriptor
+        id: descriptor
+        uses: actions/github-script@v7
+        env:
+          RUNTIME_MANIFEST_PATH: ${{ steps.runtime-manifest.outputs.path }}
+          FULL_VERSION_FILE: ${{ runner.temp }}/floorp-full-version.txt
+          BUILD_ID2_FILE: ${{ runner.temp }}/floorp-buildid2
+          FLOORP_HEAD_SHA: ${{ inputs.floorp_head_sha }}
+          SOURCE_RUN_ID: ${{ inputs.source_workflow_run_id }}
+          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          PACKAGE_ARTIFACT_ID: ${{ inputs.package_artifact_id }}
+          PACKAGE_ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
+          PLATFORM_KEY: ${{ inputs.platform_key }}
+          NATIVE_ARCH: ${{ inputs.native_arch }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const descriptorPath = path.join(
+              process.env.RUNNER_TEMP,
+              "floorp-native-verification-descriptor.json"
+            );
+            const descriptor = {
+              schema_version: 2,
+              target_key: process.env.PLATFORM_KEY,
+              native_arch: process.env.NATIVE_ARCH,
+              runtime_manifest_path: process.env.RUNTIME_MANIFEST_PATH,
+              full_version_output_path: process.env.FULL_VERSION_FILE,
+              build_id2_path: process.env.BUILD_ID2_FILE,
+              floorp: {
+                repository: `${context.repo.owner}/${context.repo.repo}`,
+                head_sha: process.env.FLOORP_HEAD_SHA,
+                workflow_run_id: Number(process.env.SOURCE_RUN_ID),
+              },
+              floorp_package: {
+                artifact_name: process.env.PACKAGE_ARTIFACT_NAME,
+                artifact_id: Number(process.env.PACKAGE_ARTIFACT_ID),
+                artifact_digest: process.env.PACKAGE_ARTIFACT_DIGEST,
+                unsigned: process.env.VALIDATION_ONLY === "true",
+              },
+            };
+            fs.writeFileSync(
+              descriptorPath,
+              JSON.stringify(descriptor, null, 2) + "\n",
+              {encoding: "utf8", flag: "wx"}
+            );
+            core.setOutput("path", descriptorPath);
+
+      - name: Generate strict native verification record
+        id: record
+        shell: pwsh
+        env:
+          DESCRIPTOR_PATH: ${{ steps.descriptor.outputs.path }}
+          RECORD_PATH: >-
+            ${{ runner.temp }}/${{ steps.contract.outputs.record-file-name }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          deno run --allow-read --allow-write `
+            tools/src/release_provenance.ts `
+            record-native-verification `
+            --descriptor $env:DESCRIPTOR_PATH `
+            --output $env:RECORD_PATH `
+            --github-output $env:GITHUB_OUTPUT
+          if ($LASTEXITCODE -ne 0) {
+            throw 'release_provenance.ts rejected the native package evidence'
+          }
+
+      - name: Upload immutable native verification record
+        id: upload-record
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.contract.outputs.record-artifact-name }}
+          path: ${{ runner.temp }}/${{ steps.contract.outputs.record-file-name }}
+          if-no-files-found: error
+          overwrite: true
+          compression-level: 0

--- a/.github/workflows/verify-release-artifact.yml
+++ b/.github/workflows/verify-release-artifact.yml
@@ -832,6 +832,57 @@ jobs:
 
           codesign_log="$RUNNER_TEMP/floorp-codesign-verification.txt"
           if [[ "$VALIDATION_ONLY" == "true" ]]; then
+            reject_validation_signature() {
+              local message="$1"
+              local code_path="$2"
+              echo "$message: $code_path" >&2
+              exit 1
+            }
+
+            assert_validation_linker_signed_adhoc() {
+              local code_path="$1"
+              cat "$codesign_log"
+              if [[ "$TARGET_ARCH" != "aarch64" ]]; then
+                reject_validation_signature \
+                  "Validation-only Floorp package contains signed code" \
+                  "$code_path"
+              fi
+
+              local signature
+              signature="$(sed -n 's/^Signature=//p' "$codesign_log" | head -n 1)"
+              if [[ "$signature" != "adhoc" ]]; then
+                reject_validation_signature \
+                  "Validation-only signature is not ad-hoc" \
+                  "$code_path"
+              fi
+
+              local team_identifier
+              team_identifier="$(
+                sed -n 's/^TeamIdentifier=//p' "$codesign_log" | head -n 1
+              )"
+              if [[ "$team_identifier" != "not set" ]]; then
+                reject_validation_signature \
+                  "Validation-only signature unexpectedly has a TeamIdentifier" \
+                  "$code_path"
+              fi
+
+              if grep -q '^Authority=' "$codesign_log"; then
+                reject_validation_signature \
+                  "Validation-only package contains certificate-backed signed code" \
+                  "$code_path"
+              fi
+
+              local code_directory
+              code_directory="$(sed -n '/^CodeDirectory /p' "$codesign_log" | head -n 1)"
+              if [[ "$code_directory" != *adhoc* ]] || [[ "$code_directory" != *linker-signed* ]]; then
+                reject_validation_signature \
+                  "Validation-only signature is not linker-generated ad-hoc metadata" \
+                  "$code_path"
+              fi
+
+              echo "Observed expected validation-only ad-hoc linker-signed metadata: $code_path"
+            }
+
             if codesign --verify --deep --strict --verbose=2 \
               "$app_bundle" > "$codesign_log" 2>&1; then
               cat "$codesign_log"
@@ -846,11 +897,9 @@ jobs:
               exit 1
             fi
             while IFS= read -r -d '' code_path; do
-              if codesign --display --verbose=2 \
+              if codesign --display --verbose=4 \
                 "$code_path" > "$codesign_log" 2>&1; then
-                cat "$codesign_log"
-                echo "Validation-only Floorp package contains signed code: $code_path" >&2
-                exit 1
+                assert_validation_linker_signed_adhoc "$code_path"
               fi
             done < <(APP_BUNDLE="$app_bundle" python3 - <<'PY'
           import os

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "7e2e9c05e1c6c0113f74e9d4ea72654cb63e7500"
+floorp_commit: "fe772e6de397ba1d44a91c45b359629b28d63bca"
 generated: true
 ---
 # Architecture Overview
@@ -121,6 +121,7 @@ Deno task inventory comes from `deno.json` and currently lists 25 tasks. The fel
 
 CI workflows recorded in the docs inventory:
 
+- `.github/workflows/assemble-release-bundle.yml` - triggers: `workflow_call`
 - `.github/workflows/build_installers.yml` - triggers: `workflow_call`, `workflow_dispatch`
 - `.github/workflows/colocated_runner_test.yml` - triggers: `pull_request`, `push`, `workflow_dispatch`
 - `.github/workflows/docs_pipeline.yml` - triggers: `pull_request`, `push`, `schedule`, `workflow_dispatch`
@@ -133,3 +134,5 @@ CI workflows recorded in the docs inventory:
 - `.github/workflows/publish_ppa.yml` - triggers: `workflow_call`, `workflow_dispatch`
 - `.github/workflows/publish_release.yml` - triggers: `workflow_call`
 - `.github/workflows/update_lepton.yml` - triggers: `schedule`, `workflow_dispatch`
+- `.github/workflows/validate-runtime-provenance.yml` - triggers: `workflow_call`
+- `.github/workflows/verify-release-artifact.yml` - triggers: `workflow_call`

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "d129e2a2e9c5983b277fc850b61d6a2995b2acff"
+floorp_commit: "fe772e6de397ba1d44a91c45b359629b28d63bca"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `d129e2a2e9c5983b277fc850b61d6a2995b2acff`.
+Inventory generated from Floorp commit `fe772e6de397ba1d44a91c45b359629b28d63bca`.
 
 ## Source Precedence
 
@@ -60,6 +60,7 @@ Inventory generated from Floorp commit `d129e2a2e9c5983b277fc850b61d6a2995b2acff
 
 ## CI Sources
 
+- `.github/workflows/assemble-release-bundle.yml` - triggers: `workflow_call`
 - `.github/workflows/build_installers.yml` - triggers: `workflow_call`, `workflow_dispatch`
 - `.github/workflows/colocated_runner_test.yml` - triggers: `pull_request`, `push`, `workflow_dispatch`
 - `.github/workflows/docs_pipeline.yml` - triggers: `pull_request`, `push`, `schedule`, `workflow_dispatch`
@@ -72,3 +73,5 @@ Inventory generated from Floorp commit `d129e2a2e9c5983b277fc850b61d6a2995b2acff
 - `.github/workflows/publish_ppa.yml` - triggers: `workflow_call`, `workflow_dispatch`
 - `.github/workflows/publish_release.yml` - triggers: `workflow_call`
 - `.github/workflows/update_lepton.yml` - triggers: `schedule`, `workflow_dispatch`
+- `.github/workflows/validate-runtime-provenance.yml` - triggers: `workflow_call`
+- `.github/workflows/verify-release-artifact.yml` - triggers: `workflow_call`

--- a/tools/act/run-package-workflow.test.ts
+++ b/tools/act/run-package-workflow.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import {
+  buildActArguments,
+  buildEventPayload,
+  formatActCommand,
+  resolvePlatforms,
+} from "./run-package-workflow.ts";
+
+Deno.test("act secret is passed by environment name, never by value", () => {
+  const sentinel = "NOT_A_REAL_TOKEN_ARG_TEST";
+  const args = buildActArguments({
+    workflowPath: ".github/workflows/package.yml",
+    payloadPath: "event.json",
+    jobName: "main",
+    platformImage: "ubuntu-22.04=image",
+    extraArgs: ["--secret", `UNRELATED=${sentinel}`],
+  });
+
+  assertEquals(args.slice(8, 10), ["-s", "GITHUB_TOKEN"]);
+  assertFalse(args.some((argument) => argument.startsWith("GITHUB_TOKEN=")));
+
+  const displayed = formatActCommand(args, 2);
+  assertFalse(displayed.includes(sentinel));
+  assert(displayed.includes("[2 additional argument(s) omitted]"));
+});
+
+Deno.test("default platform and help implementation stay aligned", () => {
+  assertEquals(resolvePlatforms(), ["Linux-x64"]);
+  assertEquals(resolvePlatforms("Linux-x64,Linux-aarch64,Linux-x64"), [
+    "Linux-x64",
+    "Linux-aarch64",
+  ]);
+});
+
+Deno.test("legacy act event contains no credentials", () => {
+  const payload = buildEventPayload({
+    ref: "main",
+    platform: "Linux-x64",
+    beta: false,
+    skipSigning: true,
+    runtimeRunId: "1234",
+  });
+  assertEquals(payload, {
+    ref: "main",
+    inputs: {
+      platform: "Linux-x64",
+      beta: "false",
+      runtime_artifact_workflow_run_id: "1234",
+      skip_signing: "true",
+    },
+  });
+  assertFalse(JSON.stringify(payload).toLowerCase().includes("token"));
+});

--- a/tools/act/run-package-workflow.ts
+++ b/tools/act/run-package-workflow.ts
@@ -4,161 +4,176 @@
 import { parseArgs } from "jsr:@std/cli@1.0.6/parse-args";
 
 const DEFAULT_PLATFORMS = ["Linux-x64"] as const;
-const PLATFORMS = ["Windows-x64", "Linux-x64", "Linux-aarch64", "macOS-x64"];
+const PLATFORMS = [
+  "Windows-x64",
+  "Linux-x64",
+  "Linux-aarch64",
+  "macOS-x64",
+] as const;
 
-type Platform = (typeof PLATFORMS)[number];
+export type Platform = (typeof PLATFORMS)[number];
 
-const parsed = parseArgs(Deno.args, {
-  string: [
-    "platform",
-    "platforms",
-    "workflow",
-    "ref",
-    "runtime-run-id",
-    "gh-token",
-    "act-path",
-    "platform-image",
-    "job",
-  ],
-  boolean: ["beta", "skip-signing", "help", "dry-run", "continue-on-error"],
-  default: {
-    workflow: ".github/workflows/package.yml",
-    ref: "main",
-    beta: false,
-    "skip-signing": true,
-    "runtime-run-id": "",
-    "act-path": "act",
-    "platform-image": "ubuntu-22.04=ghcr.io/catthehacker/ubuntu:full-latest",
-    job: "main",
-    "dry-run": false,
-    "continue-on-error": false,
-  },
-});
-
-if (parsed.help) {
-  printHelp();
-  Deno.exit(0);
-}
-
-const extraArgs = parsed._.map(String);
-const platforms = resolvePlatforms(parsed.platforms ?? parsed.platform);
-
-if (platforms.length === 0) {
-  console.error(
-    "No platforms selected. Specify with --platforms or --platform.",
-  );
-  Deno.exit(1);
-}
-
-let githubToken: string;
-try {
-  githubToken = await resolveGithubToken(String(parsed["gh-token"] ?? ""));
-} catch (error) {
-  console.error(`Failed to acquire GitHub token via gh CLI: ${error}`);
-  console.error("Run 'gh auth login' or pass --gh-token your_token_here.");
-  Deno.exit(1);
-}
-
-const workflowPath = String(parsed.workflow);
-const ref = String(parsed.ref);
-const runtimeRunId = String(parsed["runtime-run-id"] ?? "");
-const jobName = String(parsed.job);
-const betaFlag = Boolean(parsed.beta);
-const skipSigning = Boolean(parsed["skip-signing"]);
-const actExecutable = String(parsed["act-path"]);
-const platformImage = String(parsed["platform-image"]);
-const dryRun = Boolean(parsed["dry-run"]);
-const continueOnError = Boolean(parsed["continue-on-error"]);
-
-const failures: Array<
-  { platform: Platform; code: number } | { platform: Platform; error: Error }
-> = [];
-
-for (const platform of platforms) {
-  console.log(`\n=== Running act for platform: ${platform} ===`);
-  const payload = buildEventPayload({
-    ref,
-    platform,
-    beta: betaFlag,
-    skipSigning,
-    runtimeRunId,
+export async function main(args: string[] = Deno.args): Promise<number> {
+  const parsed = parseArgs(args, {
+    string: [
+      "platform",
+      "platforms",
+      "workflow",
+      "ref",
+      "runtime-run-id",
+      "gh-token",
+      "act-path",
+      "platform-image",
+      "job",
+    ],
+    boolean: ["beta", "skip-signing", "help", "dry-run", "continue-on-error"],
+    default: {
+      workflow: ".github/workflows/package.yml",
+      ref: "main",
+      beta: false,
+      "skip-signing": true,
+      "runtime-run-id": "",
+      "act-path": "act",
+      "platform-image": "ubuntu-22.04=ghcr.io/catthehacker/ubuntu:full-latest",
+      job: "main",
+      "dry-run": false,
+      "continue-on-error": false,
+    },
   });
 
-  const payloadPath = await Deno.makeTempFile({
-    prefix: `act-event-${platform.replaceAll(/[^a-zA-Z0-9]/g, "-")}-`,
-    suffix: ".json",
-  });
-  await Deno.writeTextFile(payloadPath, JSON.stringify(payload, null, 2));
-
-  const args = [
-    "-W",
-    workflowPath,
-    "-e",
-    payloadPath,
-    "-j",
-    jobName,
-    "-P",
-    platformImage,
-    "-s",
-    `GITHUB_TOKEN=${githubToken}`,
-    ...extraArgs,
-  ];
-
-  console.log(`act ${args.join(" ")}`);
-
-  if (dryRun) {
-    console.log("Dry-run requested; skipping execution.");
-    await safeRemove(payloadPath);
-    continue;
+  if (parsed.help) {
+    printHelp();
+    return 0;
   }
 
-  try {
-    const command = new Deno.Command(actExecutable, {
-      args,
-      stdout: "inherit",
-      stderr: "inherit",
+  if (parsed["gh-token"]) {
+    console.error(
+      "--gh-token was removed because command-line secrets are visible to other processes. " +
+        "Use FLOORP_ACT_GITHUB_TOKEN or authenticate gh instead.",
+    );
+    return 2;
+  }
+
+  const extraArgs = parsed._.map(String);
+  const platforms = resolvePlatforms(parsed.platforms ?? parsed.platform);
+  if (platforms.length === 0) {
+    console.error(
+      "No platforms selected. Specify with --platforms or --platform.",
+    );
+    return 1;
+  }
+
+  const workflowPath = String(parsed.workflow);
+  const ref = String(parsed.ref);
+  const runtimeRunId = String(parsed["runtime-run-id"] ?? "");
+  const jobName = String(parsed.job);
+  const betaFlag = Boolean(parsed.beta);
+  const skipSigning = Boolean(parsed["skip-signing"]);
+  const actExecutable = String(parsed["act-path"]);
+  const platformImage = String(parsed["platform-image"]);
+  const dryRun = Boolean(parsed["dry-run"]);
+  const continueOnError = Boolean(parsed["continue-on-error"]);
+
+  let githubToken = "";
+  if (!dryRun) {
+    try {
+      githubToken = await resolveGithubToken();
+    } catch (error) {
+      console.error(`Failed to acquire a GitHub token: ${error}`);
+      console.error(
+        "Set FLOORP_ACT_GITHUB_TOKEN or run 'gh auth login'. The token is never printed.",
+      );
+      return 1;
+    }
+  }
+
+  const failures: Array<
+    { platform: Platform; code: number } | { platform: Platform; error: Error }
+  > = [];
+
+  for (const platform of platforms) {
+    console.log(`\n=== Running act for platform: ${platform} ===`);
+    const payload = buildEventPayload({
+      ref,
+      platform,
+      beta: betaFlag,
+      skipSigning,
+      runtimeRunId,
     });
-    const { code } = await command.spawn().status;
-    if (code !== 0) {
-      console.error(`act exited with code ${code} for platform ${platform}`);
-      failures.push({ platform, code });
+
+    const payloadPath = await Deno.makeTempFile({
+      prefix: `act-event-${platform.replaceAll(/[^a-zA-Z0-9]/g, "-")}-`,
+      suffix: ".json",
+    });
+    await Deno.writeTextFile(payloadPath, JSON.stringify(payload, null, 2));
+
+    const actArgs = buildActArguments({
+      workflowPath,
+      payloadPath,
+      jobName,
+      platformImage,
+      extraArgs,
+    });
+    console.log(formatActCommand(actArgs, extraArgs.length));
+
+    if (dryRun) {
+      console.log(
+        "Dry-run requested; skipping token acquisition and act execution.",
+      );
+      await safeRemove(payloadPath);
+      continue;
+    }
+
+    try {
+      const command = new Deno.Command(actExecutable, {
+        args: actArgs,
+        env: { GITHUB_TOKEN: githubToken },
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      const { code } = await command.spawn().status;
+      if (code !== 0) {
+        console.error(`act exited with code ${code} for platform ${platform}`);
+        failures.push({ platform, code });
+        if (!continueOnError) {
+          await safeRemove(payloadPath);
+          break;
+        }
+      }
+    } catch (error) {
+      console.error(`Failed to execute act for platform ${platform}:`, error);
+      failures.push({ platform, error: error as Error });
       if (!continueOnError) {
         await safeRemove(payloadPath);
         break;
       }
     }
-  } catch (error) {
-    console.error(`Failed to execute act for platform ${platform}:`, error);
-    failures.push({ platform, error: error as Error });
-    if (!continueOnError) {
-      await safeRemove(payloadPath);
-      break;
-    }
+
+    await safeRemove(payloadPath);
   }
 
-  await safeRemove(payloadPath);
-}
-
-if (failures.length > 0) {
-  console.error("\nSome act runs failed:");
-  for (const failure of failures) {
-    if ("code" in failure) {
-      console.error(`  - ${failure.platform}: exit code ${failure.code}`);
-    } else {
-      console.error(`  - ${failure.platform}: ${failure.error.message}`);
+  if (failures.length > 0) {
+    console.error("\nSome act runs failed:");
+    for (const failure of failures) {
+      if ("code" in failure) {
+        console.error(`  - ${failure.platform}: exit code ${failure.code}`);
+      } else {
+        console.error(`  - ${failure.platform}: ${failure.error.message}`);
+      }
     }
+    return 1;
   }
-  Deno.exit(1);
+
+  console.log("\nAll requested act runs completed successfully.");
+  return 0;
 }
 
-console.log("\nAll requested act runs completed successfully.");
-
-function resolvePlatforms(value?: string | string[]): Platform[] {
+export function resolvePlatforms(value?: string | string[]): Platform[] {
   if (!value) {
     return [...DEFAULT_PLATFORMS];
   }
   const raw = Array.isArray(value)
-    ? value.flatMap((v) => v.split(","))
+    ? value.flatMap((entry) => entry.split(","))
     : value.split(",");
   const cleaned = raw.map((entry) => entry.trim()).filter(Boolean);
   const unknown = cleaned.filter(
@@ -168,15 +183,62 @@ function resolvePlatforms(value?: string | string[]): Platform[] {
     console.warn(`Warning: unknown platforms ignored -> ${unknown.join(", ")}`);
   }
   const known = cleaned.filter((entry): entry is Platform =>
-    PLATFORMS.includes(entry as Platform),
+    PLATFORMS.includes(entry as Platform)
   );
   return Array.from(new Set(known));
 }
 
-async function resolveGithubToken(provided: string): Promise<string> {
-  if (provided) {
-    return provided.trim();
-  }
+export function buildActArguments({
+  workflowPath,
+  payloadPath,
+  jobName,
+  platformImage,
+  extraArgs,
+}: {
+  workflowPath: string;
+  payloadPath: string;
+  jobName: string;
+  platformImage: string;
+  extraArgs: string[];
+}): string[] {
+  return [
+    "-W",
+    workflowPath,
+    "-e",
+    payloadPath,
+    "-j",
+    jobName,
+    "-P",
+    platformImage,
+    "-s",
+    "GITHUB_TOKEN",
+    ...extraArgs,
+  ];
+}
+
+export function formatActCommand(
+  args: string[],
+  extraArgumentCount: number,
+): string {
+  const visibleCount = Math.max(0, args.length - extraArgumentCount);
+  const visible = args.slice(0, visibleCount).map(shellDisplayArgument).join(
+    " ",
+  );
+  const suffix = extraArgumentCount > 0
+    ? ` [${extraArgumentCount} additional argument(s) omitted]`
+    : "";
+  return `act ${visible}${suffix}`;
+}
+
+function shellDisplayArgument(value: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
+  return JSON.stringify(value);
+}
+
+async function resolveGithubToken(): Promise<string> {
+  const fromEnvironment = Deno.env.get("FLOORP_ACT_GITHUB_TOKEN")?.trim();
+  if (fromEnvironment) return fromEnvironment;
+
   const command = new Deno.Command("gh", {
     args: ["auth", "token"],
     stdout: "piped",
@@ -188,13 +250,11 @@ async function resolveGithubToken(provided: string): Promise<string> {
     throw new Error(errorText || `gh auth token exited with code ${code}`);
   }
   const token = new TextDecoder().decode(stdout).trim();
-  if (!token) {
-    throw new Error("gh auth token returned an empty token");
-  }
+  if (!token) throw new Error("gh auth token returned an empty token");
   return token;
 }
 
-function buildEventPayload({
+export function buildEventPayload({
   ref,
   platform,
   beta,
@@ -236,7 +296,7 @@ USAGE:
   deno run --allow-run --allow-env --allow-read --allow-write tools/act/run-package-workflow.ts [options] [-- extra act args]
 
 OPTIONS:
-  --platforms <csv>        Comma-separated list of platforms to test (default: Linux-x64,Linux-aarch64)
+  --platforms <csv>        Comma-separated list of platforms to test (default: Linux-x64)
   --platform <name>        Repeatable alternative to --platforms
   --workflow <path>        Workflow file path (default: .github/workflows/package.yml)
   --ref <git-ref>          Ref used in the payload (default: main)
@@ -244,17 +304,24 @@ OPTIONS:
   --beta                   Enable beta mode (default: false)
   --skip-signing           Skip signing steps (default: true)
   --act-path <path>        act executable (default: act in PATH)
-  --platform-image <map>   Runner image map for act -P (default: ubuntu-latest=catthehacker/ubuntu:act-latest)
-  --gh-token <token>       Provide GitHub token directly (otherwise gh auth token is used)
+  --platform-image <map>   Runner image map for act -P (default: ubuntu-22.04=ghcr.io/catthehacker/ubuntu:full-latest)
   --job <name>             Workflow job name to run (default: main)
-  --dry-run                Print commands without executing act
+  --dry-run                Print a secret-free command without token acquisition or execution
   --continue-on-error      Keep running other platforms even if one fails
   --help                   Show this message
+
+AUTHENTICATION:
+  Set FLOORP_ACT_GITHUB_TOKEN, or authenticate with gh. The token is passed to
+  act through its child environment and is never placed in act argv or logs.
 
 EXAMPLES:
   deno run -A tools/act/run-package-workflow.ts
   deno run -A tools/act/run-package-workflow.ts --platforms Linux-x64,macOS-x64 --beta --skip-signing=false
-  deno run -A tools/act/run-package-workflow.ts -- --pull
+  deno run -A tools/act/run-package-workflow.ts --dry-run -- --pull
 `,
   );
+}
+
+if (import.meta.main) {
+  Deno.exit(await main());
 }

--- a/tools/src/release_provenance.test.ts
+++ b/tools/src/release_provenance.test.ts
@@ -738,6 +738,41 @@ Deno.test("exact Runtime artifact download uses the flat consolidated layout", a
   assertStringIncludes(downloadStep, "merge-multiple: true");
 });
 
+Deno.test("mac validation verifier only allows arm64 linker-signed ad-hoc metadata", async () => {
+  const verifierWorkflow = await Deno.readTextFile(
+    new URL(
+      "../../.github/workflows/verify-release-artifact.yml",
+      import.meta.url,
+    ),
+  );
+
+  for (
+    const expected of [
+      "assert_validation_linker_signed_adhoc()",
+      'if [[ "$TARGET_ARCH" != "aarch64" ]]; then',
+      "s/^Signature=//p",
+      '[[ "$signature" != "adhoc" ]]',
+      "s/^TeamIdentifier=//p",
+      '[[ "$team_identifier" != "not set" ]]',
+      "^Authority=",
+      "linker-signed",
+      "Observed expected validation-only ad-hoc linker-signed metadata",
+      "Validation-only Floorp app unexpectedly has a valid code signature",
+      "Observed expected unsigned validation-only Floorp app",
+    ]
+  ) {
+    assertStringIncludes(verifierWorkflow, expected);
+  }
+
+  const helperIndex = verifierWorkflow.indexOf(
+    "assert_validation_linker_signed_adhoc()",
+  );
+  const unsignedIndex = verifierWorkflow.indexOf(
+    "Observed expected unsigned validation-only Floorp app",
+  );
+  assertEquals(helperIndex >= 0 && unsignedIndex > helperIndex, true);
+});
+
 Deno.test("release publication is serialized across source workflow runs", async () => {
   const publishWorkflow = await Deno.readTextFile(
     new URL("../../.github/workflows/publish_release.yml", import.meta.url),

--- a/tools/src/release_provenance.test.ts
+++ b/tools/src/release_provenance.test.ts
@@ -1,0 +1,755 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import {
+  assembleReleaseBundle,
+  canonicalJson,
+  computeManifestSetId,
+  createNativeVerificationRecord,
+  parseFullVersionOutput,
+  ProvenanceError,
+  TARGETS,
+  validateNativeVerificationSet,
+  validateReleaseBundle,
+  validateRuntimeProvenance,
+  validateUuidV7,
+} from "./release_provenance.ts";
+
+const RUNTIME_SHA = "b".repeat(40);
+const FLOORP_SHA = "a".repeat(40);
+const BUILD_ID = "20260723143615";
+const RUN_ID = 1000;
+const UUIDS = [
+  "019f9000-0000-7000-8000-000000000001",
+  "019f9000-0000-7000-8000-000000000002",
+  "019f9000-0000-7000-8000-000000000003",
+  "019f9000-0000-7000-8000-000000000004",
+];
+
+async function digest(
+  algorithm: "SHA-256" | "SHA-512",
+  bytes: Uint8Array,
+): Promise<string> {
+  const result = await crypto.subtle.digest(
+    algorithm,
+    bytes as Uint8Array<ArrayBuffer>,
+  );
+  return Array.from(
+    new Uint8Array(result),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+function runtimeManifest() {
+  return {
+    schema_version: 2,
+    repository: "Floorp-Projects/Floorp-Runtime",
+    head_sha: RUNTIME_SHA,
+    workflow_run_id: RUN_ID,
+    run_created_at: "2026-07-23T14:36:15Z",
+    run_attempt: 1,
+    expected_build_id: BUILD_ID,
+    targets: TARGETS.map((target, index) => ({
+      platform: target.runtimePlatform,
+      arch: target.runtimeArch,
+      artifact_name: target.runtimeArtifactName,
+      artifact_id: 2000 + index,
+      artifact_digest: `sha256:${String(index + 5).repeat(64)}`,
+      expected_build_id: BUILD_ID,
+    })),
+  };
+}
+
+function restSnapshot() {
+  const manifest = runtimeManifest();
+  const artifact = (
+    id: number,
+    name: string,
+    value: string,
+  ) => ({
+    id,
+    name,
+    digest: value,
+    expired: false,
+    workflow_run_id: RUN_ID,
+    workflow_run_head_sha: RUNTIME_SHA,
+  });
+  return {
+    schema_version: 2,
+    repository: "Floorp-Projects/Floorp-Runtime",
+    workflow_path: ".github/workflows/daily-build.yml",
+    run: {
+      id: RUN_ID,
+      status: "completed",
+      conclusion: "success",
+      head_sha: RUNTIME_SHA,
+      run_attempt: 1,
+      created_at: "2026-07-23T14:36:15Z",
+    },
+    manifest_artifact: artifact(
+      1999,
+      "floorp-runtime-build-manifest-v2",
+      `sha256:${"f".repeat(64)}`,
+    ),
+    target_artifacts: manifest.targets.map((target) =>
+      artifact(target.artifact_id, target.artifact_name, target.artifact_digest)
+    ),
+  };
+}
+
+function normalizedRuntime() {
+  return validateRuntimeProvenance(runtimeManifest(), restSnapshot());
+}
+
+function nativeRecord(
+  targetKey: "windows" | "linux" | "linuxAarch64" | "mac",
+  nativeArch: "x86_64" | "aarch64",
+  packageId: number,
+) {
+  const targetIndex = TARGETS.findIndex((target) => target.key === targetKey);
+  const target = runtimeManifest().targets[targetIndex];
+  const packageName = {
+    windows: "noraneko-windows-x86_64-installer",
+    linux: "noraneko-linux-x86_64-installer",
+    linuxAarch64: "noraneko-linux-aarch64-installer",
+    mac: "noraneko-mac-universal-installer",
+  }[targetKey];
+  return {
+    schema_version: 2,
+    target_key: targetKey,
+    native_arch: nativeArch,
+    firefox_version: "153.0",
+    app_build_id: BUILD_ID,
+    platform_build_id: BUILD_ID,
+    build_id2: UUIDS[targetIndex],
+    runtime: {
+      repository: "Floorp-Projects/Floorp-Runtime",
+      head_sha: RUNTIME_SHA,
+      workflow_run_id: RUN_ID,
+      artifact_id: target.artifact_id,
+      artifact_digest: target.artifact_digest,
+      expected_build_id: BUILD_ID,
+    },
+    floorp: {
+      repository: "Floorp-Projects/Floorp",
+      head_sha: FLOORP_SHA,
+      workflow_run_id: 3000,
+    },
+    floorp_package: {
+      artifact_name: packageName,
+      artifact_id: packageId,
+      artifact_digest: `sha256:${String((packageId % 4) + 1).repeat(64)}`,
+      unsigned: false,
+    },
+    verification: { status: "verified", method: "full-version" },
+  };
+}
+
+function nativeRecords() {
+  const macX64 = nativeRecord("mac", "x86_64", 3004);
+  const macArm = structuredClone(macX64);
+  macArm.native_arch = "aarch64";
+  return [
+    nativeRecord("windows", "x86_64", 3001),
+    nativeRecord("linux", "x86_64", 3002),
+    nativeRecord("linuxAarch64", "aarch64", 3003),
+    macX64,
+    macArm,
+  ];
+}
+
+Deno.test("canonicalJson recursively sorts object keys and preserves arrays", () => {
+  assertEquals(
+    canonicalJson({ z: 1, a: [{ d: 4, c: 3 }, 2] }),
+    '{"a":[{"c":3,"d":4},2],"z":1}',
+  );
+});
+
+Deno.test("manifest identity is byte-compatible with the Floorp-Updates golden fixture", async () => {
+  const buildIds = [
+    "20260722010101",
+    "20260722010202",
+    "20260722010303",
+    "20260722010404",
+  ];
+  const metadata = Object.fromEntries(
+    await Promise.all(TARGETS.map(async (target, index) => {
+      const marBytes = new TextEncoder().encode(`test MAR ${target.key}`);
+      return [target.key, {
+        schema_version: 2,
+        version_display: "12.16.4@153.0",
+        version: "153.0",
+        noraneko_version: "12.16.4",
+        buildid: buildIds[index],
+        noraneko_buildid: UUIDS[index],
+        channel: "release",
+        platform: target.platform,
+        arch: target.arch,
+        manifest_set_id: `sha256:${"0".repeat(64)}`,
+        mar: {
+          url:
+            `https://github.com/Floorp-Projects/Floorp/releases/download/v12.16.4/${target.marName}`,
+          name: target.marName,
+          size: marBytes.byteLength,
+          sha512: await digest("SHA-512", marBytes),
+        },
+        provenance: {
+          runtime_repository: "Floorp-Projects/Floorp-Runtime",
+          runtime_head_sha: RUNTIME_SHA,
+          runtime_run_id: 1000,
+          runtime_artifact_id: 2000 + index,
+          runtime_artifact_digest: `sha256:${String(index + 5).repeat(64)}`,
+          floorp_repository: "Floorp-Projects/Floorp",
+          floorp_head_sha: FLOORP_SHA,
+          floorp_run_id: 3000,
+          release_tag: "v12.16.4",
+        },
+        verification: {
+          status: "verified",
+          method: "full-version",
+          app_build_id: buildIds[index],
+          build_id2: UUIDS[index],
+        },
+      }];
+    })),
+  );
+  assertEquals(
+    await computeManifestSetId(
+      metadata as Parameters<typeof computeManifestSetId>[0],
+    ),
+    "sha256:cfed918fc37125c130af2ddb1a0846cea7299ea368b3d027525caece9580657e",
+  );
+});
+
+Deno.test("validates a completed successful Runtime run and exact immutable artifacts", () => {
+  const result = normalizedRuntime();
+  assertEquals(result.expected_build_id, BUILD_ID);
+  assertEquals(result.targets.map((target) => target.artifact_id), [
+    2000,
+    2001,
+    2002,
+    2003,
+  ]);
+  assertEquals(result.manifest_artifact.id, 1999);
+});
+
+Deno.test("Runtime trust boundaries reject extra fields, mixing, stale artifacts, and bad BuildIDs", () => {
+  const extra = restSnapshot() as Record<string, unknown>;
+  extra.token = "must not be accepted";
+  assertThrows(
+    () => validateRuntimeProvenance(runtimeManifest(), extra),
+    ProvenanceError,
+    "unexpected: token",
+  );
+
+  const mixed = restSnapshot();
+  mixed.target_artifacts[1].workflow_run_id = RUN_ID + 1;
+  assertThrows(
+    () => validateRuntimeProvenance(runtimeManifest(), mixed),
+    ProvenanceError,
+    "different workflow run",
+  );
+
+  const expired = restSnapshot();
+  expired.target_artifacts[0].expired = true;
+  assertThrows(
+    () => validateRuntimeProvenance(runtimeManifest(), expired),
+    ProvenanceError,
+    "expired",
+  );
+
+  const badBuild = runtimeManifest();
+  badBuild.expected_build_id = "20260230010101";
+  assertThrows(
+    () => validateRuntimeProvenance(badBuild, restSnapshot()),
+    ProvenanceError,
+    "valid UTC timestamp",
+  );
+});
+
+Deno.test("full-version parser requires one adjacent pair and extracts Firefox version", () => {
+  assertEquals(
+    parseFullVersionOutput(`Floorp Floorp 153.0 ${BUILD_ID} ${BUILD_ID}\n`),
+    {
+      firefoxVersion: "153.0",
+      appBuildId: BUILD_ID,
+      platformBuildId: BUILD_ID,
+    },
+  );
+  assertThrows(
+    () =>
+      parseFullVersionOutput(`Floorp 153.0 ${BUILD_ID}\nnoise\n${BUILD_ID}`),
+    ProvenanceError,
+    "adjacent",
+  );
+  assertThrows(
+    () => parseFullVersionOutput(`Floorp stable ${BUILD_ID} ${BUILD_ID}`),
+    ProvenanceError,
+    "Firefox version",
+  );
+});
+
+Deno.test("UUID validation only accepts lowercase RFC UUIDv7 shape", () => {
+  assertEquals(validateUuidV7(UUIDS[0]), UUIDS[0]);
+  assertThrows(() => validateUuidV7(UUIDS[0].toUpperCase()), ProvenanceError);
+  assertThrows(
+    () => validateUuidV7("019f9000-0000-6000-8000-000000000001"),
+    ProvenanceError,
+  );
+});
+
+Deno.test("record-native-verification binds native output to raw Runtime manifest", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const manifestPath = `${root}/runtime.json`;
+    const outputPath = `${root}/full-version.txt`;
+    const buildId2Path = `${root}/buildid2`;
+    await Deno.writeTextFile(manifestPath, JSON.stringify(runtimeManifest()));
+    await Deno.writeTextFile(
+      outputPath,
+      `Floorp Floorp 153.0 ${BUILD_ID} ${BUILD_ID}\n`,
+    );
+    await Deno.writeTextFile(buildId2Path, `${UUIDS[0]}\n`);
+    const descriptor = {
+      schema_version: 2,
+      target_key: "windows",
+      native_arch: "x86_64",
+      runtime_manifest_path: manifestPath,
+      full_version_output_path: outputPath,
+      build_id2_path: buildId2Path,
+      floorp: {
+        repository: "Floorp-Projects/Floorp",
+        head_sha: FLOORP_SHA,
+        workflow_run_id: 3000,
+      },
+      floorp_package: {
+        artifact_name: "noraneko-windows-x86_64-installer",
+        artifact_id: 3001,
+        artifact_digest: `sha256:${"1".repeat(64)}`,
+        unsigned: false,
+      },
+    };
+    const record = await createNativeVerificationRecord(descriptor);
+    assertEquals(record.runtime.artifact_id, 2000);
+    assertEquals(record.build_id2, UUIDS[0]);
+
+    descriptor.floorp_package.artifact_name = "noraneko-linux-x86_64-installer";
+    await assertRejects(
+      () => createNativeVerificationRecord(descriptor),
+      ProvenanceError,
+      "artifact_name does not match target",
+    );
+    descriptor.floorp_package.artifact_name =
+      "noraneko-windows-x86_64-installer";
+    await Deno.writeTextFile(
+      outputPath,
+      "Floorp Floorp 153.0 20260723143614 20260723143614\n",
+    );
+    await assertRejects(
+      () => createNativeVerificationRecord(descriptor),
+      ProvenanceError,
+      "does not match Runtime",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("five native records reject Runtime/package mixing and mac disagreement", () => {
+  const records = nativeRecords();
+  assertEquals(
+    validateNativeVerificationSet(records, normalizedRuntime()).length,
+    5,
+  );
+
+  const mixed = structuredClone(records);
+  mixed[1].runtime.artifact_id = 9999;
+  assertThrows(
+    () => validateNativeVerificationSet(mixed, normalizedRuntime()),
+    ProvenanceError,
+    "mixed Runtime target",
+  );
+
+  const macMismatch = structuredClone(records);
+  macMismatch[4].build_id2 = "019f9000-0000-7000-8000-000000000099";
+  assertThrows(
+    () => validateNativeVerificationSet(macMismatch, normalizedRuntime()),
+    ProvenanceError,
+    "mac native verification records disagree",
+  );
+
+  const packageMismatch = structuredClone(records);
+  packageMismatch[4].floorp_package.artifact_digest = `sha256:${
+    "9".repeat(64)
+  }`;
+  assertThrows(
+    () => validateNativeVerificationSet(packageMismatch, normalizedRuntime()),
+    ProvenanceError,
+    "package identity",
+  );
+});
+
+async function releaseFixture(root: string, unsigned = false) {
+  await Deno.mkdir(root, { recursive: true });
+  const bundleDir = `${root}/bundle`;
+  await Deno.mkdir(bundleDir, { recursive: true });
+  const runtimePath = `${root}/normalized-runtime.json`;
+  await Deno.writeTextFile(runtimePath, JSON.stringify(normalizedRuntime()));
+  const records = nativeRecords();
+  if (unsigned) {
+    for (const record of records) {
+      record.floorp_package.artifact_name += "-unsigned";
+      record.floorp_package.unsigned = true;
+    }
+  }
+  const recordPaths: string[] = [];
+  for (let index = 0; index < records.length; index++) {
+    const path = `${root}/record-${index}.json`;
+    await Deno.writeTextFile(path, JSON.stringify(records[index]));
+    recordPaths.push(path);
+  }
+
+  const mars: Record<string, unknown> = {};
+  for (const target of TARGETS) {
+    const path = `${bundleDir}/${target.marName}`;
+    const bytes = new TextEncoder().encode(`real MAR ${target.key}`);
+    await Deno.writeFile(path, bytes);
+    mars[target.key] = {
+      path,
+      url:
+        `https://github.com/Floorp-Projects/Floorp/releases/download/v12.16.4/${target.marName}`,
+      size: bytes.byteLength,
+      sha512: await digest("SHA-512", bytes),
+    };
+  }
+  const releaseNames = {
+    windows: "floorp-windows-x86_64.installer.exe",
+    windowsStub: "floorp-stub.installer.exe",
+    linux: "floorp-linux-x86_64.tar.xz",
+    linuxAarch64: "floorp-linux-aarch64.tar.xz",
+    mac: "floorp-macOS-universal.dmg",
+    linuxDeb: "floorp-12.16.4.deb",
+  };
+  const releaseFiles: Record<string, unknown> = {};
+  for (const [key, name] of Object.entries(releaseNames)) {
+    const path = `${bundleDir}/${name}`;
+    const bytes = new TextEncoder().encode(`release file ${key}`);
+    await Deno.writeFile(path, bytes);
+    releaseFiles[key] = {
+      path,
+      name,
+      size: bytes.byteLength,
+      sha512: await digest("SHA-512", bytes),
+    };
+  }
+  const stubBytes = await Deno.readFile(
+    `${bundleDir}/${releaseNames.windowsStub}`,
+  );
+  return {
+    bundleDir,
+    descriptor: {
+      schema_version: 2,
+      mode: "production",
+      floorp_version: "12.16.4",
+      release_tag: "v12.16.4",
+      runtime_provenance_path: runtimePath,
+      native_verification_paths: recordPaths,
+      mars,
+      release_files: releaseFiles,
+      stub_source: {
+        repository: "Floorp-Projects/Floorp",
+        release_tag: "v12.16.3",
+        release_id: 4000,
+        asset_id: 4001,
+        asset_name: releaseNames.windowsStub,
+        asset_digest: `sha256:${await digest("SHA-256", stubBytes)}`,
+        size: stubBytes.byteLength,
+      },
+    },
+  };
+}
+
+Deno.test("assembles and revalidates four Updates-v2 metadata files from real files", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const fixture = await releaseFixture(root);
+    const assembled = await assembleReleaseBundle(
+      fixture.descriptor,
+      fixture.bundleDir,
+    );
+    assertEquals(assembled.manifest.version_display, "12.16.4@153.0");
+    assertEquals(assembled.metadata.windows.version_display, "12.16.4@153.0");
+    assertEquals(
+      assembled.metadata.windows.mar.name,
+      "floorp-windows-x86_64-full.mar",
+    );
+    assertEquals(
+      assembled.manifest.release_files.windowsStub.name,
+      "floorp-stub.installer.exe",
+    );
+    assertEquals(assembled.manifest.stub_source.release_tag, "v12.16.3");
+    assertEquals(
+      [...Deno.readDirSync(fixture.bundleDir)].length,
+      16,
+    );
+    assertEquals(
+      (await validateReleaseBundle(fixture.bundleDir, true)).manifest_set_id,
+      assembled.manifest.manifest_set_id,
+    );
+
+    const windowsMar =
+      (fixture.descriptor.mars as Record<string, { path: string }>).windows
+        .path;
+    await Deno.writeTextFile(windowsMar, "changed MAR");
+    await assertRejects(
+      () => validateReleaseBundle(fixture.bundleDir, true),
+      ProvenanceError,
+      "does not match release manifest",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("stub source is strict and binds the inherited asset bytes", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const badDigest = await releaseFixture(`${root}/bad-digest`);
+    badDigest.descriptor.stub_source.asset_digest = `sha256:${"0".repeat(64)}`;
+    await assertRejects(
+      () =>
+        assembleReleaseBundle(
+          badDigest.descriptor,
+          badDigest.bundleDir,
+        ),
+      ProvenanceError,
+      "stub_source.asset_digest does not match the real stub file",
+    );
+
+    const fixture = await releaseFixture(`${root}/strict-manifest`);
+    await assembleReleaseBundle(fixture.descriptor, fixture.bundleDir);
+    const manifestPath = `${fixture.bundleDir}/release-manifest-set-v2.json`;
+    const manifestText = await Deno.readTextFile(manifestPath);
+    const manifest = JSON.parse(manifestText);
+    manifest.stub_source.unexpected = true;
+    await Deno.writeTextFile(
+      manifestPath,
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+    await assertRejects(
+      () => validateReleaseBundle(fixture.bundleDir, true),
+      ProvenanceError,
+      "release manifest.stub_source has an invalid schema",
+    );
+
+    await Deno.writeTextFile(manifestPath, manifestText);
+    await Deno.writeTextFile(
+      `${fixture.bundleDir}/floorp-stub.installer.exe`,
+      "tampered inherited stub",
+    );
+    await assertRejects(
+      () => validateReleaseBundle(fixture.bundleDir, true),
+      ProvenanceError,
+      "floorp-stub.installer.exe does not match release manifest",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("production rejects unsigned verification and descriptor schema extras", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const unsigned = await releaseFixture(root, true);
+    await assertRejects(
+      () => assembleReleaseBundle(unsigned.descriptor, unsigned.bundleDir),
+      ProvenanceError,
+      "production release assembly rejects unsigned",
+    );
+    const second = await releaseFixture(`${root}/second`);
+    const extra = { ...second.descriptor, secret: "no" };
+    await assertRejects(
+      () => assembleReleaseBundle(extra, second.bundleDir),
+      ProvenanceError,
+      "unexpected: secret",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("validation mode accepts consistently marked unsigned artifacts", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const fixture = await releaseFixture(root, true);
+    fixture.descriptor.mode = "validation";
+    const bundle = await assembleReleaseBundle(
+      fixture.descriptor,
+      fixture.bundleDir,
+    );
+    assertEquals(bundle.manifest.mode, "validation");
+    assertEquals(
+      bundle.manifest.targets.every((target) => target.floorp_package.unsigned),
+      true,
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("bundle validation rejects metadata tampering", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const fixture = await releaseFixture(root);
+    await assembleReleaseBundle(fixture.descriptor, fixture.bundleDir);
+    const path = `${fixture.bundleDir}/win-meta.json`;
+    const text = await Deno.readTextFile(path);
+    await Deno.writeTextFile(
+      path,
+      text.replace("12.16.4@153.0", "153.0@12.16.4"),
+    );
+    await assertRejects(
+      () => validateReleaseBundle(fixture.bundleDir, true),
+      ProvenanceError,
+      "not the exact metadata",
+    );
+    await Deno.writeTextFile(path, text);
+    const hashesPath = `${fixture.bundleDir}/hashes.txt`;
+    const hashes = await Deno.readTextFile(hashesPath);
+    await Deno.writeTextFile(hashesPath, `${hashes}0  injected\n`);
+    await assertRejects(
+      () => validateReleaseBundle(fixture.bundleDir, true),
+      ProvenanceError,
+      "hashes.txt does not match",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("errors remain diagnostic without exposing descriptor contents", () => {
+  try {
+    validateRuntimeProvenance({}, {});
+  } catch (error) {
+    assertStringIncludes((error as Error).message, "missing");
+    assertEquals((error as Error).message.includes("token"), false);
+  }
+});
+
+Deno.test("workflow artifact handoffs normalize upload digests to REST form", async () => {
+  const workflow = async (name: string) =>
+    await Deno.readTextFile(
+      new URL(`../../.github/workflows/${name}`, import.meta.url),
+    );
+  const packageWorkflow = await workflow("package.yml");
+  const preflightWorkflow = await workflow("validate-runtime-provenance.yml");
+  const verifierWorkflow = await workflow("verify-release-artifact.yml");
+  const assemblerWorkflow = await workflow("assemble-release-bundle.yml");
+
+  for (
+    const expected of [
+      "format('sha256:{0}', steps.upload-installer.outputs.artifact-digest)",
+      "format('sha256:{0}', steps.upload-mar.outputs.artifact-digest)",
+      "format('sha256:{0}', steps.upload-deb.outputs.artifact-digest)",
+    ]
+  ) {
+    assertStringIncludes(packageWorkflow, expected);
+  }
+  assertStringIncludes(
+    preflightWorkflow,
+    "format('sha256:{0}', steps.upload-provenance.outputs.artifact-digest)",
+  );
+  assertStringIncludes(
+    verifierWorkflow,
+    "format('sha256:{0}', steps.upload-record.outputs.artifact-digest)",
+  );
+  assertStringIncludes(
+    assemblerWorkflow,
+    "format('sha256:{0}', steps.upload.outputs.artifact-digest)",
+  );
+});
+
+Deno.test("legacy stub updater refuses to mutate provenance-v2 releases", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL("../../.github/workflows/build_installers.yml", import.meta.url),
+  );
+  const manifestGuard = workflow.indexOf("release-manifest-set-v2.json");
+  const refusal = workflow.indexOf("Refusing to mutate provenance-v2 release");
+  const deleteStep = workflow.indexOf(
+    "- name: Delete existing stub asset (if any)",
+  );
+  const uploadStep = workflow.indexOf(
+    "- name: Upload signed installer to latest release",
+  );
+  assertEquals(
+    manifestGuard >= 0 &&
+      refusal > manifestGuard &&
+      deleteStep > refusal &&
+      uploadStep > deleteStep,
+    true,
+  );
+});
+
+Deno.test("production package entrypoint enforces Floorp and Runtime default refs", async () => {
+  const packageWorkflow = await Deno.readTextFile(
+    new URL("../../.github/workflows/package.yml", import.meta.url),
+  );
+
+  for (
+    const expected of [
+      "CURRENT_FLOORP_REF: ${{ github.ref }}",
+      "FLOORP_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
+      'const productionV2 = mode === "stable-v2"',
+      'floorpRepository !== "Floorp-Projects/Floorp"',
+      "process.env.CURRENT_FLOORP_REF !== expectedFloorpRef",
+      "await github.rest.repos.get",
+      "run.head_branch !== runtimeDefaultBranch",
+      '"workflow_dispatch"',
+      '"schedule"',
+    ]
+  ) {
+    assertStringIncludes(packageWorkflow, expected);
+  }
+  assertEquals(
+    packageWorkflow.match(/if \(productionV2\) \{/g)?.length,
+    2,
+  );
+});
+
+Deno.test("exact Runtime artifact download uses the flat consolidated layout", async () => {
+  const packageWorkflow = await Deno.readTextFile(
+    new URL("../../.github/workflows/package.yml", import.meta.url),
+  );
+  const start = packageWorkflow.indexOf(
+    "- name: Download verified Runtime artifact by ID",
+  );
+  const end = packageWorkflow.indexOf(
+    "- name: Stage exact Runtime v2 bundle",
+    start,
+  );
+  assertEquals(start >= 0 && end > start, true);
+  const downloadStep = packageWorkflow.slice(start, end);
+  assertStringIncludes(downloadStep, "artifact-ids:");
+  assertStringIncludes(downloadStep, "merge-multiple: true");
+});
+
+Deno.test("release publication is serialized across source workflow runs", async () => {
+  const publishWorkflow = await Deno.readTextFile(
+    new URL("../../.github/workflows/publish_release.yml", import.meta.url),
+  );
+  assertStringIncludes(
+    publishWorkflow,
+    "group: publish-release-v2-${{ github.repository }}",
+  );
+  assertEquals(
+    publishWorkflow.includes(
+      "group: publish-release-v2-${{ inputs.source_workflow_run_id }}",
+    ),
+    false,
+  );
+});

--- a/tools/src/release_provenance.ts
+++ b/tools/src/release_provenance.ts
@@ -1,0 +1,2482 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// Strict provenance contracts for Floorp stable release artifacts.  Every JSON
+// object accepted at a trust boundary is closed: missing and additional fields
+// are rejected before any value is used.
+
+const SHA1_RE = /^[0-9a-f]{40}$/;
+const SHA256_RE = /^sha256:[0-9a-f]{64}$/;
+const SHA512_RE = /^[0-9a-f]{128}$/;
+const BUILD_ID_RE = /^\d{14}$/;
+const UUID_V7_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const FIREFOX_VERSION_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?$/;
+const SEMVER_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const UTC_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$/;
+const FLOORP_REPOSITORY = "Floorp-Projects/Floorp";
+const STUB_ASSET_NAME = "floorp-stub.installer.exe";
+
+export class ProvenanceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProvenanceError";
+  }
+}
+
+function fail(message: string): never {
+  throw new ProvenanceError(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactObject(
+  value: unknown,
+  keys: readonly string[],
+  path: string,
+): Record<string, unknown> {
+  if (!isRecord(value)) fail(`${path} must be an object`);
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  const missing = expected.filter((key) => !actual.includes(key));
+  const extra = actual.filter((key) => !expected.includes(key));
+  if (missing.length || extra.length) {
+    fail(
+      `${path} has an invalid schema` +
+        (missing.length ? `; missing: ${missing.join(", ")}` : "") +
+        (extra.length ? `; unexpected: ${extra.join(", ")}` : ""),
+    );
+  }
+  return value;
+}
+
+function arrayValue(value: unknown, path: string): unknown[] {
+  if (!Array.isArray(value)) fail(`${path} must be an array`);
+  return value;
+}
+
+function stringValue(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${path} must be a non-empty string`);
+  }
+  return value;
+}
+
+function booleanValue(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") fail(`${path} must be a boolean`);
+  return value;
+}
+
+function positiveInteger(value: unknown, path: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    fail(`${path} must be a positive safe integer`);
+  }
+  return value as number;
+}
+
+function expectLiteral<T extends string | number | boolean>(
+  value: unknown,
+  expected: T,
+  path: string,
+): T {
+  if (value !== expected) {
+    fail(
+      `${path} must equal ${JSON.stringify(expected)}; got ${
+        JSON.stringify(value)
+      }`,
+    );
+  }
+  return expected;
+}
+
+function expectPattern(value: string, pattern: RegExp, path: string): string {
+  if (!pattern.test(value)) fail(`${path} has an invalid format`);
+  return value;
+}
+
+function validateBuildId(value: unknown, path: string): string {
+  const result = expectPattern(stringValue(value, path), BUILD_ID_RE, path);
+  const year = Number(result.slice(0, 4));
+  const month = Number(result.slice(4, 6));
+  const day = Number(result.slice(6, 8));
+  const hour = Number(result.slice(8, 10));
+  const minute = Number(result.slice(10, 12));
+  const second = Number(result.slice(12, 14));
+  const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  const roundTrip = [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+    date.getUTCHours().toString().padStart(2, "0"),
+    date.getUTCMinutes().toString().padStart(2, "0"),
+    date.getUTCSeconds().toString().padStart(2, "0"),
+  ].join("");
+  if (roundTrip !== result) fail(`${path} is not a valid UTC timestamp`);
+  return result;
+}
+
+function buildIdFromCreatedAt(value: unknown, path: string): string {
+  const timestamp = expectPattern(
+    stringValue(value, path),
+    UTC_TIMESTAMP_RE,
+    path,
+  );
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.valueOf())) {
+    fail(`${path} is not a valid UTC timestamp`);
+  }
+  const canonicalPrefix = [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+    date.getUTCHours().toString().padStart(2, "0"),
+    date.getUTCMinutes().toString().padStart(2, "0"),
+    date.getUTCSeconds().toString().padStart(2, "0"),
+  ].join("");
+  validateBuildId(canonicalPrefix, `${path} derived build ID`);
+  return canonicalPrefix;
+}
+
+function validateSha1(value: unknown, path: string): string {
+  return expectPattern(stringValue(value, path), SHA1_RE, path);
+}
+
+function validateSha256(value: unknown, path: string): string {
+  return expectPattern(stringValue(value, path), SHA256_RE, path);
+}
+
+function validateSha512(value: unknown, path: string): string {
+  return expectPattern(stringValue(value, path), SHA512_RE, path);
+}
+
+function validateFirefoxVersion(value: unknown, path: string): string {
+  return expectPattern(stringValue(value, path), FIREFOX_VERSION_RE, path);
+}
+
+function validateSemver(value: unknown, path: string): string {
+  return expectPattern(stringValue(value, path), SEMVER_RE, path);
+}
+
+export function validateUuidV7(
+  value: unknown,
+  path = "UUIDv7",
+): string {
+  return expectPattern(stringValue(value, path), UUID_V7_RE, path);
+}
+
+/** Matches the canonical JSON implementation in Floorp-Updates byte-for-byte. */
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (isRecord(value)) {
+    return "{" + Object.keys(value).sort().map((key) =>
+      JSON.stringify(key) + ":" + canonicalJson(value[key])
+    ).join(",") + "}";
+  }
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) fail("canonicalJson only accepts JSON values");
+  return encoded;
+}
+
+async function digestBytes(
+  algorithm: "SHA-256" | "SHA-512",
+  bytes: Uint8Array,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    algorithm,
+    bytes as Uint8Array<ArrayBuffer>,
+  );
+  return Array.from(
+    new Uint8Array(digest),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+async function hashFile(
+  path: string,
+  algorithm: "sha256" | "sha512",
+): Promise<{ size: number; digest: string }> {
+  let bytes: Uint8Array;
+  try {
+    bytes = await Deno.readFile(path);
+  } catch (error) {
+    fail(`could not hash ${path}: ${(error as Error).message}`);
+  }
+  if (bytes.byteLength <= 0) fail(`${path} must be a non-empty file`);
+  return {
+    size: bytes.byteLength,
+    digest: await digestBytes(
+      algorithm === "sha256" ? "SHA-256" : "SHA-512",
+      bytes,
+    ),
+  };
+}
+
+function pathBasename(path: string): string {
+  return path.replaceAll("\\", "/").split("/").at(-1) ?? "";
+}
+
+async function readJson(path: string, label: string): Promise<unknown> {
+  try {
+    return JSON.parse(await Deno.readTextFile(path));
+  } catch (error) {
+    fail(`${label} cannot be read as JSON: ${(error as Error).message}`);
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await Deno.writeTextFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export const TARGETS = [
+  {
+    key: "windows",
+    runtimePlatform: "Windows",
+    runtimeArch: "x86_64",
+    runtimeArtifactName: "floorp-windows-x86_64-moz-artifact",
+    platform: "WINNT",
+    arch: "x86_64",
+    marName: "floorp-windows-x86_64-full.mar",
+    metadataName: "win-meta.json",
+  },
+  {
+    key: "linux",
+    runtimePlatform: "Linux",
+    runtimeArch: "x86_64",
+    runtimeArtifactName: "floorp-linux-x86_64-moz-artifact",
+    platform: "Linux",
+    arch: "x86_64",
+    marName: "floorp-linux-x86_64-full.mar",
+    metadataName: "linux-meta.json",
+  },
+  {
+    key: "linuxAarch64",
+    runtimePlatform: "Linux",
+    runtimeArch: "aarch64",
+    runtimeArtifactName: "floorp-linux-aarch64-moz-artifact",
+    platform: "Linux",
+    arch: "aarch64",
+    marName: "floorp-linux-aarch64-full.mar",
+    metadataName: "linux-aarch64-meta.json",
+  },
+  {
+    key: "mac",
+    runtimePlatform: "Darwin",
+    runtimeArch: "universal",
+    runtimeArtifactName: "floorp-mac-universal-moz-artifact",
+    platform: "Darwin",
+    arch: "universal",
+    marName: "floorp-mac-universal-full.mar",
+    metadataName: "mac-meta.json",
+  },
+] as const;
+
+export type TargetKey = (typeof TARGETS)[number]["key"];
+export type NativeArch = "x86_64" | "aarch64";
+
+interface RuntimeTarget {
+  platform: string;
+  arch: string;
+  artifact_name: string;
+  artifact_id: number;
+  artifact_digest: string;
+  expected_build_id: string;
+}
+
+interface ArtifactIdentity {
+  id: number;
+  name: string;
+  digest: string;
+}
+
+export interface RuntimeProvenance {
+  schema_version: 2;
+  repository: "Floorp-Projects/Floorp-Runtime";
+  workflow_path: ".github/workflows/daily-build.yml";
+  head_sha: string;
+  workflow_run_id: number;
+  run_created_at: string;
+  run_attempt: number;
+  expected_build_id: string;
+  manifest_artifact: ArtifactIdentity;
+  targets: RuntimeTarget[];
+}
+
+function parseRuntimeManifest(
+  value: unknown,
+  path: string,
+): Omit<RuntimeProvenance, "workflow_path" | "manifest_artifact"> {
+  const root = exactObject(value, [
+    "schema_version",
+    "repository",
+    "head_sha",
+    "workflow_run_id",
+    "run_created_at",
+    "run_attempt",
+    "expected_build_id",
+    "targets",
+  ], path);
+  expectLiteral(root.schema_version, 2, `${path}.schema_version`);
+  const repository = expectLiteral(
+    root.repository,
+    "Floorp-Projects/Floorp-Runtime",
+    `${path}.repository`,
+  );
+  const headSha = validateSha1(root.head_sha, `${path}.head_sha`);
+  const workflowRunId = positiveInteger(
+    root.workflow_run_id,
+    `${path}.workflow_run_id`,
+  );
+  const runCreatedAt = stringValue(
+    root.run_created_at,
+    `${path}.run_created_at`,
+  );
+  const derivedBuildId = buildIdFromCreatedAt(
+    runCreatedAt,
+    `${path}.run_created_at`,
+  );
+  const runAttempt = positiveInteger(root.run_attempt, `${path}.run_attempt`);
+  const expectedBuildId = validateBuildId(
+    root.expected_build_id,
+    `${path}.expected_build_id`,
+  );
+  if (derivedBuildId !== expectedBuildId) {
+    fail(`${path}.expected_build_id does not match run_created_at`);
+  }
+  const rawTargets = arrayValue(root.targets, `${path}.targets`);
+  if (rawTargets.length !== TARGETS.length) {
+    fail(`${path}.targets must contain exactly ${TARGETS.length} entries`);
+  }
+  const ids = new Set<number>();
+  const digests = new Set<string>();
+  const targets = TARGETS.map((definition, index): RuntimeTarget => {
+    const targetPath = `${path}.targets[${index}]`;
+    const target = exactObject(rawTargets[index], [
+      "platform",
+      "arch",
+      "artifact_name",
+      "artifact_id",
+      "artifact_digest",
+      "expected_build_id",
+    ], targetPath);
+    const platform = expectLiteral(
+      target.platform,
+      definition.runtimePlatform,
+      `${targetPath}.platform`,
+    );
+    const arch = expectLiteral(
+      target.arch,
+      definition.runtimeArch,
+      `${targetPath}.arch`,
+    );
+    const artifactName = expectLiteral(
+      target.artifact_name,
+      definition.runtimeArtifactName,
+      `${targetPath}.artifact_name`,
+    );
+    const artifactId = positiveInteger(
+      target.artifact_id,
+      `${targetPath}.artifact_id`,
+    );
+    const artifactDigest = validateSha256(
+      target.artifact_digest,
+      `${targetPath}.artifact_digest`,
+    );
+    const targetBuildId = validateBuildId(
+      target.expected_build_id,
+      `${targetPath}.expected_build_id`,
+    );
+    if (targetBuildId !== expectedBuildId) {
+      fail(`${targetPath}.expected_build_id is mixed`);
+    }
+    if (ids.has(artifactId)) fail(`${targetPath}.artifact_id is duplicated`);
+    if (digests.has(artifactDigest)) {
+      fail(`${targetPath}.artifact_digest is duplicated`);
+    }
+    ids.add(artifactId);
+    digests.add(artifactDigest);
+    return {
+      platform,
+      arch,
+      artifact_name: artifactName,
+      artifact_id: artifactId,
+      artifact_digest: artifactDigest,
+      expected_build_id: targetBuildId,
+    };
+  });
+  return {
+    schema_version: 2,
+    repository,
+    head_sha: headSha,
+    workflow_run_id: workflowRunId,
+    run_created_at: runCreatedAt,
+    run_attempt: runAttempt,
+    expected_build_id: expectedBuildId,
+    targets,
+  };
+}
+
+function parseRestArtifact(
+  value: unknown,
+  path: string,
+  expected: { id?: number; name: string; digest?: string },
+  runId: number,
+  headSha: string,
+): ArtifactIdentity {
+  const root = exactObject(value, [
+    "id",
+    "name",
+    "digest",
+    "expired",
+    "workflow_run_id",
+    "workflow_run_head_sha",
+  ], path);
+  const id = positiveInteger(root.id, `${path}.id`);
+  const name = stringValue(root.name, `${path}.name`);
+  const digest = validateSha256(root.digest, `${path}.digest`);
+  if (expected.id !== undefined && id !== expected.id) {
+    fail(`${path}.id does not match manifest`);
+  }
+  if (name !== expected.name) {
+    fail(`${path}.name does not match expected artifact`);
+  }
+  if (expected.digest !== undefined && digest !== expected.digest) {
+    fail(`${path}.digest does not match manifest`);
+  }
+  if (booleanValue(root.expired, `${path}.expired`)) fail(`${path} is expired`);
+  if (
+    positiveInteger(root.workflow_run_id, `${path}.workflow_run_id`) !== runId
+  ) {
+    fail(`${path} belongs to a different workflow run`);
+  }
+  if (
+    validateSha1(
+      root.workflow_run_head_sha,
+      `${path}.workflow_run_head_sha`,
+    ) !== headSha
+  ) {
+    fail(`${path} belongs to a different head SHA`);
+  }
+  return { id, name, digest };
+}
+
+export function validateRuntimeProvenance(
+  manifestValue: unknown,
+  restSnapshotValue: unknown,
+): RuntimeProvenance {
+  const manifest = parseRuntimeManifest(manifestValue, "runtime manifest");
+  const snapshot = exactObject(restSnapshotValue, [
+    "schema_version",
+    "repository",
+    "workflow_path",
+    "run",
+    "manifest_artifact",
+    "target_artifacts",
+  ], "REST snapshot");
+  expectLiteral(snapshot.schema_version, 2, "REST snapshot.schema_version");
+  expectLiteral(
+    snapshot.repository,
+    manifest.repository,
+    "REST snapshot.repository",
+  );
+  const workflowPath = expectLiteral(
+    snapshot.workflow_path,
+    ".github/workflows/daily-build.yml",
+    "REST snapshot.workflow_path",
+  );
+  const run = exactObject(snapshot.run, [
+    "id",
+    "status",
+    "conclusion",
+    "head_sha",
+    "run_attempt",
+    "created_at",
+  ], "REST snapshot.run");
+  const runId = positiveInteger(run.id, "REST snapshot.run.id");
+  expectLiteral(run.status, "completed", "REST snapshot.run.status");
+  expectLiteral(run.conclusion, "success", "REST snapshot.run.conclusion");
+  const headSha = validateSha1(run.head_sha, "REST snapshot.run.head_sha");
+  const runAttempt = positiveInteger(
+    run.run_attempt,
+    "REST snapshot.run.run_attempt",
+  );
+  const createdAt = stringValue(run.created_at, "REST snapshot.run.created_at");
+  const buildId = buildIdFromCreatedAt(
+    createdAt,
+    "REST snapshot.run.created_at",
+  );
+  if (runId !== manifest.workflow_run_id) {
+    fail("REST workflow run ID does not match manifest");
+  }
+  if (headSha !== manifest.head_sha) {
+    fail("REST head SHA does not match manifest");
+  }
+  if (runAttempt !== manifest.run_attempt) {
+    fail("REST run attempt does not match manifest");
+  }
+  if (createdAt !== manifest.run_created_at) {
+    fail("REST created_at does not match manifest");
+  }
+  if (buildId !== manifest.expected_build_id) {
+    fail("REST created_at BuildID does not match manifest");
+  }
+
+  const manifestArtifact = parseRestArtifact(
+    snapshot.manifest_artifact,
+    "REST snapshot.manifest_artifact",
+    { name: "floorp-runtime-build-manifest-v2" },
+    runId,
+    headSha,
+  );
+  const rawArtifacts = arrayValue(
+    snapshot.target_artifacts,
+    "REST snapshot.target_artifacts",
+  );
+  if (rawArtifacts.length !== TARGETS.length) {
+    fail(
+      `REST snapshot.target_artifacts must contain exactly ${TARGETS.length} entries`,
+    );
+  }
+  const artifacts = manifest.targets.map((target, index) =>
+    parseRestArtifact(
+      rawArtifacts[index],
+      `REST snapshot.target_artifacts[${index}]`,
+      {
+        id: target.artifact_id,
+        name: target.artifact_name,
+        digest: target.artifact_digest,
+      },
+      runId,
+      headSha,
+    )
+  );
+  const ids = new Set([
+    manifestArtifact.id,
+    ...artifacts.map((artifact) => artifact.id),
+  ]);
+  const digests = new Set([
+    manifestArtifact.digest,
+    ...artifacts.map((artifact) => artifact.digest),
+  ]);
+  if (ids.size !== TARGETS.length + 1) {
+    fail("Runtime artifact IDs must be unique");
+  }
+  if (digests.size !== TARGETS.length + 1) {
+    fail("Runtime artifact digests must be unique");
+  }
+
+  return {
+    ...manifest,
+    workflow_path: workflowPath,
+    manifest_artifact: manifestArtifact,
+  };
+}
+
+function parseNormalizedRuntimeProvenance(value: unknown): RuntimeProvenance {
+  const root = exactObject(value, [
+    "schema_version",
+    "repository",
+    "workflow_path",
+    "head_sha",
+    "workflow_run_id",
+    "run_created_at",
+    "run_attempt",
+    "expected_build_id",
+    "manifest_artifact",
+    "targets",
+  ], "normalized Runtime provenance");
+  const manifest = parseRuntimeManifest({
+    schema_version: root.schema_version,
+    repository: root.repository,
+    head_sha: root.head_sha,
+    workflow_run_id: root.workflow_run_id,
+    run_created_at: root.run_created_at,
+    run_attempt: root.run_attempt,
+    expected_build_id: root.expected_build_id,
+    targets: root.targets,
+  }, "normalized Runtime provenance");
+  const workflowPath = expectLiteral(
+    root.workflow_path,
+    ".github/workflows/daily-build.yml",
+    "normalized Runtime provenance.workflow_path",
+  );
+  const artifact = exactObject(
+    root.manifest_artifact,
+    ["id", "name", "digest"],
+    "normalized Runtime provenance.manifest_artifact",
+  );
+  const manifestArtifact = {
+    id: positiveInteger(
+      artifact.id,
+      "normalized Runtime provenance.manifest_artifact.id",
+    ),
+    name: expectLiteral(
+      artifact.name,
+      "floorp-runtime-build-manifest-v2",
+      "normalized Runtime provenance.manifest_artifact.name",
+    ),
+    digest: validateSha256(
+      artifact.digest,
+      "normalized Runtime provenance.manifest_artifact.digest",
+    ),
+  };
+  if (
+    manifest.targets.some((target) =>
+      target.artifact_id === manifestArtifact.id
+    )
+  ) {
+    fail(
+      "normalized Runtime manifest artifact ID collides with a target artifact",
+    );
+  }
+  if (
+    manifest.targets.some((target) =>
+      target.artifact_digest === manifestArtifact.digest
+    )
+  ) {
+    fail("normalized Runtime manifest digest collides with a target artifact");
+  }
+  return {
+    ...manifest,
+    workflow_path: workflowPath,
+    manifest_artifact: manifestArtifact,
+  };
+}
+
+export interface FullVersionIdentity {
+  firefoxVersion: string;
+  appBuildId: string;
+  platformBuildId: string;
+}
+
+export function parseFullVersionOutput(output: unknown): FullVersionIdentity {
+  const value = stringValue(output, "--full-version output");
+  const buildIds = value.match(/(?<!\d)\d{14}(?!\d)/g) ?? [];
+  if (buildIds.length !== 2) {
+    fail(
+      `--full-version output must contain exactly two 14-digit build IDs; found ${buildIds.length}`,
+    );
+  }
+  const pairs = [...value.matchAll(/(?<!\d)(\d{14})\s+(\d{14})(?!\d)/g)];
+  if (pairs.length !== 1) {
+    fail(
+      `--full-version output must contain exactly one adjacent build ID pair; found ${pairs.length}`,
+    );
+  }
+  const pair = pairs[0];
+  const prefix = value.slice(0, pair.index).trimEnd();
+  const versionMatch =
+    /(?:^|\s)((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?)$/.exec(
+      prefix,
+    );
+  if (!versionMatch) {
+    fail(
+      "--full-version output must place a Firefox version immediately before the build ID pair",
+    );
+  }
+  return {
+    firefoxVersion: validateFirefoxVersion(
+      versionMatch[1],
+      "--full-version Firefox version",
+    ),
+    appBuildId: validateBuildId(pair[1], "--full-version application build ID"),
+    platformBuildId: validateBuildId(
+      pair[2],
+      "--full-version platform build ID",
+    ),
+  };
+}
+
+interface RuntimeRecordIdentity {
+  repository: "Floorp-Projects/Floorp-Runtime";
+  head_sha: string;
+  workflow_run_id: number;
+  artifact_id: number;
+  artifact_digest: string;
+  expected_build_id: string;
+}
+
+interface FloorpIdentity {
+  repository: "Floorp-Projects/Floorp";
+  head_sha: string;
+  workflow_run_id: number;
+}
+
+interface FloorpPackageIdentity {
+  artifact_name: string;
+  artifact_id: number;
+  artifact_digest: string;
+  unsigned: boolean;
+}
+
+export interface NativeVerificationRecord {
+  schema_version: 2;
+  target_key: TargetKey;
+  native_arch: NativeArch;
+  firefox_version: string;
+  app_build_id: string;
+  platform_build_id: string;
+  build_id2: string;
+  runtime: RuntimeRecordIdentity;
+  floorp: FloorpIdentity;
+  floorp_package: FloorpPackageIdentity;
+  verification: {
+    status: "verified";
+    method: "full-version";
+  };
+}
+
+interface NativeVerificationDescriptor {
+  schema_version: 2;
+  target_key: TargetKey;
+  native_arch: NativeArch;
+  runtime_manifest_path: string;
+  full_version_output_path: string;
+  build_id2_path: string;
+  floorp: FloorpIdentity;
+  floorp_package: FloorpPackageIdentity;
+}
+
+function validateTargetKey(value: unknown, path: string): TargetKey {
+  const key = stringValue(value, path);
+  if (!TARGETS.some((target) => target.key === key)) {
+    fail(`${path} is not a supported target`);
+  }
+  return key as TargetKey;
+}
+
+function validateNativeArch(value: unknown, path: string): NativeArch {
+  const arch = stringValue(value, path);
+  if (arch !== "x86_64" && arch !== "aarch64") fail(`${path} is not supported`);
+  return arch;
+}
+
+function validateTargetNativePair(
+  target: TargetKey,
+  arch: NativeArch,
+  path: string,
+): void {
+  const expected = target === "linuxAarch64" ? "aarch64" : "x86_64";
+  if (target === "mac") return;
+  if (arch !== expected) fail(`${path} must use ${expected} for ${target}`);
+}
+
+function expectedPackageArtifactName(
+  target: TargetKey,
+  unsigned: boolean,
+): string {
+  const base = {
+    windows: "noraneko-windows-x86_64-installer",
+    linux: "noraneko-linux-x86_64-installer",
+    linuxAarch64: "noraneko-linux-aarch64-installer",
+    mac: "noraneko-mac-universal-installer",
+  }[target];
+  return `${base}${unsigned ? "-unsigned" : ""}`;
+}
+
+function parseFloorpIdentity(value: unknown, path: string): FloorpIdentity {
+  const root = exactObject(
+    value,
+    ["repository", "head_sha", "workflow_run_id"],
+    path,
+  );
+  return {
+    repository: expectLiteral(
+      root.repository,
+      "Floorp-Projects/Floorp",
+      `${path}.repository`,
+    ),
+    head_sha: validateSha1(root.head_sha, `${path}.head_sha`),
+    workflow_run_id: positiveInteger(
+      root.workflow_run_id,
+      `${path}.workflow_run_id`,
+    ),
+  };
+}
+
+function parseFloorpPackageIdentity(
+  value: unknown,
+  path: string,
+): FloorpPackageIdentity {
+  const root = exactObject(
+    value,
+    ["artifact_name", "artifact_id", "artifact_digest", "unsigned"],
+    path,
+  );
+  const artifactName = stringValue(root.artifact_name, `${path}.artifact_name`);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(artifactName)) {
+    fail(`${path}.artifact_name contains unsafe characters`);
+  }
+  const unsigned = booleanValue(root.unsigned, `${path}.unsigned`);
+  if (artifactName.endsWith("-unsigned") !== unsigned) {
+    fail(
+      `${path}.unsigned must exactly match the -unsigned artifact-name suffix`,
+    );
+  }
+  return {
+    artifact_name: artifactName,
+    artifact_id: positiveInteger(root.artifact_id, `${path}.artifact_id`),
+    artifact_digest: validateSha256(
+      root.artifact_digest,
+      `${path}.artifact_digest`,
+    ),
+    unsigned,
+  };
+}
+
+function parseNativeVerificationDescriptor(
+  value: unknown,
+): NativeVerificationDescriptor {
+  const root = exactObject(value, [
+    "schema_version",
+    "target_key",
+    "native_arch",
+    "runtime_manifest_path",
+    "full_version_output_path",
+    "build_id2_path",
+    "floorp",
+    "floorp_package",
+  ], "native verification descriptor");
+  expectLiteral(
+    root.schema_version,
+    2,
+    "native verification descriptor.schema_version",
+  );
+  const targetKey = validateTargetKey(
+    root.target_key,
+    "native verification descriptor.target_key",
+  );
+  const nativeArch = validateNativeArch(
+    root.native_arch,
+    "native verification descriptor.native_arch",
+  );
+  validateTargetNativePair(
+    targetKey,
+    nativeArch,
+    "native verification descriptor.native_arch",
+  );
+  const floorpPackage = parseFloorpPackageIdentity(
+    root.floorp_package,
+    "native verification descriptor.floorp_package",
+  );
+  if (
+    floorpPackage.artifact_name !==
+      expectedPackageArtifactName(targetKey, floorpPackage.unsigned)
+  ) {
+    fail(
+      "native verification descriptor.floorp_package.artifact_name does not match target",
+    );
+  }
+  return {
+    schema_version: 2,
+    target_key: targetKey,
+    native_arch: nativeArch,
+    runtime_manifest_path: stringValue(
+      root.runtime_manifest_path,
+      "native verification descriptor.runtime_manifest_path",
+    ),
+    full_version_output_path: stringValue(
+      root.full_version_output_path,
+      "native verification descriptor.full_version_output_path",
+    ),
+    build_id2_path: stringValue(
+      root.build_id2_path,
+      "native verification descriptor.build_id2_path",
+    ),
+    floorp: parseFloorpIdentity(
+      root.floorp,
+      "native verification descriptor.floorp",
+    ),
+    floorp_package: floorpPackage,
+  };
+}
+
+export async function createNativeVerificationRecord(
+  descriptorValue: unknown,
+): Promise<NativeVerificationRecord> {
+  const descriptor = parseNativeVerificationDescriptor(descriptorValue);
+  const runtime = parseRuntimeManifest(
+    await readJson(descriptor.runtime_manifest_path, "Runtime manifest"),
+    "runtime manifest",
+  );
+  const targetIndex = TARGETS.findIndex((target) =>
+    target.key === descriptor.target_key
+  );
+  const runtimeTarget = runtime.targets[targetIndex];
+  let fullVersionOutput: string;
+  let rawBuildId2: string;
+  try {
+    [fullVersionOutput, rawBuildId2] = await Promise.all([
+      Deno.readTextFile(descriptor.full_version_output_path),
+      Deno.readTextFile(descriptor.build_id2_path),
+    ]);
+  } catch (error) {
+    fail(
+      `native verification input cannot be read: ${(error as Error).message}`,
+    );
+  }
+  const identity = parseFullVersionOutput(fullVersionOutput);
+  if (identity.appBuildId !== runtime.expected_build_id) {
+    fail("native application BuildID does not match Runtime provenance");
+  }
+  if (identity.platformBuildId !== runtime.expected_build_id) {
+    fail("native platform BuildID does not match Runtime provenance");
+  }
+  const buildId2 = validateUuidV7(rawBuildId2.trim(), "native buildID2");
+  return {
+    schema_version: 2,
+    target_key: descriptor.target_key,
+    native_arch: descriptor.native_arch,
+    firefox_version: identity.firefoxVersion,
+    app_build_id: identity.appBuildId,
+    platform_build_id: identity.platformBuildId,
+    build_id2: buildId2,
+    runtime: {
+      repository: runtime.repository,
+      head_sha: runtime.head_sha,
+      workflow_run_id: runtime.workflow_run_id,
+      artifact_id: runtimeTarget.artifact_id,
+      artifact_digest: runtimeTarget.artifact_digest,
+      expected_build_id: runtimeTarget.expected_build_id,
+    },
+    floorp: descriptor.floorp,
+    floorp_package: descriptor.floorp_package,
+    verification: { status: "verified", method: "full-version" },
+  };
+}
+
+function parseNativeVerificationRecord(
+  value: unknown,
+  path: string,
+): NativeVerificationRecord {
+  const root = exactObject(value, [
+    "schema_version",
+    "target_key",
+    "native_arch",
+    "firefox_version",
+    "app_build_id",
+    "platform_build_id",
+    "build_id2",
+    "runtime",
+    "floorp",
+    "floorp_package",
+    "verification",
+  ], path);
+  expectLiteral(root.schema_version, 2, `${path}.schema_version`);
+  const targetKey = validateTargetKey(root.target_key, `${path}.target_key`);
+  const nativeArch = validateNativeArch(
+    root.native_arch,
+    `${path}.native_arch`,
+  );
+  validateTargetNativePair(targetKey, nativeArch, `${path}.native_arch`);
+  const floorpPackage = parseFloorpPackageIdentity(
+    root.floorp_package,
+    `${path}.floorp_package`,
+  );
+  if (
+    floorpPackage.artifact_name !==
+      expectedPackageArtifactName(targetKey, floorpPackage.unsigned)
+  ) {
+    fail(`${path}.floorp_package.artifact_name does not match target`);
+  }
+  const runtimeRoot = exactObject(root.runtime, [
+    "repository",
+    "head_sha",
+    "workflow_run_id",
+    "artifact_id",
+    "artifact_digest",
+    "expected_build_id",
+  ], `${path}.runtime`);
+  const runtime: RuntimeRecordIdentity = {
+    repository: expectLiteral(
+      runtimeRoot.repository,
+      "Floorp-Projects/Floorp-Runtime",
+      `${path}.runtime.repository`,
+    ),
+    head_sha: validateSha1(runtimeRoot.head_sha, `${path}.runtime.head_sha`),
+    workflow_run_id: positiveInteger(
+      runtimeRoot.workflow_run_id,
+      `${path}.runtime.workflow_run_id`,
+    ),
+    artifact_id: positiveInteger(
+      runtimeRoot.artifact_id,
+      `${path}.runtime.artifact_id`,
+    ),
+    artifact_digest: validateSha256(
+      runtimeRoot.artifact_digest,
+      `${path}.runtime.artifact_digest`,
+    ),
+    expected_build_id: validateBuildId(
+      runtimeRoot.expected_build_id,
+      `${path}.runtime.expected_build_id`,
+    ),
+  };
+  const verificationRoot = exactObject(
+    root.verification,
+    ["status", "method"],
+    `${path}.verification`,
+  );
+  expectLiteral(
+    verificationRoot.status,
+    "verified",
+    `${path}.verification.status`,
+  );
+  expectLiteral(
+    verificationRoot.method,
+    "full-version",
+    `${path}.verification.method`,
+  );
+  const appBuildId = validateBuildId(root.app_build_id, `${path}.app_build_id`);
+  const platformBuildId = validateBuildId(
+    root.platform_build_id,
+    `${path}.platform_build_id`,
+  );
+  if (
+    appBuildId !== runtime.expected_build_id ||
+    platformBuildId !== runtime.expected_build_id
+  ) {
+    fail(`${path} BuildIDs do not match its Runtime provenance`);
+  }
+  return {
+    schema_version: 2,
+    target_key: targetKey,
+    native_arch: nativeArch,
+    firefox_version: validateFirefoxVersion(
+      root.firefox_version,
+      `${path}.firefox_version`,
+    ),
+    app_build_id: appBuildId,
+    platform_build_id: platformBuildId,
+    build_id2: validateUuidV7(root.build_id2, `${path}.build_id2`),
+    runtime,
+    floorp: parseFloorpIdentity(root.floorp, `${path}.floorp`),
+    floorp_package: floorpPackage,
+    verification: { status: "verified", method: "full-version" },
+  };
+}
+
+const NATIVE_RECORD_KEYS = [
+  "windows/x86_64",
+  "linux/x86_64",
+  "linuxAarch64/aarch64",
+  "mac/x86_64",
+  "mac/aarch64",
+] as const;
+
+function recordKey(record: NativeVerificationRecord): string {
+  return `${record.target_key}/${record.native_arch}`;
+}
+
+export function validateNativeVerificationSet(
+  values: unknown,
+  runtimeValue: unknown,
+): NativeVerificationRecord[] {
+  const rawRecords = arrayValue(values, "native verification records");
+  if (rawRecords.length !== NATIVE_RECORD_KEYS.length) {
+    fail(
+      `native verification records must contain exactly ${NATIVE_RECORD_KEYS.length} entries`,
+    );
+  }
+  const runtime = parseNormalizedRuntimeProvenance(runtimeValue);
+  const byKey = new Map<string, NativeVerificationRecord>();
+  for (let index = 0; index < rawRecords.length; index++) {
+    const record = parseNativeVerificationRecord(
+      rawRecords[index],
+      `native verification records[${index}]`,
+    );
+    const key = recordKey(record);
+    if (byKey.has(key)) fail(`duplicate native verification record ${key}`);
+    byKey.set(key, record);
+  }
+  for (const key of NATIVE_RECORD_KEYS) {
+    if (!byKey.has(key)) fail(`missing native verification record ${key}`);
+  }
+  const records = NATIVE_RECORD_KEYS.map((key) => byKey.get(key)!);
+  const first = records[0];
+  for (const record of records) {
+    if (canonicalJson(record.floorp) !== canonicalJson(first.floorp)) {
+      fail(`${recordKey(record)} has mixed Floorp provenance`);
+    }
+    if (
+      record.runtime.repository !== runtime.repository ||
+      record.runtime.head_sha !== runtime.head_sha ||
+      record.runtime.workflow_run_id !== runtime.workflow_run_id ||
+      record.runtime.expected_build_id !== runtime.expected_build_id
+    ) {
+      fail(`${recordKey(record)} has mixed Runtime run provenance`);
+    }
+    const targetIndex = TARGETS.findIndex((target) =>
+      target.key === record.target_key
+    );
+    const runtimeTarget = runtime.targets[targetIndex];
+    if (
+      record.runtime.artifact_id !== runtimeTarget.artifact_id ||
+      record.runtime.artifact_digest !== runtimeTarget.artifact_digest
+    ) {
+      fail(`${recordKey(record)} has mixed Runtime target artifact provenance`);
+    }
+    if (record.firefox_version !== first.firefox_version) {
+      fail(`${recordKey(record)} has a mixed Firefox version`);
+    }
+  }
+  const macX64 = byKey.get("mac/x86_64")!;
+  const macArm64 = byKey.get("mac/aarch64")!;
+  for (
+    const field of [
+      "firefox_version",
+      "app_build_id",
+      "platform_build_id",
+      "build_id2",
+    ] as const
+  ) {
+    if (macX64[field] !== macArm64[field]) {
+      fail(`mac native verification records disagree on ${field}`);
+    }
+  }
+  if (
+    canonicalJson(macX64.floorp_package) !==
+      canonicalJson(macArm64.floorp_package)
+  ) {
+    fail("mac native verification records disagree on package identity");
+  }
+  const packageIds = new Set<number>();
+  const packageDigests = new Set<string>();
+  for (const target of TARGETS) {
+    const targetRecords = records.filter((record) =>
+      record.target_key === target.key
+    );
+    const packageIdentity = targetRecords[0].floorp_package;
+    if (packageIds.has(packageIdentity.artifact_id)) {
+      fail(`${target.key} reuses another target's Floorp package artifact ID`);
+    }
+    if (packageDigests.has(packageIdentity.artifact_digest)) {
+      fail(
+        `${target.key} reuses another target's Floorp package artifact digest`,
+      );
+    }
+    packageIds.add(packageIdentity.artifact_id);
+    packageDigests.add(packageIdentity.artifact_digest);
+    for (const record of targetRecords.slice(1)) {
+      if (
+        canonicalJson(record.floorp_package) !== canonicalJson(packageIdentity)
+      ) {
+        fail(`${target.key} records disagree on Floorp package identity`);
+      }
+    }
+  }
+  return records;
+}
+
+interface MarMetadata {
+  url: string;
+  name: string;
+  size: number;
+  sha512: string;
+}
+
+interface ReleaseMetadata {
+  schema_version: 2;
+  version_display: string;
+  version: string;
+  noraneko_version: string;
+  buildid: string;
+  noraneko_buildid: string;
+  channel: "release";
+  platform: "WINNT" | "Linux" | "Darwin";
+  arch: "x86_64" | "aarch64" | "universal";
+  manifest_set_id: string;
+  mar: MarMetadata;
+  provenance: {
+    runtime_repository: "Floorp-Projects/Floorp-Runtime";
+    runtime_head_sha: string;
+    runtime_run_id: number;
+    runtime_artifact_id: number;
+    runtime_artifact_digest: string;
+    floorp_repository: "Floorp-Projects/Floorp";
+    floorp_head_sha: string;
+    floorp_run_id: number;
+    release_tag: string;
+  };
+  verification: {
+    status: "verified";
+    method: "full-version";
+    app_build_id: string;
+    build_id2: string;
+  };
+}
+
+export function buildManifestSetIdentity(
+  metadata: Record<TargetKey, ReleaseMetadata>,
+): Record<string, unknown> {
+  const first = metadata.windows;
+  return {
+    schema_version: 2,
+    floorp: {
+      repository: first.provenance.floorp_repository,
+      head_sha: first.provenance.floorp_head_sha,
+      run_id: first.provenance.floorp_run_id,
+      release_tag: first.provenance.release_tag,
+    },
+    targets: TARGETS.map((definition) => {
+      const value = metadata[definition.key];
+      return {
+        platform: value.platform,
+        arch: value.arch,
+        mar: {
+          name: value.mar.name,
+          size: value.mar.size,
+          sha512: value.mar.sha512,
+        },
+        runtime: {
+          repository: value.provenance.runtime_repository,
+          head_sha: value.provenance.runtime_head_sha,
+          run_id: value.provenance.runtime_run_id,
+          artifact_id: value.provenance.runtime_artifact_id,
+          artifact_digest: value.provenance.runtime_artifact_digest,
+        },
+        verification: {
+          app_build_id: value.verification.app_build_id,
+          build_id2: value.verification.build_id2,
+        },
+      };
+    }),
+  };
+}
+
+export async function computeManifestSetId(
+  metadata: Record<TargetKey, ReleaseMetadata>,
+): Promise<string> {
+  const bytes = new TextEncoder().encode(
+    canonicalJson(buildManifestSetIdentity(metadata)),
+  );
+  return `sha256:${await digestBytes("SHA-256", bytes)}`;
+}
+
+type ReleaseMode = "production" | "validation";
+
+interface FileDescriptor {
+  path: string;
+  name: string;
+  size: number;
+  sha512: string;
+}
+
+interface MarDescriptor {
+  path: string;
+  url: string;
+  size: number;
+  sha512: string;
+}
+
+export interface StubSource {
+  repository: "Floorp-Projects/Floorp";
+  release_tag: string;
+  release_id: number;
+  asset_id: number;
+  asset_name: "floorp-stub.installer.exe";
+  asset_digest: string;
+  size: number;
+}
+
+interface AssemblyDescriptor {
+  schema_version: 2;
+  mode: ReleaseMode;
+  floorp_version: string;
+  release_tag: string;
+  runtime_provenance_path: string;
+  native_verification_paths: string[];
+  mars: Record<TargetKey, MarDescriptor>;
+  release_files: Record<
+    | "windows"
+    | "windowsStub"
+    | "linux"
+    | "linuxAarch64"
+    | "mac"
+    | "linuxDeb",
+    FileDescriptor
+  >;
+  stub_source: StubSource;
+}
+
+interface ReleaseFileIdentity {
+  name: string;
+  size: number;
+  sha512: string;
+}
+
+interface ReleaseManifestTarget {
+  target_key: TargetKey;
+  platform: string;
+  arch: string;
+  metadata_name: string;
+  metadata_sha256: string;
+  mar: MarMetadata;
+  runtime_artifact: ArtifactIdentity;
+  floorp_package: FloorpPackageIdentity;
+  native_verifications: Array<{
+    native_arch: NativeArch;
+    app_build_id: string;
+    platform_build_id: string;
+    build_id2: string;
+  }>;
+}
+
+export interface ReleaseManifestSet {
+  schema_version: 2;
+  mode: ReleaseMode;
+  manifest_set_id: string;
+  version_display: string;
+  version: string;
+  noraneko_version: string;
+  channel: "release";
+  runtime: RuntimeProvenance;
+  floorp: FloorpIdentity & { release_tag: string };
+  release_files: Record<
+    | "windows"
+    | "windowsStub"
+    | "linux"
+    | "linuxAarch64"
+    | "mac"
+    | "linuxDeb",
+    ReleaseFileIdentity
+  >;
+  stub_source: StubSource;
+  targets: ReleaseManifestTarget[];
+}
+
+export interface AssembledReleaseBundle {
+  manifest: ReleaseManifestSet;
+  metadata: Record<TargetKey, ReleaseMetadata>;
+  metadataFiles: Record<TargetKey, string>;
+}
+
+function parseMode(value: unknown, path: string): ReleaseMode {
+  if (value !== "production" && value !== "validation") {
+    fail(`${path} must be production or validation`);
+  }
+  return value;
+}
+
+function parseCanonicalReleaseTag(value: unknown, path: string): string {
+  const releaseTag = stringValue(value, path);
+  if (!releaseTag.startsWith("v")) {
+    fail(`${path} must be a canonical v<SemVer> tag`);
+  }
+  const version = validateSemver(releaseTag.slice(1), path);
+  if (releaseTag !== `v${version}`) {
+    fail(`${path} must be a canonical v<SemVer> tag`);
+  }
+  return releaseTag;
+}
+
+function parseStubSource(value: unknown, path: string): StubSource {
+  const root = exactObject(value, [
+    "repository",
+    "release_tag",
+    "release_id",
+    "asset_id",
+    "asset_name",
+    "asset_digest",
+    "size",
+  ], path);
+  return {
+    repository: expectLiteral(
+      root.repository,
+      FLOORP_REPOSITORY,
+      `${path}.repository`,
+    ),
+    release_tag: parseCanonicalReleaseTag(
+      root.release_tag,
+      `${path}.release_tag`,
+    ),
+    release_id: positiveInteger(root.release_id, `${path}.release_id`),
+    asset_id: positiveInteger(root.asset_id, `${path}.asset_id`),
+    asset_name: expectLiteral(
+      root.asset_name,
+      STUB_ASSET_NAME,
+      `${path}.asset_name`,
+    ),
+    asset_digest: validateSha256(
+      root.asset_digest,
+      `${path}.asset_digest`,
+    ),
+    size: positiveInteger(root.size, `${path}.size`),
+  };
+}
+
+function parseAssemblyDescriptor(value: unknown): AssemblyDescriptor {
+  const root = exactObject(value, [
+    "schema_version",
+    "mode",
+    "floorp_version",
+    "release_tag",
+    "runtime_provenance_path",
+    "native_verification_paths",
+    "mars",
+    "release_files",
+    "stub_source",
+  ], "release assembly descriptor");
+  expectLiteral(
+    root.schema_version,
+    2,
+    "release assembly descriptor.schema_version",
+  );
+  const floorpVersion = validateSemver(
+    root.floorp_version,
+    "release assembly descriptor.floorp_version",
+  );
+  const releaseTag = stringValue(
+    root.release_tag,
+    "release assembly descriptor.release_tag",
+  );
+  if (releaseTag !== `v${floorpVersion}`) {
+    fail("release assembly descriptor.release_tag must be v<floorp_version>");
+  }
+  const rawNativePaths = arrayValue(
+    root.native_verification_paths,
+    "release assembly descriptor.native_verification_paths",
+  );
+  if (rawNativePaths.length !== NATIVE_RECORD_KEYS.length) {
+    fail(
+      `release assembly descriptor.native_verification_paths must contain exactly ${NATIVE_RECORD_KEYS.length} paths`,
+    );
+  }
+  const nativePaths = rawNativePaths.map((path, index) =>
+    stringValue(
+      path,
+      `release assembly descriptor.native_verification_paths[${index}]`,
+    )
+  );
+  if (new Set(nativePaths).size !== nativePaths.length) {
+    fail(
+      "release assembly descriptor.native_verification_paths contains duplicates",
+    );
+  }
+  const rawMars = exactObject(
+    root.mars,
+    TARGETS.map((target) => target.key),
+    "release assembly descriptor.mars",
+  );
+  const mars = {} as Record<TargetKey, MarDescriptor>;
+  for (const target of TARGETS) {
+    const path = `release assembly descriptor.mars.${target.key}`;
+    const item = exactObject(rawMars[target.key], [
+      "path",
+      "url",
+      "size",
+      "sha512",
+    ], path);
+    const expectedUrl =
+      `https://github.com/Floorp-Projects/Floorp/releases/download/${releaseTag}/${target.marName}`;
+    const url = stringValue(item.url, `${path}.url`);
+    if (url !== expectedUrl) {
+      fail(`${path}.url is not the canonical release URL`);
+    }
+    mars[target.key] = {
+      path: stringValue(item.path, `${path}.path`),
+      url,
+      size: positiveInteger(item.size, `${path}.size`),
+      sha512: validateSha512(item.sha512, `${path}.sha512`),
+    };
+  }
+
+  const expectedReleaseNames = {
+    windows: "floorp-windows-x86_64.installer.exe",
+    windowsStub: STUB_ASSET_NAME,
+    linux: "floorp-linux-x86_64.tar.xz",
+    linuxAarch64: "floorp-linux-aarch64.tar.xz",
+    mac: "floorp-macOS-universal.dmg",
+    linuxDeb: `floorp-${floorpVersion}.deb`,
+  } as const;
+  const rawReleaseFiles = exactObject(
+    root.release_files,
+    Object.keys(expectedReleaseNames),
+    "release assembly descriptor.release_files",
+  );
+  const releaseFiles = {} as AssemblyDescriptor["release_files"];
+  for (
+    const key of Object.keys(expectedReleaseNames) as Array<
+      keyof typeof expectedReleaseNames
+    >
+  ) {
+    const path = `release assembly descriptor.release_files.${key}`;
+    const item = exactObject(rawReleaseFiles[key], [
+      "path",
+      "name",
+      "size",
+      "sha512",
+    ], path);
+    const filePath = stringValue(item.path, `${path}.path`);
+    const name = stringValue(item.name, `${path}.name`);
+    if (name !== expectedReleaseNames[key]) {
+      fail(`${path}.name is not the fixed release asset name`);
+    }
+    if (pathBasename(filePath) !== name) {
+      fail(`${path}.name does not match the path basename`);
+    }
+    releaseFiles[key] = {
+      path: filePath,
+      name,
+      size: positiveInteger(item.size, `${path}.size`),
+      sha512: validateSha512(item.sha512, `${path}.sha512`),
+    };
+  }
+  return {
+    schema_version: 2,
+    mode: parseMode(root.mode, "release assembly descriptor.mode"),
+    floorp_version: floorpVersion,
+    release_tag: releaseTag,
+    runtime_provenance_path: stringValue(
+      root.runtime_provenance_path,
+      "release assembly descriptor.runtime_provenance_path",
+    ),
+    native_verification_paths: nativePaths,
+    mars,
+    release_files: releaseFiles,
+    stub_source: parseStubSource(
+      root.stub_source,
+      "release assembly descriptor.stub_source",
+    ),
+  };
+}
+
+async function verifyDescribedFile(
+  descriptor: { path: string; size: number; sha512: string },
+  path: string,
+): Promise<{ size: number; sha512: string }> {
+  const actual = await hashFile(descriptor.path, "sha512");
+  if (actual.size !== descriptor.size) {
+    fail(`${path}.size does not match the real file`);
+  }
+  if (actual.digest !== descriptor.sha512) {
+    fail(`${path}.sha512 does not match the real file`);
+  }
+  return { size: actual.size, sha512: actual.digest };
+}
+
+async function verifyStubSourceFile(
+  filePath: string,
+  source: StubSource,
+  path: string,
+): Promise<void> {
+  const actual = await hashFile(filePath, "sha256");
+  if (actual.size !== source.size) {
+    fail(`${path}.size does not match the real stub file`);
+  }
+  if (`sha256:${actual.digest}` !== source.asset_digest) {
+    fail(`${path}.asset_digest does not match the real stub file`);
+  }
+}
+
+async function prepareReleaseBundle(
+  descriptorValue: unknown,
+): Promise<AssembledReleaseBundle> {
+  const descriptor = parseAssemblyDescriptor(descriptorValue);
+  const runtime = parseNormalizedRuntimeProvenance(
+    await readJson(
+      descriptor.runtime_provenance_path,
+      "normalized Runtime provenance",
+    ),
+  );
+  const rawRecords = await Promise.all(
+    descriptor.native_verification_paths.map((path, index) =>
+      readJson(path, `native verification record ${index}`)
+    ),
+  );
+  const records = validateNativeVerificationSet(rawRecords, runtime);
+  const floorp = records[0].floorp;
+  const unsignedStates = new Set(
+    records.map((record) => record.floorp_package.unsigned),
+  );
+  if (unsignedStates.size !== 1) {
+    fail("native records mix signed and unsigned Floorp packages");
+  }
+  const unsigned = records[0].floorp_package.unsigned;
+  if (descriptor.mode === "production" && unsigned) {
+    fail(
+      "production release assembly rejects unsigned Floorp package evidence",
+    );
+  }
+
+  const marIdentities = {} as Record<TargetKey, MarMetadata>;
+  for (const target of TARGETS) {
+    const described = descriptor.mars[target.key];
+    const actual = await verifyDescribedFile(
+      described,
+      `release assembly descriptor.mars.${target.key}`,
+    );
+    if (pathBasename(described.path) !== target.marName) {
+      fail(
+        `release assembly descriptor.mars.${target.key}.path must end in ${target.marName}`,
+      );
+    }
+    marIdentities[target.key] = {
+      url: described.url,
+      name: target.marName,
+      size: actual.size,
+      sha512: actual.sha512,
+    };
+  }
+  const releaseFiles = {} as ReleaseManifestSet["release_files"];
+  for (
+    const key of Object.keys(descriptor.release_files) as Array<
+      keyof AssemblyDescriptor["release_files"]
+    >
+  ) {
+    const described = descriptor.release_files[key];
+    const actual = await verifyDescribedFile(
+      described,
+      `release assembly descriptor.release_files.${key}`,
+    );
+    releaseFiles[key] = {
+      name: described.name,
+      size: actual.size,
+      sha512: actual.sha512,
+    };
+  }
+  await verifyStubSourceFile(
+    descriptor.release_files.windowsStub.path,
+    descriptor.stub_source,
+    "release assembly descriptor.stub_source",
+  );
+
+  const metadata = {} as Record<TargetKey, ReleaseMetadata>;
+  for (const target of TARGETS) {
+    const record = records.find((candidate) =>
+      candidate.target_key === target.key
+    )!;
+    metadata[target.key] = {
+      schema_version: 2,
+      version_display: `${descriptor.floorp_version}@${record.firefox_version}`,
+      version: record.firefox_version,
+      noraneko_version: descriptor.floorp_version,
+      buildid: record.app_build_id,
+      noraneko_buildid: record.build_id2,
+      channel: "release",
+      platform: target.platform,
+      arch: target.arch,
+      manifest_set_id: "",
+      mar: marIdentities[target.key],
+      provenance: {
+        runtime_repository: record.runtime.repository,
+        runtime_head_sha: record.runtime.head_sha,
+        runtime_run_id: record.runtime.workflow_run_id,
+        runtime_artifact_id: record.runtime.artifact_id,
+        runtime_artifact_digest: record.runtime.artifact_digest,
+        floorp_repository: floorp.repository,
+        floorp_head_sha: floorp.head_sha,
+        floorp_run_id: floorp.workflow_run_id,
+        release_tag: descriptor.release_tag,
+      },
+      verification: {
+        status: "verified",
+        method: "full-version",
+        app_build_id: record.app_build_id,
+        build_id2: record.build_id2,
+      },
+    };
+  }
+  const manifestSetId = await computeManifestSetId(metadata);
+  for (const target of TARGETS) {
+    metadata[target.key].manifest_set_id = manifestSetId;
+  }
+
+  const metadataFiles = {} as Record<TargetKey, string>;
+  const manifestTargets: ReleaseManifestTarget[] = [];
+  for (const target of TARGETS) {
+    const content = `${JSON.stringify(metadata[target.key], null, 2)}\n`;
+    metadataFiles[target.key] = content;
+    const targetRecords = records.filter((record) =>
+      record.target_key === target.key
+    );
+    manifestTargets.push({
+      target_key: target.key,
+      platform: target.platform,
+      arch: target.arch,
+      metadata_name: target.metadataName,
+      metadata_sha256: `sha256:${await digestBytes(
+        "SHA-256",
+        new TextEncoder().encode(content),
+      )}`,
+      mar: marIdentities[target.key],
+      runtime_artifact: {
+        id: targetRecords[0].runtime.artifact_id,
+        name: target.runtimeArtifactName,
+        digest: targetRecords[0].runtime.artifact_digest,
+      },
+      floorp_package: targetRecords[0].floorp_package,
+      native_verifications: targetRecords.map((record) => ({
+        native_arch: record.native_arch,
+        app_build_id: record.app_build_id,
+        platform_build_id: record.platform_build_id,
+        build_id2: record.build_id2,
+      })),
+    });
+  }
+  const firefoxVersion = records[0].firefox_version;
+  return {
+    metadata,
+    metadataFiles,
+    manifest: {
+      schema_version: 2,
+      mode: descriptor.mode,
+      manifest_set_id: manifestSetId,
+      version_display: `${descriptor.floorp_version}@${firefoxVersion}`,
+      version: firefoxVersion,
+      noraneko_version: descriptor.floorp_version,
+      channel: "release",
+      runtime,
+      floorp: { ...floorp, release_tag: descriptor.release_tag },
+      release_files: releaseFiles,
+      stub_source: descriptor.stub_source,
+      targets: manifestTargets,
+    },
+  };
+}
+
+function expectedBundleFileNames(floorpVersion: string): string[] {
+  return [
+    ...TARGETS.flatMap((target) => [target.marName, target.metadataName]),
+    "floorp-windows-x86_64.installer.exe",
+    STUB_ASSET_NAME,
+    "floorp-linux-x86_64.tar.xz",
+    "floorp-linux-aarch64.tar.xz",
+    "floorp-macOS-universal.dmg",
+    `floorp-${floorpVersion}.deb`,
+    "release-manifest-set-v2.json",
+    "hashes.txt",
+  ].sort();
+}
+
+async function renderHashesFile(
+  bundleDirectory: string,
+  fileNames: string[],
+): Promise<string> {
+  const lines: string[] = [];
+  for (
+    const name of fileNames.filter((name) => name !== "hashes.txt").sort()
+  ) {
+    const hash = await hashFile(`${bundleDirectory}/${name}`, "sha256");
+    lines.push(`${hash.digest}  ${name}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function parseReleaseManifestSet(value: unknown): {
+  manifest: ReleaseManifestSet;
+  metadata: Record<TargetKey, ReleaseMetadata>;
+} {
+  const root = exactObject(value, [
+    "schema_version",
+    "mode",
+    "manifest_set_id",
+    "version_display",
+    "version",
+    "noraneko_version",
+    "channel",
+    "runtime",
+    "floorp",
+    "release_files",
+    "stub_source",
+    "targets",
+  ], "release manifest");
+  expectLiteral(root.schema_version, 2, "release manifest.schema_version");
+  const mode = parseMode(root.mode, "release manifest.mode");
+  const manifestSetId = validateSha256(
+    root.manifest_set_id,
+    "release manifest.manifest_set_id",
+  );
+  const firefoxVersion = validateFirefoxVersion(
+    root.version,
+    "release manifest.version",
+  );
+  const floorpVersion = validateSemver(
+    root.noraneko_version,
+    "release manifest.noraneko_version",
+  );
+  const versionDisplay = stringValue(
+    root.version_display,
+    "release manifest.version_display",
+  );
+  if (versionDisplay !== `${floorpVersion}@${firefoxVersion}`) {
+    fail("release manifest.version_display must be Floorp@Firefox");
+  }
+  expectLiteral(root.channel, "release", "release manifest.channel");
+  const runtime = parseNormalizedRuntimeProvenance(root.runtime);
+  const floorpRoot = exactObject(
+    root.floorp,
+    ["repository", "head_sha", "workflow_run_id", "release_tag"],
+    "release manifest.floorp",
+  );
+  const floorpIdentity = parseFloorpIdentity({
+    repository: floorpRoot.repository,
+    head_sha: floorpRoot.head_sha,
+    workflow_run_id: floorpRoot.workflow_run_id,
+  }, "release manifest.floorp");
+  const releaseTag = stringValue(
+    floorpRoot.release_tag,
+    "release manifest.floorp.release_tag",
+  );
+  if (releaseTag !== `v${floorpVersion}`) {
+    fail("release manifest release tag does not match version");
+  }
+
+  const expectedReleaseNames = {
+    windows: "floorp-windows-x86_64.installer.exe",
+    windowsStub: STUB_ASSET_NAME,
+    linux: "floorp-linux-x86_64.tar.xz",
+    linuxAarch64: "floorp-linux-aarch64.tar.xz",
+    mac: "floorp-macOS-universal.dmg",
+    linuxDeb: `floorp-${floorpVersion}.deb`,
+  } as const;
+  const rawFiles = exactObject(
+    root.release_files,
+    Object.keys(expectedReleaseNames),
+    "release manifest.release_files",
+  );
+  const releaseFiles = {} as ReleaseManifestSet["release_files"];
+  for (
+    const key of Object.keys(expectedReleaseNames) as Array<
+      keyof typeof expectedReleaseNames
+    >
+  ) {
+    const path = `release manifest.release_files.${key}`;
+    const file = exactObject(
+      rawFiles[key],
+      ["name", "size", "sha512"],
+      path,
+    );
+    releaseFiles[key] = {
+      name: expectLiteral(
+        file.name,
+        expectedReleaseNames[key],
+        `${path}.name`,
+      ),
+      size: positiveInteger(file.size, `${path}.size`),
+      sha512: validateSha512(file.sha512, `${path}.sha512`),
+    };
+  }
+  const stubSource = parseStubSource(
+    root.stub_source,
+    "release manifest.stub_source",
+  );
+
+  const rawTargets = arrayValue(root.targets, "release manifest.targets");
+  if (rawTargets.length !== TARGETS.length) {
+    fail("release manifest.targets must contain exactly four entries");
+  }
+  const targets: ReleaseManifestTarget[] = [];
+  const metadata = {} as Record<TargetKey, ReleaseMetadata>;
+  for (let index = 0; index < TARGETS.length; index++) {
+    const definition = TARGETS[index];
+    const path = `release manifest.targets[${index}]`;
+    const target = exactObject(rawTargets[index], [
+      "target_key",
+      "platform",
+      "arch",
+      "metadata_name",
+      "metadata_sha256",
+      "mar",
+      "runtime_artifact",
+      "floorp_package",
+      "native_verifications",
+    ], path);
+    expectLiteral(target.target_key, definition.key, `${path}.target_key`);
+    const platform = expectLiteral(
+      target.platform,
+      definition.platform,
+      `${path}.platform`,
+    );
+    const arch = expectLiteral(target.arch, definition.arch, `${path}.arch`);
+    const metadataName = expectLiteral(
+      target.metadata_name,
+      definition.metadataName,
+      `${path}.metadata_name`,
+    );
+    const metadataSha256 = validateSha256(
+      target.metadata_sha256,
+      `${path}.metadata_sha256`,
+    );
+    const marRoot = exactObject(
+      target.mar,
+      ["url", "name", "size", "sha512"],
+      `${path}.mar`,
+    );
+    const expectedUrl =
+      `https://github.com/Floorp-Projects/Floorp/releases/download/${releaseTag}/${definition.marName}`;
+    const mar: MarMetadata = {
+      url: expectLiteral(marRoot.url, expectedUrl, `${path}.mar.url`),
+      name: expectLiteral(
+        marRoot.name,
+        definition.marName,
+        `${path}.mar.name`,
+      ),
+      size: positiveInteger(marRoot.size, `${path}.mar.size`),
+      sha512: validateSha512(marRoot.sha512, `${path}.mar.sha512`),
+    };
+    const runtimeArtifactRoot = exactObject(
+      target.runtime_artifact,
+      ["id", "name", "digest"],
+      `${path}.runtime_artifact`,
+    );
+    const runtimeTarget = runtime.targets[index];
+    const runtimeArtifact: ArtifactIdentity = {
+      id: positiveInteger(
+        runtimeArtifactRoot.id,
+        `${path}.runtime_artifact.id`,
+      ),
+      name: expectLiteral(
+        runtimeArtifactRoot.name,
+        definition.runtimeArtifactName,
+        `${path}.runtime_artifact.name`,
+      ),
+      digest: validateSha256(
+        runtimeArtifactRoot.digest,
+        `${path}.runtime_artifact.digest`,
+      ),
+    };
+    if (
+      runtimeArtifact.id !== runtimeTarget.artifact_id ||
+      runtimeArtifact.digest !== runtimeTarget.artifact_digest
+    ) {
+      fail(
+        `${path}.runtime_artifact does not match embedded Runtime provenance`,
+      );
+    }
+    const floorpPackage = parseFloorpPackageIdentity(
+      target.floorp_package,
+      `${path}.floorp_package`,
+    );
+    if (
+      floorpPackage.artifact_name !==
+        expectedPackageArtifactName(definition.key, floorpPackage.unsigned)
+    ) {
+      fail(`${path}.floorp_package.artifact_name does not match target`);
+    }
+    const rawNative = arrayValue(
+      target.native_verifications,
+      `${path}.native_verifications`,
+    );
+    const expectedNativeArchs: NativeArch[] = definition.key === "mac"
+      ? ["x86_64", "aarch64"]
+      : [definition.key === "linuxAarch64" ? "aarch64" : "x86_64"];
+    if (rawNative.length !== expectedNativeArchs.length) {
+      fail(`${path}.native_verifications has an invalid architecture count`);
+    }
+    const nativeVerifications = rawNative.map((raw, nativeIndex) => {
+      const nativePath = `${path}.native_verifications[${nativeIndex}]`;
+      const item = exactObject(
+        raw,
+        ["native_arch", "app_build_id", "platform_build_id", "build_id2"],
+        nativePath,
+      );
+      const nativeArch = expectLiteral(
+        item.native_arch,
+        expectedNativeArchs[nativeIndex],
+        `${nativePath}.native_arch`,
+      );
+      const appBuildId = validateBuildId(
+        item.app_build_id,
+        `${nativePath}.app_build_id`,
+      );
+      const platformBuildId = validateBuildId(
+        item.platform_build_id,
+        `${nativePath}.platform_build_id`,
+      );
+      if (
+        appBuildId !== runtime.expected_build_id ||
+        platformBuildId !== runtime.expected_build_id
+      ) {
+        fail(`${nativePath} BuildIDs do not match Runtime provenance`);
+      }
+      return {
+        native_arch: nativeArch,
+        app_build_id: appBuildId,
+        platform_build_id: platformBuildId,
+        build_id2: validateUuidV7(
+          item.build_id2,
+          `${nativePath}.build_id2`,
+        ),
+      };
+    });
+    if (
+      nativeVerifications.length === 2 &&
+      canonicalJson({ ...nativeVerifications[0], native_arch: "" }) !==
+        canonicalJson({ ...nativeVerifications[1], native_arch: "" })
+    ) {
+      fail("release manifest mac native verifications disagree");
+    }
+    const primary = nativeVerifications[0];
+    metadata[definition.key] = {
+      schema_version: 2,
+      version_display: versionDisplay,
+      version: firefoxVersion,
+      noraneko_version: floorpVersion,
+      buildid: primary.app_build_id,
+      noraneko_buildid: primary.build_id2,
+      channel: "release",
+      platform,
+      arch,
+      manifest_set_id: manifestSetId,
+      mar,
+      provenance: {
+        runtime_repository: runtime.repository,
+        runtime_head_sha: runtime.head_sha,
+        runtime_run_id: runtime.workflow_run_id,
+        runtime_artifact_id: runtimeArtifact.id,
+        runtime_artifact_digest: runtimeArtifact.digest,
+        floorp_repository: floorpIdentity.repository,
+        floorp_head_sha: floorpIdentity.head_sha,
+        floorp_run_id: floorpIdentity.workflow_run_id,
+        release_tag: releaseTag,
+      },
+      verification: {
+        status: "verified",
+        method: "full-version",
+        app_build_id: primary.app_build_id,
+        build_id2: primary.build_id2,
+      },
+    };
+    targets.push({
+      target_key: definition.key,
+      platform,
+      arch,
+      metadata_name: metadataName,
+      metadata_sha256: metadataSha256,
+      mar,
+      runtime_artifact: runtimeArtifact,
+      floorp_package: floorpPackage,
+      native_verifications: nativeVerifications,
+    });
+  }
+  if (
+    new Set(targets.map((target) => target.floorp_package.artifact_id)).size !==
+      TARGETS.length
+  ) {
+    fail("release manifest Floorp package artifact IDs must be unique");
+  }
+  if (
+    new Set(targets.map((target) => target.floorp_package.artifact_digest))
+      .size !== TARGETS.length
+  ) {
+    fail("release manifest Floorp package artifact digests must be unique");
+  }
+  return {
+    metadata,
+    manifest: {
+      schema_version: 2,
+      mode,
+      manifest_set_id: manifestSetId,
+      version_display: versionDisplay,
+      version: firefoxVersion,
+      noraneko_version: floorpVersion,
+      channel: "release",
+      runtime,
+      floorp: { ...floorpIdentity, release_tag: releaseTag },
+      release_files: releaseFiles,
+      stub_source: stubSource,
+      targets,
+    },
+  };
+}
+
+export async function assembleReleaseBundle(
+  descriptorValue: unknown,
+  outputDirectory: string,
+): Promise<AssembledReleaseBundle> {
+  const descriptor = parseAssemblyDescriptor(descriptorValue);
+  const bundle = await prepareReleaseBundle(descriptorValue);
+  await Deno.mkdir(outputDirectory, { recursive: true });
+  const outputRoot = await Deno.realPath(outputDirectory);
+  for (const target of TARGETS) {
+    const expected = await Deno.realPath(
+      `${outputRoot}/${target.marName}`,
+    );
+    const actual = await Deno.realPath(descriptor.mars[target.key].path);
+    if (actual !== expected) {
+      fail(
+        `release assembly descriptor.mars.${target.key}.path must point into the flat output directory`,
+      );
+    }
+  }
+  for (
+    const key of Object.keys(descriptor.release_files) as Array<
+      keyof AssemblyDescriptor["release_files"]
+    >
+  ) {
+    const file = descriptor.release_files[key];
+    const expected = await Deno.realPath(`${outputRoot}/${file.name}`);
+    const actual = await Deno.realPath(file.path);
+    if (actual !== expected) {
+      fail(
+        `release assembly descriptor.release_files.${key}.path must point into the flat output directory`,
+      );
+    }
+  }
+  for (const target of TARGETS) {
+    await Deno.writeTextFile(
+      `${outputDirectory}/${target.metadataName}`,
+      bundle.metadataFiles[target.key],
+    );
+  }
+  await writeJson(
+    `${outputDirectory}/release-manifest-set-v2.json`,
+    bundle.manifest,
+  );
+  const expectedFiles = expectedBundleFileNames(descriptor.floorp_version);
+  await Deno.writeTextFile(
+    `${outputDirectory}/hashes.txt`,
+    await renderHashesFile(outputDirectory, expectedFiles),
+  );
+  await validateReleaseBundle(
+    outputDirectory,
+    descriptor.mode === "production",
+  );
+  return bundle;
+}
+
+export async function validateReleaseBundle(
+  bundleDirectory: string,
+  requireProduction = false,
+): Promise<ReleaseManifestSet> {
+  const manifestPath = `${bundleDirectory}/release-manifest-set-v2.json`;
+  const { manifest, metadata } = parseReleaseManifestSet(
+    await readJson(manifestPath, "release manifest"),
+  );
+  if (requireProduction && manifest.mode !== "production") {
+    fail("--production requires a production release manifest");
+  }
+  if (
+    requireProduction &&
+    manifest.targets.some((target) => target.floorp_package.unsigned)
+  ) {
+    fail("--production rejects unsigned Floorp package evidence");
+  }
+  const unsignedStates = new Set(
+    manifest.targets.map((target) => target.floorp_package.unsigned),
+  );
+  if (unsignedStates.size !== 1) {
+    fail("release manifest mixes signed and unsigned package evidence");
+  }
+  if (manifest.mode === "production" && [...unsignedStates][0]) {
+    fail("production release manifest contains unsigned package evidence");
+  }
+
+  const expectedFiles = expectedBundleFileNames(manifest.noraneko_version);
+  const entries: string[] = [];
+  for await (const entry of Deno.readDir(bundleDirectory)) {
+    if (!entry.isFile) {
+      fail(`release bundle contains non-file entry ${entry.name}`);
+    }
+    entries.push(entry.name);
+  }
+  entries.sort();
+  if (canonicalJson(entries) !== canonicalJson(expectedFiles)) {
+    fail(
+      `release bundle must contain the exact 16-file set; got ${
+        entries.join(", ")
+      }`,
+    );
+  }
+
+  for (const target of TARGETS) {
+    const manifestTarget = manifest.targets.find((item) =>
+      item.target_key === target.key
+    )!;
+    const marHash = await hashFile(
+      `${bundleDirectory}/${target.marName}`,
+      "sha512",
+    );
+    if (
+      marHash.size !== manifestTarget.mar.size ||
+      marHash.digest !== manifestTarget.mar.sha512
+    ) {
+      fail(`${target.marName} does not match release manifest size/SHA-512`);
+    }
+    const expectedMetadata = `${
+      JSON.stringify(metadata[target.key], null, 2)
+    }\n`;
+    const metadataPath = `${bundleDirectory}/${target.metadataName}`;
+    let actualMetadata: string;
+    try {
+      actualMetadata = await Deno.readTextFile(metadataPath);
+    } catch (error) {
+      fail(
+        `${target.metadataName} cannot be read: ${(error as Error).message}`,
+      );
+    }
+    if (actualMetadata !== expectedMetadata) {
+      fail(
+        `${target.metadataName} is not the exact metadata bound by release manifest`,
+      );
+    }
+    const metadataDigest = `sha256:${await digestBytes(
+      "SHA-256",
+      new TextEncoder().encode(actualMetadata),
+    )}`;
+    if (metadataDigest !== manifestTarget.metadata_sha256) {
+      fail(`${target.metadataName} SHA-256 does not match release manifest`);
+    }
+  }
+  for (const file of Object.values(manifest.release_files)) {
+    const actual = await hashFile(
+      `${bundleDirectory}/${file.name}`,
+      "sha512",
+    );
+    if (actual.size !== file.size || actual.digest !== file.sha512) {
+      fail(`${file.name} does not match release manifest size/SHA-512`);
+    }
+  }
+  await verifyStubSourceFile(
+    `${bundleDirectory}/${manifest.release_files.windowsStub.name}`,
+    manifest.stub_source,
+    "release manifest.stub_source",
+  );
+  const recomputedManifestSetId = await computeManifestSetId(metadata);
+  if (recomputedManifestSetId !== manifest.manifest_set_id) {
+    fail("release manifest_set_id does not match canonical metadata identity");
+  }
+  const expectedManifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const actualManifestText = await Deno.readTextFile(manifestPath);
+  if (actualManifestText !== expectedManifestText) {
+    fail("release-manifest-set-v2.json is not normalized exact JSON");
+  }
+  const expectedHashes = await renderHashesFile(
+    bundleDirectory,
+    expectedFiles,
+  );
+  const actualHashes = await Deno.readTextFile(
+    `${bundleDirectory}/hashes.txt`,
+  );
+  if (actualHashes !== expectedHashes) {
+    fail("hashes.txt does not match the exact flat bundle files");
+  }
+  return manifest;
+}
+
+const HELP = `Floorp release provenance v2
+
+Usage:
+  deno run --allow-read --allow-write tools/src/release_provenance.ts validate-runtime \\
+    --manifest runtime-build-manifest-v2.json \\
+    --rest-snapshot runtime-rest-snapshot-v2.json \\
+    --output normalized-runtime-provenance-v2.json [--github-output PATH]
+
+  deno run --allow-read --allow-write tools/src/release_provenance.ts record-native-verification \\
+    --descriptor native-verification-descriptor-v2.json \\
+    --output native-verification-v2.json [--github-output PATH]
+
+  deno run --allow-read --allow-write tools/src/release_provenance.ts assemble-release \\
+    --descriptor release-assembly-descriptor-v2.json \\
+    --output-dir release-bundle [--github-output PATH]
+
+  deno run --allow-read --allow-write tools/src/release_provenance.ts validate-release-bundle \\
+    --bundle-dir release-bundle [--production] [--github-output PATH]
+
+All JSON inputs use closed schema-v2 contracts. Unknown/missing fields, mixed
+workflow identities, stale/expired artifacts, non-native evidence, unsigned
+production packages, and changed file hashes are rejected. Normalized JSON is
+printed to stdout; --github-output appends non-secret scalar outputs to PATH.
+`;
+
+function parseFlags(
+  args: string[],
+  allowed: readonly string[],
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      fail(
+        `arguments must be --name value pairs; got ${flag ?? "end of input"}`,
+      );
+    }
+    const name = flag.slice(2);
+    if (!allowed.includes(name)) fail(`unknown argument --${name}`);
+    if (name in result) fail(`duplicate argument --${name}`);
+    result[name] = value;
+  }
+  return result;
+}
+
+function requiredFlag(flags: Record<string, string>, name: string): string {
+  const value = flags[name];
+  if (!value) fail(`missing required argument --${name}`);
+  return value;
+}
+
+async function appendGithubOutputs(
+  path: string | undefined,
+  outputs: Record<string, string | number>,
+): Promise<void> {
+  if (!path) return;
+  const lines: string[] = [];
+  for (const [name, rawValue] of Object.entries(outputs)) {
+    if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(name)) {
+      fail(`invalid GitHub output name ${name}`);
+    }
+    const value = String(rawValue);
+    if (/[\r\n]/.test(value)) fail(`GitHub output ${name} must be one line`);
+    lines.push(`${name}=${value}`);
+  }
+  await Deno.writeTextFile(path, `${lines.join("\n")}\n`, {
+    append: true,
+    create: true,
+  });
+}
+
+async function absoluteExistingPath(path: string): Promise<string> {
+  try {
+    return await Deno.realPath(path);
+  } catch (error) {
+    fail(`cannot resolve output path ${path}: ${(error as Error).message}`);
+  }
+}
+
+async function runCli(args: string[]): Promise<void> {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "help") {
+    console.log(HELP);
+    return;
+  }
+  const command = args[0];
+  if (args.slice(1).includes("--help")) {
+    console.log(HELP);
+    return;
+  }
+  if (command === "validate-runtime") {
+    const flags = parseFlags(args.slice(1), [
+      "manifest",
+      "rest-snapshot",
+      "output",
+      "github-output",
+    ]);
+    const manifest = await readJson(
+      requiredFlag(flags, "manifest"),
+      "Runtime manifest",
+    );
+    const snapshot = await readJson(
+      requiredFlag(flags, "rest-snapshot"),
+      "REST snapshot",
+    );
+    const provenance = validateRuntimeProvenance(manifest, snapshot);
+    const output = requiredFlag(flags, "output");
+    await writeJson(output, provenance);
+    const outputPath = await absoluteExistingPath(output);
+    const targetOutputs: Record<string, string | number> = {};
+    for (let index = 0; index < TARGETS.length; index++) {
+      const key = TARGETS[index].key;
+      targetOutputs[`${key}-artifact-id`] =
+        provenance.targets[index].artifact_id;
+      targetOutputs[`${key}-artifact-digest`] =
+        provenance.targets[index].artifact_digest;
+    }
+    await appendGithubOutputs(flags["github-output"], {
+      "provenance-path": outputPath,
+      "runtime-run-id": provenance.workflow_run_id,
+      "runtime-head-sha": provenance.head_sha,
+      "runtime-build-id": provenance.expected_build_id,
+      "runtime-manifest-artifact-id": provenance.manifest_artifact.id,
+      "runtime-manifest-artifact-digest": provenance.manifest_artifact.digest,
+      ...targetOutputs,
+    });
+    console.log(JSON.stringify(provenance));
+    return;
+  }
+  if (command === "record-native-verification") {
+    const flags = parseFlags(args.slice(1), [
+      "descriptor",
+      "output",
+      "github-output",
+    ]);
+    const descriptor = await readJson(
+      requiredFlag(flags, "descriptor"),
+      "native descriptor",
+    );
+    const record = await createNativeVerificationRecord(descriptor);
+    const output = requiredFlag(flags, "output");
+    await writeJson(output, record);
+    const outputPath = await absoluteExistingPath(output);
+    await appendGithubOutputs(flags["github-output"], {
+      "record-path": outputPath,
+      "target-key": record.target_key,
+      "native-arch": record.native_arch,
+      "firefox-version": record.firefox_version,
+      "app-build-id": record.app_build_id,
+      "platform-build-id": record.platform_build_id,
+      "build-id2": record.build_id2,
+    });
+    console.log(JSON.stringify(record));
+    return;
+  }
+  if (command === "assemble-release") {
+    const flags = parseFlags(args.slice(1), [
+      "descriptor",
+      "output-dir",
+      "github-output",
+    ]);
+    const descriptor = await readJson(
+      requiredFlag(flags, "descriptor"),
+      "release descriptor",
+    );
+    const outputDirectory = requiredFlag(flags, "output-dir");
+    const bundle = await assembleReleaseBundle(descriptor, outputDirectory);
+    const bundlePath = await absoluteExistingPath(outputDirectory);
+    const metadataOutputs: Record<string, string> = {};
+    for (const target of TARGETS) {
+      metadataOutputs[`${target.key}-metadata-path`] =
+        await absoluteExistingPath(
+          `${outputDirectory}/${target.metadataName}`,
+        );
+    }
+    await appendGithubOutputs(flags["github-output"], {
+      "bundle-dir": bundlePath,
+      "manifest-path": await absoluteExistingPath(
+        `${outputDirectory}/release-manifest-set-v2.json`,
+      ),
+      "manifest-set-id": bundle.manifest.manifest_set_id,
+      "firefox-version": bundle.manifest.version,
+      "floorp-version": bundle.manifest.noraneko_version,
+      ...metadataOutputs,
+    });
+    console.log(JSON.stringify(bundle.manifest));
+    return;
+  }
+  if (command === "validate-release-bundle") {
+    const productionCount = args.slice(1).filter((argument) =>
+      argument === "--production"
+    ).length;
+    if (productionCount > 1) fail("duplicate argument --production");
+    const production = productionCount === 1;
+    const flags = parseFlags(
+      args.slice(1).filter((argument) => argument !== "--production"),
+      ["bundle-dir", "github-output"],
+    );
+    const bundleDirectory = requiredFlag(flags, "bundle-dir");
+    const manifest = await validateReleaseBundle(bundleDirectory, production);
+    await appendGithubOutputs(flags["github-output"], {
+      "bundle-dir": await absoluteExistingPath(bundleDirectory),
+      "manifest-path": await absoluteExistingPath(
+        `${bundleDirectory}/release-manifest-set-v2.json`,
+      ),
+      "manifest-set-id": manifest.manifest_set_id,
+      "firefox-version": manifest.version,
+      "floorp-version": manifest.noraneko_version,
+      "validated": "true",
+    });
+    console.log(JSON.stringify(manifest));
+    return;
+  }
+  fail(`unknown subcommand ${command}; use --help`);
+}
+
+if (import.meta.main) {
+  try {
+    await runCli(Deno.args);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    Deno.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

Fix the stable release pipeline implicated by Floorp-Projects/Floorp#2584 by binding every published artifact and updater record to one immutable Runtime workflow run.

The Windows update URL itself was correct. The incident was caused by inconsistent release metadata: the initially published 12.16.3 XML used BuildID `20260721191913`, while the shipped Windows binary reported `20260721164720`. The updater therefore rejected the otherwise valid request.

## Changes

- require one successful Runtime run and one exact manifest artifact ID
- validate Runtime repository, ref, event, run conclusion, artifact IDs, names, digests, BuildID, buildID2, and target matrix before packaging
- download exact artifacts by immutable ID and keep the consolidated layout flat
- verify packaged applications natively on Windows, Linux x86_64/aarch64, and macOS x86_64/aarch64
- assemble one exact 16-file release bundle, including `floorp-stub.installer.exe`
- preserve strict source provenance for the inherited stub and reject post-publication stub replacement
- publish public GitHub assets only after byte-for-byte bundle validation
- dispatch the correlated Floorp-Updates v2 run, verify its result artifact, wait for the exact Cloudflare Pages deployment, and probe every production endpoint
- serialize all production publications
- provide `validation_only` mode so the complete unsigned pipeline can be exercised without publishing
- reject `--gh-token` in the local `act` helper and pass `GITHUB_TOKEN` by child environment name, never by argv value or log output

## Validation

Local/static:

- `deno fmt --check`: pass
- `deno check --frozen`: pass
- `deno lint`: pass
- provenance/tamper tests: 20/20 pass
- local act credential tests: 3/3 pass
- actionlint v1.7.12: all 7 touched provenance workflows pass
- embedded `actions/github-script` syntax: 21/21 blocks parse
- docs verification: pass
- browser integration: 131/131 pass on run 30032943748 attempt 3
- independent Tier-1 A/B/C/A audit: no code-level P0/P1

Canonical validation-only GitHub Actions proof:

- run: https://github.com/Floorp-Projects/Floorp/actions/runs/30034073529
- exact Floorp head: `42e9b376791336b7d181abbec9ec511f04b6ffef`
- immutable Runtime input: run `30016595833`, manifest artifact `8572748299`
- result: success; 4/4 package jobs and 5/5 native verifier jobs passed
- macOS aarch64 accepted only observed `adhoc,linker-signed` validation metadata with no TeamIdentifier or Authority; production strict signing checks remain unchanged
- assembler and validation completion: success
- production publisher: skipped as required by `validation_only=true`
- bundle artifact: `floorp-release-bundle-v2-validation`, ID `8575156713`
- bundle size/digest: `1017234030`, `sha256:2c75b29f84595a3e0da76487f59952ac16150a6218c2761b9fc4c446fe608325`
- manifest set: `sha256:91778a28b4093232adc3618e9a8f955560a3dd737bed485f2d5925398543639e`
- independent full-download audit: exact flat 16 files; hashes.txt 15/15 SHA-256; manifest payload/MAR references 10/10 size and SHA-512; official bundle validator passed

## Production rollout status

The implementation and branch-level validation are complete, but these exact heads/runs are **not production-deployable as-is**:

- Floorp `v12.16.3` already exists, and the production workflow correctly rejects an existing release.
- Runtime run `30016595833` came from a feature branch; production requires a new run from Runtime's default branch `nora-0.2.0`.
- Floorp-Updates v2 is still only in Draft PR #6 and is not callable from `main` yet.
- Production signing, public release publication, Updates v2 deployment, Cloudflare convergence, and portable release were intentionally not exercised by validation mode.

Required rollout order:

1. Merge Floorp-Projects/Floorp-Updates#6 to `main` and confirm the v2 workflow is available.
2. Merge Floorp-Projects/Floorp-Runtime#55 to `nora-0.2.0`; run it again from that default branch and capture the exact successful run/manifest artifact IDs.
3. Merge this PR to Floorp `main`.
4. Use a new, not-yet-published Floorp version and run `validation_only=true` on the exact release head with the post-merge Runtime inputs.
5. Only after that proof, run production publication from Floorp `main` through the manual approval gates.

## Known follow-ups

- use an explicit future bundle input when rotating the online stub instead of mutating a published release
- optionally replace the trusted GitHub artifact-service boundary with a strict cross-platform ZIP downloader that hard-fails on transport digest mismatch
- bind optional PPA handoff to immutable artifact ID/digest
- split updater/portable dispatch tokens further for least privilege

Fixes Floorp-Projects/Floorp#2584.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a provenance-validated release process covering Windows, Linux, and macOS artifacts.
  * Added immutable release bundle assembly with manifest and integrity verification.
  * Added validation-only releases to verify packages without publishing them.
  * Added platform-specific verification before release publication.
  * Added safeguards against modifying existing provenance-v2 releases.

* **Documentation**
  * Updated development documentation to include the expanded release workflow.

* **Bug Fixes**
  * Improved local workflow execution defaults and prevented credentials from appearing in commands or logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->