### PR TITLE
fix(feles-build): shut down dev servers when the launched browser exits

### DIFF
--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "9548e3a8526f2be38c5d9da7fee9429ab4c90cb0"
+floorp_commit: "548fe69ffece93f0a62c3bddeee26a95445ee131"
 generated: true
 ---
 # Command Reference
@@ -308,7 +308,7 @@ Source: `deno.json:81`
 feles-build build --phase <before-mach|after-mach>
 ```
 
-Source: `tools/feles-build.ts:287`
+Source: `tools/feles-build.ts:297`
 
 ### `dev`
 
@@ -316,7 +316,7 @@ Source: `tools/feles-build.ts:287`
 feles-build dev
 ```
 
-Source: `tools/feles-build.ts:259`
+Source: `tools/feles-build.ts:269`
 
 ### `misc`
 
@@ -324,7 +324,7 @@ Source: `tools/feles-build.ts:259`
 feles-build misc patch --action <apply|create|init>
 ```
 
-Source: `tools/feles-build.ts:299`
+Source: `tools/feles-build.ts:309`
 
 ### `stage`
 
@@ -332,7 +332,7 @@ Source: `tools/feles-build.ts:299`
 feles-build stage [--marionette]
 ```
 
-Source: `tools/feles-build.ts:279`
+Source: `tools/feles-build.ts:289`
 
 ### `test`
 
@@ -340,4 +340,4 @@ Source: `tools/feles-build.ts:279`
 feles-build test
 ```
 
-Source: `tools/feles-build.ts:268`
+Source: `tools/feles-build.ts:278`

--- a/tools/feles-build.ts
+++ b/tools/feles-build.ts
@@ -82,7 +82,6 @@ async function runDev(): Promise<void> {
       // Launch browser; when it exits (or fails to launch), take the dev
       // servers down with it — otherwise they keep listening on their
       // ports and the next run dies with "port already in use".
-      // deno-lint-ignore no-explicit-any
       BrowserLauncher.run().then(() => {
         logger.info("Browser closed — shutting down dev servers.");
         DevServer.shutdown();
@@ -150,7 +149,6 @@ async function runStage(options: { marionette?: boolean } = {}): Promise<void> {
       // servers down with it — otherwise ~9 vite servers keep listening
       // on 5170-5190 after "Browser Closed" and the next stage run fails
       // with "Port 5181 is already in use".
-      // deno-lint-ignore no-explicit-any
       BrowserLauncher.run({ marionette }).then(() => {
         logger.info("Browser closed — shutting down dev servers.");
         DevServer.shutdown();

--- a/tools/feles-build.ts
+++ b/tools/feles-build.ts
@@ -79,10 +79,19 @@ async function runDev(): Promise<void> {
   pipe.on("data", (chunk: string) => {
     if (isDevServerReady(chunk)) {
       logger.success("Dev servers are ready.");
-      // Launch browser
+      // Launch browser; when it exits (or fails to launch), take the dev
+      // servers down with it — otherwise they keep listening on their
+      // ports and the next run dies with "port already in use".
       // deno-lint-ignore no-explicit-any
-      BrowserLauncher.run().catch((e: any) => {
+      BrowserLauncher.run().then(() => {
+        logger.info("Browser closed — shutting down dev servers.");
+        DevServer.shutdown();
+        Deno.exit(0);
+        // deno-lint-ignore no-explicit-any
+      }).catch((e: any) => {
         logger.error(`Browser launcher failed: ${e?.message ?? e}`);
+        DevServer.shutdown();
+        Deno.exit(1);
       });
     }
   });
@@ -94,11 +103,6 @@ async function runDev(): Promise<void> {
     logger.error(`Dev server failed: ${e?.message ?? e}`);
     Deno.exit(1);
   });
-
-  // Wait until browser finishes; the BrowserLauncher.run call above is async but we don't await here
-  // After browser closed, shut down servers
-  // Simple polling to detect when ready was received and browser process done is not trivial here.
-  // Keep process alive until SIGINT or process termination from BrowserLauncher path
 }
 
 async function runStage(options: { marionette?: boolean } = {}): Promise<void> {
@@ -142,10 +146,20 @@ async function runStage(options: { marionette?: boolean } = {}): Promise<void> {
   pipe.on("data", (chunk: string) => {
     if (isDevServerReady(chunk)) {
       logger.success("Dev servers are ready.");
-      // Launch browser
+      // Launch browser; when it exits (or fails to launch), take the dev
+      // servers down with it — otherwise ~9 vite servers keep listening
+      // on 5170-5190 after "Browser Closed" and the next stage run fails
+      // with "Port 5181 is already in use".
       // deno-lint-ignore no-explicit-any
-      BrowserLauncher.run({ marionette }).catch((e: any) => {
+      BrowserLauncher.run({ marionette }).then(() => {
+        logger.info("Browser closed — shutting down dev servers.");
+        DevServer.shutdown();
+        Deno.exit(0);
+        // deno-lint-ignore no-explicit-any
+      }).catch((e: any) => {
         logger.error(`Browser launcher failed: ${e?.message ?? e}`);
+        DevServer.shutdown();
+        Deno.exit(1);
       });
     }
   });
@@ -157,8 +171,6 @@ async function runStage(options: { marionette?: boolean } = {}): Promise<void> {
     logger.error(`Dev server failed: ${e?.message ?? e}`);
     Deno.exit(1);
   });
-
-  // Keep process alive until SIGINT or browser termination like runDev
 }
 
 async function runTest(): Promise<void> {


### PR DESCRIPTION
## Summary

- shut down the managed Vite development servers when the launched browser exits
- apply the same cleanup path when browser launch fails
- remove the lint suppressions made obsolete by that promise-chain change

## Why

`feles-build dev` and `feles-build stage` previously left their managed Vite processes listening after the browser closed. A subsequent run could fail because the ports were still occupied. This connects the browser lifetime to the existing `DevServer.shutdown()` path.

This is a rescue of the abandoned [PR #2550](https://github.com/Floorp-Projects/Floorp/pull/2550), contributed as part of [issue #2569](https://github.com/Floorp-Projects/Floorp/issues/2569). The two source commits were replayed with `-x` from exact pull head `b7ea88bb510fe65476043a60bee502366676d98d`, preserving the original author and co-author metadata.

## Impact

The change is limited to `tools/feles-build.ts`. It affects development and staging process teardown after the browser process resolves or rejects; it does not change packaged browser behavior.

## Validation

- `deno check tools/feles-build.ts`
- `deno lint tools/feles-build.ts`
- `deno fmt --check` on the committed blob
- `deno task test:smoke` (six steps; 41 colocated runner tests)
- three real development-browser launches on Windows, including two consecutive `deno task feles-build dev` runs and one retained development-tool run
- graceful browser close on all runs
- after each exit: no listener on ports `5170..5192` and no known browser/Vite process survivor
- the immediate second run started without an address-in-use error
- focused run-3 evidence retained with live PID/listener snapshot, exact shutdown log lines, and immediate zero-survivor poll

`deno task feles-build stage` is not counted as runtime proof: current `main` fails earlier in `pages-newtab` because the installed `lucide-react@0.562.0` package does not provide imports requested by that package. The changed path is not involved in that build error.

## Review notes

Independent review found no P0/P1 issue. Two P2 follow-ups remain visible for maintainers:

- `DevServer.shutdown()` signals child PIDs but does not await their status; the race did not reproduce in the three real runs.
- `BrowserLauncher.run()` currently discards a non-zero browser exit code, so abnormal browser termination is not propagated by this patch.

This PR is intentionally Draft while project review and CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Development and staging sessions now shut down cleanly when the browser closes.
  - Browser launch failures now trigger proper cleanup and a nonzero exit status.
- **Documentation**
  - Updated command reference links to point to the current source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->