### PR TITLE
fix(workspaces): persist config-store writes

### DIFF
--- a/browser-features/chrome/common/workspaces/data/config.ts
+++ b/browser-features/chrome/common/workspaces/data/config.ts
@@ -20,7 +20,6 @@ import {
   createStore,
   type SetStoreFunction,
   type Store,
-  unwrap,
 } from "solid-js/store";
 import {
   WORKSPACE_ENABLED_PREF_NAME,
@@ -95,9 +94,17 @@ function createConfig(): [
   const [configStore, setConfigStore] = createStore(finalConfig);
 
   createEffect(() => {
+    // Spread, not unwrap(): unwrap() returns the raw target object, so the
+    // effect tracked no dependencies and fired exactly once at startup —
+    // setConfigStore() writes were never persisted. Masked historically
+    // because the settings UI writes this pref directly and the observer
+    // below feeds the store from the pref. The spread reads every top-level
+    // key through the proxy (the config object is flat), registering them
+    // all as dependencies. data.ts already does this correctly by calling
+    // trackStore() before its unwrap().
     Services.prefs.setStringPref(
       WORKSPACED_CONFIG_PREF_NAME,
-      JSON.stringify(unwrap(configStore)),
+      JSON.stringify({ ...configStore }),
     );
   });
 

--- a/browser-features/chrome/common/workspaces/test/configPersistence.test.ts
+++ b/browser-features/chrome/common/workspaces/test/configPersistence.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import { configStore, setConfigStore } from "../data/config.ts";
+import { WORKSPACED_CONFIG_PREF_NAME } from "../utils/workspaces-static-names.ts";
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+
+async function testConfigStoreUpdatePersistsToPref(): Promise<void> {
+  const originalValue = configStore.closePopupAfterClick;
+  const originalPref = Services.prefs.getStringPref(
+    WORKSPACED_CONFIG_PREF_NAME,
+  );
+  const updatedValue = !originalValue;
+
+  try {
+    setConfigStore("closePopupAfterClick", updatedValue);
+    await Promise.resolve();
+
+    const persisted = JSON.parse(
+      Services.prefs.getStringPref(WORKSPACED_CONFIG_PREF_NAME),
+    ) as Record<string, unknown>;
+
+    assertEquals(
+      persisted.closePopupAfterClick,
+      updatedValue,
+      "setConfigStore update should persist to floorp.workspaces.v4.config",
+    );
+  } finally {
+    setConfigStore("closePopupAfterClick", originalValue);
+    await Promise.resolve();
+    Services.prefs.setStringPref(WORKSPACED_CONFIG_PREF_NAME, originalPref);
+  }
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "config-store update persists to workspace config pref",
+      fn: testConfigStoreUpdatePersistsToPref,
+    },
+  ];
+
+  await runTests("configPersistence.test.ts", tests);
+}


### PR DESCRIPTION
## Summary

- persist workspace configuration updates made through `setConfigStore`
- replace `unwrap(configStore)` with a shallow spread so Solid tracks every flat config field
- add a browser-colocated regression test for the store-to-pref boundary

## Why

`unwrap()` returns the store's raw target. The persistence effect therefore registered no reactive dependencies and ran only at startup; later `setConfigStore()` changes were lost on restart. Reading the flat store through `{ ...configStore }` makes those fields dependencies of the effect.

This rescues the source change from abandoned [PR #2571](https://github.com/Floorp-Projects/Floorp/pull/2571), contributed through [issue #2569](https://github.com/Floorp-Projects/Floorp/issues/2569). The exact source commit was replayed with `-x` from pull head `c87d2853cd306e83b9486763c2b80a6e50ac97d0`, preserving the original author and co-author. The added test commit records the same provenance.

## Impact

The workspace config schema, migration, defaults, and pref-to-store observer are unchanged. The patch repairs only the existing store-to-pref direction and adds its regression test.

## Validation

- `deno install --frozen`
- focused test discovery: exactly one committed target
- targeted `deno check --sloppy-imports`, `deno lint`, and new-test `deno fmt --check`
- `git diff --check origin/main..HEAD`
- `deno task test:smoke` (41 runner tests; 102/20/16 browser/ESM/pages targets; 8,669-file lint)
- real locked-browser run of `configPersistence.test.ts`: `1` passed, `0` failed
- separate two-process disposable-profile probe:
  - process A changed the value through `setConfigStore` and flushed the resulting pref
  - process B cold-started from that profile and hydrated `configStore` with the saved value
  - process B restored the original pref/store and cleared the marker
- after both runs: temporary probe removed, worktree clean, target listener/process counts `0`

Independent review found no P0/P1/P2 issue.

This PR is intentionally Draft while project review and CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace configuration changes now persist reliably when settings are updated.
* **Tests**
  * Added coverage to verify that changes to workspace popup behavior are saved and restored correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->