### PR TITLE
fix(modal-parent): make request lifecycle fail-safe

### DIFF
--- a/browser-features/chrome/common/modal-parent/index.ts
+++ b/browser-features/chrome/common/modal-parent/index.ts
@@ -15,7 +15,9 @@ import type { TForm, TFormResult } from "./utils/type.ts";
 @noraComponent(import.meta.hot)
 export default class ModalParent extends NoraComponentBase {
   private static instance: ModalParent;
-  private modalManager: ModalManager | null = null;
+  // NoraComponentBase invokes init() during super(). This declaration must not
+  // emit a class-field initializer that would overwrite the manager afterward.
+  declare private modalManager: ModalManager | null;
 
   public static getInstance(): ModalParent {
     if (!ModalParent.instance) {
@@ -26,31 +28,38 @@ export default class ModalParent extends NoraComponentBase {
 
   constructor() {
     super();
+    // The loader may construct the decorated component before a caller uses
+    // getInstance(). Preserve that rendered owner as the public singleton.
+    if (!ModalParent.instance) {
+      ModalParent.instance = this;
+    }
   }
 
   init(): void {
-    this.modalManager = new ModalManager();
-    ModalElement.getInstance().initializeModal();
+    if (!this.modalManager) {
+      this.modalManager = new ModalManager();
+    }
+    ModalElement.getInstance().initializeModal(this.modalManager);
   }
 
   public async showNoraModal(
     forms: TForm,
     options: { width: number; height: number },
-    callback: (result: TFormResult) => void,
-  ): Promise<void> {
+    callback: (result: TFormResult | null) => void,
+  ): Promise<TFormResult | null> {
     if (!this.modalManager) {
       throw new Error("ModalManager not initialized. Call init() first.");
     }
     const result = await this.modalManager.show(forms, options);
-    callback(result as TFormResult);
-    this.modalManager.hide();
+    callback(result);
+    return result;
   }
 
   public hideNoraModal(): void {
     if (!this.modalManager) {
       throw new Error("ModalManager not initialized. Call init() first.");
     }
-    this.modalManager.hide();
+    this.modalManager.hide("hide");
   }
 
   public setModalSize(newSize: ModalSize): void {

--- a/browser-features/chrome/common/modal-parent/modalElement.tsx
+++ b/browser-features/chrome/common/modal-parent/modalElement.tsx
@@ -4,13 +4,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { createRootHMR, render } from "@nora/solid-xul";
+import { onCleanup } from "solid-js";
 import { Modal } from "./components/modal.tsx";
 import style from "./style.css?inline";
 import { ModalManager } from "./modalManager.tsx";
 
+export function attachModalBackdropListener(
+  targetParent: HTMLElement,
+  getModalManager: () => Pick<ModalManager, "hide"> | null,
+): () => void {
+  const listener = (event: MouseEvent) => {
+    const target = event.target;
+    if (
+      target instanceof HTMLElement && target.id === "modal-parent-container"
+    ) {
+      getModalManager()?.hide("backdrop");
+    }
+  };
+  targetParent.addEventListener("click", listener);
+  return () => targetParent.removeEventListener("click", listener);
+}
+
 export class ModalElement {
   private static instance: ModalElement;
   private initialized: boolean = false;
+  private currentManager: ModalManager | null = null;
 
   private constructor() {
     // Private constructor for singleton
@@ -23,10 +41,10 @@ export class ModalElement {
     return ModalElement.instance;
   }
 
-  public initializeModal(): void {
+  public initializeModal(modalManager: ModalManager): void {
+    this.currentManager = modalManager;
     if (this.initialized) return;
 
-    const ModalManagerInstance = new ModalManager();
     const head = document?.head;
     if (!head) {
       console.warn(
@@ -61,11 +79,16 @@ export class ModalElement {
             <Modal
               targetParent={targetParent}
               onBackdropClick={(e) =>
-                ModalManagerInstance.handleBackdropClick(e)}
+                this.currentManager?.handleBackdropClick(e)}
             />
           ),
           targetParent,
         );
+        const detachBackdrop = attachModalBackdropListener(
+          targetParent,
+          () => this.currentManager,
+        );
+        onCleanup(detachBackdrop);
       } catch (error) {
         const reason = error instanceof Error
           ? error

--- a/browser-features/chrome/common/modal-parent/modalManager.tsx
+++ b/browser-features/chrome/common/modal-parent/modalManager.tsx
@@ -5,19 +5,195 @@
 
 import { onCleanup } from "solid-js";
 import {
-  isModalVisible,
   type ModalSize,
+  modalSize,
   setModalSize,
   setModalVisible,
 } from "./data/data.ts";
-import type { TForm, TFormResult } from "./utils/type.ts";
+import type {
+  ModalCancelRequest,
+  ModalRequestIdentity,
+  ModalResultEnvelope,
+  ModalShowRequest,
+  ModalTerminalReason,
+  TForm,
+  TFormResult,
+} from "./utils/type.ts";
+import { MODAL_TERMINAL_REASONS } from "./utils/type.ts";
+
+export interface ModalActorLike {
+  sendQuery(message: string, data: unknown): Promise<unknown>;
+}
 
 interface BrowsingContextLike {
   currentWindowGlobal: {
-    getActor(name: string): {
-      sendQuery(message: string, data: unknown): Promise<unknown>;
-    };
+    getActor(name: string): ModalActorLike;
   };
+}
+
+interface FocusableElement {
+  focus(): void;
+}
+
+type TimerHandle = number | ReturnType<typeof globalThis.setTimeout>;
+
+export interface ModalManagerEnvironment {
+  getContainer(): FocusableElement | null;
+  getActor(): ModalActorLike | null;
+  getSize(): ModalSize;
+  setVisible(visible: boolean): void;
+  setSize(size: ModalSize): void;
+  focusWindow(): void;
+  notifyHidden(): void;
+  addKeydownListener(listener: (event: KeyboardEvent) => void): void;
+  removeKeydownListener(listener: (event: KeyboardEvent) => void): void;
+  setTimer(callback: () => void, delayMs: number): TimerHandle;
+  clearTimer(handle: TimerHandle): void;
+  createRequestId(epoch: number): string;
+}
+
+export const MODAL_WATCHDOG_DELAY_MS = 8_000;
+export const MODAL_PING_TIMEOUT_MS = 3_000;
+
+type ModalProbeResult = "alive" | "dead" | "actor-error" | "timeout";
+
+interface ModalPingResponse extends ModalRequestIdentity {
+  ready: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function matchesIdentity(
+  expected: ModalRequestIdentity,
+  actual: unknown,
+): actual is ModalRequestIdentity & Record<string, unknown> {
+  return isRecord(actual) &&
+    actual.requestId === expected.requestId &&
+    actual.epoch === expected.epoch;
+}
+
+function isTerminalReason(value: unknown): value is ModalTerminalReason {
+  return typeof value === "string" &&
+    (MODAL_TERMINAL_REASONS as readonly string[]).includes(value);
+}
+
+function isResultEnvelope(
+  expected: ModalRequestIdentity,
+  value: unknown,
+): value is ModalResultEnvelope {
+  if (!matchesIdentity(expected, value) || !isTerminalReason(value.reason)) {
+    return false;
+  }
+
+  if (value.reason !== "submit") {
+    return value.result === null;
+  }
+
+  return isRecord(value.result) &&
+    Object.values(value.result).every((entry) =>
+      typeof entry === "string" || typeof entry === "number"
+    );
+}
+
+function isPingResponse(
+  expected: ModalRequestIdentity,
+  value: unknown,
+): value is ModalPingResponse {
+  return matchesIdentity(expected, value) && typeof value.ready === "boolean";
+}
+
+function defaultEnvironment(): ModalManagerEnvironment {
+  return {
+    getContainer: () =>
+      document?.getElementById("modal-parent-container") as
+        | (HTMLElement & FocusableElement)
+        | null,
+    getActor: () => {
+      const browser = document?.getElementById("modal-child-browser") as
+        | (XULElement & { browsingContext: BrowsingContextLike })
+        | null;
+      if (!browser?.browsingContext?.currentWindowGlobal) {
+        return null;
+      }
+      return browser.browsingContext.currentWindowGlobal.getActor(
+        "NRChromeModal",
+      );
+    },
+    getSize: modalSize,
+    setVisible: setModalVisible,
+    setSize: (size) => setModalSize(size),
+    focusWindow: () => globalThis.focus(),
+    notifyHidden: () => {
+      try {
+        Services.obs.notifyObservers({}, "nora:modal:hide", "");
+      } catch {
+        // Compatibility notification is best-effort and never owns cleanup.
+      }
+    },
+    addKeydownListener: (listener) =>
+      globalThis.addEventListener("keydown", listener),
+    removeKeydownListener: (listener) =>
+      globalThis.removeEventListener("keydown", listener),
+    setTimer: (callback, delayMs) => globalThis.setTimeout(callback, delayMs),
+    clearTimer: (handle) => globalThis.clearTimeout(handle),
+    createRequestId: (epoch) => {
+      if (typeof globalThis.crypto?.randomUUID === "function") {
+        return globalThis.crypto.randomUUID();
+      }
+      return `nora-modal-${Date.now()}-${epoch}`;
+    },
+  };
+}
+
+export function probeModalChildAlive(
+  actor: ModalActorLike,
+  identity: ModalRequestIdentity,
+  pingTimeoutMs: number = MODAL_PING_TIMEOUT_MS,
+  timers: Pick<ModalManagerEnvironment, "setTimer" | "clearTimer"> =
+    defaultEnvironment(),
+): Promise<ModalProbeResult> {
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (result: ModalProbeResult) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      timers.clearTimer(timeout);
+      resolve(result);
+    };
+
+    const timeout = timers.setTimer(() => finish("timeout"), pingTimeoutMs);
+
+    const request: ModalRequestIdentity = {
+      requestId: identity.requestId,
+      epoch: identity.epoch,
+    };
+
+    try {
+      actor.sendQuery("NRChromeModal:ping", request).then(
+        (response: unknown) => {
+          if (!isPingResponse(identity, response)) {
+            finish("dead");
+            return;
+          }
+          finish(response.ready ? "alive" : "dead");
+        },
+        () => finish("actor-error"),
+      );
+    } catch {
+      finish("actor-error");
+    }
+  });
+}
+
+interface PendingModal extends ModalRequestIdentity {
+  actor: ModalActorLike;
+  resolve(result: TFormResult | null): void;
+  settled: boolean;
+  watchdog: TimerHandle | null;
 }
 
 export class ModalManager {
@@ -25,77 +201,241 @@ export class ModalManager {
     return document?.getElementById("main-window") as HTMLElement | null;
   }
 
-  constructor() {
-    const handleKeydown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isModalVisible()) {
-        this.hide();
+  private readonly environment: ModalManagerEnvironment;
+  private readonly handleKeydown: (event: KeyboardEvent) => void;
+  private pending: PendingModal | null = null;
+  private epoch = 0;
+  private disposed = false;
+
+  public readonly watchdogDelayMs: number;
+  public readonly pingTimeoutMs: number;
+
+  constructor(
+    environment: Partial<ModalManagerEnvironment> = {},
+    timings: {
+      watchdogDelayMs?: number;
+      pingTimeoutMs?: number;
+    } = {},
+  ) {
+    this.environment = { ...defaultEnvironment(), ...environment };
+    this.watchdogDelayMs = timings.watchdogDelayMs ?? MODAL_WATCHDOG_DELAY_MS;
+    this.pingTimeoutMs = timings.pingTimeoutMs ?? MODAL_PING_TIMEOUT_MS;
+    this.handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && this.pending !== null) {
+        this.hide("escape");
       }
     };
-    globalThis.addEventListener("keydown", handleKeydown);
-    onCleanup(() => globalThis.removeEventListener("keydown", handleKeydown));
+    this.environment.addKeydownListener(this.handleKeydown);
+    onCleanup(() => this.dispose());
   }
 
   public show(
     form: TForm,
     options: { width: number; height: number },
-  ): Promise<TFormResult | null> | undefined {
-    const container = document?.getElementById(
-      "modal-parent-container",
-    ) as unknown as XULElement;
-    if (container) {
-      setModalVisible(true);
-      setModalSize({
-        width: options.width,
-        height: options.height,
-      });
-      container.focus();
-
-      const browser = document?.getElementById(
-        "modal-child-browser",
-      ) as unknown as XULElement & { browsingContext: BrowsingContextLike } | null;
-
-      if (!browser) {
-        return;
-      }
-
-      const actor = browser.browsingContext.currentWindowGlobal.getActor(
-        "NRChromeModal",
-      );
-
-      const safeForm = JSON.parse(JSON.stringify(form));
-
-      return new Promise((resolve) => {
-        actor
-          .sendQuery("NRChromeModal:show", safeForm)
-          .then((response: unknown) => {
-            resolve(response as TFormResult | null);
-          });
-      });
+  ): Promise<TFormResult | null> {
+    if (this.disposed) {
+      return Promise.resolve(null);
     }
+
+    const replaced = this.pending;
+    if (replaced) {
+      this.settleOnce(replaced, "replacement", null, true, false);
+    }
+
+    const epoch = ++this.epoch;
+    let requestId: string;
+    try {
+      requestId = this.environment.createRequestId(epoch);
+    } catch {
+      this.hideOverlay();
+      return Promise.resolve(null);
+    }
+    const identity: ModalRequestIdentity = { requestId, epoch };
+
+    const container = this.environment.getContainer();
+    if (!container) {
+      this.hideOverlay();
+      return Promise.resolve(null);
+    }
+
+    let actor: ModalActorLike | null;
+    try {
+      actor = this.environment.getActor();
+    } catch {
+      actor = null;
+    }
+    if (!actor) {
+      this.hideOverlay();
+      return Promise.resolve(null);
+    }
+
+    let safeForm: TForm;
+    try {
+      safeForm = JSON.parse(JSON.stringify(form)) as TForm;
+    } catch {
+      this.hideOverlay();
+      return Promise.resolve(null);
+    }
+
+    this.environment.setVisible(true);
+    this.environment.setSize({
+      width: options.width,
+      height: options.height,
+    });
+    container.focus();
+
+    return new Promise((resolve) => {
+      const pending: PendingModal = {
+        ...identity,
+        actor,
+        resolve,
+        settled: false,
+        watchdog: null,
+      };
+
+      // Ownership is established before the actor query or any asynchronous work.
+      this.pending = pending;
+
+      pending.watchdog = this.environment.setTimer(() => {
+        void probeModalChildAlive(
+          actor,
+          identity,
+          this.pingTimeoutMs,
+          this.environment,
+        ).then((probeResult) => {
+          if (probeResult === "alive") {
+            return;
+          }
+          const reason: ModalTerminalReason = probeResult === "actor-error"
+            ? "actor-error"
+            : probeResult === "timeout"
+            ? "timeout"
+            : "dead";
+          this.settleOnce(pending, reason, null, true, true);
+        });
+      }, this.watchdogDelayMs);
+
+      const request: ModalShowRequest = {
+        ...identity,
+        form: safeForm,
+      };
+
+      try {
+        actor.sendQuery("NRChromeModal:show", request).then(
+          (response: unknown) => {
+            if (!isResultEnvelope(identity, response)) {
+              this.settleOnce(pending, "dead", null, true, true);
+              return;
+            }
+            this.settleOnce(
+              pending,
+              response.reason,
+              response.result,
+              response.reason !== "submit",
+              true,
+            );
+          },
+          () => {
+            this.settleOnce(pending, "actor-error", null, true, true);
+          },
+        );
+      } catch {
+        this.settleOnce(pending, "actor-error", null, true, true);
+      }
+    });
   }
 
-  public hide(): void {
-    const browser = document?.getElementById(
-      "modal-parent-container",
-    ) as unknown as XULElement;
-    if (browser) {
-      setModalVisible(false);
-      setModalSize({ width: 600, height: 800 });
-      globalThis.focus();
-      Services.obs.notifyObservers({}, "nora:modal:hide", "");
+  public hide(reason: ModalTerminalReason = "hide"): void {
+    const pending = this.pending;
+    if (!pending) {
+      this.hideOverlay();
+      return;
     }
+    this.settleOnce(pending, reason, null, true, true);
   }
 
   public setModalSize(newSize: ModalSize): void {
-    setModalSize((current) => ({ ...current, ...newSize }));
+    this.environment.setSize({ ...this.environment.getSize(), ...newSize });
   }
 
-  public handleBackdropClick(_event: MouseEvent): void {
-    //TODO: Make more stable
-    // const target = event.target as HTMLElement;
-    // if (target.id === "modal-parent-container") {
-    //   this.hide();
-    // }
+  public handleBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget && this.pending !== null) {
+      this.hide("backdrop");
+    }
+  }
+
+  public getActiveRequestIdentity(): ModalRequestIdentity | null {
+    return this.pending
+      ? { requestId: this.pending.requestId, epoch: this.pending.epoch }
+      : null;
+  }
+
+  public dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.environment.removeKeydownListener(this.handleKeydown);
+    const pending = this.pending;
+    if (pending) {
+      this.settleOnce(pending, "remove", null, true, true);
+    }
+  }
+
+  private settleOnce(
+    request: PendingModal,
+    reason: ModalTerminalReason,
+    result: TFormResult | null,
+    cancelActor: boolean,
+    hideOverlay: boolean,
+  ): boolean {
+    if (
+      request.settled ||
+      this.pending !== request ||
+      this.pending.requestId !== request.requestId ||
+      this.pending.epoch !== request.epoch
+    ) {
+      return false;
+    }
+
+    request.settled = true;
+    this.pending = null;
+    if (request.watchdog !== null) {
+      this.environment.clearTimer(request.watchdog);
+      request.watchdog = null;
+    }
+
+    if (cancelActor) {
+      this.cancelActor(request, reason);
+    }
+    if (hideOverlay) {
+      this.hideOverlay();
+    }
+    request.resolve(result);
+    return true;
+  }
+
+  private cancelActor(
+    request: PendingModal,
+    reason: ModalTerminalReason,
+  ): void {
+    const cancel: ModalCancelRequest = {
+      requestId: request.requestId,
+      epoch: request.epoch,
+      reason,
+    };
+    try {
+      request.actor.sendQuery("NRChromeModal:cancel", cancel).catch(() => {});
+    } catch {
+      // The actor may already be dead. Cancellation never owns another request.
+    }
+  }
+
+  private hideOverlay(): void {
+    this.environment.setVisible(false);
+    this.environment.setSize({ width: 600, height: 800 });
+    this.environment.focusWindow();
+    this.environment.notifyHidden();
   }
 
   public static get parentElement(): HTMLElement | null {

--- a/browser-features/chrome/common/modal-parent/test/modalParent.test.ts
+++ b/browser-features/chrome/common/modal-parent/test/modalParent.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../test/utils/test_harness.ts";
 import ModalParent from "../index.ts";
 import { isModalVisible, setModalVisible } from "../data/data.ts";
+import { attachModalBackdropListener } from "../modalElement.tsx";
 
 // ---------------------------------------------------------------------------
 // Helpers – save/restore modal visibility state
@@ -73,6 +74,54 @@ function testGetInstanceIsSingleton(): void {
   assertEquals(a, b, "getInstance should return the same instance");
 }
 
+function testFirstConstructedInstanceOwnsSingletonManager(): void {
+  const constructorState = ModalParent as unknown as {
+    instance: ModalParent | undefined;
+  };
+  const savedInstance = constructorState.instance;
+  constructorState.instance = undefined;
+
+  let firstManager: { dispose(): void } | null = null;
+  let laterManager: { dispose(): void } | null = null;
+  try {
+    const first = new ModalParent();
+    const firstState = first as unknown as {
+      modalManager: { dispose(): void } | null;
+    };
+    firstManager = firstState.modalManager;
+    assert(
+      firstManager !== null,
+      "base initialization should create a manager",
+    );
+    assertEquals(
+      ModalParent.getInstance(),
+      first,
+      "the first constructed component should become the singleton",
+    );
+
+    first.init();
+    assertEquals(
+      firstState.modalManager,
+      firstManager,
+      "repeated init should preserve the rendered manager owner",
+    );
+
+    const later = new ModalParent();
+    laterManager = (later as unknown as {
+      modalManager: { dispose(): void } | null;
+    }).modalManager;
+    assertEquals(
+      ModalParent.getInstance(),
+      first,
+      "later construction must not replace the singleton owner",
+    );
+  } finally {
+    firstManager?.dispose();
+    laterManager?.dispose();
+    constructorState.instance = savedInstance;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Uninitialized state error tests
 // ---------------------------------------------------------------------------
@@ -92,7 +141,11 @@ async function testShowNoraModalUsesManager(): Promise<void> {
   );
 
   assertEquals(fakeModalCalls.show, showBefore + 1, "manager show called");
-  assertEquals(fakeModalCalls.hide, hideBefore + 1, "manager hide called");
+  assertEquals(
+    fakeModalCalls.hide,
+    hideBefore,
+    "completed wrapper must not unconditionally hide a replacement",
+  );
   assert(callbackCalled, "showNoraModal should invoke the callback");
 }
 
@@ -267,8 +320,58 @@ function testModalParentPublicMethodsAreAvailable(): void {
   );
 }
 
+function testNativeBackdropListenerForwardsAndCleansUp(): void {
+  const targetParent = document.createElement("div");
+  const backdrop = document.createElement("div");
+  const child = document.createElement("button");
+  backdrop.id = "modal-parent-container";
+  backdrop.append(child);
+  targetParent.append(backdrop);
+  const firstReasons: Array<string | undefined> = [];
+  const secondReasons: Array<string | undefined> = [];
+  let currentManager: { hide(reason?: string): void } | null = {
+    hide: (reason) => firstReasons.push(reason),
+  };
+  const detach = attachModalBackdropListener(
+    targetParent,
+    () => currentManager,
+  );
+
+  child.click();
+  assertEquals(
+    firstReasons.length,
+    0,
+    "child clicks should not dismiss the modal",
+  );
+
+  backdrop.click();
+  assertEquals(firstReasons.length, 1, "exact backdrop should dismiss once");
+  assertEquals(
+    firstReasons[0],
+    "backdrop",
+    "backdrop reason should be forwarded",
+  );
+
+  currentManager = {
+    hide: (reason) => secondReasons.push(reason),
+  };
+  backdrop.click();
+  assertEquals(
+    firstReasons.length,
+    1,
+    "manager rebinding should stop calls to the old owner",
+  );
+  assertEquals(secondReasons.length, 1, "rebound manager should receive click");
+  assertEquals(secondReasons[0], "backdrop", "rebound reason should match");
+
+  detach();
+  backdrop.click();
+  assertEquals(secondReasons.length, 1, "cleanup should remove the listener");
+}
+
 async function testShowNoraModalBeforeInit(): Promise<void> {
   const inst = new ModalParent();
+  (inst as unknown as { modalManager: unknown }).modalManager = null;
   let message = "";
   try {
     await inst.showNoraModal(
@@ -288,6 +391,7 @@ async function testShowNoraModalBeforeInit(): Promise<void> {
 
 function testHideNoraModalBeforeInit(): void {
   const inst = new ModalParent();
+  (inst as unknown as { modalManager: unknown }).modalManager = null;
   let message = "";
   try {
     inst.hideNoraModal();
@@ -303,6 +407,7 @@ function testHideNoraModalBeforeInit(): void {
 
 function testSetModalSizeBeforeInit(): void {
   const inst = new ModalParent();
+  (inst as unknown as { modalManager: unknown }).modalManager = null;
   let message = "";
   try {
     inst.setModalSize({ width: 300, height: 400 });
@@ -382,6 +487,10 @@ function testModalParentMethodChaining(): void {
 const tests: TestCase[] = [
   { name: "getInstance returns object", fn: testGetInstanceReturnsObject },
   { name: "getInstance is singleton", fn: testGetInstanceIsSingleton },
+  {
+    name: "first constructed instance owns singleton manager",
+    fn: testFirstConstructedInstanceOwnsSingletonManager,
+  },
   { name: "showNoraModal uses manager", fn: testShowNoraModalUsesManager },
   { name: "hideNoraModal uses manager", fn: testHideNoraModalUsesManager },
   { name: "setModalSize uses manager", fn: testSetModalSizeUsesManager },
@@ -406,6 +515,10 @@ const tests: TestCase[] = [
   {
     name: "ModalParent public methods are available",
     fn: testModalParentPublicMethodsAreAvailable,
+  },
+  {
+    name: "native backdrop listener forwards and cleans up",
+    fn: testNativeBackdropListenerForwardsAndCleansUp,
   },
   {
     name: "showNoraModal before init",

--- a/browser-features/chrome/common/modal-parent/test/modalRequestLifecycle.test.ts
+++ b/browser-features/chrome/common/modal-parent/test/modalRequestLifecycle.test.ts
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import {
+  type ModalActorLike,
+  ModalManager,
+  type ModalManagerEnvironment,
+} from "../modalManager.tsx";
+import type {
+  ModalRequestIdentity,
+  ModalResultEnvelope,
+  ModalShowRequest,
+  ModalTerminalReason,
+  TFormResult,
+} from "../utils/type.ts";
+
+type DeferredQuery = {
+  request: ModalShowRequest;
+  resolve(value: unknown): void;
+  reject(reason: unknown): void;
+};
+
+class FakeActor implements ModalActorLike {
+  readonly sent: Array<{ name: string; data: unknown }> = [];
+  readonly shows = new Map<string, DeferredQuery>();
+  pingMode: "alive" | "dead" | "silent" | "reject" = "alive";
+  throwOnShow = false;
+
+  sendQuery(name: string, data: unknown): Promise<unknown> {
+    this.sent.push({ name, data });
+    if (name === "NRChromeModal:show") {
+      if (this.throwOnShow) {
+        throw new Error("actor threw");
+      }
+      const request = data as ModalShowRequest;
+      return new Promise((resolve, reject) => {
+        this.shows.set(request.requestId, { request, resolve, reject });
+      });
+    }
+    if (name === "NRChromeModal:ping") {
+      const identity = data as ModalRequestIdentity;
+      if (this.pingMode === "silent") {
+        return new Promise(() => {});
+      }
+      if (this.pingMode === "reject") {
+        return Promise.reject(new Error("actor unavailable"));
+      }
+      return Promise.resolve({
+        ...identity,
+        ready: this.pingMode === "alive",
+      });
+    }
+    return Promise.resolve(true);
+  }
+
+  finish(
+    identity: ModalRequestIdentity,
+    reason: ModalTerminalReason,
+    result: TFormResult | null,
+  ): void {
+    const response: ModalResultEnvelope = { ...identity, reason, result };
+    this.shows.get(identity.requestId)?.resolve(response);
+  }
+
+  fail(identity: ModalRequestIdentity): void {
+    this.shows.get(identity.requestId)?.reject(new Error("query failed"));
+  }
+}
+
+class FakeClock {
+  private nextHandle = 1;
+  private readonly timers = new Map<number, () => void>();
+  private readonly allCallbacks = new Map<number, () => void>();
+
+  setTimer = (callback: () => void, _delayMs: number): number => {
+    const handle = this.nextHandle++;
+    this.timers.set(handle, callback);
+    this.allCallbacks.set(handle, callback);
+    return handle;
+  };
+
+  clearTimer = (handle: number | ReturnType<typeof globalThis.setTimeout>) => {
+    this.timers.delete(Number(handle));
+  };
+
+  runNext(): number {
+    const entry = this.timers.entries().next().value as
+      | [number, () => void]
+      | undefined;
+    if (!entry) {
+      throw new Error("no pending timer");
+    }
+    const [handle, callback] = entry;
+    this.timers.delete(handle);
+    callback();
+    return handle;
+  }
+
+  runEvenIfCleared(handle: number): void {
+    const callback = this.allCallbacks.get(handle);
+    if (!callback) {
+      throw new Error(`unknown timer ${handle}`);
+    }
+    callback();
+  }
+
+  firstHandle(): number {
+    const handle = this.allCallbacks.keys().next().value;
+    if (typeof handle !== "number") {
+      throw new Error("no timer was registered");
+    }
+    return handle;
+  }
+}
+
+type ManagerHarness = {
+  actor: FakeActor;
+  clock: FakeClock;
+  manager: ModalManager;
+  visible: boolean;
+  hiddenCount: number;
+  keydown: ((event: KeyboardEvent) => void) | null;
+};
+
+function createHarness(actor = new FakeActor()): ManagerHarness {
+  const clock = new FakeClock();
+  const state: ManagerHarness = {
+    actor,
+    clock,
+    manager: null as unknown as ModalManager,
+    visible: false,
+    hiddenCount: 0,
+    keydown: null,
+  };
+  const environment: Partial<ModalManagerEnvironment> = {
+    getContainer: () => ({ focus: () => {} }),
+    getActor: () => actor,
+    setVisible: (visible) => {
+      state.visible = visible;
+      if (!visible) {
+        state.hiddenCount++;
+      }
+    },
+    setSize: () => {},
+    focusWindow: () => {},
+    notifyHidden: () => {},
+    addKeydownListener: (listener) => {
+      state.keydown = listener;
+    },
+    removeKeydownListener: (listener) => {
+      if (state.keydown === listener) {
+        state.keydown = null;
+      }
+    },
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    createRequestId: (epoch) => `request-${epoch}`,
+  };
+  state.manager = new ModalManager(environment, {
+    watchdogDelayMs: 10,
+    pingTimeoutMs: 10,
+  });
+  return state;
+}
+
+const form = { forms: [], title: "lifecycle" };
+const size = { width: 400, height: 300 };
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function testRegistersBeforeActorContinuation(): void {
+  const harness = createHarness();
+  void harness.manager.show(form, size);
+  const active = harness.manager.getActiveRequestIdentity();
+  const query = harness.actor.sent[0];
+  assert(active !== null, "request must be active synchronously");
+  assertEquals(query.name, "NRChromeModal:show", "show query is sent");
+  assertEquals(
+    (query.data as ModalShowRequest).requestId,
+    active.requestId,
+    "the actor receives the registered request identity",
+  );
+  harness.manager.hide();
+  harness.manager.dispose();
+}
+
+async function testRapidReplacementIgnoresStaleCompletion(): Promise<void> {
+  const harness = createHarness();
+  const first = harness.manager.show(form, size);
+  const firstIdentity = harness.manager.getActiveRequestIdentity();
+  assert(firstIdentity !== null, "first request is active");
+  const staleWatchdog = harness.clock.firstHandle();
+
+  const second = harness.manager.show(form, size);
+  const secondIdentity = harness.manager.getActiveRequestIdentity();
+  assert(secondIdentity !== null, "replacement is active");
+  assertEquals(await first, null, "old caller settles once with null");
+  assert(harness.visible, "replacement keeps the overlay visible");
+
+  const replacementCancel = harness.actor.sent.find((entry) =>
+    entry.name === "NRChromeModal:cancel" &&
+    (entry.data as ModalRequestIdentity).requestId === firstIdentity.requestId
+  );
+  assert(replacementCancel !== undefined, "old actor request is targeted");
+  assertEquals(
+    (replacementCancel.data as { reason: string }).reason,
+    "replacement",
+    "replacement cancellation has an explicit reason",
+  );
+
+  harness.clock.runEvenIfCleared(staleWatchdog);
+  harness.actor.finish(firstIdentity, "submit", { stale: "value" });
+  await flushPromises();
+  assertEquals(
+    harness.manager.getActiveRequestIdentity()?.requestId,
+    secondIdentity.requestId,
+    "stale timer and result cannot clear the replacement",
+  );
+  assert(harness.visible, "stale completion cannot hide the replacement");
+
+  const expected = { current: "value" };
+  harness.actor.finish(secondIdentity, "submit", expected);
+  assertEquals(await second, expected, "replacement result is delivered");
+  assertEquals(harness.visible, false, "matching submit hides the overlay");
+  assertEquals(harness.hiddenCount, 1, "only matching completion hides once");
+  harness.manager.dispose();
+}
+
+async function testEscapeAndProgrammaticHideAreTargeted(): Promise<void> {
+  const escapeHarness = createHarness();
+  const escaped = escapeHarness.manager.show(form, size);
+  const escapeIdentity = escapeHarness.manager.getActiveRequestIdentity();
+  assert(escapeIdentity !== null, "escape request is active");
+  escapeHarness.keydown?.({ key: "Escape" } as KeyboardEvent);
+  assertEquals(await escaped, null, "Escape settles null");
+  const escapeCancel = escapeHarness.actor.sent.find((entry) =>
+    entry.name === "NRChromeModal:cancel"
+  );
+  assertEquals(
+    (escapeCancel?.data as { reason: string }).reason,
+    "escape",
+    "Escape sends a targeted reason",
+  );
+  escapeHarness.manager.dispose();
+
+  const hideHarness = createHarness();
+  const hidden = hideHarness.manager.show(form, size);
+  hideHarness.manager.hide("hide");
+  assertEquals(await hidden, null, "programmatic hide settles null");
+  const hideCancel = hideHarness.actor.sent.find((entry) =>
+    entry.name === "NRChromeModal:cancel"
+  );
+  assertEquals(
+    (hideCancel?.data as { reason: string }).reason,
+    "hide",
+    "programmatic hide sends a targeted reason",
+  );
+  hideHarness.manager.dispose();
+}
+
+async function testBackdropIsMatchingCancellation(): Promise<void> {
+  const harness = createHarness();
+  const shown = harness.manager.show(form, size);
+  const target = {};
+  harness.manager.handleBackdropClick({
+    target,
+    currentTarget: target,
+  } as unknown as MouseEvent);
+  assertEquals(await shown, null, "backdrop settles null");
+  const cancel = harness.actor.sent.find((entry) =>
+    entry.name === "NRChromeModal:cancel"
+  );
+  assertEquals(
+    (cancel?.data as { reason: string }).reason,
+    "backdrop",
+    "backdrop sends a targeted reason",
+  );
+  harness.manager.dispose();
+}
+
+async function testDeadSilentAndActorErrorsSettleOnce(): Promise<void> {
+  const deadActor = new FakeActor();
+  deadActor.pingMode = "dead";
+  const deadHarness = createHarness(deadActor);
+  const dead = deadHarness.manager.show(form, size);
+  deadHarness.clock.runNext();
+  await flushPromises();
+  assertEquals(await dead, null, "dead child settles null");
+  assertEquals(deadHarness.hiddenCount, 1, "dead child hides once");
+  deadHarness.manager.dispose();
+
+  const silentActor = new FakeActor();
+  silentActor.pingMode = "silent";
+  const silentHarness = createHarness(silentActor);
+  const silent = silentHarness.manager.show(form, size);
+  silentHarness.clock.runNext();
+  silentHarness.clock.runNext();
+  await flushPromises();
+  assertEquals(await silent, null, "silent child watchdog settles null");
+  assertEquals(silentHarness.hiddenCount, 1, "timeout hides once");
+  silentHarness.manager.dispose();
+
+  const throwingActor = new FakeActor();
+  throwingActor.throwOnShow = true;
+  const throwingHarness = createHarness(throwingActor);
+  assertEquals(
+    await throwingHarness.manager.show(form, size),
+    null,
+    "actor throw settles null",
+  );
+  assertEquals(throwingHarness.hiddenCount, 1, "actor throw hides once");
+  throwingHarness.manager.dispose();
+
+  const rejectingActor = new FakeActor();
+  const rejectingHarness = createHarness(rejectingActor);
+  const rejected = rejectingHarness.manager.show(form, size);
+  const rejectedIdentity = rejectingHarness.manager
+    .getActiveRequestIdentity();
+  assert(rejectedIdentity !== null, "rejecting request is active");
+  rejectingActor.fail(rejectedIdentity);
+  assertEquals(await rejected, null, "actor query rejection settles null");
+  assertEquals(
+    rejectingHarness.hiddenCount,
+    1,
+    "actor query rejection hides once",
+  );
+  rejectingHarness.manager.dispose();
+}
+
+const tests: TestCase[] = [
+  {
+    name: "request is registered before actor continuation",
+    fn: testRegistersBeforeActorContinuation,
+  },
+  {
+    name: "rapid replacement ignores stale completion",
+    fn: testRapidReplacementIgnoresStaleCompletion,
+  },
+  {
+    name: "Escape and programmatic hide are targeted",
+    fn: testEscapeAndProgrammaticHideAreTargeted,
+  },
+  {
+    name: "backdrop is matching cancellation",
+    fn: testBackdropIsMatchingCancellation,
+  },
+  {
+    name: "dead silent and actor errors settle once",
+    fn: testDeadSilentAndActorErrorsSettleOnce,
+  },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("modalRequestLifecycle.test.ts", tests);
+}

--- a/browser-features/chrome/common/modal-parent/utils/type.ts
+++ b/browser-features/chrome/common/modal-parent/utils/type.ts
@@ -38,3 +38,36 @@ export interface TForm {
 export interface TFormResult {
   [key: string]: string | number;
 }
+
+export const MODAL_TERMINAL_REASONS = [
+  "submit",
+  "cancel",
+  "escape",
+  "backdrop",
+  "hide",
+  "replacement",
+  "timeout",
+  "dead",
+  "actor-error",
+  "remove",
+] as const;
+
+export type ModalTerminalReason = typeof MODAL_TERMINAL_REASONS[number];
+
+export interface ModalRequestIdentity {
+  requestId: string;
+  epoch: number;
+}
+
+export interface ModalShowRequest extends ModalRequestIdentity {
+  form: TForm;
+}
+
+export interface ModalCancelRequest extends ModalRequestIdentity {
+  reason: ModalTerminalReason;
+}
+
+export interface ModalResultEnvelope extends ModalRequestIdentity {
+  reason: ModalTerminalReason;
+  result: TFormResult | null;
+}

--- a/browser-features/chrome/common/panel-sidebar/test/modalCallerRequestLifecycle.test.ts
+++ b/browser-features/chrome/common/panel-sidebar/test/modalCallerRequestLifecycle.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import ModalParent from "../../modal-parent/index.ts";
+import {
+  type ModalActorLike,
+  ModalManager,
+  type ModalManagerEnvironment,
+} from "../../modal-parent/modalManager.tsx";
+import type {
+  ModalRequestIdentity,
+  ModalShowRequest,
+  TFormResult,
+} from "../../modal-parent/utils/type.ts";
+import { PanelSidebarAddModal } from "../components/panel-sidebar-modal.tsx";
+import { panelSidebarData, setPanelSidebarData } from "../data/data.ts";
+import type { Panel } from "../utils/type.ts";
+
+class CallerActor implements ModalActorLike {
+  readonly requests: ModalShowRequest[] = [];
+  private readonly resolvers = new Map<string, (value: unknown) => void>();
+
+  sendQuery(name: string, data: unknown): Promise<unknown> {
+    if (name !== "NRChromeModal:show") {
+      return Promise.resolve(true);
+    }
+    const request = data as ModalShowRequest;
+    this.requests.push(request);
+    return new Promise((resolve) => {
+      this.resolvers.set(request.requestId, resolve);
+    });
+  }
+
+  submit(identity: ModalRequestIdentity, result: TFormResult): void {
+    this.resolvers.get(identity.requestId)?.({
+      ...identity,
+      reason: "submit",
+      result,
+    });
+  }
+}
+
+function createManager(actor: CallerActor): ModalManager {
+  let timer = 0;
+  const environment: Partial<ModalManagerEnvironment> = {
+    getContainer: () => ({ focus: () => {} }),
+    getActor: () => actor,
+    setVisible: () => {},
+    setSize: () => {},
+    focusWindow: () => {},
+    notifyHidden: () => {},
+    addKeydownListener: () => {},
+    removeKeydownListener: () => {},
+    setTimer: () => ++timer,
+    clearTimer: () => {},
+    createRequestId: (epoch) => `panel-${epoch}`,
+  };
+  return new ModalManager(environment);
+}
+
+function createCaller(parent: ModalParent): PanelSidebarAddModal {
+  const caller = Object.create(
+    PanelSidebarAddModal.prototype,
+  ) as PanelSidebarAddModal;
+  const state = caller as unknown as {
+    modalParent: ModalParent;
+    createFormConfig(): object;
+  };
+  state.modalParent = parent;
+  state.createFormConfig = () => ({ forms: [], title: "Panel" });
+  return caller;
+}
+
+function panelResult(url: string): TFormResult {
+  return {
+    type: "web",
+    width: "450",
+    url,
+    userContextId: "0",
+    userAgent: "false",
+  };
+}
+
+const parent = ModalParent.getInstance();
+const parentState = parent as unknown as { modalManager: ModalManager | null };
+
+async function testPanelSubmit(): Promise<void> {
+  const actor = new CallerActor();
+  const manager = createManager(actor);
+  parentState.modalManager = manager;
+  const shown = createCaller(parent).showAddPanelModal();
+  const request = actor.requests[0];
+  assert(request !== undefined, "panel caller reaches modal actor");
+  const expected = panelResult("https://example.com");
+  actor.submit(request, expected);
+  assertEquals(await shown, expected, "panel submit returns public result");
+  assert(
+    panelSidebarData().some((panel: Panel) =>
+      panel.url === "https://example.com"
+    ),
+    "real panel caller applies submitted result",
+  );
+  manager.dispose();
+}
+
+async function testPanelCancelReturnsNull(): Promise<void> {
+  const actor = new CallerActor();
+  const manager = createManager(actor);
+  parentState.modalManager = manager;
+  const shown = createCaller(parent).showAddPanelModal();
+  parent.hideNoraModal();
+  assertEquals(await shown, null, "panel public callback accepts null");
+  manager.dispose();
+}
+
+async function testPanelRapidReplacement(): Promise<void> {
+  const actor = new CallerActor();
+  const manager = createManager(actor);
+  parentState.modalManager = manager;
+  const caller = createCaller(parent);
+  const first = caller.showAddPanelModal();
+  const firstRequest = actor.requests[0];
+  const second = caller.showAddPanelModal();
+  const secondRequest = actor.requests[1];
+  assert(firstRequest !== undefined, "first panel caller reached actor");
+  assert(secondRequest !== undefined, "replacement reached actor");
+  assertEquals(await first, null, "replaced panel caller settles null");
+
+  actor.submit(firstRequest, panelResult("https://stale.example"));
+  const expected = panelResult("https://replacement.example");
+  actor.submit(secondRequest, expected);
+  assertEquals(await second, expected, "replacement panel remains active");
+  assert(
+    !panelSidebarData().some((panel: Panel) =>
+      panel.url === "https://stale.example"
+    ),
+    "stale panel result is not applied",
+  );
+  manager.dispose();
+}
+
+const tests: TestCase[] = [
+  { name: "panel submit", fn: testPanelSubmit },
+  { name: "panel cancel returns null", fn: testPanelCancelReturnsNull },
+  { name: "panel rapid replacement", fn: testPanelRapidReplacement },
+];
+
+export async function runAllTests(): Promise<void> {
+  const savedManager = parentState.modalManager;
+  const savedPanels = [...panelSidebarData()];
+  try {
+    await runTests("modalCallerRequestLifecycle.test.ts", tests);
+  } finally {
+    parentState.modalManager = savedManager;
+    setPanelSidebarData(savedPanels);
+  }
+}

--- a/browser-features/chrome/common/workspaces/test/modalCallerRequestLifecycle.test.ts
+++ b/browser-features/chrome/common/workspaces/test/modalCallerRequestLifecycle.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import ModalParent from "../../modal-parent/index.ts";
+import {
+  type ModalActorLike,
+  ModalManager,
+  type ModalManagerEnvironment,
+} from "../../modal-parent/modalManager.tsx";
+import type {
+  ModalRequestIdentity,
+  ModalShowRequest,
+  TFormResult,
+} from "../../modal-parent/utils/type.ts";
+import { WorkspaceManageModal } from "../workspace-modal.tsx";
+import type { TWorkspaceID } from "../utils/type.ts";
+
+class CallerActor implements ModalActorLike {
+  readonly requests: ModalShowRequest[] = [];
+  private readonly resolvers = new Map<string, (value: unknown) => void>();
+
+  sendQuery(name: string, data: unknown): Promise<unknown> {
+    if (name !== "NRChromeModal:show") {
+      return Promise.resolve(true);
+    }
+    const request = data as ModalShowRequest;
+    this.requests.push(request);
+    return new Promise((resolve) => {
+      this.resolvers.set(request.requestId, resolve);
+    });
+  }
+
+  submit(identity: ModalRequestIdentity, result: TFormResult): void {
+    this.resolvers.get(identity.requestId)?.({
+      ...identity,
+      reason: "submit",
+      result,
+    });
+  }
+}
+
+function createManager(actor: CallerActor): ModalManager {
+  let timer = 0;
+  const environment: Partial<ModalManagerEnvironment> = {
+    getContainer: () => ({ focus: () => {} }),
+    getActor: () => actor,
+    setVisible: () => {},
+    setSize: () => {},
+    focusWindow: () => {},
+    notifyHidden: () => {},
+    addKeydownListener: () => {},
+    removeKeydownListener: () => {},
+    setTimer: () => ++timer,
+    clearTimer: () => {},
+    createRequestId: (epoch) => `workspace-${epoch}`,
+  };
+  return new ModalManager(environment);
+}
+
+function createCaller(parent: ModalParent): WorkspaceManageModal {
+  const caller = Object.create(
+    WorkspaceManageModal.prototype,
+  ) as WorkspaceManageModal;
+  const state = caller as unknown as {
+    ctx: {
+      getRawWorkspace(id: unknown): object | null;
+      getSelectedWorkspaceID(): TWorkspaceID;
+    };
+    modalParent: ModalParent;
+    createFormConfig(workspace: object): object;
+  };
+  state.ctx = {
+    getRawWorkspace: () => ({ id: "workspace", name: "Workspace" }),
+    getSelectedWorkspaceID: () => "workspace" as TWorkspaceID,
+  };
+  state.modalParent = parent;
+  state.createFormConfig = () => ({ forms: [], title: "Workspace" });
+  return caller;
+}
+
+const parent = ModalParent.getInstance();
+const parentState = parent as unknown as { modalManager: ModalManager | null };
+const workspaceId = "workspace" as TWorkspaceID;
+
+async function testWorkspaceSubmit(): Promise<void> {
+  const actor = new CallerActor();
+  const manager = createManager(actor);
+  parentState.modalManager = manager;
+  const caller = createCaller(parent);
+  const shown = caller.showWorkspacesModal(workspaceId);
+  const request = actor.requests[0];
+  assert(request !== undefined, "workspace caller reaches modal actor");
+  const expected = { name: "Renamed" };
+  actor.submit(request, expected);
+  assertEquals(await shown, expected, "workspace submit returns public result");
+  manager.dispose();
+}
+
+async function testWorkspaceCancelReturnsNull(): Promise<void> {
+  const actor = new CallerActor();
+  const manager = createManager(actor);
+  parentState.modalManager = manager;
+  const shown = createCaller(parent).showWorkspacesModal(workspaceId);
+  parent.hideNoraModal();
+  assertEquals(await shown, null, "workspace public callback accepts null");
+  manager.dispose();
+}
+
+async function testWorkspaceRapidReplacement(): Promise<void> {
+  const actor = new CallerActor();
+  const manager = createManager(actor);
+  parentState.modalManager = manager;
+  const caller = createCaller(parent);
+  const first = caller.showWorkspacesModal(workspaceId);
+  const firstRequest = actor.requests[0];
+  const second = caller.showWorkspacesModal(workspaceId);
+  const secondRequest = actor.requests[1];
+  assert(firstRequest !== undefined, "first caller reached actor");
+  assert(secondRequest !== undefined, "replacement reached actor");
+  assertEquals(await first, null, "replaced workspace caller settles null");
+
+  actor.submit(firstRequest, { stale: "ignored" });
+  const expected = { name: "Replacement" };
+  actor.submit(secondRequest, expected);
+  assertEquals(await second, expected, "replacement remains active");
+  manager.dispose();
+}
+
+const tests: TestCase[] = [
+  { name: "workspace submit", fn: testWorkspaceSubmit },
+  { name: "workspace cancel returns null", fn: testWorkspaceCancelReturnsNull },
+  { name: "workspace rapid replacement", fn: testWorkspaceRapidReplacement },
+];
+
+export async function runAllTests(): Promise<void> {
+  const savedManager = parentState.modalManager;
+  try {
+    await runTests("modalCallerRequestLifecycle.test.ts", tests);
+  } finally {
+    parentState.modalManager = savedManager;
+  }
+}

--- a/browser-features/modules/actors/NRChromeModalChild.request.test.mts
+++ b/browser-features/modules/actors/NRChromeModalChild.request.test.mts
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../chrome/test/utils/test_harness.ts";
+import { ModalChildRequestController } from "./NRChromeModalChild.sys.mts";
+import type {
+  ModalRequestIdentity,
+  ModalShowRequest,
+} from "../../chrome/common/modal-parent/utils/type.ts";
+
+class FakeModalWindow {
+  readonly document = {
+    documentElement: { dataset: {} as Record<string, string> },
+  };
+  readonly messages: unknown[] = [];
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+  private readonly intervals = new Map<number, () => void>();
+  private readonly allIntervals = new Map<number, () => void>();
+  private nextInterval = 1;
+  throwOnPost = false;
+
+  addEventListener(
+    type: string,
+    listener: (event: MessageEvent) => void,
+  ): void {
+    if (type === "message") {
+      this.listeners.add(listener);
+    }
+  }
+
+  removeEventListener(
+    type: string,
+    listener: (event: MessageEvent) => void,
+  ): void {
+    if (type === "message") {
+      this.listeners.delete(listener);
+    }
+  }
+
+  setInterval(callback: () => void, _delayMs: number): number {
+    const handle = this.nextInterval++;
+    this.intervals.set(handle, callback);
+    this.allIntervals.set(handle, callback);
+    return handle;
+  }
+
+  clearInterval(handle: number): void {
+    this.intervals.delete(handle);
+  }
+
+  postMessage(message: unknown, _targetOrigin: string): void {
+    if (this.throwOnPost) {
+      throw new Error("WindowGlobal is gone");
+    }
+    this.messages.push(message);
+  }
+
+  dispatch(message: unknown): void {
+    for (const listener of [...this.listeners]) {
+      listener({ data: message } as MessageEvent);
+    }
+  }
+
+  setReady(ready: boolean): void {
+    if (ready) {
+      this.document.documentElement.dataset.noraModalReady = "true";
+    } else {
+      delete this.document.documentElement.dataset.noraModalReady;
+    }
+  }
+
+  fireIntervalEvenIfCleared(handle: number): void {
+    this.allIntervals.get(handle)?.();
+  }
+
+  firstInterval(): number {
+    const handle = this.allIntervals.keys().next().value;
+    if (typeof handle !== "number") {
+      throw new Error("no interval registered");
+    }
+    return handle;
+  }
+
+  listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+function asWindow(win: FakeModalWindow): Window {
+  return win as unknown as Window;
+}
+
+function showRequest(
+  requestId: string,
+  epoch: number,
+): ModalShowRequest {
+  return {
+    requestId,
+    epoch,
+    form: { forms: [], title: requestId },
+  };
+}
+
+function matchingMessages(
+  win: FakeModalWindow,
+  type: string,
+  identity: ModalRequestIdentity,
+): unknown[] {
+  return win.messages.filter((value) => {
+    const message = value as Record<string, unknown>;
+    return message.type === type &&
+      message.requestId === identity.requestId &&
+      message.epoch === identity.epoch;
+  });
+}
+
+async function testCancelBeforeReadyIsEffective(): Promise<void> {
+  const controller = new ModalChildRequestController();
+  const win = new FakeModalWindow();
+  const request = showRequest("before-ready", 1);
+  const result = controller.show(asWindow(win), request);
+  const staleInterval = win.firstInterval();
+
+  assertEquals(win.listenerCount(), 1, "submit listener is registered early");
+  assertEquals(
+    matchingMessages(win, "nora-modal-init", request).length,
+    0,
+    "init waits for readiness",
+  );
+  assert(
+    controller.cancel({ ...request, reason: "cancel" }),
+    "matching cancel is accepted before ready",
+  );
+  assertEquals((await result)?.reason, "cancel", "query settles as cancel");
+  assertEquals((await result)?.result, null, "cancel result is null");
+  assertEquals(win.listenerCount(), 0, "listener is removed on cancel");
+
+  win.setReady(true);
+  win.fireIntervalEvenIfCleared(staleInterval);
+  assertEquals(
+    matchingMessages(win, "nora-modal-init", request).length,
+    0,
+    "stale ready continuation cannot render cancelled request",
+  );
+}
+
+async function testTaggedSubmitAndRemove(): Promise<void> {
+  const controller = new ModalChildRequestController();
+  const win = new FakeModalWindow();
+  win.setReady(true);
+  const request = showRequest("submit", 2);
+  const result = controller.show(asWindow(win), request);
+
+  assertEquals(
+    matchingMessages(win, "nora-modal-init", request).length,
+    1,
+    "tagged init is posted",
+  );
+  win.dispatch({ type: "nora-modal-submit", result: { ignored: "yes" } });
+  win.dispatch({
+    type: "nora-modal-submit",
+    requestId: "stale",
+    epoch: 1,
+    reason: "submit",
+    result: { ignored: "yes" },
+  });
+  assertEquals(
+    controller.getActiveRequestIdentity()?.requestId,
+    request.requestId,
+    "untagged and stale submit are ignored",
+  );
+
+  win.dispatch({
+    type: "nora-modal-submit",
+    requestId: request.requestId,
+    epoch: request.epoch,
+    reason: "submit",
+    result: { accepted: "yes" },
+  });
+  assertEquals((await result)?.result?.accepted, "yes", "result is delivered");
+  assertEquals(
+    matchingMessages(win, "nora-modal-remove", request).length,
+    1,
+    "matching tagged remove is posted once",
+  );
+
+  win.dispatch({
+    type: "nora-modal-submit",
+    requestId: request.requestId,
+    epoch: request.epoch,
+    reason: "submit",
+    result: { accepted: "twice" },
+  });
+  assertEquals(
+    matchingMessages(win, "nora-modal-remove", request).length,
+    1,
+    "duplicate channel delivery cannot settle twice",
+  );
+}
+
+async function testReplacementRejectsStaleContinuations(): Promise<void> {
+  const controller = new ModalChildRequestController();
+  const win = new FakeModalWindow();
+  const firstRequest = showRequest("first", 3);
+  const first = controller.show(asWindow(win), firstRequest);
+  const staleInterval = win.firstInterval();
+
+  win.setReady(true);
+  const secondRequest = showRequest("second", 4);
+  const second = controller.show(asWindow(win), secondRequest);
+  assertEquals((await first)?.reason, "replacement", "old query is replaced");
+  assertEquals((await first)?.result, null, "old query settles null");
+
+  win.fireIntervalEvenIfCleared(staleInterval);
+  win.dispatch({
+    type: "nora-modal-submit",
+    requestId: firstRequest.requestId,
+    epoch: firstRequest.epoch,
+    reason: "submit",
+    result: { stale: "yes" },
+  });
+  assertEquals(
+    controller.ping(firstRequest)?.ready,
+    false,
+    "stale ping cannot claim the active request",
+  );
+  assertEquals(
+    controller.getActiveRequestIdentity()?.requestId,
+    secondRequest.requestId,
+    "stale ready and submit leave replacement active",
+  );
+
+  win.dispatch({
+    type: "nora-modal-submit",
+    requestId: secondRequest.requestId,
+    epoch: secondRequest.epoch,
+    reason: "cancel",
+    result: null,
+  });
+  assertEquals((await second)?.reason, "cancel", "replacement can cancel");
+}
+
+async function testDestroyAndActorErrorAreMatching(): Promise<void> {
+  const controller = new ModalChildRequestController();
+  const win = new FakeModalWindow();
+  win.setReady(true);
+  const request = showRequest("destroy", 5);
+  const result = controller.show(asWindow(win), request);
+  controller.destroy();
+  assertEquals(
+    (await result)?.reason,
+    "dead",
+    "destroy settles active request",
+  );
+  assertEquals(win.listenerCount(), 0, "destroy tears down listener");
+
+  const errorController = new ModalChildRequestController();
+  const throwingWindow = new FakeModalWindow();
+  throwingWindow.setReady(true);
+  throwingWindow.throwOnPost = true;
+  const error = await errorController.show(
+    asWindow(throwingWindow),
+    showRequest("actor-error", 6),
+  );
+  assertEquals(error?.reason, "actor-error", "post failure is normalized");
+  assertEquals(error?.result, null, "post failure settles null");
+}
+
+const tests: TestCase[] = [
+  {
+    name: "cancel before ready is effective",
+    fn: testCancelBeforeReadyIsEffective,
+  },
+  { name: "tagged submit and remove", fn: testTaggedSubmitAndRemove },
+  {
+    name: "replacement rejects stale continuations",
+    fn: testReplacementRejectsStaleContinuations,
+  },
+  {
+    name: "destroy and actor error are matching",
+    fn: testDestroyAndActorErrorAreMatching,
+  },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("NRChromeModalChild.request.test.mts", tests);
+}

--- a/browser-features/modules/actors/NRChromeModalChild.sys.mts
+++ b/browser-features/modules/actors/NRChromeModalChild.sys.mts
@@ -3,118 +3,299 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { TForm } from "../../chrome/common/modal-parent/utils/type.ts";
-export class NRChromeModalChild extends JSWindowActorChild {
-  actorCreated() {
-    console.log("NRChromeModalChild actor created");
+import type {
+  ModalCancelRequest,
+  ModalRequestIdentity,
+  ModalResultEnvelope,
+  ModalShowRequest,
+  ModalTerminalReason,
+  TFormResult,
+} from "../../chrome/common/modal-parent/utils/type.ts";
+import { MODAL_TERMINAL_REASONS } from "../../chrome/common/modal-parent/utils/type.ts";
+
+type IntervalHandle = number | ReturnType<typeof globalThis.setInterval>;
+
+interface PendingActorRequest extends ModalRequestIdentity {
+  win: Window;
+  form: ModalShowRequest["form"];
+  resolve(response: ModalResultEnvelope): void;
+  settled: boolean;
+  rendered: boolean;
+  readyInterval: IntervalHandle | null;
+  messageHandler: (event: MessageEvent) => void;
+}
+
+interface ModalPingResponse extends ModalRequestIdentity {
+  ready: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRequestIdentity(
+  value: unknown,
+): value is ModalRequestIdentity & Record<string, unknown> {
+  return isRecord(value) &&
+    typeof value.requestId === "string" &&
+    value.requestId.length > 0 &&
+    Number.isSafeInteger(value.epoch) &&
+    (value.epoch as number) > 0;
+}
+
+function isTerminalReason(value: unknown): value is ModalTerminalReason {
+  return typeof value === "string" &&
+    (MODAL_TERMINAL_REASONS as readonly string[]).includes(value);
+}
+
+function isShowRequest(value: unknown): value is ModalShowRequest {
+  if (!isRequestIdentity(value) || !isRecord(value.form)) {
+    return false;
+  }
+  return Array.isArray(value.form.forms) &&
+    typeof value.form.title === "string";
+}
+
+function isCancelRequest(value: unknown): value is ModalCancelRequest {
+  return isRequestIdentity(value) && isTerminalReason(value.reason);
+}
+
+function matchesRequest(
+  request: ModalRequestIdentity,
+  value: unknown,
+): value is ModalRequestIdentity & Record<string, unknown> {
+  return isRequestIdentity(value) &&
+    request.requestId === value.requestId &&
+    request.epoch === value.epoch;
+}
+
+function isSubmitMessage(
+  request: ModalRequestIdentity,
+  value: unknown,
+): value is ModalResultEnvelope & { type: "nora-modal-submit" } {
+  if (
+    !matchesRequest(request, value) ||
+    value.type !== "nora-modal-submit" ||
+    (value.reason !== "submit" && value.reason !== "cancel")
+  ) {
+    return false;
   }
 
-  async receiveMessage(message: ReceiveMessageArgument) {
-    const window = this.contentWindow as Window;
-    switch (message.name) {
-      case "NRChromeModal:show": {
-        await this.waitForReady(window);
-        this.renderContent(window, message.data);
-        return await this.waitForUserInput(window);
-      }
+  if (value.reason === "cancel") {
+    return value.result === null;
+  }
+
+  return isRecord(value.result) &&
+    Object.values(value.result).every((entry) =>
+      typeof entry === "string" || typeof entry === "number"
+    );
+}
+
+function pageIsReady(win: Window): boolean {
+  const doc = win.document as Document & { documentElement: HTMLElement };
+  return doc?.documentElement?.dataset?.noraModalReady === "true";
+}
+
+export class ModalChildRequestController {
+  private activeRequest: PendingActorRequest | null = null;
+
+  public show(
+    win: Window,
+    value: unknown,
+  ): Promise<ModalResultEnvelope | null> {
+    if (!isShowRequest(value)) {
+      return Promise.resolve(null);
     }
-    return null;
-  }
 
-  private waitForReady(win: Window): Promise<void> {
-    return new Promise((resolve) => {
-      const doc = win.document as Document & { documentElement: HTMLElement };
-      if (doc?.documentElement?.dataset?.noraModalReady === "true") {
-        resolve();
+    const replaced = this.activeRequest;
+    if (replaced) {
+      this.settleOnce(replaced, "replacement", null);
+    }
+
+    let resolveRequest!: (response: ModalResultEnvelope) => void;
+    const response = new Promise<ModalResultEnvelope>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const request: PendingActorRequest = {
+      requestId: value.requestId,
+      epoch: value.epoch,
+      form: value.form,
+      win,
+      resolve: resolveRequest,
+      settled: false,
+      rendered: false,
+      readyInterval: null,
+      messageHandler: () => {},
+    };
+
+    request.messageHandler = (event: MessageEvent) => {
+      if (!request.rendered || !isSubmitMessage(request, event.data)) {
         return;
       }
+      this.settleOnce(request, event.data.reason, event.data.result);
+    };
 
-      let count = 0;
-      const interval = win.setInterval(() => {
-        const currentDoc = win.document as Document & {
-          documentElement: HTMLElement;
-        };
-        if (currentDoc?.documentElement?.dataset?.noraModalReady === "true") {
-          win.clearInterval(interval);
-          resolve();
-        } else if (count > 50) {
-          win.clearInterval(interval);
-          console.error(
-            "NRChromeModalChild: Timeout waiting for nora-modal-ready",
-          );
-          resolve();
-        }
-        count++;
-      }, 100);
-    });
+    // Register identity and terminal ingress before observing page readiness.
+    this.activeRequest = request;
+    win.addEventListener("message", request.messageHandler);
+
+    if (pageIsReady(win)) {
+      this.renderContent(request);
+    } else {
+      this.waitForReady(request);
+    }
+
+    return response;
   }
 
-  renderContent(win: Window, from: TForm) {
-    // Use postMessage instead of CustomEvent to bypass strict security wrapper issues
-    // postMessage handles structured cloning automatically across boundaries
-    try {
-      const detail = JSON.stringify(from);
+  public cancel(value: unknown): boolean {
+    if (!isCancelRequest(value)) {
+      return false;
+    }
+    const request = this.activeRequest;
+    if (!request || !matchesRequest(request, value)) {
+      return false;
+    }
+    return this.settleOnce(request, value.reason, null);
+  }
 
-      // Post message to the window
-      // We use "*" as targetOrigin because we are in a restricted modal environment
-      // and we want to ensure the message reaches the content
-      win.postMessage({ type: "nora-modal-init", detail }, "*");
-    } catch (e) {
-      console.error("NRChromeModalChild: Error posting message", e);
+  public ping(value: unknown): ModalPingResponse | null {
+    if (!isRequestIdentity(value)) {
+      return null;
+    }
+    const request = this.activeRequest;
+    return {
+      requestId: value.requestId,
+      epoch: value.epoch,
+      ready: request !== null &&
+        matchesRequest(request, value) &&
+        request.rendered &&
+        pageIsReady(request.win),
+    };
+  }
+
+  public destroy(): void {
+    const request = this.activeRequest;
+    if (request) {
+      this.settleOnce(request, "dead", null);
     }
   }
 
-  private waitForUserInput(win: Window): Promise<Record<string, unknown>> {
-    return new Promise((resolve) => {
-      // Listen for messages from the content window
-      // We need to listen on the window itself because postMessage targets the window
-      // But in actor context, we might need to listen to the message manager or add listener to the window
+  public getActiveRequestIdentity(): ModalRequestIdentity | null {
+    return this.activeRequest
+      ? {
+        requestId: this.activeRequest.requestId,
+        epoch: this.activeRequest.epoch,
+      }
+      : null;
+  }
 
-      const messageHandler = (event: MessageEvent) => {
-        // Verify the message is from our content
-        // In actor, event.source might be a proxy or wrapper, strict equality check might fail
-        // So we rely on the message structure
-        if (event.data && event.data.type === "nora-modal-submit") {
-          win.removeEventListener("message", messageHandler);
+  private waitForReady(request: PendingActorRequest): void {
+    let count = 0;
+    request.readyInterval = request.win.setInterval(() => {
+      if (!this.isActive(request)) {
+        return;
+      }
+      if (pageIsReady(request.win)) {
+        this.clearReadyInterval(request);
+        this.renderContent(request);
+        return;
+      }
+      if (count++ >= 50) {
+        this.settleOnce(request, "timeout", null);
+      }
+    }, 100);
+  }
 
-          const data = event.data.detail;
-          resolve(data);
-          this.removeContent(win);
-        }
-      };
+  private renderContent(request: PendingActorRequest): void {
+    if (!this.isActive(request)) {
+      return;
+    }
+    request.rendered = true;
+    try {
+      request.win.postMessage({
+        type: "nora-modal-init",
+        requestId: request.requestId,
+        epoch: request.epoch,
+        form: request.form,
+      }, "*");
+    } catch {
+      this.settleOnce(request, "actor-error", null);
+    }
+  }
 
-      // Add listener to the content window
-      // Note: In JSWindowActorChild, we are in the same process but separated by security wrapper
-      // Listening on 'win' should catch postMessage from content to itself
-      win.addEventListener("message", messageHandler);
+  private settleOnce(
+    request: PendingActorRequest,
+    reason: ModalTerminalReason,
+    result: TFormResult | null,
+  ): boolean {
+    if (!this.isActive(request)) {
+      return false;
+    }
 
-      // Fallback: also support legacy sendForm injection for safety or if postMessage fails
-      const originalSendForm = win.sendForm;
-      win.sendForm = (data: Record<string, unknown>) => {
-        win.removeEventListener("message", messageHandler);
-        resolve(data);
-        if (originalSendForm) {
-          return originalSendForm.call(win, data);
-        }
-        this.removeContent(win);
+    request.settled = true;
+    this.activeRequest = null;
+    this.clearReadyInterval(request);
+    request.win.removeEventListener("message", request.messageHandler);
+
+    try {
+      request.win.postMessage({
+        type: "nora-modal-remove",
+        requestId: request.requestId,
+        epoch: request.epoch,
+        reason,
+        result: null,
+      }, "*");
+    } catch {
+      // A dead WindowGlobal cannot receive cleanup, but the query still settles.
+    }
+
+    request.resolve({
+      requestId: request.requestId,
+      epoch: request.epoch,
+      reason,
+      result,
+    });
+    return true;
+  }
+
+  private isActive(request: PendingActorRequest): boolean {
+    return !request.settled && this.activeRequest === request &&
+      this.activeRequest.requestId === request.requestId &&
+      this.activeRequest.epoch === request.epoch;
+  }
+
+  private clearReadyInterval(request: PendingActorRequest): void {
+    if (request.readyInterval === null) {
+      return;
+    }
+    request.win.clearInterval(request.readyInterval);
+    request.readyInterval = null;
+  }
+}
+
+export class NRChromeModalChild extends JSWindowActorChild {
+  private readonly requests = new ModalChildRequestController();
+
+  receiveMessage(message: ReceiveMessageArgument) {
+    const win = this.contentWindow as Window;
+    switch (message.name) {
+      case "NRChromeModal:show":
+        return this.requests.show(win, message.data);
+      case "NRChromeModal:cancel":
+        return this.requests.cancel(message.data);
+      case "NRChromeModal:ping":
+        return this.requests.ping(message.data);
+      default:
         return null;
-      };
-    });
-  }
-
-  private removeContent(win: Window) {
-    // Use postMessage to trigger cleanup in the content
-    try {
-      win.postMessage({ type: "nora-modal-remove" }, "*");
-    } catch (e) {
-      console.error("NRChromeModalChild: Error removing content", e);
-    }
-
-    // Legacy fallback
-    if (typeof win.removeForm === "function") {
-      win.removeForm();
     }
   }
+
+  didDestroy(): void {
+    this.requests.destroy();
+  }
+
   handleEvent(_event: Event): void {
     // No-op
   }

--- a/browser-features/pages-modal-child/src/App.tsx
+++ b/browser-features/pages-modal-child/src/App.tsx
@@ -9,16 +9,20 @@ import { createPortal } from "react-dom";
 import type {
   TForm,
   TFormItem,
-} from "../../../common/modal-parent/utils/type.ts";
+} from "../../chrome/common/modal-parent/utils/type.ts";
+import {
+  applyModalInit,
+  applyModalRemove,
+  createModalCancelMessage,
+  createModalSubmitMessage,
+  isNoraModalInitMessage,
+  isNoraModalRemoveMessage,
+  type ModalPageState,
+  type NoraModalSubmitMessage,
+} from "./modalProtocol.ts";
 
 interface FormValues {
   [key: string]: string;
-}
-
-declare global {
-  var buildFormFromConfig: (config: TForm) => void;
-  var sendForm: (data: FormValues | null) => void;
-  var removeForm: () => void;
 }
 
 interface FormFieldProps {
@@ -360,50 +364,15 @@ const FormField = ({ item, control }: FormFieldProps) => {
   }
 };
 
-interface NoraModalInitMessage {
-  type: "nora-modal-init";
-  detail: string | TForm;
-}
-
-interface NoraModalRemoveMessage {
-  type: "nora-modal-remove";
-}
-
-interface NoraModalSubmitMessage {
-  type: "nora-modal-submit";
-  detail: FormValues | null;
-}
-
-type NoraMessage =
-  | NoraModalInitMessage
-  | NoraModalRemoveMessage
-  | NoraModalSubmitMessage;
-
-function isNoraMessage(data: unknown): data is NoraMessage {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "type" in data &&
-    typeof (data as { type: unknown }).type === "string" &&
-    (data as { type: string }).type.startsWith("nora-modal-")
-  );
-}
-
-function postNoraMessage(message: NoraMessage) {
-  // 1. Post to current window (for actor listening on window)
+function postNoraMessage(message: NoraModalSubmitMessage) {
   globalThis.postMessage(message, "*");
-
-  // 2. Post to opener/parent if available
-  if (globalThis.opener || globalThis.parent !== window) {
-    const target = globalThis.opener || globalThis.parent;
-    target.postMessage(message, "*");
-  }
 }
 
 function App() {
   const methods = useForm<FormValues>();
   const { control, watch } = methods;
   const [formConfig, setFormConfig] = useState<TForm | null>(null);
+  const activeStateRef = useRef<ModalPageState | null>(null);
 
   const values = watch();
 
@@ -425,85 +394,54 @@ function App() {
   };
 
   const onSubmit = (data: FormValues) => {
-    postNoraMessage({ type: "nora-modal-submit", detail: data });
-
-    if (typeof globalThis.sendForm === "function") {
-      globalThis.sendForm(data);
+    const current = activeStateRef.current;
+    if (current) {
+      postNoraMessage(createModalSubmitMessage(current, data));
     }
   };
 
   const handleCancel = () => {
-    postNoraMessage({ type: "nora-modal-submit", detail: null });
-
-    if (typeof globalThis.sendForm === "function") {
-      globalThis.sendForm(null);
+    const current = activeStateRef.current;
+    if (current) {
+      postNoraMessage(createModalCancelMessage(current));
     }
   };
 
   useEffect(() => {
-    const handler = (e: Event) => {
-      if (e instanceof CustomEvent) {
-        methods.reset(e.detail);
-      }
-    };
-
     const messageHandler = (e: MessageEvent) => {
-      if (!isNoraMessage(e.data)) {
-        return;
-      }
-
-      const message = e.data;
-
-      if (message.type === "nora-modal-init") {
-        try {
-          const detail = message.detail;
-          const config = typeof detail === "string"
-            ? JSON.parse(detail)
-            : detail;
-
-          if (!config || !config.forms) {
-            console.error("Invalid config received:", config);
-            return;
-          }
-
-          setFormConfig(config);
-          const initialValues: FormValues = {};
-          config.forms.forEach((item: TFormItem) => {
-            initialValues[item.id] = String(item.value || "");
-          });
-          methods.reset(initialValues);
-        } catch (err) {
-          console.error("Failed to parse modal config:", err);
+      if (isNoraModalInitMessage(e.data)) {
+        const current = activeStateRef.current;
+        const next = applyModalInit(current, e.data);
+        if (next === current || next === null) {
+          return;
         }
-      } else if (message.type === "nora-modal-remove") {
+        activeStateRef.current = next;
+        setFormConfig(next.form);
+        const initialValues: FormValues = {};
+        next.form.forms.forEach((item: TFormItem) => {
+          initialValues[item.id] = String(item.value || "");
+        });
+        methods.reset(initialValues);
+      } else if (isNoraModalRemoveMessage(e.data)) {
+        const current = activeStateRef.current;
+        const next = applyModalRemove(current, e.data);
+        if (next === current) {
+          return;
+        }
+        activeStateRef.current = next;
         setFormConfig(null);
       }
     };
 
-    globalThis.addEventListener("form-update", handler);
     globalThis.addEventListener("message", messageHandler);
 
-    // Signal readiness
     document.documentElement.dataset.noraModalReady = "true";
 
     return () => {
-      globalThis.removeEventListener("form-update", handler);
       globalThis.removeEventListener("message", messageHandler);
+      delete document.documentElement.dataset.noraModalReady;
     };
   }, [methods]);
-
-  globalThis.buildFormFromConfig = (config: TForm) => {
-    setFormConfig(config);
-    const initialValues: FormValues = {};
-    config.forms.forEach((item) => {
-      initialValues[item.id] = String(item.value || "");
-    });
-    methods.reset(initialValues);
-  };
-
-  globalThis.removeForm = () => {
-    setFormConfig(null);
-  };
 
   return (
     <>

--- a/browser-features/pages-modal-child/src/modalProtocol.ts
+++ b/browser-features/pages-modal-child/src/modalProtocol.ts
@@ -1,0 +1,197 @@
+import type {
+  ModalRequestIdentity,
+  ModalTerminalReason,
+  TForm,
+  TFormResult,
+} from "../../chrome/common/modal-parent/utils/type.ts";
+import { MODAL_TERMINAL_REASONS } from "../../chrome/common/modal-parent/utils/type.ts";
+
+export interface NoraModalInitMessage extends ModalRequestIdentity {
+  type: "nora-modal-init";
+  form: TForm;
+}
+
+export interface NoraModalSubmitMessage extends ModalRequestIdentity {
+  type: "nora-modal-submit";
+  reason: "submit" | "cancel";
+  result: TFormResult | null;
+}
+
+export interface NoraModalRemoveMessage extends ModalRequestIdentity {
+  type: "nora-modal-remove";
+  reason: ModalTerminalReason;
+  result: null;
+}
+
+export interface ModalPageState extends ModalRequestIdentity {
+  form: TForm;
+}
+
+export type NoraModalMessage =
+  | NoraModalInitMessage
+  | NoraModalSubmitMessage
+  | NoraModalRemoveMessage;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isModalRequestIdentity(
+  value: unknown,
+): value is ModalRequestIdentity & Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.requestId === "string" &&
+    value.requestId.length > 0 &&
+    Number.isSafeInteger(value.epoch) &&
+    (value.epoch as number) > 0;
+}
+
+export function isModalTerminalReason(
+  value: unknown,
+): value is ModalTerminalReason {
+  return typeof value === "string" &&
+    (MODAL_TERMINAL_REASONS as readonly string[]).includes(value);
+}
+
+function isForm(value: unknown): value is TForm {
+  return isRecord(value) &&
+    Array.isArray(value.forms) &&
+    typeof value.title === "string";
+}
+
+function isFormResult(value: unknown): value is TFormResult {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Object.values(value).every((entry) =>
+    typeof entry === "string" || typeof entry === "number"
+  );
+}
+
+export function isNoraModalInitMessage(
+  value: unknown,
+): value is NoraModalInitMessage {
+  return isModalRequestIdentity(value) &&
+    value.type === "nora-modal-init" &&
+    isForm(value.form);
+}
+
+export function isNoraModalSubmitMessage(
+  value: unknown,
+): value is NoraModalSubmitMessage {
+  if (
+    !isModalRequestIdentity(value) ||
+    value.type !== "nora-modal-submit" ||
+    (value.reason !== "submit" && value.reason !== "cancel")
+  ) {
+    return false;
+  }
+
+  return value.reason === "submit"
+    ? isFormResult(value.result)
+    : value.result === null;
+}
+
+export function isNoraModalRemoveMessage(
+  value: unknown,
+): value is NoraModalRemoveMessage {
+  return isModalRequestIdentity(value) &&
+    value.type === "nora-modal-remove" &&
+    isModalTerminalReason(value.reason) &&
+    value.result === null;
+}
+
+export function matchesModalRequest(
+  current: ModalRequestIdentity | null,
+  incoming: ModalRequestIdentity,
+): boolean {
+  return current !== null &&
+    current.requestId === incoming.requestId &&
+    current.epoch === incoming.epoch;
+}
+
+export function shouldAcceptModalInit(
+  current: ModalRequestIdentity | null,
+  incoming: ModalRequestIdentity,
+): boolean {
+  if (current === null) {
+    return true;
+  }
+
+  return incoming.epoch > current.epoch ||
+    matchesModalRequest(current, incoming);
+}
+
+export function applyModalInit(
+  current: ModalPageState | null,
+  incoming: unknown,
+): ModalPageState | null {
+  if (
+    !isNoraModalInitMessage(incoming) ||
+    !shouldAcceptModalInit(current, incoming)
+  ) {
+    return current;
+  }
+
+  return {
+    requestId: incoming.requestId,
+    epoch: incoming.epoch,
+    form: incoming.form,
+  };
+}
+
+export function applyModalRemove(
+  current: ModalPageState | null,
+  incoming: unknown,
+): ModalPageState | null {
+  if (
+    !isNoraModalRemoveMessage(incoming) ||
+    !matchesModalRequest(current, incoming)
+  ) {
+    return current;
+  }
+
+  return null;
+}
+
+export function createModalSubmitMessage(
+  identity: ModalRequestIdentity,
+  result: TFormResult,
+): NoraModalSubmitMessage {
+  return {
+    type: "nora-modal-submit",
+    requestId: identity.requestId,
+    epoch: identity.epoch,
+    reason: "submit",
+    result,
+  };
+}
+
+export function createModalCancelMessage(
+  identity: ModalRequestIdentity,
+): NoraModalSubmitMessage {
+  return {
+    type: "nora-modal-submit",
+    requestId: identity.requestId,
+    epoch: identity.epoch,
+    reason: "cancel",
+    result: null,
+  };
+}
+
+export function createModalRemoveMessage(
+  identity: ModalRequestIdentity,
+  reason: ModalTerminalReason,
+): NoraModalRemoveMessage {
+  return {
+    type: "nora-modal-remove",
+    requestId: identity.requestId,
+    epoch: identity.epoch,
+    reason,
+    result: null,
+  };
+}

--- a/browser-features/pages-modal-child/test/modalProtocol.test.ts
+++ b/browser-features/pages-modal-child/test/modalProtocol.test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../chrome/test/utils/test_harness.ts";
+import {
+  applyModalInit,
+  applyModalRemove,
+  createModalCancelMessage,
+  createModalRemoveMessage,
+  createModalSubmitMessage,
+  isNoraModalInitMessage,
+  isNoraModalRemoveMessage,
+  isNoraModalSubmitMessage,
+  matchesModalRequest,
+  type ModalPageState,
+  shouldAcceptModalInit,
+} from "../src/modalProtocol.ts";
+
+const form = {
+  forms: [{ id: "name", type: "text" as const, value: "Floorp" }],
+  title: "Protocol",
+};
+
+function init(requestId: string, epoch: number) {
+  return { type: "nora-modal-init" as const, requestId, epoch, form };
+}
+
+function testEnvelopeValidationFailsClosed(): void {
+  assert(isNoraModalInitMessage(init("valid", 1)), "valid init is accepted");
+  assertEquals(
+    isNoraModalInitMessage({ type: "nora-modal-init", form }),
+    false,
+    "untagged init is rejected",
+  );
+  assertEquals(
+    isNoraModalSubmitMessage({
+      type: "nora-modal-submit",
+      requestId: "valid",
+      epoch: 1,
+      reason: "cancel",
+      result: { not: "null" },
+    }),
+    false,
+    "cancel must carry null",
+  );
+  assertEquals(
+    isNoraModalRemoveMessage({
+      type: "nora-modal-remove",
+      requestId: "valid",
+      epoch: 1,
+      reason: "remove",
+    }),
+    false,
+    "remove must carry explicit null",
+  );
+}
+
+function testCurrentAndNewerInitOnly(): void {
+  const current = applyModalInit(null, init("current", 2));
+  assert(current !== null, "first valid init creates state");
+  assert(
+    shouldAcceptModalInit(current, init("current", 2)),
+    "same request is idempotently accepted",
+  );
+  assertEquals(
+    shouldAcceptModalInit(current, init("different", 2)),
+    false,
+    "same epoch cannot change identity",
+  );
+  assertEquals(
+    applyModalInit(current, init("older", 1)),
+    current,
+    "older init is ignored",
+  );
+  const newer = applyModalInit(current, init("newer", 3));
+  assertEquals(newer?.requestId, "newer", "newer epoch replaces current");
+}
+
+function testStaleRemoveCannotClearNewerState(): void {
+  const current = applyModalInit(null, init("current", 4));
+  assert(current !== null, "current state exists");
+  const staleRemove = createModalRemoveMessage(
+    { requestId: "stale", epoch: 3 },
+    "replacement",
+  );
+  assertEquals(
+    applyModalRemove(current, staleRemove),
+    current,
+    "stale remove preserves current state",
+  );
+  assertEquals(
+    applyModalRemove(
+      current,
+      createModalRemoveMessage(current, "cancel"),
+    ),
+    null,
+    "matching remove clears state",
+  );
+}
+
+function testIdentityEchoForSubmitAndCancel(): void {
+  const state: ModalPageState = {
+    requestId: "echo",
+    epoch: 5,
+    form,
+  };
+  const submit = createModalSubmitMessage(state, { name: "Floorp" });
+  const cancel = createModalCancelMessage(state);
+  assert(isNoraModalSubmitMessage(submit), "built submit validates");
+  assert(isNoraModalSubmitMessage(cancel), "built cancel validates");
+  assert(
+    matchesModalRequest(state, submit),
+    "submit echoes rendered identity",
+  );
+  assert(
+    matchesModalRequest(state, cancel),
+    "cancel echoes rendered identity",
+  );
+  assertEquals(submit.result?.name, "Floorp", "submit payload is preserved");
+  assertEquals(cancel.result, null, "cancel payload is null");
+}
+
+function testStaleSubmitDoesNotMatchCurrent(): void {
+  const current = applyModalInit(null, init("current", 7));
+  assert(current !== null, "current state exists");
+  const stale = createModalSubmitMessage(
+    { requestId: "old", epoch: 6 },
+    { stale: "value" },
+  );
+  assertEquals(
+    matchesModalRequest(current, stale),
+    false,
+    "stale submit cannot target newer form",
+  );
+}
+
+const tests: TestCase[] = [
+  {
+    name: "envelope validation fails closed",
+    fn: testEnvelopeValidationFailsClosed,
+  },
+  { name: "current and newer init only", fn: testCurrentAndNewerInitOnly },
+  {
+    name: "stale remove cannot clear newer state",
+    fn: testStaleRemoveCannotClearNewerState,
+  },
+  {
+    name: "identity echo for submit and cancel",
+    fn: testIdentityEchoForSubmitAndCancel,
+  },
+  {
+    name: "stale submit does not match current",
+    fn: testStaleSubmitDoesNotMatchCurrent,
+  },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("modalProtocol.test.ts", tests);
+}


### PR DESCRIPTION
## Summary

- tag each modal request with `requestId` and `epoch` so replacement and stale continuations cannot settle the wrong caller
- make submit, cancel, Escape, backdrop, replacement, watchdog, missing/dead child, and teardown paths settle exactly once
- validate the parent/actor/page protocol and let workspace and panel-sidebar callers handle the nullable cancellation result
- keep one modal owner across initialization and HMR while cleaning actor/page listeners deterministically

## Rescue provenance and classification

This is a fresh redesign replacing the closed, unmerged [PR #2549](https://github.com/Floorp-Projects/Floorp/pull/2549), contributed through [issue #2569](https://github.com/Floorp-Projects/Floorp/issues/2569). It does **not** cherry-pick the abandoned implementation.

- preserved original head: `5bf92b29df40a3d68c86594190df98cd1f5a11ad`
- original author: `100mountains <nobody@nowhere.com>`
- original co-author trailer: `Claude Fable 5 <noreply@anthropic.com>`
- replacement commit: `471f99a8e00ca221cb410ebe631b97e7c0f13bb2`

## Validation

- exact locked Floorp Runtime `153.0`, BuildID `20260725075208`
- real-browser harness: **10/10 flows passed** — workspace and panel submit/cancel/Escape/backdrop, persistent-child A→B stale-request race, and cancel-before-ready
- one modal container and browser remained in the same browsing context; final overlay was hidden, child state was empty/ready, and modal-related console errors were `0`
- focused and broad modal-parent, actor, page-protocol, workspace-caller, and panel-caller tests passed with non-zero discovery
- `deno task test:smoke`: all six stages and 41 runner tests passed
- exact-path formatting, targeted type/sloppy-import checks, focused lint, modal-child production build, and `git diff --check` passed
- independent Tier 1 A/B/C review found no P0/P1 issue

## Known fidelity gaps

- public `hideNoraModal()` and dead/silent/throwing actor branches were exercised by locked browser tests with controlled doubles, not destructive manipulation of the live UI actor
- full `feles-build stage --marionette` is blocked before browser startup by the unrelated canonical-main `pages-newtab` / `lucide-react` default-export failure
- the existing dev modal CSP transform misses its self-closing meta tag; real UI proof therefore used the separately built modal page through a temporary generated chrome registration in the exact locked browser. That registration was removed, and no tracked manifest/CSP/config source changed

This PR is intentionally opened as a Draft for maintainer review and CI. It does not authorize Ready status or merge.
## CI baseline

GitHub Actions run [30240440831](https://github.com/Floorp-Projects/Floorp/actions/runs/30240440831) reached **208 passed / 1 failed** in host-tool tests. The only failure is the existing canonical-main localization assertion `ja-JP locale must define about.noraneko`; this branch changes no localization path. The dependent Native Runtime matrix was skipped after that smoke failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable modal request tracking to prevent outdated submissions or cancellations from affecting the current modal.
  - Modal cancellation now returns a clear empty result when dismissed.
  - Added dismissal by clicking the backdrop or pressing Escape.
  - Added safeguards for unavailable, unresponsive, or interrupted modal windows.

- **Bug Fixes**
  - Prevented duplicate completion, stale responses, and lingering modal state.
  - Improved cleanup when modals are replaced or closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->