### PR TITLE
feat(tab-stacks): add opt-in native-group foundation

### DIFF
--- a/browser-features/chrome/common/tab-stacks/index.ts
+++ b/browser-features/chrome/common/tab-stacks/index.ts
@@ -1,0 +1,76 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { onCleanup } from "solid-js";
+import {
+  noraComponent,
+  NoraComponentBase,
+} from "#features-chrome/utils/base.ts";
+import {
+  type TabStacksBrowser,
+  TabStacksController,
+  type TabStacksControllerOptions,
+  type TabStacksServices,
+} from "./stack-bar.tsx";
+
+export const TAB_STACKS_ENABLED_PREF = "floorp.tabstacks.enabled";
+
+type TabStacksPrefReader = Pick<
+  TabStacksServices["prefs"],
+  "getBoolPref"
+>;
+
+export function isTabStacksFoundationEnabled(
+  prefs: TabStacksPrefReader,
+): boolean {
+  return prefs.getBoolPref(TAB_STACKS_ENABLED_PREF, false);
+}
+
+export function initializeTabStacksFoundation(
+  options: TabStacksControllerOptions,
+): TabStacksController | null {
+  if (!isTabStacksFoundationEnabled(options.services.prefs)) {
+    return null;
+  }
+
+  const controller = new TabStacksController(options);
+  controller.init();
+  return controller;
+}
+
+@noraComponent(import.meta.hot)
+export default class TabStacksFoundation extends NoraComponentBase {
+  init(): void {
+    if (
+      typeof document === "undefined" ||
+      typeof window === "undefined" ||
+      typeof Services === "undefined"
+    ) {
+      return;
+    }
+
+    const controller = initializeTabStacksFoundation({
+      document,
+      eventTarget: window,
+      services: Services as unknown as TabStacksServices,
+      getBrowser: () => {
+        return (
+          (globalThis as unknown as { gBrowser?: TabStacksBrowser }).gBrowser ??
+            null
+        );
+      },
+      logger: this.logger,
+    });
+
+    if (!controller) {
+      this.logger.info(
+        "Tab stacks foundation is disabled (floorp.tabstacks.enabled=false).",
+      );
+      return;
+    }
+
+    onCleanup(() => controller.destroy());
+  }
+}

--- a/browser-features/chrome/common/tab-stacks/stack-bar.tsx
+++ b/browser-features/chrome/common/tab-stacks/stack-bar.tsx
@@ -1,0 +1,551 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import tabStacksStyles from "./styles.css?inline";
+
+export const TAB_STACKS_ROW_ID = "floorp-tab-stacks-row";
+export const TAB_STACKS_STYLE_ID = "floorp-tab-stacks-styles";
+export const VERTICAL_TABS_PREF = "sidebar.verticalTabs";
+export const WORKSPACES_CHANGED_TOPIC = "floorp.workspaces.changed";
+
+export const TAB_STACKS_REBUILD_EVENTS = [
+  "TabGroupUpdate",
+  "TabGrouped",
+  "TabUngrouped",
+  "TabShow",
+  "TabHide",
+  "TabSelect",
+  "TabGroupCreate",
+  "TabGroupRemoved",
+  "TabGroupCollapse",
+  "TabGroupExpand",
+] as const;
+
+type Observer = (
+  subject?: unknown,
+  topic?: string,
+  data?: string,
+) => void;
+
+export interface TabStacksServices {
+  prefs: {
+    getBoolPref(name: string, fallback?: boolean): boolean;
+    addObserver(name: string, observer: Observer): void;
+    removeObserver(name: string, observer: Observer): void;
+  };
+  obs: {
+    addObserver(observer: Observer, topic: string): void;
+    removeObserver(observer: Observer, topic: string): void;
+  };
+}
+
+export interface TabStacksLogger {
+  debug(message: string): void;
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+export type NativeStackTab = XULElement & {
+  label?: string;
+  linkedPanel?: string;
+  selected?: boolean;
+  hidden?: boolean;
+  closing?: boolean;
+  splitview?: XULElement | null;
+};
+
+export type NativeStackGroup = XULElement & {
+  id: string;
+  label?: string;
+  defaultGroupName: string;
+  color?: string;
+  collapsed?: boolean;
+  tabs: NativeStackTab[];
+  tabsAndSplitViews?: Array<XULElement>;
+};
+
+export interface TabStacksBrowser {
+  tabGroups: NativeStackGroup[];
+  visibleTabs: NativeStackTab[];
+  selectedTab: NativeStackTab;
+}
+
+export interface TabStacksControllerOptions {
+  document: Document;
+  eventTarget: EventTarget;
+  services: TabStacksServices;
+  getBrowser: () => TabStacksBrowser | null;
+  logger?: TabStacksLogger;
+}
+
+export interface ActiveGroupSnapshot {
+  group: NativeStackGroup;
+  groupName: string;
+  eligibleTabs: NativeStackTab[];
+  selectedTab: NativeStackTab;
+}
+
+const noopLogger: TabStacksLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+};
+
+function isSplitViewWrapper(value: Element | null | undefined): boolean {
+  return value?.tagName?.toLowerCase() === "tab-split-view-wrapper";
+}
+
+/**
+ * Split View can expose both flattened `group.tabs` and wrapper-preserving
+ * `group.tabsAndSplitViews`. A native group containing either representation
+ * is intentionally ineligible for this foundation mirror.
+ */
+export function groupContainsSplitView(
+  group: NativeStackGroup,
+): boolean {
+  if (
+    group.tabsAndSplitViews?.some((item) => isSplitViewWrapper(item)) ||
+    Array.from(group.children ?? []).some((item) => isSplitViewWrapper(item)) ||
+    isSplitViewWrapper(group.closest?.("tab-split-view-wrapper"))
+  ) {
+    return true;
+  }
+
+  return group.tabs.some((tab) => {
+    return Boolean(tab.splitview) ||
+      isSplitViewWrapper(tab.closest?.("tab-split-view-wrapper")) ||
+      tab.hasAttribute?.("floorpSplitViewGroupId") ||
+      tab.hasAttribute?.("floorpsplitviewgroupid") ||
+      tab.hasAttribute?.("data-floorp-split-tab");
+  });
+}
+
+function isEligibleVisibleTab(
+  tab: NativeStackTab,
+  visibleTabs: Set<NativeStackTab>,
+): boolean {
+  return visibleTabs.has(tab) &&
+    tab.isConnected !== false &&
+    !tab.hidden &&
+    !tab.closing &&
+    !tab.hasAttribute?.("hidden");
+}
+
+/**
+ * Resolve the row entirely from current native state. No membership, label,
+ * color, collapse, or selection state is persisted by the feature.
+ */
+export function getActiveGroupSnapshot(
+  browser: TabStacksBrowser | null,
+): ActiveGroupSnapshot | null {
+  if (!browser?.selectedTab) {
+    return null;
+  }
+
+  const selectedTab = browser.selectedTab;
+  const group = Array.from(browser.tabGroups ?? []).find((candidate) =>
+    Array.from(candidate.tabs ?? []).includes(selectedTab)
+  );
+
+  if (
+    !group ||
+    !group.isConnected ||
+    group.collapsed ||
+    group.hasAttribute?.("collapsed") ||
+    groupContainsSplitView(group)
+  ) {
+    return null;
+  }
+
+  const visibleTabs = new Set(browser.visibleTabs ?? []);
+  const eligibleTabs = Array.from(group.tabs ?? []).filter((tab) =>
+    isEligibleVisibleTab(tab, visibleTabs)
+  );
+
+  if (
+    eligibleTabs.length < 2 ||
+    !eligibleTabs.includes(selectedTab)
+  ) {
+    return null;
+  }
+
+  return {
+    group,
+    groupName: group.label || group.defaultGroupName,
+    eligibleTabs,
+    selectedTab,
+  };
+}
+
+function createHTMLElement<K extends keyof HTMLElementTagNameMap>(
+  document: Document,
+  name: K,
+): HTMLElementTagNameMap[K] {
+  return document.createElementNS(
+    "http://www.w3.org/1999/xhtml",
+    name,
+  ) as HTMLElementTagNameMap[K];
+}
+
+function getTabLabel(tab: NativeStackTab): string {
+  return tab.label ?? tab.getAttribute?.("label") ?? "";
+}
+
+function getLinkedPanelId(tab: NativeStackTab): string {
+  return tab.linkedPanel ?? tab.getAttribute?.("linkedpanel") ?? "";
+}
+
+export class TabStacksController {
+  private readonly document: Document;
+  private readonly eventTarget: EventTarget;
+  private readonly services: TabStacksServices;
+  private readonly getBrowser: () => TabStacksBrowser | null;
+  private readonly logger: TabStacksLogger;
+  private initialized = false;
+  private row: HTMLElement | null = null;
+  private styleElement: HTMLStyleElement | null = null;
+  private domReadyListening = false;
+  private readonly proxyTargets = new WeakMap<
+    HTMLElement,
+    { group: NativeStackGroup; tab: NativeStackTab }
+  >();
+
+  constructor(options: TabStacksControllerOptions) {
+    this.document = options.document;
+    this.eventTarget = options.eventTarget;
+    this.services = options.services;
+    this.getBrowser = options.getBrowser;
+    this.logger = options.logger ?? noopLogger;
+  }
+
+  init(): void {
+    if (this.initialized) {
+      return;
+    }
+    this.initialized = true;
+
+    for (const type of TAB_STACKS_REBUILD_EVENTS) {
+      this.eventTarget.addEventListener(type, this.onNativeStateChanged);
+    }
+    this.eventTarget.addEventListener("unload", this.onUnload);
+    this.services.prefs.addObserver(
+      VERTICAL_TABS_PREF,
+      this.onVerticalTabsChanged,
+    );
+    this.services.obs.addObserver(
+      this.onWorkspaceChanged,
+      WORKSPACES_CHANGED_TOPIC,
+    );
+
+    if (this.document.readyState === "loading") {
+      this.document.addEventListener("DOMContentLoaded", this.onDomReady);
+      this.domReadyListening = true;
+    }
+
+    this.rebuild();
+  }
+
+  rebuild(): void {
+    if (!this.initialized) {
+      return;
+    }
+
+    if (
+      this.services.prefs.getBoolPref(VERTICAL_TABS_PREF, false)
+    ) {
+      this.destroyPresentation();
+      return;
+    }
+
+    this.ensureStyles();
+    const snapshot = getActiveGroupSnapshot(this.getBrowser());
+    if (!snapshot) {
+      this.destroyRow();
+      return;
+    }
+
+    const toolbox = this.document.getElementById("navigator-toolbox");
+    const navBar = this.document.getElementById("nav-bar");
+    if (!toolbox || !navBar || navBar.parentNode !== toolbox) {
+      this.destroyRow();
+      this.logger.warn(
+        "Tab stacks foundation could not find the horizontal toolbox mount point.",
+      );
+      return;
+    }
+
+    const focusedIndex = this.getFocusedProxyIndex();
+    this.destroyRow();
+
+    const row = createHTMLElement(this.document, "div");
+    row.id = TAB_STACKS_ROW_ID;
+    row.className = "floorp-tab-stacks-row";
+    row.setAttribute("role", "tablist");
+    row.setAttribute("aria-label", snapshot.groupName);
+    row.dataset.groupId = snapshot.group.id ?? "";
+    row.dataset.groupColor = snapshot.group.color ?? "";
+
+    const nativeColor = snapshot.group.style?.getPropertyValue(
+      "--tab-group-color",
+    );
+    if (nativeColor) {
+      row.style.setProperty("--floorp-tab-stacks-color", nativeColor);
+    } else if (snapshot.group.color) {
+      row.style.setProperty(
+        "--floorp-tab-stacks-color",
+        `var(--tab-group-color-${snapshot.group.color})`,
+      );
+    }
+
+    const groupMeta = createHTMLElement(this.document, "div");
+    groupMeta.className = "floorp-tab-stacks-group-meta";
+    groupMeta.setAttribute("aria-hidden", "true");
+
+    const color = createHTMLElement(this.document, "span");
+    color.className = "floorp-tab-stacks-group-color";
+
+    const name = createHTMLElement(this.document, "span");
+    name.className = "floorp-tab-stacks-group-name";
+    name.textContent = snapshot.groupName;
+
+    const count = createHTMLElement(this.document, "span");
+    count.className = "floorp-tab-stacks-group-count";
+    count.textContent = String(snapshot.eligibleTabs.length);
+    count.setAttribute("aria-hidden", "true");
+
+    groupMeta.append(color, name, count);
+    row.appendChild(groupMeta);
+
+    snapshot.eligibleTabs.forEach((tab, index) => {
+      const proxy = createHTMLElement(this.document, "button");
+      const selected = tab === snapshot.selectedTab;
+      proxy.type = "button";
+      proxy.className = "floorp-tab-stacks-proxy";
+      proxy.dataset.proxyIndex = String(index);
+      if (tab.id) {
+        proxy.dataset.nativeTabId = tab.id;
+      }
+      this.proxyTargets.set(proxy, { group: snapshot.group, tab });
+      proxy.setAttribute("role", "tab");
+      proxy.setAttribute("aria-label", getTabLabel(tab));
+      proxy.setAttribute("aria-selected", String(selected));
+      proxy.tabIndex = selected ? 0 : -1;
+
+      const linkedPanelId = getLinkedPanelId(tab);
+      if (linkedPanelId && this.document.getElementById(linkedPanelId)) {
+        proxy.setAttribute("aria-controls", linkedPanelId);
+      }
+
+      const label = createHTMLElement(this.document, "span");
+      label.className = "floorp-tab-stacks-proxy-label";
+      label.setAttribute("aria-hidden", "true");
+      label.textContent = getTabLabel(tab);
+      proxy.appendChild(label);
+      row.appendChild(proxy);
+    });
+
+    row.addEventListener("click", this.onRowClick);
+    row.addEventListener("keydown", this.onRowKeyDown);
+    toolbox.insertBefore(row, navBar);
+    this.row = row;
+
+    if (focusedIndex !== null) {
+      const proxies = this.getProxyElements();
+      const target = proxies[Math.min(focusedIndex, proxies.length - 1)];
+      target?.focus();
+    }
+  }
+
+  destroy(): void {
+    if (!this.initialized) {
+      this.destroyPresentation();
+      return;
+    }
+
+    for (const type of TAB_STACKS_REBUILD_EVENTS) {
+      this.eventTarget.removeEventListener(type, this.onNativeStateChanged);
+    }
+    this.eventTarget.removeEventListener("unload", this.onUnload);
+    this.services.prefs.removeObserver(
+      VERTICAL_TABS_PREF,
+      this.onVerticalTabsChanged,
+    );
+    this.services.obs.removeObserver(
+      this.onWorkspaceChanged,
+      WORKSPACES_CHANGED_TOPIC,
+    );
+
+    if (this.domReadyListening) {
+      this.document.removeEventListener("DOMContentLoaded", this.onDomReady);
+      this.domReadyListening = false;
+    }
+
+    this.destroyPresentation();
+    this.initialized = false;
+  }
+
+  getRowElement(): HTMLElement | null {
+    return this.row;
+  }
+
+  getStyleElement(): HTMLStyleElement | null {
+    return this.styleElement;
+  }
+
+  private readonly onNativeStateChanged = (): void => {
+    this.rebuild();
+  };
+
+  private readonly onWorkspaceChanged: Observer = (): void => {
+    this.rebuild();
+  };
+
+  private readonly onVerticalTabsChanged: Observer = (): void => {
+    if (this.services.prefs.getBoolPref(VERTICAL_TABS_PREF, false)) {
+      this.destroyPresentation();
+      return;
+    }
+    this.rebuild();
+  };
+
+  private readonly onDomReady = (): void => {
+    this.document.removeEventListener("DOMContentLoaded", this.onDomReady);
+    this.domReadyListening = false;
+    this.rebuild();
+  };
+
+  private readonly onUnload = (): void => {
+    this.destroy();
+  };
+
+  private readonly onRowClick = (event: Event): void => {
+    const target = event.target as Element | null;
+    const proxy = target?.closest?.(".floorp-tab-stacks-proxy") as
+      | HTMLElement
+      | null;
+    if (!proxy || !this.row?.contains(proxy)) {
+      return;
+    }
+    this.activateProxy(proxy);
+  };
+
+  private readonly onRowKeyDown = (event: Event): void => {
+    const keyEvent = event as KeyboardEvent;
+    const target = keyEvent.target as Element | null;
+    const proxy = target?.closest?.(".floorp-tab-stacks-proxy") as
+      | HTMLElement
+      | null;
+    if (!proxy || !this.row?.contains(proxy)) {
+      return;
+    }
+
+    const proxies = this.getProxyElements();
+    const currentIndex = proxies.indexOf(proxy);
+    if (currentIndex < 0) {
+      return;
+    }
+
+    let focusIndex: number | null = null;
+    switch (keyEvent.key) {
+      case "ArrowLeft":
+        focusIndex = (currentIndex - 1 + proxies.length) % proxies.length;
+        break;
+      case "ArrowRight":
+        focusIndex = (currentIndex + 1) % proxies.length;
+        break;
+      case "Home":
+        focusIndex = 0;
+        break;
+      case "End":
+        focusIndex = proxies.length - 1;
+        break;
+      case "Enter":
+      case " ":
+      case "Spacebar":
+        keyEvent.preventDefault();
+        this.activateProxy(proxy);
+        return;
+      default:
+        return;
+    }
+
+    keyEvent.preventDefault();
+    proxies[focusIndex]?.focus();
+  };
+
+  private activateProxy(proxy: HTMLElement): void {
+    const target = this.proxyTargets.get(proxy);
+    if (!target) {
+      return;
+    }
+
+    const browser = this.getBrowser();
+    const snapshot = getActiveGroupSnapshot(browser);
+    if (
+      !browser ||
+      !snapshot ||
+      snapshot.group !== target.group ||
+      !snapshot.eligibleTabs.includes(target.tab)
+    ) {
+      this.rebuild();
+      return;
+    }
+
+    // Selecting an existing native tab is the mirror's only product mutation.
+    browser.selectedTab = target.tab;
+  }
+
+  private getProxyElements(): HTMLElement[] {
+    return this.row
+      ? Array.from(
+        this.row.querySelectorAll<HTMLElement>(".floorp-tab-stacks-proxy"),
+      )
+      : [];
+  }
+
+  private getFocusedProxyIndex(): number | null {
+    const active = this.document.activeElement as HTMLElement | null;
+    if (!active || !this.row?.contains(active)) {
+      return null;
+    }
+    const proxy = active.closest?.(".floorp-tab-stacks-proxy") as
+      | HTMLElement
+      | null;
+    const index = Number(proxy?.dataset.proxyIndex);
+    return Number.isInteger(index) && index >= 0 ? index : null;
+  }
+
+  private ensureStyles(): void {
+    if (this.styleElement?.isConnected) {
+      return;
+    }
+    const head = this.document.head;
+    if (!head) {
+      return;
+    }
+
+    const style = this.document.createElement("style");
+    style.id = TAB_STACKS_STYLE_ID;
+    style.textContent = tabStacksStyles;
+    head.appendChild(style);
+    this.styleElement = style;
+  }
+
+  private destroyRow(): void {
+    if (!this.row) {
+      return;
+    }
+    this.row.removeEventListener("click", this.onRowClick);
+    this.row.removeEventListener("keydown", this.onRowKeyDown);
+    this.row.remove();
+    this.row = null;
+  }
+
+  private destroyPresentation(): void {
+    this.destroyRow();
+    this.styleElement?.remove();
+    this.styleElement = null;
+  }
+}

--- a/browser-features/chrome/common/tab-stacks/styles.css
+++ b/browser-features/chrome/common/tab-stacks/styles.css
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#floorp-tab-stacks-row {
+  display: flex;
+  align-items: stretch;
+  min-height: var(--tab-min-height, 32px);
+  padding-inline: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  color: var(--toolbar-color, currentColor);
+  background: var(--toolbar-bgcolor);
+  border-block-end: 1px solid
+    var(--chrome-content-separator-color, rgba(0, 0, 0, 0.2));
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-group-meta {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  max-width: 180px;
+  padding-inline: 8px 10px;
+  border-inline-end: 1px solid
+    color-mix(in srgb, currentColor 18%, transparent);
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-group-color {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--floorp-tab-stacks-color, currentColor);
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-group-name {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-weight: 600;
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-group-count {
+  flex: 0 0 auto;
+  min-width: 1.5em;
+  text-align: center;
+  opacity: 0.72;
+  font-variant-numeric: tabular-nums;
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-proxy {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  flex: 0 1 180px;
+  min-width: var(--tab-min-width, 76px);
+  max-width: 220px;
+  margin: 0;
+  padding-inline: 10px;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  background: transparent;
+  border: 0;
+  border-inline-end: 1px solid
+    color-mix(in srgb, currentColor 16%, transparent);
+  border-radius: 0;
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-proxy:hover {
+  background: color-mix(in srgb, currentColor 9%, transparent);
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-proxy[aria-selected="true"] {
+  background: color-mix(
+    in srgb,
+    var(--floorp-tab-stacks-color, currentColor) 22%,
+    transparent
+  );
+  box-shadow: inset 0 -2px 0 var(--floorp-tab-stacks-color, currentColor);
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-proxy:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--focus-outline-color, #0060df);
+  outline-offset: -2px;
+}
+
+#floorp-tab-stacks-row .floorp-tab-stacks-proxy-label {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/browser-features/chrome/common/tab-stacks/test/tabStacksEventContract.test.ts
+++ b/browser-features/chrome/common/tab-stacks/test/tabStacksEventContract.test.ts
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  type NativeStackGroup,
+  type NativeStackTab,
+  TAB_STACKS_REBUILD_EVENTS,
+  TAB_STACKS_ROW_ID,
+  TAB_STACKS_STYLE_ID,
+  type TabStacksBrowser,
+  TabStacksController,
+  type TabStacksServices,
+  VERTICAL_TABS_PREF,
+  WORKSPACES_CHANGED_TOPIC,
+} from "../stack-bar.tsx";
+import {
+  assert,
+  assertEquals,
+  runTests,
+} from "../../../test/utils/test_harness.ts";
+
+type Observer = (
+  subject?: unknown,
+  topic?: string,
+  data?: string,
+) => void;
+
+class TrackingEventTarget extends EventTarget {
+  readonly added: string[] = [];
+  readonly removed: string[] = [];
+
+  override addEventListener(
+    type: string,
+    callback: EventListener | null,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    this.added.push(type);
+    super.addEventListener(type, callback, options);
+  }
+
+  override removeEventListener(
+    type: string,
+    callback: EventListener | null,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    this.removed.push(type);
+    super.removeEventListener(type, callback, options);
+  }
+}
+
+class FakeServices implements TabStacksServices {
+  vertical = false;
+  readonly prefObservers: Observer[] = [];
+  readonly removedPrefObservers: Observer[] = [];
+  readonly workspaceObservers: Observer[] = [];
+  readonly removedWorkspaceObservers: Observer[] = [];
+
+  readonly prefs = {
+    getBoolPref: (name: string, fallback?: boolean): boolean =>
+      name === VERTICAL_TABS_PREF ? this.vertical : fallback ?? false,
+    addObserver: (name: string, observer: Observer): void => {
+      assertEquals(
+        name,
+        VERTICAL_TABS_PREF,
+        "only vertical pref may be observed",
+      );
+      this.prefObservers.push(observer);
+    },
+    removeObserver: (name: string, observer: Observer): void => {
+      assertEquals(
+        name,
+        VERTICAL_TABS_PREF,
+        "only vertical pref may be removed",
+      );
+      this.removedPrefObservers.push(observer);
+    },
+  };
+
+  readonly obs = {
+    addObserver: (observer: Observer, topic: string): void => {
+      assertEquals(
+        topic,
+        WORKSPACES_CHANGED_TOPIC,
+        "workspace topic must be exact",
+      );
+      this.workspaceObservers.push(observer);
+    },
+    removeObserver: (observer: Observer, topic: string): void => {
+      assertEquals(
+        topic,
+        WORKSPACES_CHANGED_TOPIC,
+        "workspace removal must be exact",
+      );
+      this.removedWorkspaceObservers.push(observer);
+    },
+  };
+
+  notifyWorkspace(): void {
+    for (const observer of this.workspaceObservers) {
+      if (!this.removedWorkspaceObservers.includes(observer)) {
+        observer(null, WORKSPACES_CHANGED_TOPIC);
+      }
+    }
+  }
+}
+
+function setProperty(
+  target: object,
+  name: string,
+  value: unknown,
+): void {
+  Object.defineProperty(target, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function row(document: Document): HTMLElement | null {
+  return document.getElementById(TAB_STACKS_ROW_ID) as HTMLElement | null;
+}
+
+function count(document: Document): string | null | undefined {
+  return row(document)?.querySelector(".floorp-tab-stacks-group-count")
+    ?.textContent;
+}
+
+function dispatch(target: EventTarget, type: string, detail?: unknown): void {
+  target.dispatchEvent(new CustomEvent(type, { detail }));
+}
+
+function testExactEventsAlwaysRebuildFromLiveState(): void {
+  const testDocument = document.implementation.createHTMLDocument(
+    "tab-stacks-events",
+  );
+  const toolbox = testDocument.createElement("div");
+  toolbox.id = "navigator-toolbox";
+  const navBar = testDocument.createElement("div");
+  navBar.id = "nav-bar";
+  toolbox.appendChild(navBar);
+  testDocument.body!.appendChild(toolbox);
+
+  const makeTab = (label: string, id: string): NativeStackTab => {
+    const tab = testDocument.createElement("tab") as unknown as NativeStackTab;
+    tab.id = id;
+    setProperty(tab, "label", label);
+    setProperty(tab, "linkedPanel", "");
+    setProperty(tab, "splitview", null);
+    setProperty(tab, "closing", false);
+    return tab;
+  };
+  const first = makeTab("First", "event-tab-1");
+  const second = makeTab("Second", "event-tab-2");
+  const third = makeTab("Third", "event-tab-3");
+  const liveTabs = [first, second];
+
+  const group = testDocument.createElement(
+    "tab-group",
+  ) as unknown as NativeStackGroup;
+  group.id = "event-group";
+  setProperty(group, "label", "Before update");
+  setProperty(group, "defaultGroupName", "Default group");
+  setProperty(group, "color", "blue");
+  setProperty(group, "collapsed", false);
+  Object.defineProperty(group, "tabs", {
+    configurable: true,
+    get: () => liveTabs,
+  });
+  Object.defineProperty(group, "tabsAndSplitViews", {
+    configurable: true,
+    get: () => [...liveTabs],
+  });
+  group.style.setProperty("--tab-group-color", "var(--tab-group-color-blue)");
+  group.append(first, second);
+  testDocument.body!.appendChild(group);
+
+  const browser: TabStacksBrowser = {
+    tabGroups: [group],
+    visibleTabs: [first, second],
+    selectedTab: first,
+  };
+  const events = new TrackingEventTarget();
+  const services = new FakeServices();
+  const controller = new TabStacksController({
+    document: testDocument,
+    eventTarget: events,
+    services,
+    getBrowser: () => browser,
+  });
+  controller.init();
+
+  assertEquals(
+    events.added.filter((type) => type !== "unload").join(","),
+    TAB_STACKS_REBUILD_EVENTS.join(","),
+    "controller should attach exactly the locked Firefox 153 rebuild events",
+  );
+  assert(row(testDocument), "initial live group should render");
+
+  const beforeUpdate = row(testDocument);
+  setProperty(group, "label", "After update");
+  setProperty(group, "color", "purple");
+  group.style.setProperty("--tab-group-color", "var(--tab-group-color-purple)");
+  dispatch(events, "TabGroupUpdate", { staleLabel: "ignored" });
+  assert(
+    row(testDocument) !== beforeUpdate,
+    "TabGroupUpdate should rebuild row DOM",
+  );
+  assertEquals(
+    row(testDocument)?.getAttribute("aria-label"),
+    "After update",
+    "TabGroupUpdate should read the current native label, not event detail",
+  );
+  assertEquals(
+    row(testDocument)?.dataset.groupColor,
+    "purple",
+    "TabGroupUpdate should read the current native color",
+  );
+
+  liveTabs.push(third);
+  group.appendChild(third);
+  browser.visibleTabs = [first, second, third];
+  dispatch(events, "TabGrouped", first);
+  assertEquals(
+    count(testDocument),
+    "3",
+    "TabGrouped should enumerate live membership instead of event.detail",
+  );
+
+  liveTabs.pop();
+  third.remove();
+  browser.visibleTabs = [first, second];
+  dispatch(events, "TabUngrouped", third);
+  assertEquals(
+    count(testDocument),
+    "2",
+    "TabUngrouped should enumerate live membership after the change",
+  );
+
+  browser.visibleTabs = [first];
+  dispatch(events, "TabHide");
+  assertEquals(row(testDocument), null, "TabHide should apply live visibility");
+  browser.visibleTabs = [first, second];
+  dispatch(events, "TabShow");
+  assert(row(testDocument), "TabShow should rebuild eligible live members");
+
+  browser.selectedTab = second;
+  dispatch(events, "TabSelect");
+  const selected = row(testDocument)?.querySelectorAll<HTMLElement>(
+    ".floorp-tab-stacks-proxy",
+  )[1];
+  assertEquals(
+    selected?.getAttribute("aria-selected"),
+    "true",
+    "TabSelect should mirror current native selection",
+  );
+
+  setProperty(group, "collapsed", true);
+  dispatch(events, "TabGroupCollapse");
+  assertEquals(row(testDocument), null, "collapse should remove the mirror");
+  setProperty(group, "collapsed", false);
+  dispatch(events, "TabGroupExpand");
+  assert(row(testDocument), "expand should regenerate the mirror");
+
+  browser.tabGroups = [];
+  dispatch(events, "TabGroupRemoved");
+  assertEquals(
+    row(testDocument),
+    null,
+    "removed live group should remove the row",
+  );
+  browser.tabGroups = [group];
+  dispatch(events, "TabGroupCreate");
+  assert(row(testDocument), "created live group should regenerate the row");
+
+  browser.visibleTabs = [second];
+  services.notifyWorkspace();
+  assertEquals(
+    row(testDocument),
+    null,
+    "workspace notification should filter off-workspace members from live state",
+  );
+  browser.visibleTabs = [first, second];
+  services.notifyWorkspace();
+  assert(
+    row(testDocument),
+    "workspace notification should restore current members",
+  );
+
+  services.vertical = true;
+  services.prefObservers[0](null, VERTICAL_TABS_PREF);
+  assertEquals(row(testDocument), null, "vertical pref should destroy the row");
+  assertEquals(
+    testDocument.getElementById(TAB_STACKS_STYLE_ID),
+    null,
+    "vertical pref should destroy owned styles",
+  );
+  services.vertical = false;
+  services.prefObservers[0](null, VERTICAL_TABS_PREF);
+  assert(row(testDocument), "horizontal pref should rebuild from native state");
+
+  dispatch(events, "unload");
+  assertEquals(row(testDocument), null, "unload should remove the row");
+  assertEquals(
+    testDocument.getElementById(TAB_STACKS_STYLE_ID),
+    null,
+    "unload should remove styles",
+  );
+  assertEquals(
+    events.removed.filter((type) => type !== "unload").join(","),
+    TAB_STACKS_REBUILD_EVENTS.join(","),
+    "unload should remove every exact native event listener",
+  );
+  assertEquals(
+    events.removed.filter((type) => type === "unload").length,
+    1,
+    "unload should remove its own window listener",
+  );
+  assertEquals(
+    services.removedPrefObservers[0],
+    services.prefObservers[0],
+    "unload should remove the exact pref observer identity",
+  );
+  assertEquals(
+    services.removedWorkspaceObservers[0],
+    services.workspaceObservers[0],
+    "unload should remove the exact workspace observer identity",
+  );
+
+  controller.destroy();
+  assertEquals(
+    services.removedPrefObservers.length,
+    1,
+    "destroy after unload should remain idempotent",
+  );
+  assertEquals(
+    events.removed.filter((type) => type === "unload").length,
+    1,
+    "destroy after unload must not repeat listener teardown",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  await runTests("tabStacksEventContract.test.ts", [
+    {
+      name: "exact Firefox events rebuild from live native state and clean up",
+      fn: testExactEventsAlwaysRebuildFromLiveState,
+    },
+  ]);
+}

--- a/browser-features/chrome/common/tab-stacks/test/tabStacksFoundation.test.ts
+++ b/browser-features/chrome/common/tab-stacks/test/tabStacksFoundation.test.ts
@@ -1,0 +1,715 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  initializeTabStacksFoundation,
+  TAB_STACKS_ENABLED_PREF,
+} from "../index.ts";
+import {
+  groupContainsSplitView,
+  type NativeStackGroup,
+  type NativeStackTab,
+  TAB_STACKS_REBUILD_EVENTS,
+  TAB_STACKS_ROW_ID,
+  TAB_STACKS_STYLE_ID,
+  type TabStacksBrowser,
+  type TabStacksController,
+  type TabStacksServices,
+  VERTICAL_TABS_PREF,
+  WORKSPACES_CHANGED_TOPIC,
+} from "../stack-bar.tsx";
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+
+type Observer = (
+  subject?: unknown,
+  topic?: string,
+  data?: string,
+) => void;
+
+class TrackingEventTarget extends EventTarget {
+  readonly added: string[] = [];
+  readonly removed: string[] = [];
+
+  override addEventListener(
+    type: string,
+    callback: EventListener | null,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    this.added.push(type);
+    super.addEventListener(type, callback, options);
+  }
+
+  override removeEventListener(
+    type: string,
+    callback: EventListener | null,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    this.removed.push(type);
+    super.removeEventListener(type, callback, options);
+  }
+}
+
+class FakeServices implements TabStacksServices {
+  readonly values = new Map<string, boolean>();
+  readonly getCalls: Array<{ name: string; fallback: boolean | undefined }> =
+    [];
+  readonly prefAdded: Array<{ name: string; observer: Observer }> = [];
+  readonly prefRemoved: Array<{ name: string; observer: Observer }> = [];
+  readonly topicAdded: Array<{ topic: string; observer: Observer }> = [];
+  readonly topicRemoved: Array<{ topic: string; observer: Observer }> = [];
+  persistenceWrites = 0;
+
+  readonly prefs = {
+    getBoolPref: (name: string, fallback?: boolean): boolean => {
+      this.getCalls.push({ name, fallback });
+      return this.values.get(name) ?? fallback ?? false;
+    },
+    addObserver: (name: string, observer: Observer): void => {
+      this.prefAdded.push({ name, observer });
+    },
+    removeObserver: (name: string, observer: Observer): void => {
+      this.prefRemoved.push({ name, observer });
+    },
+    setBoolPref: (): void => {
+      this.persistenceWrites++;
+    },
+    setStringPref: (): void => {
+      this.persistenceWrites++;
+    },
+  };
+
+  readonly obs = {
+    addObserver: (observer: Observer, topic: string): void => {
+      this.topicAdded.push({ topic, observer });
+    },
+    removeObserver: (observer: Observer, topic: string): void => {
+      this.topicRemoved.push({ topic, observer });
+    },
+  };
+
+  notifyPref(name: string): void {
+    for (const entry of this.prefAdded) {
+      if (
+        entry.name === name &&
+        !this.prefRemoved.some((removed) =>
+          removed.name === name && removed.observer === entry.observer
+        )
+      ) {
+        entry.observer(null, name);
+      }
+    }
+  }
+}
+
+interface Harness {
+  document: Document;
+  events: TrackingEventTarget;
+  services: FakeServices;
+  tabs: NativeStackTab[];
+  group: NativeStackGroup;
+  browser: TabStacksBrowser;
+  controller: TabStacksController;
+}
+
+function setProperty(
+  target: object,
+  name: string,
+  value: unknown,
+): void {
+  Object.defineProperty(target, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function createTestDocument(): Document {
+  const testDocument = document.implementation.createHTMLDocument(
+    "tab-stacks-test",
+  );
+  const toolbox = testDocument.createElement("div");
+  toolbox.id = "navigator-toolbox";
+  const tabsToolbar = testDocument.createElement("div");
+  tabsToolbar.id = "TabsToolbar";
+  const navBar = testDocument.createElement("div");
+  navBar.id = "nav-bar";
+  toolbox.append(tabsToolbar, navBar);
+  testDocument.body!.appendChild(toolbox);
+  return testDocument;
+}
+
+function createTab(
+  testDocument: Document,
+  label: string,
+  id: string,
+): NativeStackTab {
+  const tab = testDocument.createElement("tab") as unknown as NativeStackTab;
+  tab.id = id;
+  setProperty(tab, "label", label);
+  setProperty(tab, "linkedPanel", `${id}-panel`);
+  setProperty(tab, "closing", false);
+  setProperty(tab, "splitview", null);
+  return tab;
+}
+
+function createHarness(
+  options: {
+    labels?: string[];
+    groupLabel?: string;
+    defaultGroupName?: string;
+    color?: string;
+    selectedIndex?: number;
+  } = {},
+): Harness {
+  const testDocument = createTestDocument();
+  const labels = options.labels ?? ["Alpha", "Beta", "Gamma"];
+  const tabs = labels.map((label, index) =>
+    createTab(testDocument, label, `native-tab-${index}`)
+  );
+
+  const group = testDocument.createElement(
+    "tab-group",
+  ) as unknown as NativeStackGroup;
+  group.id = "native-group-1";
+  setProperty(group, "label", options.groupLabel ?? "Project tabs");
+  setProperty(group, "defaultGroupName", options.defaultGroupName ?? "Group");
+  setProperty(group, "color", options.color ?? "blue");
+  setProperty(group, "collapsed", false);
+  setProperty(group, "tabs", tabs);
+  setProperty(group, "tabsAndSplitViews", [...tabs]);
+  group.style.setProperty("--tab-group-color", "var(--tab-group-color-blue)");
+  group.append(...tabs);
+  testDocument.body!.appendChild(group);
+
+  const selectedIndex = options.selectedIndex ?? 0;
+  const browser: TabStacksBrowser = {
+    tabGroups: [group],
+    visibleTabs: [...tabs],
+    selectedTab: tabs[selectedIndex],
+  };
+  const events = new TrackingEventTarget();
+  const services = new FakeServices();
+  services.values.set(TAB_STACKS_ENABLED_PREF, true);
+  services.values.set(VERTICAL_TABS_PREF, false);
+
+  const controller = initializeTabStacksFoundation({
+    document: testDocument,
+    eventTarget: events,
+    services,
+    getBrowser: () => browser,
+  });
+  assert(controller, "enabled fixture should create a controller");
+
+  return {
+    document: testDocument,
+    events,
+    services,
+    tabs,
+    group,
+    browser,
+    controller,
+  };
+}
+
+function proxies(testDocument: Document): HTMLElement[] {
+  return Array.from(
+    testDocument.querySelectorAll<HTMLElement>(
+      `#${TAB_STACKS_ROW_ID} .floorp-tab-stacks-proxy`,
+    ),
+  );
+}
+
+function syntheticKeydown(key: string): Event {
+  const event = new Event("keydown", {
+    bubbles: true,
+    cancelable: true,
+  });
+  setProperty(event, "key", key);
+  return event;
+}
+
+function testMissingPrefIsInert(): void {
+  const testDocument = createTestDocument();
+  const events = new TrackingEventTarget();
+  const services = new FakeServices();
+
+  const controller = initializeTabStacksFoundation({
+    document: testDocument,
+    eventTarget: events,
+    services,
+    getBrowser: () => null,
+  });
+
+  assertEquals(controller, null, "missing enabled pref should stay disabled");
+  assertEquals(services.getCalls.length, 1, "enabled pref should be read once");
+  assertEquals(
+    services.getCalls[0].name,
+    TAB_STACKS_ENABLED_PREF,
+    "startup should read the approved feature pref",
+  );
+  assertEquals(
+    services.getCalls[0].fallback,
+    false,
+    "missing feature pref must use a false fallback",
+  );
+  assertEquals(
+    events.added.length,
+    0,
+    "pref-off startup must add no listeners",
+  );
+  assertEquals(
+    services.prefAdded.length,
+    0,
+    "pref-off startup must add no pref observers",
+  );
+  assertEquals(
+    services.topicAdded.length,
+    0,
+    "pref-off startup must add no Services observers",
+  );
+  assertEquals(
+    testDocument.getElementById(TAB_STACKS_ROW_ID),
+    null,
+    "pref-off startup must not mount a row",
+  );
+  assertEquals(
+    testDocument.getElementById(TAB_STACKS_STYLE_ID),
+    null,
+    "pref-off startup must not mount styles",
+  );
+}
+
+function testPresentationAndAccessibility(): void {
+  const harness = createHarness();
+  try {
+    const { document: testDocument, group, tabs } = harness;
+    const nativeBefore = group.outerHTML;
+    const panel = testDocument.createElement("div");
+    panel.id = "native-tab-0-panel";
+    testDocument.body!.appendChild(panel);
+    harness.controller.rebuild();
+
+    const row = testDocument.getElementById(TAB_STACKS_ROW_ID);
+    assert(row, "eligible active native group should render a row");
+    assertEquals(
+      row.getAttribute("role"),
+      "tablist",
+      "row role should be tablist",
+    );
+    assertEquals(
+      row.getAttribute("aria-label"),
+      "Project tabs",
+      "row accessible name should equal the native group name",
+    );
+    assertEquals(
+      (row as HTMLElement).dataset.groupColor,
+      "blue",
+      "row should reflect the native group color code",
+    );
+    assertEquals(
+      (row as HTMLElement).style.getPropertyValue("--floorp-tab-stacks-color"),
+      "var(--tab-group-color-blue)",
+      "row should reflect the native group color value",
+    );
+    assertEquals(
+      row.querySelector(".floorp-tab-stacks-group-count")?.textContent,
+      "3",
+      "count should use the eligible live member count",
+    );
+    assertEquals(
+      row.querySelector(".floorp-tab-stacks-group-meta")?.getAttribute(
+        "aria-hidden",
+      ),
+      "true",
+      "visual group metadata and count should be presentational",
+    );
+
+    const rendered = proxies(testDocument);
+    assertEquals(
+      rendered.length,
+      3,
+      "all eligible native members should proxy",
+    );
+    rendered.forEach((proxy, index) => {
+      assertEquals(
+        proxy.getAttribute("role"),
+        "tab",
+        "proxy role should be tab",
+      );
+      assertEquals(
+        proxy.getAttribute("aria-label"),
+        tabs[index].label ?? "",
+        "proxy accessible name should equal the native tab label",
+      );
+      assertEquals(
+        proxy.getAttribute("aria-selected"),
+        String(index === 0),
+        "proxy selected state should mirror the native selected tab",
+      );
+      assertEquals(
+        proxy.tabIndex,
+        index === 0 ? 0 : -1,
+        "proxy tabindex should rove from the selected native tab",
+      );
+    });
+    assertEquals(
+      rendered[0].getAttribute("aria-controls"),
+      "native-tab-0-panel",
+      "proxy should expose aria-controls only for an existing linked panel",
+    );
+    assertEquals(
+      rendered[1].hasAttribute("aria-controls"),
+      false,
+      "proxy should omit aria-controls when its panel is absent",
+    );
+    assertEquals(
+      group.outerHTML,
+      nativeBefore,
+      "rendering must not mutate native group or member presentation",
+    );
+  } finally {
+    harness.controller.destroy();
+  }
+}
+
+function testEligibilityFallbackAndSplitExclusion(): void {
+  const harness = createHarness({
+    groupLabel: "",
+    defaultGroupName: "Unnamed group",
+  });
+  try {
+    const { browser, controller, document: testDocument, group, tabs } =
+      harness;
+    tabs[1].hidden = true;
+    browser.visibleTabs = [tabs[0], tabs[1], tabs[2]];
+    controller.rebuild();
+
+    const row = testDocument.getElementById(TAB_STACKS_ROW_ID);
+    assert(row, "two eligible visible members should still render");
+    assertEquals(
+      row.getAttribute("aria-label"),
+      "Unnamed group",
+      "empty native label should use defaultGroupName exactly",
+    );
+    assertEquals(
+      proxies(testDocument).length,
+      2,
+      "hidden members should be filtered",
+    );
+    assertEquals(
+      proxies(testDocument)[1].getAttribute("aria-label"),
+      "Gamma",
+      "off-workspace and hidden members must not become proxy targets",
+    );
+
+    setProperty(group, "collapsed", true);
+    controller.rebuild();
+    assertEquals(
+      testDocument.getElementById(TAB_STACKS_ROW_ID),
+      null,
+      "collapsed active group should render no mirror",
+    );
+    assertEquals(
+      group.collapsed,
+      true,
+      "mirror must not expand a native group",
+    );
+
+    setProperty(group, "collapsed", false);
+    setProperty(tabs[2], "splitview", testDocument.createElement("div"));
+    controller.rebuild();
+    assertEquals(
+      testDocument.getElementById(TAB_STACKS_ROW_ID),
+      null,
+      "any split member should exclude the whole native group",
+    );
+    assert(
+      groupContainsSplitView(group),
+      "split membership should be detected",
+    );
+
+    setProperty(tabs[2], "splitview", null);
+    const wrapper = testDocument.createElement("tab-split-view-wrapper");
+    setProperty(group, "tabsAndSplitViews", [tabs[0], wrapper]);
+    controller.rebuild();
+    assertEquals(
+      testDocument.getElementById(TAB_STACKS_ROW_ID),
+      null,
+      "a split-view wrapper should exclude the whole native group",
+    );
+
+    setProperty(group, "tabsAndSplitViews", [...tabs]);
+    setProperty(group, "tabs", []);
+    controller.rebuild();
+    assertEquals(
+      testDocument.getElementById(TAB_STACKS_ROW_ID),
+      null,
+      "an empty live group should render no mirror",
+    );
+
+    setProperty(group, "tabs", tabs);
+    browser.visibleTabs = [tabs[0]];
+    controller.rebuild();
+    assertEquals(
+      testDocument.getElementById(TAB_STACKS_ROW_ID),
+      null,
+      "one eligible member should render no mirror",
+    );
+    assertEquals(
+      harness.services.persistenceWrites,
+      0,
+      "foundation must not write custom persistence",
+    );
+  } finally {
+    harness.controller.destroy();
+  }
+}
+
+function testClickAndKeyboardSelection(): void {
+  const harness = createHarness();
+  try {
+    const { browser, controller, document: testDocument, events, tabs } =
+      harness;
+    for (const tab of tabs) {
+      tab.id = "";
+    }
+    controller.rebuild();
+    let rendered = proxies(testDocument);
+    let focused = -1;
+    rendered.forEach((proxy, index) => {
+      proxy.focus = () => {
+        focused = index;
+      };
+    });
+
+    rendered[0].dispatchEvent(syntheticKeydown("ArrowRight"));
+    assertEquals(focused, 1, "ArrowRight should move focus to the next proxy");
+    assertEquals(
+      browser.selectedTab,
+      tabs[0],
+      "arrow navigation should not change native selection",
+    );
+    rendered[0].dispatchEvent(syntheticKeydown("ArrowLeft"));
+    assertEquals(focused, 2, "ArrowLeft should wrap focus to the final proxy");
+
+    rendered[1].dispatchEvent(syntheticKeydown("End"));
+    assertEquals(focused, 2, "End should move focus to the final proxy");
+    rendered[2].dispatchEvent(syntheticKeydown("Home"));
+    assertEquals(focused, 0, "Home should move focus to the first proxy");
+
+    rendered[1].dispatchEvent(syntheticKeydown("Enter"));
+    assertEquals(
+      browser.selectedTab,
+      tabs[1],
+      "Enter should select the corresponding existing native tab",
+    );
+    events.dispatchEvent(new Event("TabSelect"));
+    rendered = proxies(testDocument);
+    assertEquals(
+      rendered[1].getAttribute("aria-selected"),
+      "true",
+      "TabSelect rebuild should mirror the new native selection",
+    );
+    assertEquals(
+      rendered[1].tabIndex,
+      0,
+      "newly selected proxy should own tabindex 0",
+    );
+
+    rendered[2].dispatchEvent(syntheticKeydown(" "));
+    assertEquals(
+      browser.selectedTab,
+      tabs[2],
+      "Space should select the corresponding existing native tab",
+    );
+
+    rendered[0].dispatchEvent(new Event("click", { bubbles: true }));
+    assertEquals(
+      browser.selectedTab,
+      tabs[0],
+      "click should select the corresponding existing native tab",
+    );
+
+    tabs[1].hidden = true;
+    browser.visibleTabs = [tabs[0], tabs[2]];
+    rendered[1].dispatchEvent(new Event("click", { bubbles: true }));
+    assertEquals(
+      browser.selectedTab,
+      tabs[0],
+      "a stale proxy must not retarget to a different live native tab",
+    );
+    assertEquals(
+      proxies(testDocument).map((proxy) => proxy.getAttribute("aria-label"))
+        .join(","),
+      "Alpha,Gamma",
+      "stale activation should rebuild to the eligible live member list",
+    );
+  } finally {
+    harness.controller.destroy();
+  }
+}
+
+function testVerticalLifecycleAndExplicitDestroy(): void {
+  const harness = createHarness();
+  const nativeBefore = harness.group.outerHTML;
+  assert(
+    harness.document.getElementById(TAB_STACKS_ROW_ID),
+    "horizontal enabled state should start with a row",
+  );
+
+  harness.services.values.set(VERTICAL_TABS_PREF, true);
+  harness.services.notifyPref(VERTICAL_TABS_PREF);
+  assertEquals(
+    harness.document.getElementById(TAB_STACKS_ROW_ID),
+    null,
+    "vertical tabs should destroy the mirror row",
+  );
+  assertEquals(
+    harness.document.getElementById(TAB_STACKS_STYLE_ID),
+    null,
+    "vertical tabs should destroy owned styles",
+  );
+  assertEquals(
+    harness.group.outerHTML,
+    nativeBefore,
+    "vertical transition must leave native presentation untouched",
+  );
+
+  harness.services.values.set(VERTICAL_TABS_PREF, false);
+  harness.services.notifyPref(VERTICAL_TABS_PREF);
+  assert(
+    harness.document.getElementById(TAB_STACKS_ROW_ID),
+    "returning horizontal should rebuild from live native state",
+  );
+
+  harness.controller.destroy();
+  assertEquals(
+    harness.document.getElementById(TAB_STACKS_ROW_ID),
+    null,
+    "explicit destroy should remove the row",
+  );
+  assertEquals(
+    harness.document.getElementById(TAB_STACKS_STYLE_ID),
+    null,
+    "explicit destroy should remove styles",
+  );
+  assertEquals(
+    harness.services.prefRemoved.length,
+    1,
+    "explicit destroy should remove the vertical pref observer",
+  );
+  assertEquals(
+    harness.services.prefRemoved[0].name,
+    VERTICAL_TABS_PREF,
+    "only the vertical lifecycle pref should be observed",
+  );
+  assertEquals(
+    harness.services.topicRemoved[0].topic,
+    WORKSPACES_CHANGED_TOPIC,
+    "explicit destroy should remove the workspace observer",
+  );
+  assertEquals(
+    harness.events.removed.filter((type) => type !== "unload").join(","),
+    TAB_STACKS_REBUILD_EVENTS.join(","),
+    "explicit destroy should remove every exact native event listener",
+  );
+}
+
+function testLoadingDocumentListenerCleanup(): void {
+  const testDocument = createTestDocument();
+  setProperty(testDocument, "readyState", "loading");
+
+  const documentListenersAdded: string[] = [];
+  const documentListenersRemoved: string[] = [];
+  const originalAddEventListener = testDocument.addEventListener.bind(
+    testDocument,
+  );
+  const originalRemoveEventListener = testDocument.removeEventListener.bind(
+    testDocument,
+  );
+  setProperty(
+    testDocument,
+    "addEventListener",
+    (
+      type: string,
+      callback: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ): void => {
+      documentListenersAdded.push(type);
+      originalAddEventListener(type, callback, options);
+    },
+  );
+  setProperty(
+    testDocument,
+    "removeEventListener",
+    (
+      type: string,
+      callback: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions,
+    ): void => {
+      documentListenersRemoved.push(type);
+      originalRemoveEventListener(type, callback, options);
+    },
+  );
+
+  const services = new FakeServices();
+  services.values.set(TAB_STACKS_ENABLED_PREF, true);
+  services.values.set(VERTICAL_TABS_PREF, false);
+  const controller = initializeTabStacksFoundation({
+    document: testDocument,
+    eventTarget: new TrackingEventTarget(),
+    services,
+    getBrowser: () => null,
+  });
+  assert(controller, "enabled loading document should create a controller");
+  assertEquals(
+    documentListenersAdded.filter((type) => type === "DOMContentLoaded")
+      .length,
+    1,
+    "loading startup should attach one DOMContentLoaded listener",
+  );
+
+  controller.destroy();
+  assertEquals(
+    documentListenersRemoved.filter((type) => type === "DOMContentLoaded")
+      .length,
+    1,
+    "destroy before DOM readiness should remove the DOM listener",
+  );
+}
+
+const tests: TestCase[] = [
+  {
+    name: "missing pref is inert and defaults false",
+    fn: testMissingPrefIsInert,
+  },
+  {
+    name: "eligible native group renders accessible read-only proxies",
+    fn: testPresentationAndAccessibility,
+  },
+  {
+    name: "eligibility, unnamed fallback, and split exclusion use live state",
+    fn: testEligibilityFallbackAndSplitExclusion,
+  },
+  {
+    name: "click and keyboard activate only existing native tabs",
+    fn: testClickAndKeyboardSelection,
+  },
+  {
+    name: "vertical lifecycle and explicit destroy clean all owned state",
+    fn: testVerticalLifecycleAndExplicitDestroy,
+  },
+  {
+    name: "loading-document teardown removes its DOM readiness listener",
+    fn: testLoadingDocumentListenerCleanup,
+  },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("tabStacksFoundation.test.ts", tests);
+}

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Architecture Overview
@@ -58,7 +58,7 @@ Window Actors are registered from `browser-features/modules/modules/BrowserGlue.
 
 ## Chrome UI Features
 
-Common chrome features are discovered from `browser-features/chrome/common/mod.ts:4` with the glob pattern `./*/index.ts`. The current inventory lists 30 common features:
+Common chrome features are discovered from `browser-features/chrome/common/mod.ts:4` with the glob pattern `./*/index.ts`. The current inventory lists 31 common features:
 
 - `addons`
 - `browser-share-mode`
@@ -85,6 +85,7 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 - `tab`
 - `tab-refresh`
 - `tab-sleep-exclusion`
+- `tab-stacks`
 - `tabbar`
 - `ui-custom`
 - `undo-closed-tab`

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Common Chrome Features
@@ -10,7 +10,7 @@ The `browser-features/chrome/common/` directory contains loader-managed browser 
 
 ## Discovery And Loading
 
-Common features are discovered by `browser-features/chrome/common/mod.ts:4` using the glob pattern `./*/index.ts`. The current inventory contains 30 common feature entries.
+Common features are discovered by `browser-features/chrome/common/mod.ts:4` using the glob pattern `./*/index.ts`. The current inventory contains 31 common feature entries.
 
 The bridge loader turns discovered entries into loadable modules, while each feature entrypoint remains responsible for its own component, services, styles, context menus, or lifecycle hooks.
 
@@ -94,7 +94,9 @@ Small chrome utilities and action helpers that do not own a broader feature fami
 
 ### Uncategorized
 
-All discovered common chrome features are currently assigned to a generated category.
+| Feature | Source | Entrypoints | Description |
+|---|---|---|---|
+| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
 
 ## Relationship To Other Layers
 

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "410c211c202012631159d1bce1f3ab208305d2b7"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Common Chrome Feature Catalog

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "410c211c202012631159d1bce1f3ab208305d2b7"
 generated: true
 ---
 # Common Chrome Feature Catalog
@@ -37,6 +37,7 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 | tab | `browser-features/chrome/common/tab/index.ts` | `default class Tab`, `init` | Owns the tab feature through the Tab chrome component and wires `scroll`, `openPosition`, `sizeSpecification`. |
 | tab-refresh | `browser-features/chrome/common/tab-refresh/index.ts` | `default class TabRefresh`, `init` | Owns the tab refresh feature through the TabRefresh chrome component and wires `controller`. |
 | tab-sleep-exclusion | `browser-features/chrome/common/tab-sleep-exclusion/index.ts` | `default class TabSleepExclusion`, `init` | Owns the tab sleep exclusion feature through the TabSleepExclusion chrome component. |
+| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
 | tabbar | `browser-features/chrome/common/tabbar/index.ts` | `default class TabBar`, `init` | Owns the tabbar feature through the TabBar chrome component and wires `multirow-tabbar/multirow-tabbar`, `tabbbar-style/tabbar-style`. |
 | ui-custom | `browser-features/chrome/common/ui-custom/index.ts` | `default class UICustomization`, `init`, `initBeforeSessionStoreInit` | Owns the ui custom feature through the UICustomization chrome component and wires `styles/style-manager`, `layout/dom-manipulator`. |
 | undo-closed-tab | `browser-features/chrome/common/undo-closed-tab/index.ts` | `default class UndoClosedTab`, `init` | Owns the undo closed tab feature through the UndoClosedTab chrome component and wires `styleElem`. |

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Browser UI Customization

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "410c211c202012631159d1bce1f3ab208305d2b7"
 generated: true
 ---
 # Common Chrome Feature Categories
@@ -18,7 +18,10 @@ This nested catalog is generated from `browser-features/chrome/common`. It group
 | [Input & Shortcuts](./input-and-shortcuts) | 4 | Keyboard, mouse gesture, context menu, and command palette interaction features. |
 | [Web Apps & Integration](./webapps-and-integration) | 6 | PWA, profile, add-on, external browser, share mode, and container integration features. |
 | [Utilities & Actions](./utilities-and-actions) | 2 | Small chrome utilities and action helpers that do not own a broader feature family. |
+| Uncategorized | 1 | Entries discovered from `browser-features/chrome/common` that do not yet have a docs category. |
 
 ## Uncategorized Entries
 
-All discovered common chrome features are currently assigned to a generated category.
+| Feature | Source | Entrypoints | Description |
+|---|---|---|---|
+| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "410c211c202012631159d1bce1f3ab208305d2b7"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Common Chrome Feature Categories

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Window Actor Categories

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Settings & Internal Page Actors

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Web Content & Store Actors

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Browser Features Catalog
@@ -10,7 +10,7 @@ This catalog is generated from loader-discovered chrome feature entrypoints, the
 
 ## Catalog Sections
 
-- Common chrome features: 30 entries from `browser-features/chrome/common`.
+- Common chrome features: 31 entries from `browser-features/chrome/common`.
 - Static chrome features: 3 entries from `browser-features/chrome/static`.
 - Settings page routes: 14 routes from `browser-features/pages-settings/src/App.tsx`.
 - Window Actors: 23 actors from `browser-features/modules/modules/BrowserGlue.sys.mts`.

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Window Actor Catalog

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "1d1a9c886fed24a1d426c981baa3117003d03415"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "548fe69ffece93f0a62c3bddeee26a95445ee131"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "ef70a7ef84573ff3ce46125169750c5a7cad3898"
+floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `ef70a7ef84573ff3ce46125169750c5a7cad3898`.
+Inventory generated from Floorp commit `89512cb30d94bdc984f14c7d199440b911885dea`.
 
 ## Source Precedence
 
@@ -52,7 +52,7 @@ Inventory generated from Floorp commit `ef70a7ef84573ff3ce46125169750c5a7cad3898
 
 ## Feature Catalog Sources
 
-- Common chrome features: `browser-features/chrome/common` (30 entries)
+- Common chrome features: `browser-features/chrome/common` (31 entries)
 - Static chrome features: `browser-features/chrome/static` (3 entries)
 - Settings routes: `browser-features/pages-settings/src/App.tsx` (14 routes)
 - Window Actors: `browser-features/modules/modules/BrowserGlue.sys.mts` (23 actors)


### PR DESCRIPTION
Replacement for the abandoned #2574, as part of #2569.

This is an intentionally bounded redesign: it delivers a verified, default-off foundation for presenting the active native Firefox tab group in a second horizontal row. It does not claim the abandoned PR's full chip, drag-and-drop, group-kind, close-button, or add-tab feature set.

## Scope

The feature remains disabled unless `floorp.tabstacks.enabled` is true. Native Firefox tab groups remain the sole data model and persistence owner.

Exactly 11 repository paths change:

- `browser-features/chrome/common/tab-stacks/index.ts`
- `browser-features/chrome/common/tab-stacks/stack-bar.tsx`
- `browser-features/chrome/common/tab-stacks/styles.css`
- `browser-features/chrome/common/tab-stacks/test/tabStacksEventContract.test.ts`
- `browser-features/chrome/common/tab-stacks/test/tabStacksFoundation.test.ts`
- `docs/development/architecture-overview.mdx`
- `docs/development/directories/browser-features/chrome/common.mdx`
- `docs/development/features/browser-features/chrome-common.mdx`
- `docs/development/features/browser-features/common/overview.mdx`
- `docs/development/features/browser-features/overview.mdx`
- `docs/development/reference/source-inventory.mdx`

The mirror:

- derives membership, labels, color, collapse, selection, and restore state from live native objects;
- no-ops for missing/false pref, vertical tabs, collapsed groups, split-view groups, and ineligible groups;
- provides tablist/tab semantics, roving keyboard focus, Enter/Space/click activation, and conditional aria-controls;
- uses exact native group/tab object identity plus live membership revalidation, including native tabs whose id is empty;
- owns no custom persistence and fully removes its row, styles, listeners, and observers.

## Verification

Canonical locked Runtime proof:

- Runtime 153.0
- BuildID 20260725075208
- Windows artifact 489491165

Observed in the real browser:

- pref-off inert startup and reload;
- active-group rendering and accessibility state;
- click, Enter, Space, arrow, Home, and End behavior;
- rename, recolor, membership, workspace, collapse/expand, default-name, split-view, and vertical-tab transitions;
- normal quit plus same-profile cold restart restoring the native group and regenerated two-proxy row;
- zero custom storage keys.

Automated and build evidence:

- Tab Stacks browser tests: 2/2 passed
- adjacent Workspaces browser tests: 7/7 passed
- adjacent Split View browser tests: 3/3 passed
- smoke, scoped fmt/lint/check: passed
- production browser-features build: passed (594 modules)
- docs-pipeline tests: 49/49 passed
- independent Tier 1 review and audit: no P0/P1/P2 findings

The native Windows docs verifier still reports pre-existing generated-page EOL/provenance drift outside this 11-path scope; normalized inventory comparison shows zero semantic drift. GitHub's Linux docs check is the publication gate.

## Residual scope

This Draft has Windows locked-runtime proof, not a macOS host run. Full functionality from the abandoned #2574 remains explicitly out of scope for this foundation and can be layered in later reviewable PRs.
## Initial GitHub checks

- Docs verify: passed
- Moderate Content: passed
- Smoke: 208 passed, 1 failed only in the existing canonical-main localization parity check (`ja-JP locale must define about.noraneko`)

None of this PR's 11 paths touches localization or `tools/src/localization_targets.test.ts`; the Native Runtime matrix job was skipped after that baseline smoke gate.