### PR TITLE
fix(shortcuts): preserve typing in editable content

### DIFF
--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -6,6 +6,11 @@
 import { getConfig, isEnabled, isSafeErrorHandling } from "./config.ts";
 import { gestureActions } from "../mouse-gesture/utils/gestures.ts";
 import type { ShortcutConfig } from "./type.ts";
+import {
+  isBarePrintableKeyEvent,
+  isKeyboardShortcutTypingContext,
+  type KeyboardShortcutFocusStoreReader,
+} from "./editable-focus.ts";
 
 export class KeyboardShortcutController {
   private eventListenersAttached = false;
@@ -18,9 +23,14 @@ export class KeyboardShortcutController {
   };
 
   private targetWindow: Window;
+  private remoteFocusStore: KeyboardShortcutFocusStoreReader | null;
 
-  constructor(win: Window = globalThis as unknown as Window) {
+  constructor(
+    win: Window = globalThis as unknown as Window,
+    remoteFocusStore: KeyboardShortcutFocusStoreReader | null = null,
+  ) {
     this.targetWindow = win;
+    this.remoteFocusStore = remoteFocusStore;
     this.init();
   }
 
@@ -34,7 +44,11 @@ export class KeyboardShortcutController {
 
   public destroy(): void {
     if (this.eventListenersAttached) {
-      this.targetWindow.removeEventListener("keydown", this.handleKeyDown, true);
+      this.targetWindow.removeEventListener(
+        "keydown",
+        this.handleKeyDown,
+        true,
+      );
       this.targetWindow.removeEventListener("keyup", this.handleKeyUp, true);
       this.eventListenersAttached = false;
     }
@@ -62,6 +76,19 @@ export class KeyboardShortcutController {
     };
 
     const code = event.code;
+
+    if (
+      isBarePrintableKeyEvent(event) &&
+      isKeyboardShortcutTypingContext(
+        this.targetWindow,
+        this.remoteFocusStore,
+      )
+    ) {
+      // Do not retain a repeated key from before focus entered an editable.
+      this.pressedKeys.delete(code);
+      return;
+    }
+
     this.pressedKeys.add(code);
 
     // Ignore pure modifier key presses. Using startsWith keeps this concise

--- a/browser-features/chrome/common/keyboard-shortcut/editable-focus.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/editable-focus.ts
@@ -1,0 +1,76 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export interface KeyboardShortcutFocusStoreReader {
+  isEditableFocused(browser: object): boolean;
+}
+
+type ChromeFocusElement = Element & {
+  isContentEditable?: boolean;
+};
+
+/**
+ * Bare printable key events are the only events the typing guard suppresses.
+ * Matching still uses KeyboardEvent.code in the controller.
+ */
+export function isBarePrintableKeyEvent(event: KeyboardEvent): boolean {
+  return event.key.length === 1 &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    !event.isComposing &&
+    !event.getModifierState?.("AltGraph");
+}
+
+/** Return whether focus is in an editable owned by the chrome document. */
+export function isChromeEditableFocused(win: Window): boolean {
+  const element = win.document?.activeElement as ChromeFocusElement | null;
+  if (!element) {
+    return false;
+  }
+
+  const localName = element.localName?.toLowerCase() ?? "";
+  if (localName === "input" || localName === "textarea") {
+    return true;
+  }
+  if (element.isContentEditable === true) {
+    return true;
+  }
+
+  // These chrome controls host their editable in anonymous/shadow content,
+  // so the document activeElement can be the host rather than the input.
+  return element.closest("#urlbar, #searchbar, findbar") !== null;
+}
+
+/** Return the remote browser that currently owns chrome focus, if any. */
+export function getFocusedRemoteBrowser(win: Window): object | null {
+  const element = win.document?.activeElement;
+  return element?.localName?.toLowerCase() === "browser" ? element : null;
+}
+
+/**
+ * Synchronously combine independent chrome and remote editable state.
+ * A missing or failed remote reader intentionally preserves prior behavior.
+ */
+export function isKeyboardShortcutTypingContext(
+  win: Window,
+  remoteFocusStore: KeyboardShortcutFocusStoreReader | null,
+): boolean {
+  if (isChromeEditableFocused(win)) {
+    return true;
+  }
+
+  const browser = getFocusedRemoteBrowser(win);
+  if (!browser || !remoteFocusStore) {
+    return false;
+  }
+
+  try {
+    return remoteFocusStore.isEditableFocused(browser);
+  } catch (_error) {
+    return false;
+  }
+}

--- a/browser-features/chrome/common/keyboard-shortcut/service.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/service.ts
@@ -8,12 +8,30 @@ import { KeyboardShortcutController } from "./controller.ts";
 import { createRootHMR } from "@nora/solid-xul";
 import { createEffect } from "solid-js";
 import type { KeyboardShortcutConfig } from "./type.ts";
+import type { KeyboardShortcutFocusStoreReader } from "./editable-focus.ts";
+
+const FOCUS_PARENT_MODULE =
+  "resource://noraneko/actors/NRKeyboardShortcutFocusParent.sys.mjs";
+
+function loadRemoteFocusStore(): KeyboardShortcutFocusStoreReader | null {
+  try {
+    const actorModule = ChromeUtils.importESModule(FOCUS_PARENT_MODULE) as {
+      nrKeyboardShortcutFocusStore?: KeyboardShortcutFocusStoreReader;
+    };
+    return actorModule.nrKeyboardShortcutFocusStore ?? null;
+  } catch (_error) {
+    // Missing remote state deliberately preserves the pre-guard behavior.
+    return null;
+  }
+}
 
 export class KeyboardShortcutService {
   private controllers: Map<Window, KeyboardShortcutController> = new Map();
   private lastConfigString = "";
+  private readonly remoteFocusStore: KeyboardShortcutFocusStoreReader | null;
 
-  constructor() {
+  constructor(remoteFocusStore = loadRemoteFocusStore()) {
+    this.remoteFocusStore = remoteFocusStore;
     this.initialize();
 
     createEffect(() => {
@@ -62,7 +80,10 @@ export class KeyboardShortcutService {
     }
 
     if (isEnabled()) {
-      const controller = new KeyboardShortcutController(win);
+      const controller = new KeyboardShortcutController(
+        win,
+        this.remoteFocusStore,
+      );
       this.controllers.set(win, controller);
 
       // Mark the window as having a controller attached

--- a/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutTypingGuard.test.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutTypingGuard.test.ts
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import { KeyboardShortcutController } from "../controller.ts";
+import {
+  isBarePrintableKeyEvent,
+  isChromeEditableFocused,
+  type KeyboardShortcutFocusStoreReader,
+} from "../editable-focus.ts";
+import {
+  KEYBOARD_SHORTCUT_CONFIG_PREF,
+  KEYBOARD_SHORTCUT_ENABLED_PREF,
+  setConfig,
+  setEnabled,
+} from "../config.ts";
+import type { KeyboardShortcutConfig, Modifiers } from "../type.ts";
+
+type FocusElement = Element & { isContentEditable?: boolean };
+
+function withPrefs(fn: () => void): void {
+  const hadEnabled = Services.prefs.prefHasUserValue(
+    KEYBOARD_SHORTCUT_ENABLED_PREF,
+  );
+  const hadConfig = Services.prefs.prefHasUserValue(
+    KEYBOARD_SHORTCUT_CONFIG_PREF,
+  );
+  const savedEnabled = hadEnabled
+    ? Services.prefs.getBoolPref(KEYBOARD_SHORTCUT_ENABLED_PREF)
+    : null;
+  const savedConfig = hadConfig
+    ? Services.prefs.getStringPref(KEYBOARD_SHORTCUT_CONFIG_PREF)
+    : null;
+
+  try {
+    fn();
+  } finally {
+    if (hadEnabled && savedEnabled !== null) {
+      Services.prefs.setBoolPref(
+        KEYBOARD_SHORTCUT_ENABLED_PREF,
+        savedEnabled,
+      );
+    } else {
+      Services.prefs.clearUserPref(KEYBOARD_SHORTCUT_ENABLED_PREF);
+    }
+    if (hadConfig && savedConfig !== null) {
+      Services.prefs.setStringPref(
+        KEYBOARD_SHORTCUT_CONFIG_PREF,
+        savedConfig,
+      );
+    } else {
+      Services.prefs.clearUserPref(KEYBOARD_SHORTCUT_CONFIG_PREF);
+    }
+  }
+}
+
+function applyShortcut(key: string, modifiers: Modifiers): void {
+  const config: KeyboardShortcutConfig = {
+    enabled: true,
+    shortcuts: {
+      "typing-guard-test": {
+        key,
+        modifiers,
+        action: "typing-guard-test",
+      },
+    },
+  };
+  setEnabled(true);
+  setConfig(config);
+}
+
+function createFocusElement(
+  localName: string,
+  options: { contentEditable?: boolean; chromeHost?: boolean } = {},
+): FocusElement {
+  const element = {
+    localName,
+    isContentEditable: options.contentEditable ?? false,
+    closest: () => options.chromeHost ? element : null,
+  };
+  return element as unknown as FocusElement;
+}
+
+function createFakeWindow(activeElement: FocusElement | null): Window {
+  const target = new EventTarget();
+  Object.defineProperty(target, "document", {
+    configurable: true,
+    value: { activeElement },
+  });
+  return target as unknown as Window;
+}
+
+function dispatchKey(
+  win: Window,
+  init: KeyboardEventInit & { key: string; code: string },
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  win.dispatchEvent(event);
+  return event;
+}
+
+function modifiers(overrides: Partial<Modifiers> = {}): Modifiers {
+  return {
+    alt: false,
+    ctrl: false,
+    meta: false,
+    shift: false,
+    ...overrides,
+  };
+}
+
+function predicateEvent(
+  overrides: Partial<KeyboardEvent> = {},
+): KeyboardEvent {
+  return {
+    key: "z",
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    isComposing: false,
+    getModifierState: () => false,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+function testBarePrintablePredicateIsExact(): void {
+  assertEquals(
+    isBarePrintableKeyEvent(predicateEvent()),
+    true,
+    "a single unmodified printable key should be guarded",
+  );
+  for (
+    const event of [
+      predicateEvent({ key: "Escape" }),
+      predicateEvent({ altKey: true }),
+      predicateEvent({ ctrlKey: true }),
+      predicateEvent({ metaKey: true }),
+      predicateEvent({ shiftKey: true }),
+      predicateEvent({ isComposing: true }),
+      predicateEvent({ getModifierState: (name) => name === "AltGraph" }),
+    ]
+  ) {
+    assertEquals(
+      isBarePrintableKeyEvent(event),
+      false,
+      "non-bare, non-printable, composing, and AltGraph events stay active",
+    );
+  }
+}
+
+function testChromeEditableCoverage(): void {
+  const cases: Array<[string, FocusElement]> = [
+    ["input", createFocusElement("input")],
+    ["textarea", createFocusElement("textarea")],
+    ["contenteditable", createFocusElement("div", { contentEditable: true })],
+    ["urlbar", createFocusElement("div", { chromeHost: true })],
+    ["searchbar", createFocusElement("searchbar", { chromeHost: true })],
+    ["findbar", createFocusElement("findbar", { chromeHost: true })],
+  ];
+  for (const [name, element] of cases) {
+    assertEquals(
+      isChromeEditableFocused(createFakeWindow(element)),
+      true,
+      `${name} focus should be recognized as chrome editable`,
+    );
+  }
+  assertEquals(
+    isChromeEditableFocused(createFakeWindow(createFocusElement("button"))),
+    false,
+    "a non-editable chrome control should not be guarded",
+  );
+}
+
+function testChromeInputSuppressesBarePrintableShortcut(): void {
+  withPrefs(() => {
+    applyShortcut("Z", modifiers());
+    const win = createFakeWindow(createFocusElement("input"));
+    const controller = new KeyboardShortcutController(win);
+    const event = dispatchKey(win, { key: "z", code: "KeyZ" });
+    assertEquals(
+      event.defaultPrevented,
+      false,
+      "typing in a chrome input should receive the bare printable key",
+    );
+    controller.destroy();
+  });
+}
+
+function testRemoteInputSuppressesBarePrintableShortcut(): void {
+  withPrefs(() => {
+    applyShortcut("Z", modifiers());
+    const browser = createFocusElement("browser");
+    const win = createFakeWindow(browser);
+    const store: KeyboardShortcutFocusStoreReader = {
+      isEditableFocused(candidate): boolean {
+        return candidate === browser;
+      },
+    };
+    const controller = new KeyboardShortcutController(win, store);
+    const event = dispatchKey(win, { key: "z", code: "KeyZ" });
+    assertEquals(
+      event.defaultPrevented,
+      false,
+      "remote editable state should suppress a bare printable shortcut",
+    );
+    controller.destroy();
+  });
+}
+
+function testMissingRemoteStatePreservesBehavior(): void {
+  withPrefs(() => {
+    applyShortcut("Z", modifiers());
+    const win = createFakeWindow(createFocusElement("browser"));
+    const controller = new KeyboardShortcutController(win, null);
+    const event = dispatchKey(win, { key: "z", code: "KeyZ" });
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "missing actor state should preserve existing shortcut dispatch",
+    );
+    controller.destroy();
+  });
+}
+
+function testFailedRemoteStateReadPreservesBehavior(): void {
+  withPrefs(() => {
+    applyShortcut("Z", modifiers());
+    const win = createFakeWindow(createFocusElement("browser"));
+    const store: KeyboardShortcutFocusStoreReader = {
+      isEditableFocused(): boolean {
+        throw new Error("actor store unavailable");
+      },
+    };
+    const controller = new KeyboardShortcutController(win, store);
+    const event = dispatchKey(win, { key: "z", code: "KeyZ" });
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "a failed remote state read should preserve existing shortcut dispatch",
+    );
+    controller.destroy();
+  });
+}
+
+function testChordRemainsActiveWhileRemoteTyping(): void {
+  withPrefs(() => {
+    applyShortcut("Z", modifiers({ ctrl: true }));
+    const browser = createFocusElement("browser");
+    const win = createFakeWindow(browser);
+    const store: KeyboardShortcutFocusStoreReader = {
+      isEditableFocused: () => true,
+    };
+    const controller = new KeyboardShortcutController(win, store);
+    const event = dispatchKey(win, {
+      key: "z",
+      code: "KeyZ",
+      ctrlKey: true,
+    });
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "modified chords should remain active while remote content is editable",
+    );
+    controller.destroy();
+  });
+}
+
+function testNonPrintableCommandRemainsActiveWhileRemoteTyping(): void {
+  withPrefs(() => {
+    applyShortcut("F2", modifiers());
+    const browser = createFocusElement("browser");
+    const win = createFakeWindow(browser);
+    const store: KeyboardShortcutFocusStoreReader = {
+      isEditableFocused: () => true,
+    };
+    const controller = new KeyboardShortcutController(win, store);
+    const event = dispatchKey(win, { key: "F2", code: "F2" });
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "function-key commands should remain active while typing",
+    );
+    controller.destroy();
+  });
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "bare printable predicate is exact",
+      fn: testBarePrintablePredicateIsExact,
+    },
+    { name: "chrome editable coverage", fn: testChromeEditableCoverage },
+    {
+      name: "chrome input suppresses bare printable shortcut",
+      fn: testChromeInputSuppressesBarePrintableShortcut,
+    },
+    {
+      name: "remote input suppresses bare printable shortcut",
+      fn: testRemoteInputSuppressesBarePrintableShortcut,
+    },
+    {
+      name: "missing remote state preserves behavior",
+      fn: testMissingRemoteStatePreservesBehavior,
+    },
+    {
+      name: "failed remote state read preserves behavior",
+      fn: testFailedRemoteStateReadPreservesBehavior,
+    },
+    {
+      name: "modified chord remains active while typing",
+      fn: testChordRemainsActiveWhileRemoteTyping,
+    },
+    {
+      name: "non-printable command remains active while typing",
+      fn: testNonPrintableCommandRemainsActiveWhileRemoteTyping,
+    },
+  ];
+  await runTests("keyboardShortcutTypingGuard.test.ts", tests);
+}

--- a/browser-features/modules/actors/NRKeyboardShortcutFocusChild.sys.mts
+++ b/browser-features/modules/actors/NRKeyboardShortcutFocusChild.sys.mts
@@ -1,0 +1,112 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  NR_KEYBOARD_SHORTCUT_FOCUS_MESSAGE,
+  type NRKeyboardShortcutFocusUpdate,
+} from "../common/NRKeyboardShortcutFocusTypes.ts";
+
+type EditableElement = Element & {
+  isContentEditable?: boolean;
+};
+
+export function isKeyboardShortcutEditableTarget(
+  target: EventTarget | null,
+  designMode: string | null | undefined,
+): boolean {
+  if (designMode?.toLowerCase() === "on") {
+    return true;
+  }
+
+  const element = target as EditableElement | null;
+  const localName = element?.localName?.toLowerCase() ?? "";
+  if (localName === "input" || localName === "textarea") {
+    return true;
+  }
+  if (element?.isContentEditable === true) {
+    return true;
+  }
+
+  let current: Element | null = element;
+  while (current) {
+    const value = current.getAttribute?.("contenteditable");
+    if (value !== null && value !== undefined) {
+      return value.toLowerCase() !== "false";
+    }
+    current = current.parentElement;
+  }
+  return false;
+}
+
+export function isKeyboardShortcutEditableFocusEvent(
+  event: Event,
+  doc: Document,
+): boolean {
+  const path = event.composedPath?.() ?? [];
+  for (const target of path) {
+    if (isKeyboardShortcutEditableTarget(target, doc.designMode)) {
+      return true;
+    }
+  }
+  return isKeyboardShortcutEditableTarget(doc.activeElement, doc.designMode);
+}
+
+export class NRKeyboardShortcutFocusChild extends JSWindowActorChild {
+  private lastEditable = false;
+
+  actorCreated(): void {
+    this.publishCurrentFocus();
+  }
+
+  handleEvent(event: Event): void {
+    const doc = this.contentWindow?.document;
+    if (!doc) {
+      this.publish(false);
+      return;
+    }
+
+    switch (event.type) {
+      case "focusin":
+        this.publish(isKeyboardShortcutEditableFocusEvent(event, doc));
+        break;
+      case "DOMContentLoaded":
+      case "pageshow":
+        this.publishCurrentFocus();
+        break;
+      case "focusout":
+      case "blur":
+      case "pagehide":
+        this.publish(false);
+        break;
+    }
+  }
+
+  willDestroy(): void {
+    this.publish(false);
+  }
+
+  private publishCurrentFocus(): void {
+    const doc = this.contentWindow?.document;
+    this.publish(
+      doc
+        ? isKeyboardShortcutEditableTarget(doc.activeElement, doc.designMode)
+        : false,
+    );
+  }
+
+  private publish(editable: boolean): void {
+    if (editable === this.lastEditable) {
+      return;
+    }
+    this.lastEditable = editable;
+
+    const data: NRKeyboardShortcutFocusUpdate = { editable };
+    try {
+      this.sendAsyncMessage(NR_KEYBOARD_SHORTCUT_FOCUS_MESSAGE, data);
+    } catch (_error) {
+      // Teardown can invalidate the actor between the event and this send.
+    }
+  }
+}

--- a/browser-features/modules/actors/NRKeyboardShortcutFocusParent.sys.mts
+++ b/browser-features/modules/actors/NRKeyboardShortcutFocusParent.sys.mts
@@ -1,0 +1,57 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  nrKeyboardShortcutFocusStore,
+} from "../common/NRKeyboardShortcutFocusStore.ts";
+import type { NRKeyboardShortcutFocusStore } from "../common/NRKeyboardShortcutFocusStore.ts";
+import {
+  NR_KEYBOARD_SHORTCUT_FOCUS_MESSAGE,
+  type NRKeyboardShortcutFocusUpdate,
+} from "../common/NRKeyboardShortcutFocusTypes.ts";
+
+export { nrKeyboardShortcutFocusStore };
+
+export function applyKeyboardShortcutFocusUpdate(
+  store: NRKeyboardShortcutFocusStore,
+  frame: object,
+  browser: object | null,
+  data: unknown,
+): void {
+  if (!browser) {
+    store.removeFrame(frame);
+    return;
+  }
+
+  const editable = (data as Partial<NRKeyboardShortcutFocusUpdate> | null)
+    ?.editable;
+  if (typeof editable !== "boolean") {
+    store.removeFrame(frame);
+    return;
+  }
+
+  store.setFrameEditable(browser, frame, editable);
+}
+
+export class NRKeyboardShortcutFocusParent extends JSWindowActorParent {
+  receiveMessage(message: { name: string; data?: unknown }): void {
+    if (message.name !== NR_KEYBOARD_SHORTCUT_FOCUS_MESSAGE) {
+      return;
+    }
+
+    const browser = this.browsingContext?.top?.embedderElement ?? null;
+    applyKeyboardShortcutFocusUpdate(
+      nrKeyboardShortcutFocusStore,
+      this,
+      browser,
+      message.data,
+    );
+  }
+
+  didDestroy(): void {
+    // Navigation, tab closure, and actor teardown all remove this frame token.
+    nrKeyboardShortcutFocusStore.removeFrame(this);
+  }
+}

--- a/browser-features/modules/actors/test/NRKeyboardShortcutFocusActors.test.ts
+++ b/browser-features/modules/actors/test/NRKeyboardShortcutFocusActors.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../chrome/test/utils/test_harness.ts";
+import {
+  isKeyboardShortcutEditableFocusEvent,
+  isKeyboardShortcutEditableTarget,
+} from "../NRKeyboardShortcutFocusChild.sys.mts";
+import { applyKeyboardShortcutFocusUpdate } from "../NRKeyboardShortcutFocusParent.sys.mts";
+import { NRKeyboardShortcutFocusStore } from "../../common/NRKeyboardShortcutFocusStore.ts";
+
+function requireDocument(): Document {
+  if (!document) {
+    throw new Error("document is unavailable in this test context");
+  }
+  return document;
+}
+
+function testChildRecognizesInputTextareaAndContenteditable(): void {
+  const doc = requireDocument();
+  const input = doc.createElement("input");
+  const textarea = doc.createElement("textarea");
+  const editable = doc.createElement("div");
+  editable.setAttribute("contenteditable", "true");
+  const nested = doc.createElement("span");
+  editable.appendChild(nested);
+
+  for (const target of [input, textarea, editable, nested]) {
+    assertEquals(
+      isKeyboardShortcutEditableTarget(target, "off"),
+      true,
+      "input, textarea, and inherited contenteditable should be editable",
+    );
+  }
+}
+
+function testContenteditableFalseStopsInheritance(): void {
+  const doc = requireDocument();
+  const editable = doc.createElement("div");
+  editable.setAttribute("contenteditable", "true");
+  const disabled = doc.createElement("span");
+  disabled.setAttribute("contenteditable", "false");
+  editable.appendChild(disabled);
+  assertEquals(
+    isKeyboardShortcutEditableTarget(disabled, "off"),
+    false,
+    "contenteditable=false should stop inherited editability",
+  );
+}
+
+function testDesignModeIsEditable(): void {
+  const doc = requireDocument();
+  assertEquals(
+    isKeyboardShortcutEditableTarget(doc.body, "on"),
+    true,
+    "designMode=on should mark the focused document editable",
+  );
+}
+
+function testComposedFocusPathFindsShadowEditable(): void {
+  const doc = requireDocument();
+  const input = doc.createElement("input");
+  const event = {
+    composedPath: () => [input],
+  } as unknown as Event;
+  assertEquals(
+    isKeyboardShortcutEditableFocusEvent(event, doc),
+    true,
+    "the composed focus path should expose a shadow-tree editable",
+  );
+}
+
+function testParentAggregatesAndClearsFrameMessages(): void {
+  const store = new NRKeyboardShortcutFocusStore();
+  const browser = {};
+  const frame = {};
+
+  applyKeyboardShortcutFocusUpdate(store, frame, browser, { editable: true });
+  assertEquals(
+    store.isEditableFocused(browser),
+    true,
+    "a true child update should mark the top browser editable",
+  );
+  applyKeyboardShortcutFocusUpdate(store, frame, browser, { editable: false });
+  assertEquals(
+    store.isEditableFocused(browser),
+    false,
+    "a false child update should remove the frame",
+  );
+}
+
+function testMissingEmbedderAndMalformedMessagesFailOpen(): void {
+  const store = new NRKeyboardShortcutFocusStore();
+  const browser = {};
+  const frame = {};
+
+  applyKeyboardShortcutFocusUpdate(store, frame, browser, { editable: true });
+  applyKeyboardShortcutFocusUpdate(store, frame, null, { editable: true });
+  assertEquals(
+    store.isEditableFocused(browser),
+    false,
+    "a missing top embedder should remove stale frame state",
+  );
+
+  applyKeyboardShortcutFocusUpdate(store, frame, browser, { editable: true });
+  applyKeyboardShortcutFocusUpdate(store, frame, browser, { editable: "yes" });
+  assertEquals(
+    store.isEditableFocused(browser),
+    false,
+    "malformed actor data should remove stale state",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "child recognizes input textarea and contenteditable",
+      fn: testChildRecognizesInputTextareaAndContenteditable,
+    },
+    {
+      name: "contenteditable false stops inheritance",
+      fn: testContenteditableFalseStopsInheritance,
+    },
+    { name: "designMode focus is editable", fn: testDesignModeIsEditable },
+    {
+      name: "composed path finds shadow editable",
+      fn: testComposedFocusPathFindsShadowEditable,
+    },
+    {
+      name: "parent aggregates and clears frame messages",
+      fn: testParentAggregatesAndClearsFrameMessages,
+    },
+    {
+      name: "missing embedder and malformed messages fail open",
+      fn: testMissingEmbedderAndMalformedMessagesFailOpen,
+    },
+  ];
+  await runTests("NRKeyboardShortcutFocusActors.test.ts", tests);
+}

--- a/browser-features/modules/common/NRKeyboardShortcutFocusStore.test.ts
+++ b/browser-features/modules/common/NRKeyboardShortcutFocusStore.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../chrome/test/utils/test_harness.ts";
+import { NRKeyboardShortcutFocusStore } from "./NRKeyboardShortcutFocusStore.ts";
+
+function testAggregatesEditableFramesPerBrowser(): void {
+  const store = new NRKeyboardShortcutFocusStore();
+  const browser = {};
+  const firstFrame = {};
+  const secondFrame = {};
+
+  store.setFrameEditable(browser, firstFrame, true);
+  store.setFrameEditable(browser, secondFrame, true);
+  store.removeFrame(firstFrame);
+  assertEquals(
+    store.isEditableFocused(browser),
+    true,
+    "one remaining editable frame should keep the browser focused",
+  );
+  store.removeFrame(secondFrame);
+  assertEquals(
+    store.isEditableFocused(browser),
+    false,
+    "the browser should clear after its last editable frame",
+  );
+}
+
+function testFramesMoveBetweenTopBrowsers(): void {
+  const store = new NRKeyboardShortcutFocusStore();
+  const firstBrowser = {};
+  const secondBrowser = {};
+  const frame = {};
+
+  store.setFrameEditable(firstBrowser, frame, true);
+  store.setFrameEditable(secondBrowser, frame, true);
+  assertEquals(
+    store.isEditableFocused(firstBrowser),
+    false,
+    "moving a frame should remove its old browser entry",
+  );
+  assertEquals(
+    store.isEditableFocused(secondBrowser),
+    true,
+    "moving a frame should add its new browser entry",
+  );
+}
+
+function testFalseUpdateAndFrameRemovalAreIdempotent(): void {
+  const store = new NRKeyboardShortcutFocusStore();
+  const browser = {};
+  const frame = {};
+
+  store.setFrameEditable(browser, frame, true);
+  store.setFrameEditable(browser, frame, false);
+  store.removeFrame(frame);
+  assertEquals(
+    store.isEditableFocused(browser),
+    false,
+    "false updates and repeated teardown should leave no stale state",
+  );
+}
+
+function testClearBrowserRemovesEveryFrame(): void {
+  const store = new NRKeyboardShortcutFocusStore();
+  const browser = {};
+  const firstFrame = {};
+  const secondFrame = {};
+
+  store.setFrameEditable(browser, firstFrame, true);
+  store.setFrameEditable(browser, secondFrame, true);
+  store.clearBrowser(browser);
+  assertEquals(
+    store.isEditableFocused(browser),
+    false,
+    "tab/browser teardown should clear all aggregated frames",
+  );
+
+  store.removeFrame(firstFrame);
+  store.removeFrame(secondFrame);
+  assertEquals(
+    store.isEditableFocused(browser),
+    false,
+    "later actor teardown should stay idempotent",
+  );
+}
+
+function testTwoBrowsersStayIsolated(): void {
+  const store = new NRKeyboardShortcutFocusStore();
+  const firstBrowser = {};
+  const secondBrowser = {};
+
+  store.setFrameEditable(firstBrowser, {}, true);
+  assertEquals(
+    store.isEditableFocused(firstBrowser),
+    true,
+    "the focused browser should report editable state",
+  );
+  assertEquals(
+    store.isEditableFocused(secondBrowser),
+    false,
+    "another window's browser should remain isolated",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "aggregates editable frames per browser",
+      fn: testAggregatesEditableFramesPerBrowser,
+    },
+    {
+      name: "moves frames between browsers",
+      fn: testFramesMoveBetweenTopBrowsers,
+    },
+    {
+      name: "false updates and removal are idempotent",
+      fn: testFalseUpdateAndFrameRemovalAreIdempotent,
+    },
+    {
+      name: "clearBrowser removes every frame",
+      fn: testClearBrowserRemovesEveryFrame,
+    },
+    { name: "two browsers stay isolated", fn: testTwoBrowsersStayIsolated },
+  ];
+  await runTests("NRKeyboardShortcutFocusStore.test.ts", tests);
+}

--- a/browser-features/modules/common/NRKeyboardShortcutFocusStore.ts
+++ b/browser-features/modules/common/NRKeyboardShortcutFocusStore.ts
@@ -1,0 +1,70 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Parent-process aggregate of editable frames, keyed by the top browser.
+ * Frame and browser keys are weak so teardown cannot keep either alive.
+ */
+export class NRKeyboardShortcutFocusStore {
+  private readonly editableFramesByBrowser = new WeakMap<
+    object,
+    Set<object>
+  >();
+  private readonly browserByFrame = new WeakMap<object, object>();
+
+  public setFrameEditable(
+    browser: object,
+    frame: object,
+    editable: boolean,
+  ): void {
+    if (!editable) {
+      this.removeFrame(frame);
+      return;
+    }
+
+    const previousBrowser = this.browserByFrame.get(frame);
+    if (previousBrowser && previousBrowser !== browser) {
+      this.removeFrame(frame);
+    }
+
+    let frames = this.editableFramesByBrowser.get(browser);
+    if (!frames) {
+      frames = new Set<object>();
+      this.editableFramesByBrowser.set(browser, frames);
+    }
+    frames.add(frame);
+    this.browserByFrame.set(frame, browser);
+  }
+
+  public removeFrame(frame: object): void {
+    const browser = this.browserByFrame.get(frame);
+    if (!browser) {
+      return;
+    }
+
+    const frames = this.editableFramesByBrowser.get(browser);
+    frames?.delete(frame);
+    if (frames?.size === 0) {
+      this.editableFramesByBrowser.delete(browser);
+    }
+    this.browserByFrame.delete(frame);
+  }
+
+  public clearBrowser(browser: object): void {
+    const frames = this.editableFramesByBrowser.get(browser);
+    if (frames) {
+      for (const frame of frames) {
+        this.browserByFrame.delete(frame);
+      }
+    }
+    this.editableFramesByBrowser.delete(browser);
+  }
+
+  public isEditableFocused(browser: object): boolean {
+    return (this.editableFramesByBrowser.get(browser)?.size ?? 0) > 0;
+  }
+}
+
+export const nrKeyboardShortcutFocusStore = new NRKeyboardShortcutFocusStore();

--- a/browser-features/modules/common/NRKeyboardShortcutFocusTypes.ts
+++ b/browser-features/modules/common/NRKeyboardShortcutFocusTypes.ts
@@ -1,0 +1,11 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const NR_KEYBOARD_SHORTCUT_FOCUS_MESSAGE =
+  "NRKeyboardShortcutFocus:Update";
+
+export interface NRKeyboardShortcutFocusUpdate {
+  editable: boolean;
+}

--- a/browser-features/modules/modules/BrowserGlue.sys.mts
+++ b/browser-features/modules/modules/BrowserGlue.sys.mts
@@ -379,6 +379,28 @@ const JS_WINDOW_ACTORS: {
       "*://127.0.0.1/*",
     ],
   },
+  NRKeyboardShortcutFocus: {
+    parent: {
+      esModuleURI: localPathToResourceURI(
+        "../actors/NRKeyboardShortcutFocusParent.sys.mts",
+      ),
+    },
+    child: {
+      esModuleURI: localPathToResourceURI(
+        "../actors/NRKeyboardShortcutFocusChild.sys.mts",
+      ),
+      events: {
+        DOMContentLoaded: {},
+        focusin: { capture: true },
+        focusout: { capture: true },
+        blur: { capture: true },
+        pageshow: {},
+        pagehide: {},
+      },
+    },
+    matches: ["http://*/*", "https://*/*", "file:///*", "about:*"],
+    allFrames: true,
+  },
   NRMouseGestureScroll: {
     parent: {
       esModuleURI: localPathToResourceURI(

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
 generated: true
 ---
 # Architecture Overview
@@ -30,7 +30,7 @@ The loader development server is configured by `bridge/loader-features/vite.conf
 
 ## Privileged Modules And Window Actors
 
-Window Actors are registered from `browser-features/modules/modules/BrowserGlue.sys.mts:398`. The current inventory lists 22 actors:
+Window Actors are registered from `browser-features/modules/modules/BrowserGlue.sys.mts:420`. The current inventory lists 23 actors:
 
 - `NRAboutPreferences`
 - `NRAppConstants`
@@ -38,6 +38,7 @@ Window Actors are registered from `browser-features/modules/modules/BrowserGlue.
 - `NRChromeWebStore`
 - `NRExperimemmt`
 - `NRI18n`
+- `NRKeyboardShortcutFocus`
 - `NRMouseGestureScroll`
 - `NROSAutomotor`
 - `NRPanelSidebar`

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
 generated: true
 ---
 # Common Chrome Features
@@ -97,6 +97,6 @@ All discovered common chrome features are currently assigned to a generated cate
 
 ## Relationship To Other Layers
 
-- Window Actor integration is registered in `browser-features/modules/modules/BrowserGlue.sys.mts:398`.
+- Window Actor integration is registered in `browser-features/modules/modules/BrowserGlue.sys.mts:420`.
 - Settings pages may expose user-facing controls for selected common features; use the settings route catalog for route ownership.
 - Static chrome features live in the separate static catalog and are not duplicated in this common-feature directory page.

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
 generated: true
 ---
 # Window Actor Categories
@@ -15,7 +15,10 @@ This nested catalog is generated from the `JS_WINDOW_ACTORS` table in `browser-f
 | [Settings & Internal Page Actors](./settings-and-internal-pages-actors) | 13 | Actors used by settings, internal pages, localization, browser constants, restart, modal, search, and tab-manager surfaces. |
 | [Web Content & Store Actors](./web-content-and-store-actors) | 5 | Actors that connect browser chrome with web content, scraping, automation, plugin-store, chrome-web-store, and scroll gesture behavior. |
 | [PWA, Workspaces & Profile Actors](./pwa-workspaces-profile-actors) | 4 | Actors that support PWA windows, workspace state, PWA management, and profile management. |
+| Uncategorized | 1 | Actors discovered in `browser-features/modules/modules/BrowserGlue.sys.mts` that do not yet have a docs category. |
 
 ## Uncategorized Entries
 
-All discovered Window Actors are currently assigned to a generated category.
+| Actor | Source |
+|---|---|
+| NRKeyboardShortcutFocus | `browser-features/modules/modules/BrowserGlue.sys.mts:382` |

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
 generated: true
 ---
 # Web Content & Store Actors
@@ -13,7 +13,7 @@ Actors that connect browser chrome with web content, scraping, automation, plugi
 | Actor | Source |
 |---|---|
 | NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:339` |
-| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:382` |
+| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:404` |
 | NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:305` |
 | NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:359` |
 | NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:287` |

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
 generated: true
 ---
 # Browser Features Catalog
@@ -13,7 +13,7 @@ This catalog is generated from loader-discovered chrome feature entrypoints, the
 - Common chrome features: 29 entries from `browser-features/chrome/common`.
 - Static chrome features: 3 entries from `browser-features/chrome/static`.
 - Settings page routes: 14 routes from `browser-features/pages-settings/src/App.tsx`.
-- Window Actors: 22 actors from `browser-features/modules/modules/BrowserGlue.sys.mts`.
+- Window Actors: 23 actors from `browser-features/modules/modules/BrowserGlue.sys.mts`.
 
 ## How To Read This Catalog
 

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
 generated: true
 ---
 # Window Actor Catalog
@@ -16,7 +16,8 @@ This page is generated from the `JS_WINDOW_ACTORS` table in `browser-features/mo
 | NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:339` |
 | NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:54` |
 | NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:322` |
-| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:382` |
+| NRKeyboardShortcutFocus | `browser-features/modules/modules/BrowserGlue.sys.mts:382` |
+| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:404` |
 | NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:305` |
 | NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:70` |
 | NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:359` |

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `1d1a9c886fed24a1d426c981baa3117003d03415`.
+Inventory generated from Floorp commit `ef70a7ef84573ff3ce46125169750c5a7cad3898`.
 
 ## Source Precedence
 
@@ -55,7 +55,7 @@ Inventory generated from Floorp commit `1d1a9c886fed24a1d426c981baa3117003d03415
 - Common chrome features: `browser-features/chrome/common` (29 entries)
 - Static chrome features: `browser-features/chrome/static` (3 entries)
 - Settings routes: `browser-features/pages-settings/src/App.tsx` (14 routes)
-- Window Actors: `browser-features/modules/modules/BrowserGlue.sys.mts` (22 actors)
+- Window Actors: `browser-features/modules/modules/BrowserGlue.sys.mts` (23 actors)
 - Floorp OS API routes: `browser-features/modules/modules/os-server` (120 routes)
 
 ## CI Sources


### PR DESCRIPTION
## Summary

- suppress unmodified printable shortcuts while chrome or remote editable content has focus
- aggregate editable focus synchronously across nested and cross-origin frames through a per-browser actor store
- preserve modified chords, non-printable keys, `event.code` matching, composition/AltGraph behavior, and fail-open behavior when remote state is unavailable
- clean navigation, frame, tab, and window state without an async actor round trip in the keydown path

## Rescue provenance and split classification

This is a fresh **split redesign** replacing only the typing-guard portion of the closed, unmerged [PR #2575](https://github.com/Floorp-Projects/Floorp/pull/2575), contributed through [issue #2569](https://github.com/Floorp-Projects/Floorp/issues/2569). It is not an exact replay or cherry-pick; the original Zen-key and window-drag concerns are handled as separate replacement slices.

- preserved original head: `d277580eadf122635e69c713257633853c020ce0`
- original author: `100mountains <nobody@nowhere.com>`
- original co-author trailer: `Claude Fable 5 <noreply@anthropic.com>`
- replacement commit: `ef70a7ef84573ff3ce46125169750c5a7cad3898`

## Validation

- canonical locked Windows x86_64 Runtime asset `489491165`: Floorp/platform `153.0`, BuildID `20260725075208`
- real-browser probe: **11/11 cases passed** — chrome URL bar; remote input, textarea, contenteditable, and designMode; nested same-origin and cross-origin frames; modified `Ctrl+K`; navigation and tab-close cleanup; and two-window isolation
- shortcut preferences were restored; the evidence hold runner passed `1/1`; exact worktree processes and ports `2828`/`5181` were absent after teardown
- focused keyboard directory `4/4`, store `1/1`, and actor `1/1` browser suites passed
- after deleting the evidence-only hold test, final discovery found only the permanent shortcut/store/actor targets
- `deno task test:smoke`: all six stages and 41 runner tests passed; broad type-check and lint passed
- exact 11-path format, check, lint, and `git diff --check` passed
- independent Tier 1 A/B/C review found no unresolved P0/P1 issue

## Known fidelity gaps

- the focused keyboard/store/actor suites ran on an earlier Firefox 153 BuildID before the canonical lock refresh; they were not rerun on BuildID `20260725075208`. The exact-build 11-case real-browser probe plus final discovery/static/smoke gates are the publication substitute
- full `feles-build stage --marionette` is blocked before launch by the unrelated canonical-main `pages-newtab` / `lucide-react` default-export failure
- transactional Runtime backup directories are retained intentionally as rollback evidence and are not tracked by this PR

This PR is intentionally opened as a Draft for maintainer review and CI. It does not authorize Ready status or merge.
## Current CI status

- GitHub smoke run [30241896313](https://github.com/Floorp-Projects/Floorp/actions/runs/30241896313) reached **208 passed / 1 failed**. The only failure is the existing canonical-main assertion `ja-JP locale must define about.noraneko`; this branch changes no localization path, and the dependent Native Runtime matrix was skipped.
- Docs verify run [30241896316](https://github.com/Floorp-Projects/Floorp/actions/runs/30241896316) reports seven deterministic generated pages stale because the new actor/store files enter the source inventory. The approved #2575a scope did not include docs, so no unapproved docs or pipeline change has been added. A minimal docs-only Procedure amendment is being prepared for explicit approval before this Draft is updated.