### PR TITLE
fix(workspaces): guard SessionStore.persistTabAttribute for runtimes that removed it

### DIFF
--- a/browser-features/chrome/@types/xul-window.d.ts
+++ b/browser-features/chrome/@types/xul-window.d.ts
@@ -162,7 +162,8 @@ declare namespace globalThis {
     getClosedTabCount(window?: Window): number;
     getClosedTabData(window?: Window): unknown[];
     promiseInitialized: Promise<void>;
-    persistTabAttribute(attrName: string): void;
+    /** Removed in Firefox 152 — feature-detect before calling. */
+    persistTabAttribute?(attrName: string): void;
   };
   var DownloadsPanel: {
     show(): Promise<void>;

--- a/browser-features/chrome/common/workspaces/workspacesService.ts
+++ b/browser-features/chrome/common/workspaces/workspacesService.ts
@@ -110,28 +110,37 @@ export class WorkspacesService implements WorkspacesDataManagerBase {
       this.setCurrentWorkspaceID(id);
     }
 
-    // Register persistTabAttribute early (after promiseInitialized) so
-    // SessionStore knows to save/restore our custom tab attributes.
-    // IMPORTANT: This must happen before restoration completes so that
-    // SessionStore includes floorpWorkspaceId in the restored tab data.
-    globalThis.SessionStore.promiseInitialized.then(() => {
-      // Firefox 152 removed SessionStore.persistTabAttribute; guard so
-      // window initialization survives on newer runtimes. Split-view's
-      // session-restore patch shows the setCustomTabValue fallback that
-      // real persistence needs — porting workspaces onto it is the
-      // follow-up; this keeps the feature from throwing until then.
-      const ss = globalThis.SessionStore as unknown as {
-        persistTabAttribute?: (attr: string) => void;
-      };
-      if (typeof ss.persistTabAttribute === "function") {
-        ss.persistTabAttribute(WORKSPACE_TAB_ATTRIBUTION_ID);
-        ss.persistTabAttribute(WORKSPACE_LAST_SHOW_ID);
-      } else {
-        console.warn(
-          "[workspaces] SessionStore.persistTabAttribute unavailable; workspace tab attributes will not persist across restarts",
+    // Register persistTabAttribute early (after promiseInitialized) where the
+    // runtime still offers it, so SessionStore saves and restores our tab
+    // attributes itself.
+    //
+    // Firefox 152 removed it: SessionStore.sys.mjs has no such method, and
+    // TabAttributes.sys.mjs now hard-codes PERSISTED_ATTRIBUTES to
+    // ["customizemode"] with no way to register another name. Calling it
+    // unguarded rejects at window init.
+    //
+    // Losing it costs us nothing, because the workspace attributes do not
+    // depend on it: the runtime patches persist them directly —
+    // tools/patches/browser-modules-sessionstore-TabState.sys.patch writes
+    // tabData.floorpWorkspaceId / floorpLastShowWorkspaceId when tab state is
+    // collected, and browser-chrome-...-tabbrowser.patch sets both attributes
+    // back on the restored tab. This call stays as belt-and-braces for
+    // runtimes that still have the API.
+    globalThis.SessionStore.promiseInitialized
+      .then(() => {
+        if (typeof globalThis.SessionStore.persistTabAttribute === "function") {
+          globalThis.SessionStore.persistTabAttribute(
+            WORKSPACE_TAB_ATTRIBUTION_ID,
+          );
+          globalThis.SessionStore.persistTabAttribute(WORKSPACE_LAST_SHOW_ID);
+        }
+      })
+      .catch((e: unknown) => {
+        console.error(
+          "[workspaces] failed to register persisted tab attributes",
+          e,
         );
-      }
-    });
+      });
 
     // Delay TabOpen handler and ProgressListener registration until AFTER
     // session restore completes. During restore (between promiseInitialized

--- a/browser-features/chrome/common/workspaces/workspacesService.ts
+++ b/browser-features/chrome/common/workspaces/workspacesService.ts
@@ -115,8 +115,22 @@ export class WorkspacesService implements WorkspacesDataManagerBase {
     // IMPORTANT: This must happen before restoration completes so that
     // SessionStore includes floorpWorkspaceId in the restored tab data.
     globalThis.SessionStore.promiseInitialized.then(() => {
-      globalThis.SessionStore.persistTabAttribute(WORKSPACE_TAB_ATTRIBUTION_ID);
-      globalThis.SessionStore.persistTabAttribute(WORKSPACE_LAST_SHOW_ID);
+      // Firefox 152 removed SessionStore.persistTabAttribute; guard so
+      // window initialization survives on newer runtimes. Split-view's
+      // session-restore patch shows the setCustomTabValue fallback that
+      // real persistence needs — porting workspaces onto it is the
+      // follow-up; this keeps the feature from throwing until then.
+      const ss = globalThis.SessionStore as unknown as {
+        persistTabAttribute?: (attr: string) => void;
+      };
+      if (typeof ss.persistTabAttribute === "function") {
+        ss.persistTabAttribute(WORKSPACE_TAB_ATTRIBUTION_ID);
+        ss.persistTabAttribute(WORKSPACE_LAST_SHOW_ID);
+      } else {
+        console.warn(
+          "[workspaces] SessionStore.persistTabAttribute unavailable; workspace tab attributes will not persist across restarts",
+        );
+      }
     });
 
     // Delay TabOpen handler and ProgressListener registration until AFTER


### PR DESCRIPTION
## Summary

- treat `SessionStore.persistTabAttribute` as an optional runtime API
- call it only when the locked runtime provides it
- catch initialization failures instead of leaving an unhandled promise rejection
- document the existing Floorp runtime patches that independently collect and restore workspace tab attributes

## Why

The Firefox 153 runtime used by current Floorp does not expose `SessionStore.persistTabAttribute`. Calling it unconditionally rejects during every workspace window initialization.

This is a rescue of the abandoned [PR #2551](https://github.com/Floorp-Projects/Floorp/pull/2551), contributed as part of [issue #2569](https://github.com/Floorp-Projects/Floorp/issues/2569). Both source commits were replayed with `-x` from exact pull head `5c21ad6bb71fc355cd9f7ee6b3d287c0e999cf6c`, preserving original author/co-author metadata and matching stable patch IDs.

## Impact

The change is limited to the SessionStore type declaration and workspace service startup. It does not replace Floorp's existing persistence mechanism: the locked runtime's TabState and tabbrowser patches already serialize and restore the DOM attributes `floorpWorkspaceId` and `floorpWorkspaceLastShowId` (the latter is stored in session data as `floorpLastShowWorkspaceId`).

## Validation

- `deno install --frozen`
- targeted `deno check --sloppy-imports` and `deno lint`
- `git diff --check origin/main..HEAD`
- `deno task test:smoke` (six steps; 41 runner tests; runtime check; 8,658-file lint)
- real Floorp/Firefox 153 launch from this branch's disposable profile
- observed `typeof SessionStore.persistTabAttribute === "undefined"`
- initial startup and cold restarts with no matching registration exception in the browser console
- live `SessionStore.getTabState()` serialization of both workspace attributes
- graceful shutdown/cold restart with valid workspace store/tab state
- post-run repository-owned process and target-port counts: `0`

Only the current Firefox 153 absent-API branch was runtime-exercised. A runtime where `persistTabAttribute` still exists is covered by static code evidence only.

Independent review found no P0/P1 issue; the unexercised present-API compatibility branch remains a disclosed P2 verification gap.

This PR is intentionally Draft while project review and CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Firefox versions where tab-attribute persistence is unavailable.
  * Workspace initialization now handles registration failures gracefully and records diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->