### PR TITLE
fix(solid-xul): handle nullish props before decoding

### DIFF
--- a/browser-features/chrome/test/unit/solidXulNullProps.test.ts
+++ b/browser-features/chrome/test/unit/solidXulNullProps.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import { setProp } from "@nora/solid-xul";
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+  runTests,
+} from "../utils/test_harness.ts";
+
+function testNullRemovesAttribute(): void {
+  const element = document.createElement("div");
+  element.setAttribute("data-value", "old");
+
+  setProp(element, "data-value", null);
+
+  assert(
+    !element.hasAttribute("data-value"),
+    "null should remove the attribute",
+  );
+}
+
+function testUndefinedRemovesAttribute(): void {
+  const element = document.createElement("div");
+  element.setAttribute("data-value", "old");
+
+  setProp(element, "data-value", undefined);
+
+  assert(
+    !element.hasAttribute("data-value"),
+    "undefined should remove the attribute",
+  );
+}
+
+function testStringSetsAttribute(): void {
+  const element = document.createElement("div");
+
+  setProp(element, "data-value", "text");
+
+  assertEquals(
+    element.getAttribute("data-value"),
+    "text",
+    "string should set the attribute value",
+  );
+}
+
+function testNumberSetsAttribute(): void {
+  const element = document.createElement("div");
+
+  setProp(element, "data-value", 42);
+
+  assertEquals(
+    element.getAttribute("data-value"),
+    "42",
+    "number should set its string representation",
+  );
+}
+
+function testBooleanSetsAttribute(): void {
+  const element = document.createElement("div");
+
+  setProp(element, "data-value", false);
+
+  assertEquals(
+    element.getAttribute("data-value"),
+    "false",
+    "boolean should set its string representation",
+  );
+}
+
+function testStyleObjectSetsAttribute(): void {
+  const element = document.createElement("div");
+
+  setProp(element, "style", { color: "red", display: "none" });
+
+  assertEquals(
+    element.getAttribute("style"),
+    "color:red;display:none;",
+    "style object should be serialized into the attribute",
+  );
+}
+
+function testFunctionEventListener(): void {
+  const element = document.createElement("div");
+  let callCount = 0;
+
+  setProp(element, "onclick", () => callCount++);
+  element.dispatchEvent(new Event("click"));
+
+  assertEquals(callCount, 1, "function listener should receive the event");
+}
+
+function testObjectEventListener(): void {
+  const element = document.createElement("div");
+  let callCount = 0;
+  const listener = {
+    handleEvent: () => callCount++,
+  };
+
+  setProp(element, "oncommand", listener);
+  element.dispatchEvent(new Event("command"));
+
+  assertEquals(callCount, 1, "object listener should receive the event");
+}
+
+function testUnsupportedObjectThrows(): void {
+  const element = document.createElement("div");
+  const error = assertThrows(
+    () => setProp(element, "data-value", { nested: { value: "unsupported" } }),
+    "unsupported object should throw",
+  );
+
+  assert(
+    error?.message.includes(
+      "the value is not EventListener, style object, string, number, nor boolean",
+    ),
+    "unsupported object should preserve the renderer contract error",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  await runTests("solidXulNullProps.test.ts", [
+    { name: "null removes attribute", fn: testNullRemovesAttribute },
+    { name: "undefined removes attribute", fn: testUndefinedRemovesAttribute },
+    { name: "string sets attribute", fn: testStringSetsAttribute },
+    { name: "number sets attribute", fn: testNumberSetsAttribute },
+    { name: "boolean sets attribute", fn: testBooleanSetsAttribute },
+    { name: "style object sets attribute", fn: testStyleObjectSetsAttribute },
+    { name: "function event listener", fn: testFunctionEventListener },
+    { name: "object event listener", fn: testObjectEventListener },
+    { name: "unsupported object throws", fn: testUnsupportedObjectThrows },
+  ]);
+}

--- a/libs/solid-xul/index.ts
+++ b/libs/solid-xul/index.ts
@@ -56,6 +56,11 @@ const {
     _prev?: T,
   ): void => {
     if (node instanceof Element) {
+      if (value === null || value === undefined) {
+        node.removeAttribute(name);
+        return;
+      }
+
       const resultStyleObject = CStyleObject.decode(value);
       if (isEventListener(value)) {
         //? the eventListener name is on~~~
@@ -72,8 +77,6 @@ const {
         node.setAttribute(name, value);
       } else if (typeof value === "number" || typeof value === "boolean") {
         node.setAttribute(name, value.toString());
-      } else if (value === undefined) {
-        node.removeAttribute(name);
       } else {
         throw Error(
           `unreachable! @nora/solid-xul:setProperty the value is not EventListener, style object, string, number, nor boolean | is ${value}`,


### PR DESCRIPTION
## Summary

- remove an attribute and return when a Solid XUL property value is `null` or `undefined`
- perform that nullish check before style decoding and event-listener detection
- add browser-colocated coverage for nullish, primitive, style, listener, and unsupported-object contracts

## Why

The abandoned patch correctly identified that a null property can take down a renderer tree, but its ordering was unsafe: `null` could reach object/event-listener detection first. This replacement implements the intended semantics at the renderer boundary and verifies the surrounding contracts.

This is a corrected rescue of abandoned [PR #2573](https://github.com/Floorp-Projects/Floorp/pull/2573), contributed through [issue #2569](https://github.com/Floorp-Projects/Floorp/issues/2569). It cites exact original head `3c41d23135c5668df872237e053c881b16616883`, the original author, and co-author in the replacement commit.

## Impact

The change is limited to `@nora/solid-xul` property handling plus its focused test. `null` now follows the already-intended no-attribute semantics of `undefined`; supported primitives, style objects, and event listeners keep their existing behavior, and unsupported objects still throw.

This patch does not redesign the renderer's pre-existing event-listener replacement/removal behavior. The renderer currently ignores `_prev`, so a handler-to-null or handler-to-handler transition can leave the previous listener registered. That is a separate renderer-lifecycle follow-up, not a behavior introduced by this null-decoding fix.

## Validation

- focused discovery: exactly one browser-chrome target
- targeted `deno fmt --check`, `deno check`, and `deno lint`
- DOM-shim execution: 9/9 cases passed
- `git diff --check origin/main..HEAD`
- `deno task test:smoke` (six steps; 41 runner tests; broad type-check; 8,669-file lint)
- real locked Floorp browser run of `solidXulNullProps.test.ts`: `1` passed, `0` failed
- actual browser DOM/event paths covered as individual value cases for `null`, `undefined`, string, number, boolean, style object, function listener, object listener, and unsupported object
- post-run target listener and worktree-owned process counts: `0`

Independent review found no P0/P1 issue. It identified the pre-existing listener-transition lifecycle as P2; handler-to-null and handler replacement are not claimed as covered here. Consumer-specific lazy-tab/tab-stack scenarios remain acceptance work for a future tab-stack PR.

This PR is intentionally Draft while project review and CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Setting element properties to null now properly removes the attribute, matching undefined behavior.

* **Tests**
  * Added unit test coverage for property-setting behavior with various value types, including null, undefined, strings, numbers, booleans, styles, and function listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->