### PR TITLE
fix(initializer): use locked Runtime by default

### DIFF
--- a/.github/workflows/colocated_runner_test.yml
+++ b/.github/workflows/colocated_runner_test.yml
@@ -248,8 +248,6 @@ jobs:
       - name: Run combined browser test suite against locked Runtime
         if: matrix.browser_suite == true
         shell: bash
-        env:
-          FLOORP_RUNTIME_LOCKED: "1"
         run: |
           set -euo pipefail
           mkdir -p _dist _dist/profile/test

--- a/tools/src/initializer.test.ts
+++ b/tools/src/initializer.test.ts
@@ -6,7 +6,6 @@ import {
   filterRuntimeEntries,
   type InitializerRunDependencies,
   installLockedRuntime,
-  isLockedRuntimeRequested,
   type LockedReleaseMetadata,
   lockedReleasePublicDownloadUrl,
   type LockedRuntimeOperations,
@@ -461,39 +460,26 @@ async function writeOldRuntime(binRoot: string): Promise<void> {
   await Deno.writeTextFile(`${binRoot}/applied_patches/marker`, "old-patch");
 }
 
-Deno.test("locked Runtime opt-in accepts only the literal value 1", () => {
-  assert(isLockedRuntimeRequested("1"));
-  for (const value of [undefined, "", "true", "yes", "01", " 1 "]) {
-    assertEquals(isLockedRuntimeRequested(value), false);
-  }
-});
-
 interface RunProbe {
   dependencies: InitializerRunDependencies;
   calls: {
-    legacy: number;
     loadLock: number;
     installLock: number;
     savePrefs: number;
   };
 }
 
-function runProbe(getEnv: InitializerRunDependencies["getEnv"]): RunProbe {
-  const calls = { legacy: 0, loadLock: 0, installLock: 0, savePrefs: 0 };
+function runProbe(): RunProbe {
+  const calls = { loadLock: 0, installLock: 0, savePrefs: 0 };
   return {
     calls,
     dependencies: {
-      getEnv,
       loadLock: () => {
         calls.loadLock += 1;
         return Promise.resolve(lockedRuntime());
       },
       installLock: () => {
         calls.installLock += 1;
-        return Promise.resolve();
-      },
-      runLegacy: () => {
-        calls.legacy += 1;
         return Promise.resolve();
       },
       savePrefs: () => {
@@ -503,9 +489,20 @@ function runProbe(getEnv: InitializerRunDependencies["getEnv"]): RunProbe {
   };
 }
 
-Deno.test("run falls back to legacy initialization when env access is unavailable", async () => {
-  const getters: InitializerRunDependencies["getEnv"][] = [
+Deno.test("run uses locked initialization by default", async () => {
+  const probe = runProbe();
+  await run(probe.dependencies);
+  assertEquals(probe.calls, {
+    loadLock: 1,
+    installLock: 1,
+    savePrefs: 1,
+  });
+});
+
+Deno.test("run ignores legacy environment and initializer hooks", async () => {
+  const environmentReaders = [
     () => undefined,
+    () => "1",
     () => {
       throw new Deno.errors.PermissionDenied("injected permission denial");
     },
@@ -513,44 +510,76 @@ Deno.test("run falls back to legacy initialization when env access is unavailabl
       throw new Deno.errors.NotCapable("injected env capability denial");
     },
   ];
-  for (const getEnv of getters) {
-    const probe = runProbe(getEnv);
-    await run(probe.dependencies);
+  for (const readEnvironment of environmentReaders) {
+    const probe = runProbe();
+    let environmentReads = 0;
+    let legacyRuns = 0;
+    const legacyDependencies = {
+      ...probe.dependencies,
+      getEnv: () => {
+        environmentReads += 1;
+        return readEnvironment();
+      },
+      runLegacy: () => {
+        legacyRuns += 1;
+        return Promise.resolve();
+      },
+    };
+    await run(legacyDependencies);
+    assertEquals(environmentReads, 0);
+    assertEquals(legacyRuns, 0);
     assertEquals(probe.calls, {
-      legacy: 1,
-      loadLock: 0,
-      installLock: 0,
+      loadLock: 1,
+      installLock: 1,
       savePrefs: 1,
     });
   }
 });
 
-Deno.test("run uses locked initialization only for the literal opt-in", async () => {
-  const probe = runProbe(() => "1");
-  await run(probe.dependencies);
+Deno.test("run does not save preferences when locked installation fails", async () => {
+  const probe = runProbe();
+  probe.dependencies.installLock = () => {
+    probe.calls.installLock += 1;
+    return Promise.reject(new Error("injected locked installation failure"));
+  };
+  await assertRejects(
+    () => run(probe.dependencies),
+    Error,
+    "injected locked installation failure",
+  );
   assertEquals(probe.calls, {
-    legacy: 0,
     loadLock: 1,
     installLock: 1,
-    savePrefs: 1,
+    savePrefs: 0,
   });
 });
 
-Deno.test("run rethrows unrelated environment errors", async () => {
-  const probe = runProbe(() => {
-    throw new TypeError("injected unrelated error");
-  });
+Deno.test("run does not install or save when the Runtime lock fails to load", async () => {
+  const probe = runProbe();
+  probe.dependencies.loadLock = () => {
+    probe.calls.loadLock += 1;
+    return Promise.reject(new Error("injected Runtime lock load failure"));
+  };
   await assertRejects(
     () => run(probe.dependencies),
-    TypeError,
-    "injected unrelated error",
+    Error,
+    "injected Runtime lock load failure",
   );
   assertEquals(probe.calls, {
-    legacy: 0,
-    loadLock: 0,
+    loadLock: 1,
     installLock: 0,
     savePrefs: 0,
   });
+});
+
+Deno.test("combined browser workflow does not require a Runtime opt-in", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL(
+      "../../.github/workflows/colocated_runner_test.yml",
+      import.meta.url,
+    ),
+  );
+  assertEquals(workflow.includes("FLOORP_RUNTIME_LOCKED"), false);
 });
 
 Deno.test("locked Runtime native target mapping fails closed", () => {

--- a/tools/src/initializer.ts
+++ b/tools/src/initializer.ts
@@ -34,7 +34,6 @@ const logger = new Logger("initializer");
 const RUNTIME_BASE_URL = "https://dev-assets.floorp.app/floorp-runtime-builds/";
 const RUNTIME_INDEX_URL = `${RUNTIME_BASE_URL}.ftp-deploy-sync-state.json`;
 
-export const LOCKED_RUNTIME_ENV = "FLOORP_RUNTIME_LOCKED";
 export const LOCKED_RUNTIME_GITHUB_TOKEN_ENV = "FLOORP_RUNTIME_GITHUB_TOKEN";
 export const LOCKED_RUNTIME_MARKER = ".floorp-runtime-lock.json";
 
@@ -103,10 +102,8 @@ export interface LockedRuntimeInstallResult {
 }
 
 export interface InitializerRunDependencies {
-  getEnv(name: string): string | undefined;
   loadLock(): Promise<RuntimeLock>;
   installLock(lock: RuntimeLock): Promise<void>;
-  runLegacy(): Promise<void>;
   savePrefs(): void;
 }
 
@@ -133,10 +130,6 @@ interface RuntimeLayout {
   executable: string;
   legacyVersionFile: string;
 }
-
-export const isLockedRuntimeRequested = (
-  value: string | undefined,
-): boolean => value === "1";
 
 export const isEnvironmentPermissionError = (error: unknown): boolean =>
   error instanceof Deno.errors.PermissionDenied ||
@@ -1629,36 +1622,19 @@ export async function run(
   overrides: Partial<InitializerRunDependencies> = {},
 ): Promise<void> {
   const dependencies: InitializerRunDependencies = {
-    getEnv: overrides.getEnv ?? ((name) => Deno.env.get(name)),
     loadLock: overrides.loadLock ?? (() => loadRuntimeLock()),
     installLock: overrides.installLock ??
       (async (lock) => {
         await installLockedRuntime({ lock });
       }),
-    runLegacy: overrides.runLegacy ?? runLegacyInitializer,
     savePrefs: overrides.savePrefs ?? savePrefsForProfile,
   };
-  let lockedRuntimeRequested = false;
-  try {
-    lockedRuntimeRequested = isLockedRuntimeRequested(
-      dependencies.getEnv(LOCKED_RUNTIME_ENV),
-    );
-  } catch (error) {
-    if (!isEnvironmentPermissionError(error)) throw error;
-    // Preserve the historical initializer for callers without env permission.
-  }
-
-  if (lockedRuntimeRequested) {
-    logger.info("Locked Runtime mode enabled by FLOORP_RUNTIME_LOCKED=1.");
-    await dependencies.installLock(await dependencies.loadLock());
-  } else {
-    await dependencies.runLegacy();
-  }
-
+  await dependencies.installLock(await dependencies.loadLock());
   dependencies.savePrefs();
 }
 
-async function runLegacyInitializer(): Promise<void> {
+/** Explicit compatibility entry point for the retired CDN bootstrap. */
+export async function runLegacyInitializerForCompatibility(): Promise<void> {
   const hasVersion = exists(BIN_VERSION);
   const hasBin = exists(BIN_PATH_EXE);
   let needInit = false;


### PR DESCRIPTION
## Summary

- make the pinned `floorp-runtime.lock.json` Runtime the unconditional production initializer path
- remove the `FLOORP_RUNTIME_LOCKED` opt-in from the combined browser-suite workflow
- keep the legacy CDN initializer only as an explicit compatibility entry point that production `run()` cannot reach
- save developer preferences only after the locked Runtime install succeeds

## Rescue provenance and classification

This is a fresh, security-focused redesign replacing the closed, unmerged [PR #2552](https://github.com/Floorp-Projects/Floorp/pull/2552), contributed through [issue #2569](https://github.com/Floorp-Projects/Floorp/issues/2569). It does **not** cherry-pick the abandoned implementation, whose `/releases/latest` fallback and runtime-lock removal were retained only as negative/reference material.

- preserved original head: `3a56f67301914df1ecf81e434e66fc4ff61bc206`
- original author: `100mountains <nobody@nowhere.com>`
- original co-author trailer: `Claude Fable 5 <noreply@anthropic.com>`
- replacement commit: `0611a13d5361dc50274317e047a67021a34d0abc`

## Validation

- `deno fmt --check`: passed
- focused lint for the three changed paths: passed
- `deno test --allow-read --allow-write tools/src/initializer.test.ts`: **44 passed, 0 failed**
- `deno task test:smoke`: passed all 6 steps
- `deno run -A tools/runtime-lock/runtime_lock_cli.ts validate-lock`: passed
- `deno run -A tools/runtime-lock/runtime_lock_cli.ts validate-native --out _dist/runtime-validation-pr2552`: passed for locked Windows x86_64 artifact `489491165`
- exact-commit disposable no-env bootstrap: installed and then reused Runtime `153.0`, BuildID `20260725075208`
- marker artifact SHA-256 and companion SHA-256 matched the canonical lock
- seeded swap failure restored the previous live Runtime tree; the complete exact-commit rollback/integrity suite passed
- `git diff --check origin/main...HEAD`: passed

The exact bootstrap ran from an initially absent disposable `_dist/bin`, with both `FLOORP_RUNTIME_LOCKED` and `FLOORP_RUNTIME_GITHUB_TOKEN` removed from the process environment. Deno 2.7.13 gives `deno eval` implicit permissions, so the procedure's older `deno eval -A` spelling was exercised with its current equivalent while preserving the exact imported `run()` entry point.

## Known baseline gap

`deno task test:host` passed 209 tests and failed only the existing canonical-`main` localization parity assertion that `ja-JP` must define `about.noraneko`. This branch does not touch localization files and reproduces no additional host-test failure.

This PR is intentionally opened as a Draft for review and CI. It does not authorize Ready status or merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Locked Runtime initialization is now enabled by default.
  * Browser workflows no longer require an additional Runtime opt-in setting.

* **Bug Fixes**
  * Preferences are no longer saved when Runtime installation or lock loading fails.
  * Legacy startup remains available through a compatibility path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->