### PR TITLE
fix(workspaces): keep URL bar navigation in container tabs

### DIFF
--- a/browser-features/chrome/static/overrides/modules/workspaces/index.ts
+++ b/browser-features/chrome/static/overrides/modules/workspaces/index.ts
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Workspaces from "#features-chrome/common/workspaces";
+import { resolveWorkspaceOpenLinkUserContext } from "./open-link-user-context.ts";
 
 console.log("Workspaces override loaded");
 
@@ -78,40 +79,15 @@ export const overrides = [
       const workspaceUserContextId =
         gWorkspacesServices?.getCurrentWorkspaceUserContextId() ?? 0;
 
-      // Merge options, applying workspace container if:
-      // 1. Workspace has a container (userContextId > 0)
-      // 2. No userContextId is explicitly specified in options
-      // Note: If userContextId is explicitly set to 0 ("no container"), respect that choice
-      const baseOptions = options ?? {};
-      const hasExplicitUserContextId = "userContextId" in baseOptions;
-      const originalUserContextId =
-        typeof baseOptions.userContextId === "number"
-          ? baseOptions.userContextId
-          : undefined;
-
-      const potentialTargetBrowser = baseOptions.targetBrowser;
-      const targetBrowserUserContextId =
-        typeof potentialTargetBrowser === "object" &&
-        potentialTargetBrowser !== null &&
-        typeof (potentialTargetBrowser as { userContextId?: unknown })
-          .userContextId === "number"
-          ? (potentialTargetBrowser as { userContextId: number }).userContextId
-          : undefined;
-
-      const shouldRespectExistingContext =
-        where === "current" || targetBrowserUserContextId !== undefined;
-
-      const shouldApplyWorkspaceContainer =
-        workspaceUserContextId > 0 &&
-        !hasExplicitUserContextId &&
-        !shouldRespectExistingContext;
-
-      const mergedOptions = {
-        ...baseOptions,
-        userContextId: shouldApplyWorkspaceContainer
-          ? workspaceUserContextId
-          : (originalUserContextId ?? targetBrowserUserContextId ?? 0),
-      };
+      const {
+        options: mergedOptions,
+        originalUserContextId,
+        shouldApplyWorkspaceContainer,
+      } = resolveWorkspaceOpenLinkUserContext(
+        options,
+        where,
+        workspaceUserContextId,
+      );
 
       console.debug("Workspaces: openTrustedLinkIn override", {
         url: typeof url === "string" ? url : url.spec,
@@ -140,41 +116,15 @@ export const overrides = [
         const workspaceUserContextId =
           gWorkspacesServices?.getCurrentWorkspaceUserContextId() ?? 0;
 
-        // Merge params, applying workspace container if:
-        // 1. Workspace has a container (userContextId > 0)
-        // 2. No userContextId is explicitly specified in params
-        // Note: If userContextId is explicitly set to 0 ("no container"), respect that choice
-        const baseParams = params ?? {};
-        const hasExplicitUserContextId = "userContextId" in baseParams;
-        const originalUserContextId =
-          typeof baseParams.userContextId === "number"
-            ? baseParams.userContextId
-            : undefined;
-
-        const potentialTargetBrowser = baseParams.targetBrowser;
-        const targetBrowserUserContextId =
-          typeof potentialTargetBrowser === "object" &&
-          potentialTargetBrowser !== null &&
-          typeof (potentialTargetBrowser as { userContextId?: unknown })
-            .userContextId === "number"
-            ? (potentialTargetBrowser as { userContextId: number })
-                .userContextId
-            : undefined;
-
-        const shouldRespectExistingContext =
-          where === "current" || targetBrowserUserContextId !== undefined;
-
-        const shouldApplyWorkspaceContainer =
-          workspaceUserContextId > 0 &&
-          !hasExplicitUserContextId &&
-          !shouldRespectExistingContext;
-
-        const mergedParams = {
-          ...baseParams,
-          userContextId: shouldApplyWorkspaceContainer
-            ? workspaceUserContextId
-            : (originalUserContextId ?? targetBrowserUserContextId ?? 0),
-        };
+        const {
+          options: mergedParams,
+          originalUserContextId,
+          shouldApplyWorkspaceContainer,
+        } = resolveWorkspaceOpenLinkUserContext(
+          params,
+          where,
+          workspaceUserContextId,
+        );
 
         console.debug("Workspaces: openUILinkIn override", {
           url: typeof url === "string" ? url : url.spec,

--- a/browser-features/chrome/static/overrides/modules/workspaces/open-link-user-context.ts
+++ b/browser-features/chrome/static/overrides/modules/workspaces/open-link-user-context.ts
@@ -1,0 +1,68 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type OpenLinkUserContextInput = {
+  userContextId?: number;
+  targetBrowser?: unknown;
+  [key: string]: unknown;
+};
+
+export type WorkspaceOpenLinkUserContextResolution = {
+  options: OpenLinkUserContextInput;
+  originalUserContextId: number | undefined;
+  shouldApplyWorkspaceContainer: boolean;
+};
+
+export function resolveWorkspaceOpenLinkUserContext(
+  input: OpenLinkUserContextInput | undefined,
+  where: string,
+  workspaceUserContextId: number,
+): WorkspaceOpenLinkUserContextResolution {
+  const baseInput = input ?? {};
+  const originalUserContextId = typeof baseInput.userContextId === "number"
+    ? baseInput.userContextId
+    : undefined;
+
+  if (where === "current") {
+    const options = { ...baseInput };
+
+    if (originalUserContextId === undefined) {
+      delete options.userContextId;
+    } else {
+      options.userContextId = originalUserContextId;
+    }
+
+    return {
+      options,
+      originalUserContextId,
+      shouldApplyWorkspaceContainer: false,
+    };
+  }
+
+  const potentialTargetBrowser = baseInput.targetBrowser;
+  const targetBrowserUserContextId =
+    typeof potentialTargetBrowser === "object" &&
+      potentialTargetBrowser !== null &&
+      typeof (potentialTargetBrowser as { userContextId?: unknown })
+          .userContextId === "number"
+      ? (potentialTargetBrowser as { userContextId: number }).userContextId
+      : undefined;
+
+  const hasUserContextId = "userContextId" in baseInput;
+  const shouldApplyWorkspaceContainer = workspaceUserContextId > 0 &&
+    !hasUserContextId &&
+    targetBrowserUserContextId === undefined;
+
+  return {
+    options: {
+      ...baseInput,
+      userContextId: shouldApplyWorkspaceContainer
+        ? workspaceUserContextId
+        : (originalUserContextId ?? targetBrowserUserContextId ?? 0),
+    },
+    originalUserContextId,
+    shouldApplyWorkspaceContainer,
+  };
+}

--- a/browser-features/chrome/static/overrides/modules/workspaces/test/openLinkUserContext.test.ts
+++ b/browser-features/chrome/static/overrides/modules/workspaces/test/openLinkUserContext.test.ts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import { resolveWorkspaceOpenLinkUserContext } from "../open-link-user-context.ts";
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../../test/utils/test_harness.ts";
+
+function assertSameOwnProperties(
+  actual: Record<string, unknown>,
+  expected: Record<string, unknown>,
+  message: string,
+): void {
+  const actualKeys = Object.keys(actual).sort();
+  const expectedKeys = Object.keys(expected).sort();
+
+  assertEquals(
+    actualKeys.join("\n"),
+    expectedKeys.join("\n"),
+    `${message}: own keys should match`,
+  );
+
+  for (const key of expectedKeys) {
+    assertEquals(
+      actual[key],
+      expected[key],
+      `${message}: ${key} should match`,
+    );
+  }
+}
+
+function testCurrentWithoutOptionsOmitsUserContextId(): void {
+  const resolution = resolveWorkspaceOpenLinkUserContext(
+    undefined,
+    "current",
+    7,
+  );
+
+  assert(
+    !Object.hasOwn(resolution.options, "userContextId"),
+    "current navigation without options should omit userContextId",
+  );
+  assertEquals(
+    resolution.shouldApplyWorkspaceContainer,
+    false,
+    "current navigation should not apply the workspace container",
+  );
+}
+
+function testCurrentWithTargetBrowserOmitsUserContextId(): void {
+  const targetBrowser = { userContextId: 4 };
+  const resolution = resolveWorkspaceOpenLinkUserContext(
+    { targetBrowser },
+    "current",
+    7,
+  );
+
+  assert(
+    !Object.hasOwn(resolution.options, "userContextId"),
+    "current target-browser navigation should omit top-level userContextId",
+  );
+  assertEquals(
+    resolution.options.targetBrowser,
+    targetBrowser,
+    "targetBrowser should be preserved",
+  );
+}
+
+function testCurrentWithUndefinedUserContextIdOmitsKey(): void {
+  const input = { userContextId: undefined, marker: "preserved" };
+  const resolution = resolveWorkspaceOpenLinkUserContext(
+    input,
+    "current",
+    7,
+  );
+
+  assert(
+    !Object.hasOwn(resolution.options, "userContextId"),
+    "current navigation should remove an undefined userContextId",
+  );
+  assert(
+    Object.hasOwn(input, "userContextId"),
+    "resolving should not mutate the input object",
+  );
+  assertEquals(
+    resolution.options.marker,
+    "preserved",
+    "unrelated options should be preserved",
+  );
+}
+
+function testExplicitNumericUserContextIdsArePreserved(): void {
+  for (const where of ["current", "tab"]) {
+    for (const userContextId of [0, 5]) {
+      const resolution = resolveWorkspaceOpenLinkUserContext(
+        {
+          userContextId,
+          targetBrowser: { userContextId: 9 },
+        },
+        where,
+        7,
+      );
+
+      assert(
+        Object.hasOwn(resolution.options, "userContextId"),
+        `${where} should retain explicit userContextId ${userContextId}`,
+      );
+      assertEquals(
+        resolution.options.userContextId,
+        userContextId,
+        `${where} should preserve explicit userContextId ${userContextId}`,
+      );
+    }
+  }
+}
+
+function testNonCurrentWorkspaceInjection(): void {
+  const withoutTarget = resolveWorkspaceOpenLinkUserContext({}, "tab", 7);
+  const targetBrowser = { currentURI: "https://example.com/" };
+  const withTargetWithoutDirectId = resolveWorkspaceOpenLinkUserContext(
+    { targetBrowser },
+    "tabshifted",
+    7,
+  );
+
+  assertEquals(
+    withoutTarget.options.userContextId,
+    7,
+    "non-current navigation should apply the workspace container",
+  );
+  assertEquals(
+    withTargetWithoutDirectId.options.userContextId,
+    7,
+    "a targetBrowser without a direct ID should not block workspace injection",
+  );
+  assertEquals(
+    withTargetWithoutDirectId.options.targetBrowser,
+    targetBrowser,
+    "targetBrowser without a direct ID should be preserved",
+  );
+  assertEquals(
+    withTargetWithoutDirectId.shouldApplyWorkspaceContainer,
+    true,
+    "workspace injection should be reported for a target without a direct ID",
+  );
+}
+
+function testNonCurrentTargetBrowserUserContextIdTakesPrecedence(): void {
+  const resolution = resolveWorkspaceOpenLinkUserContext(
+    { targetBrowser: { userContextId: 3 } },
+    "tab",
+    7,
+  );
+
+  assertEquals(
+    resolution.options.userContextId,
+    3,
+    "targetBrowser userContextId should take precedence over fallback",
+  );
+  assertEquals(
+    resolution.shouldApplyWorkspaceContainer,
+    false,
+    "a targetBrowser userContextId should block workspace injection",
+  );
+}
+
+function testNonCurrentUndefinedUserContextIdRetainsFallback(): void {
+  const input = { userContextId: undefined };
+  const resolution = resolveWorkspaceOpenLinkUserContext(input, "tab", 7);
+
+  assertEquals(
+    resolution.options.userContextId,
+    0,
+    "an own undefined userContextId should retain the existing fallback",
+  );
+  assertEquals(
+    resolution.shouldApplyWorkspaceContainer,
+    false,
+    "an own undefined userContextId should block workspace injection",
+  );
+  assertEquals(
+    input.userContextId,
+    undefined,
+    "resolving should not mutate the undefined input value",
+  );
+}
+
+function testWorkspaceZeroUsesFallback(): void {
+  const resolution = resolveWorkspaceOpenLinkUserContext({}, "tab", 0);
+
+  assertEquals(
+    resolution.options.userContextId,
+    0,
+    "workspace ID 0 should retain the existing fallback",
+  );
+  assertEquals(
+    resolution.shouldApplyWorkspaceContainer,
+    false,
+    "workspace ID 0 should not be treated as an injected container",
+  );
+}
+
+function testResolutionIsIdempotent(): void {
+  const currentOnce = resolveWorkspaceOpenLinkUserContext(
+    { targetBrowser: { userContextId: 3 }, marker: "current" },
+    "current",
+    7,
+  ).options;
+  const currentTwice = resolveWorkspaceOpenLinkUserContext(
+    currentOnce,
+    "current",
+    7,
+  ).options;
+
+  assertSameOwnProperties(
+    currentTwice,
+    currentOnce,
+    "applying the current resolution twice",
+  );
+  assert(
+    currentTwice !== currentOnce,
+    "current resolution should return a fresh object",
+  );
+
+  const tabOnce = resolveWorkspaceOpenLinkUserContext(
+    { marker: "tab" },
+    "tab",
+    7,
+  ).options;
+  const tabTwice = resolveWorkspaceOpenLinkUserContext(
+    tabOnce,
+    "tab",
+    7,
+  ).options;
+
+  assertSameOwnProperties(
+    tabTwice,
+    tabOnce,
+    "applying the non-current resolution twice",
+  );
+  assert(tabTwice !== tabOnce, "non-current resolution should be fresh");
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "current without options omits userContextId",
+      fn: testCurrentWithoutOptionsOmitsUserContextId,
+    },
+    {
+      name: "current targetBrowser omits userContextId",
+      fn: testCurrentWithTargetBrowserOmitsUserContextId,
+    },
+    {
+      name: "current undefined userContextId omits key",
+      fn: testCurrentWithUndefinedUserContextIdOmitsKey,
+    },
+    {
+      name: "explicit numeric userContextIds are preserved",
+      fn: testExplicitNumericUserContextIdsArePreserved,
+    },
+    {
+      name: "non-current workspace injection",
+      fn: testNonCurrentWorkspaceInjection,
+    },
+    {
+      name: "non-current targetBrowser userContextId",
+      fn: testNonCurrentTargetBrowserUserContextIdTakesPrecedence,
+    },
+    {
+      name: "non-current undefined userContextId fallback",
+      fn: testNonCurrentUndefinedUserContextIdRetainsFallback,
+    },
+    {
+      name: "workspace ID 0 fallback",
+      fn: testWorkspaceZeroUsesFallback,
+    },
+    {
+      name: "resolution is idempotent",
+      fn: testResolutionIsIdempotent,
+    },
+  ];
+
+  await runTests("openLinkUserContext.test.ts", tests);
+}


### PR DESCRIPTION
## Summary

- Keep non-explicit current-tab URL bar navigation in the selected container tab.
- Preserve explicit numeric `userContextId` values and existing non-current workspace-container behavior.
- Share context resolution between the `openTrustedLinkIn` and legacy `openUILinkIn` overrides.
- Add focused coverage for current and non-current context resolution.

## Root cause

Floorp's workspace open-link override synthesized `userContextId: 0` when a `where: "current"` call did not explicitly provide a context. Gecko 153 tightened current-tab container mismatch handling, so that explicitly present zero conflicts with a selected container tab and opens a new default-context tab.

The fix omits `userContextId` only for non-explicit current loads, allowing them to inherit the selected browser's context. Explicit numeric IDs and non-current behavior remain unchanged.

## Validation

- `deno check --frozen --sloppy-imports` on the three relevant files
- `deno lint` on the three relevant files
- `deno fmt --check` on the new helper and test
- focused resolver test: passed
- colocated browser-test discovery: exactly one test found
- 304-case old/new context-resolution comparison: passed
- production loader build: 591 modules transformed
- isolated source-loaded Floorp Gecko 153 Marionette validation: 7/7 passed
  - URL bar Enter
  - Go button
  - plain search tab/container invariants
  - omitted current-load ID
  - explicit matching container ID
  - explicit zero opening a default-context tab
  - normal-tab URL bar regression
- `git diff --check`

On Gecko 153, `globalThis.openUILinkIn` is unavailable; that legacy wrapper is covered by the shared resolver tests and production build rather than a live runtime call.

Closes #2588


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link-opening behavior across workspaces and navigation targets.
  * Preserved explicitly selected browsing contexts while correctly applying workspace context when appropriate.
  * Prevented unintended changes to link-opening options during context resolution.

* **Tests**
  * Added coverage for current-tab, new-tab, shifted-tab, nested browser context, empty, and repeated-resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->