### PR TITLE
feat(tabbar): add opt-in inline tab URL editing

### DIFF
--- a/browser-features/chrome/common/keyboard-shortcut/actions.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/actions.ts
@@ -1,0 +1,38 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gestureActions } from "../mouse-gesture/utils/gestures.ts";
+import { openInlineTabUrlEditorForSelectedTab } from "../tab-inline-edit/controller.ts";
+import type {
+  KeyboardActionFn,
+  KeyboardOnlyActionRegistration,
+} from "./type.ts";
+
+export const INLINE_TAB_URL_ACTION_ID = "floorp-edit-tab-url" as const;
+
+export const KEYBOARD_ONLY_ACTIONS: readonly KeyboardOnlyActionRegistration[] =
+  Object.freeze([
+    Object.freeze({
+      name: INLINE_TAB_URL_ACTION_ID,
+      fn: (win: Window): void => {
+        openInlineTabUrlEditorForSelectedTab(win);
+      },
+    }),
+  ]);
+
+const keyboardOnlyActionMap = new Map(
+  KEYBOARD_ONLY_ACTIONS.map((action) => [action.name, action.fn]),
+);
+
+export function getKeyboardOnlyActions(): readonly KeyboardOnlyActionRegistration[] {
+  return KEYBOARD_ONLY_ACTIONS;
+}
+
+export function getKeyboardShortcutAction(
+  actionId: string,
+): KeyboardActionFn | undefined {
+  return keyboardOnlyActionMap.get(actionId) ??
+    gestureActions.getAction(actionId);
+}

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getConfig, isEnabled, isSafeErrorHandling } from "./config.ts";
-import { gestureActions } from "../mouse-gesture/utils/gestures.ts";
+import { getKeyboardShortcutAction } from "./actions.ts";
 import type { ShortcutConfig } from "./type.ts";
 import {
   isBarePrintableKeyEvent,
@@ -163,7 +163,7 @@ export class KeyboardShortcutController {
       // Expanded try-catch covers both getAction() resolution and fn()
       // invocation so callers can always run cleanup.
       try {
-        const fn = gestureActions.getAction(shortcut.action);
+        const fn = getKeyboardShortcutAction(shortcut.action);
         if (fn) {
           fn(this.targetWindow);
         }
@@ -175,7 +175,7 @@ export class KeyboardShortcutController {
       }
     } else {
       // Control: original behaviour (try-catch only around fn call)
-      const fn = gestureActions.getAction(shortcut.action);
+      const fn = getKeyboardShortcutAction(shortcut.action);
       if (fn) {
         try {
           fn(this.targetWindow);

--- a/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutActionCatalog.test.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutActionCatalog.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import enUS from "#i18n/en-US/browser-chrome.json" with {
+  type: "json",
+};
+import jaJP from "#i18n/ja-JP/browser-chrome.json" with {
+  type: "json",
+};
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import {
+  getKeyboardOnlyActions,
+  getKeyboardShortcutAction,
+  INLINE_TAB_URL_ACTION_ID,
+  KEYBOARD_ONLY_ACTIONS,
+} from "../actions.ts";
+import { defaultConfig } from "../config.ts";
+import {
+  gestureActions,
+  getAllGestureActions,
+} from "../../mouse-gesture/utils/gestures.ts";
+import { getPaletteCommands } from "../../command-palette/command-registry.ts";
+
+function testFrozenKeyboardOnlyCatalog(): void {
+  assertEquals(
+    INLINE_TAB_URL_ACTION_ID,
+    "floorp-edit-tab-url",
+    "inline URL action ID must remain stable",
+  );
+  assert(Object.isFrozen(KEYBOARD_ONLY_ACTIONS), "catalog should be frozen");
+
+  const matches = getKeyboardOnlyActions().filter((action) =>
+    action.name === INLINE_TAB_URL_ACTION_ID
+  );
+  assertEquals(matches.length, 1, "catalog should contain the action once");
+  assert(
+    typeof getKeyboardShortcutAction(INLINE_TAB_URL_ACTION_ID) === "function",
+    "keyboard controller should resolve the keyboard-only action",
+  );
+}
+
+function testNoDefaultBinding(): void {
+  assert(
+    !Object.hasOwn(defaultConfig.shortcuts, INLINE_TAB_URL_ACTION_ID),
+    "inline URL action must not ship with a default shortcut",
+  );
+  assert(
+    !Object.values(defaultConfig.shortcuts).some((shortcut) =>
+      shortcut.action === INLINE_TAB_URL_ACTION_ID
+    ),
+    "inline URL action must not appear in any shipped default binding",
+  );
+}
+
+function testAbsentFromGestureRegistry(): void {
+  assertEquals(
+    gestureActions.getAction(INLINE_TAB_URL_ACTION_ID),
+    undefined,
+    "keyboard-only action must not resolve from gestureActions",
+  );
+  assert(
+    !getAllGestureActions().some((action) =>
+      action.name === INLINE_TAB_URL_ACTION_ID
+    ),
+    "keyboard-only action must not enter the gesture catalog",
+  );
+}
+
+function testAbsentFromCommandPalette(): void {
+  assert(
+    !getPaletteCommands().some((command) =>
+      command.id === INLINE_TAB_URL_ACTION_ID
+    ),
+    "keyboard-only action must not enter the command palette",
+  );
+}
+
+function testFailsClosedWithoutEnabledController(): void {
+  const action = getKeyboardShortcutAction(INLINE_TAB_URL_ACTION_ID);
+  assert(action, "keyboard-only action should resolve");
+  const detachedWindow = new EventTarget() as unknown as Window;
+  action(detachedWindow);
+}
+
+function testChromeLocales(): void {
+  assertEquals(
+    enUS.tabInlineEdit.keyboardAction,
+    "Edit Tab URL",
+    "English chrome action label should exist",
+  );
+  assertEquals(
+    enUS.tabInlineEdit.inputLabel,
+    "Tab URL",
+    "English accessible input label should exist",
+  );
+  assertEquals(
+    jaJP.tabInlineEdit.keyboardAction,
+    "タブの URL を編集",
+    "Japanese chrome action label should exist",
+  );
+  assertEquals(
+    jaJP.tabInlineEdit.inputLabel,
+    "タブの URL",
+    "Japanese accessible input label should exist",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    { name: "frozen keyboard-only catalog", fn: testFrozenKeyboardOnlyCatalog },
+    { name: "no default binding", fn: testNoDefaultBinding },
+    { name: "absent from gesture registry", fn: testAbsentFromGestureRegistry },
+    { name: "absent from command palette", fn: testAbsentFromCommandPalette },
+    {
+      name: "fails closed without enabled controller",
+      fn: testFailsClosedWithoutEnabledController,
+    },
+    { name: "EN/JA chrome locales", fn: testChromeLocales },
+  ];
+  await runTests("keyboardShortcutActionCatalog.test.ts", tests);
+}

--- a/browser-features/chrome/common/keyboard-shortcut/type.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/type.ts
@@ -5,7 +5,6 @@
 
 import * as t from "io-ts";
 import type { GestureActionRegistration } from "../mouse-gesture/utils/gestures.ts";
-
 export const zModifiers = t.type({
   alt: t.boolean,
   ctrl: t.boolean,
@@ -35,4 +34,12 @@ export const zKeyboardShortcutConfig = t.intersection([
 export type Modifiers = t.TypeOf<typeof zModifiers>;
 export type ShortcutConfig = t.TypeOf<typeof zShortcutConfig>;
 export type KeyboardShortcutConfig = t.TypeOf<typeof zKeyboardShortcutConfig>;
+
+export type KeyboardActionFn = (win: Window) => void;
+
+export interface KeyboardOnlyActionRegistration {
+  name: string;
+  fn: KeyboardActionFn;
+}
+
 export type { GestureActionRegistration };

--- a/browser-features/chrome/common/tab-inline-edit/controller.ts
+++ b/browser-features/chrome/common/tab-inline-edit/controller.ts
@@ -1,0 +1,826 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import i18next from "i18next";
+
+export const TAB_INLINE_EDIT_PREF = "floorp.tabs.inlineUrlEdit.enabled";
+export const TAB_INLINE_EDIT_INPUT_ID = "floorp-tab-inline-url-editor";
+export const TAB_INLINE_EDIT_CONTEXT_ITEM_ID =
+  "floorp-tab-inline-url-editor-context-item";
+
+const CONTROLLER_OWNER_KEY = "__floorpTabInlineEditController";
+
+function stripAsciiWhitespaceAndControls(value: string): string {
+  let stripped = "";
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code > 0x20 && code !== 0x7f) {
+      stripped += character;
+    }
+  }
+  return stripped;
+}
+
+export type InlineTab = Element & {
+  closing?: boolean;
+  linkedPanel?: string;
+  multiselected?: boolean;
+  focus?: (options?: FocusOptions) => void;
+};
+
+export type InlineBrowser = {
+  currentURI?: { spec?: string };
+  focus?: (options?: FocusOptions) => void;
+};
+
+export type InlineGBrowser = {
+  tabs?: Iterable<InlineTab> | ArrayLike<InlineTab>;
+  selectedTab?: InlineTab | null;
+  selectedTabs?: ArrayLike<InlineTab>;
+  selectedBrowser?: InlineBrowser | null;
+  tabContainer?: EventTarget | null;
+  getBrowserForTab: (tab: InlineTab) => InlineBrowser;
+};
+
+export type InlineSessionStore = {
+  getLazyTabValue: (tab: InlineTab, key: string) => string | undefined;
+};
+
+export type InlineUrlFixupResult = {
+  url: string;
+  postData?: unknown;
+};
+
+export type InlineUrlFixup = (
+  input: string,
+) => Promise<InlineUrlFixupResult>;
+
+export type InlineTabLoadOptions = {
+  targetBrowser: InlineBrowser;
+  triggeringPrincipal: unknown;
+  allowInheritPrincipal: false;
+  allowThirdPartyFixup: true;
+  indicateErrorPageLoad: true;
+  allowPinnedTabHostChange: true;
+  postData?: unknown;
+};
+
+export interface TabInlineEditControllerDependencies {
+  gBrowser: InlineGBrowser | null;
+  contextMenu: Element | null;
+  overlayParent: Element | null;
+  getContextTab: () => InlineTab | null;
+  sessionStore: InlineSessionStore | null;
+  fixup: InlineUrlFixup;
+  openTrustedLinkIn: (
+    url: string,
+    where: "current",
+    options: InlineTabLoadOptions,
+  ) => void;
+  getSystemPrincipal: () => unknown;
+  translate: (key: string, fallback: string) => string;
+}
+
+type ControllerWindow = Window & {
+  document: Document;
+  [CONTROLLER_OWNER_KEY]?: Pick<
+    TabInlineEditController,
+    "destroy" | "openForSelectedTab" | "updateLocalizedLabels"
+  >;
+  gBrowser?: InlineGBrowser;
+  TabContextMenu?: { contextTab?: InlineTab | null };
+  SessionStore?: InlineSessionStore;
+  openTrustedLinkIn?: (
+    url: string,
+    where: "current",
+    options: InlineTabLoadOptions,
+  ) => void;
+};
+
+type EditorState = {
+  input: HTMLInputElement;
+  targetTab: InlineTab;
+  previousFocus: Element | null;
+  cleanups: Array<() => void>;
+  animationFrame: number | null;
+  submitting: boolean;
+};
+
+function collectionIncludesTab(
+  collection: Iterable<InlineTab> | ArrayLike<InlineTab> | undefined,
+  target: InlineTab,
+): boolean {
+  if (!collection) {
+    return true;
+  }
+  try {
+    return Array.from(collection).includes(target);
+  } catch {
+    return false;
+  }
+}
+
+export function isDangerousInlineUrl(value: string): boolean {
+  const normalized = stripAsciiWhitespaceAndControls(value).toLowerCase();
+  return normalized.startsWith("javascript:") || normalized.startsWith("data:");
+}
+
+export function normalizeInlineTabPrefill(value: string | undefined): string {
+  if (!value || value.toLowerCase() === "about:blank") {
+    return "";
+  }
+  return value;
+}
+
+export function getSafeInlineTabPrefill(
+  tab: InlineTab,
+  gBrowser: InlineGBrowser,
+  sessionStore: InlineSessionStore | null,
+): string {
+  const isLazy = tab.hasAttribute("pending") ||
+    tab.hasAttribute("discarded");
+
+  if (isLazy) {
+    try {
+      return normalizeInlineTabPrefill(
+        sessionStore?.getLazyTabValue(tab, "url"),
+      );
+    } catch {
+      return "";
+    }
+  }
+
+  try {
+    return normalizeInlineTabPrefill(
+      gBrowser.getBrowserForTab(tab).currentURI?.spec,
+    );
+  } catch {
+    return "";
+  }
+}
+
+export async function resolveInlineTabUrlInput(
+  rawInput: string,
+  fixup: InlineUrlFixup,
+): Promise<InlineUrlFixupResult | null> {
+  const input = rawInput.trim();
+  if (!input || isDangerousInlineUrl(input)) {
+    return null;
+  }
+
+  const fixed = await fixup(input);
+  const fixedUrl = fixed.url?.trim();
+  if (!fixedUrl || isDangerousInlineUrl(fixedUrl)) {
+    return null;
+  }
+
+  return { ...fixed, url: fixedUrl };
+}
+
+export function buildInlineTabLoadOptions(
+  targetBrowser: InlineBrowser,
+  triggeringPrincipal: unknown,
+  postData?: unknown,
+): InlineTabLoadOptions {
+  const options: InlineTabLoadOptions = {
+    targetBrowser,
+    triggeringPrincipal,
+    allowInheritPrincipal: false,
+    allowThirdPartyFixup: true,
+    indicateErrorPageLoad: true,
+    allowPinnedTabHostChange: true,
+  };
+  if (postData !== undefined && postData !== null) {
+    options.postData = postData;
+  }
+  return options;
+}
+
+function defaultFixup(input: string): Promise<InlineUrlFixupResult> {
+  const imported = ChromeUtils.importESModule(
+    "moz-src:///browser/components/urlbar/UrlbarUtils.sys.mjs",
+  ) as {
+    UrlbarUtils: {
+      getShortcutOrURIAndPostData: (
+        value: string,
+      ) => Promise<InlineUrlFixupResult>;
+    };
+  };
+  return imported.UrlbarUtils.getShortcutOrURIAndPostData(input);
+}
+
+function defaultTranslate(key: string, fallback: string): string {
+  return i18next.t(key, { defaultValue: fallback });
+}
+
+function createDefaultDependencies(
+  win: ControllerWindow,
+): TabInlineEditControllerDependencies {
+  return {
+    gBrowser: win.gBrowser ?? null,
+    contextMenu: win.document.getElementById("tabContextMenu"),
+    overlayParent: win.document.documentElement,
+    getContextTab: () => win.TabContextMenu?.contextTab ?? null,
+    sessionStore: win.SessionStore ?? null,
+    fixup: defaultFixup,
+    openTrustedLinkIn: (url, where, options) => {
+      if (typeof win.openTrustedLinkIn !== "function") {
+        throw new Error("openTrustedLinkIn is unavailable");
+      }
+      win.openTrustedLinkIn(url, where, options);
+    },
+    getSystemPrincipal: () =>
+      Services.scriptSecurityManager.getSystemPrincipal(),
+    translate: defaultTranslate,
+  };
+}
+
+function mergeDependencies(
+  defaults: TabInlineEditControllerDependencies,
+  overrides: Partial<TabInlineEditControllerDependencies>,
+): TabInlineEditControllerDependencies {
+  return {
+    ...defaults,
+    ...overrides,
+  };
+}
+
+export class TabInlineEditController {
+  private readonly win: ControllerWindow;
+  private readonly deps: TabInlineEditControllerDependencies;
+  private contextItem: Element | null = null;
+  private editor: EditorState | null = null;
+  private destroyed = false;
+  private navigationEpoch = 0;
+  private waitingForDOMContentLoaded = false;
+
+  private readonly handleWindowUnload = () => this.destroy();
+  private readonly handleDOMContentLoaded = () => {
+    this.waitingForDOMContentLoaded = false;
+    if (!this.deps.contextMenu) {
+      this.deps.contextMenu = this.win.document.getElementById(
+        "tabContextMenu",
+      );
+    }
+    this.installContextItem();
+  };
+  private readonly handleContextMenuShowing = (event: Event) => {
+    if (event.target !== this.deps.contextMenu) {
+      return;
+    }
+    this.updateContextItemState();
+  };
+  private readonly handleContextCommand = () => {
+    this.openForContextTab();
+  };
+
+  constructor(
+    win: Window = globalThis as unknown as Window,
+    dependencies: Partial<TabInlineEditControllerDependencies> = {},
+  ) {
+    this.win = win as ControllerWindow;
+
+    const existing = this.win[CONTROLLER_OWNER_KEY];
+    if (existing && existing !== this) {
+      existing.destroy();
+    }
+
+    this.deps = mergeDependencies(
+      createDefaultDependencies(this.win),
+      dependencies,
+    );
+    this.win[CONTROLLER_OWNER_KEY] = this;
+
+    this.win.addEventListener("unload", this.handleWindowUnload, {
+      once: true,
+    });
+    this.installContextItem();
+  }
+
+  public openForContextTab(): boolean {
+    return this.openForTab(this.deps.getContextTab());
+  }
+
+  public openForSelectedTab(): boolean {
+    return this.openForTab(this.deps.gBrowser?.selectedTab ?? null);
+  }
+
+  public openForTab(tab: InlineTab | null | undefined): boolean {
+    if (this.destroyed || !tab || !this.canEditTab(tab)) {
+      return false;
+    }
+
+    if (this.editor?.targetTab === tab) {
+      this.editor.input.focus({ preventScroll: true });
+      this.editor.input.select();
+      return true;
+    }
+
+    this.navigationEpoch++;
+    const previousFocus = this.editor?.previousFocus ??
+      this.win.document.activeElement;
+    this.closeEditor(false);
+
+    const input = this.createInput();
+    const parent = this.deps.overlayParent;
+    const gBrowser = this.deps.gBrowser;
+    if (!input || !parent || !gBrowser) {
+      return false;
+    }
+
+    input.value = getSafeInlineTabPrefill(
+      tab,
+      gBrowser,
+      this.deps.sessionStore,
+    );
+    parent.appendChild(input);
+
+    this.editor = {
+      input,
+      targetTab: tab,
+      previousFocus,
+      cleanups: [],
+      animationFrame: null,
+      submitting: false,
+    };
+    this.installEditorListeners(this.editor);
+    this.repositionEditor();
+
+    try {
+      input.focus({ preventScroll: true });
+    } catch {
+      input.focus();
+    }
+    input.select();
+    return true;
+  }
+
+  public updateLocalizedLabels(): void {
+    const menuLabel = this.deps.translate(
+      "tabInlineEdit.contextMenu",
+      "Edit Tab URL",
+    );
+    this.contextItem?.setAttribute("label", menuLabel);
+
+    if (this.editor) {
+      const inputLabel = this.deps.translate(
+        "tabInlineEdit.inputLabel",
+        "Tab URL",
+      );
+      this.editor.input.setAttribute("aria-label", inputLabel);
+      this.editor.input.setAttribute("placeholder", inputLabel);
+    }
+  }
+
+  public destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.navigationEpoch++;
+
+    this.closeEditor(true);
+    this.win.removeEventListener("unload", this.handleWindowUnload);
+
+    if (this.waitingForDOMContentLoaded) {
+      this.win.document.removeEventListener(
+        "DOMContentLoaded",
+        this.handleDOMContentLoaded,
+      );
+      this.waitingForDOMContentLoaded = false;
+    }
+
+    this.deps.contextMenu?.removeEventListener(
+      "popupshowing",
+      this.handleContextMenuShowing,
+    );
+    this.contextItem?.removeEventListener(
+      "command",
+      this.handleContextCommand,
+    );
+    this.contextItem?.remove();
+    this.contextItem = null;
+
+    if (this.win[CONTROLLER_OWNER_KEY] === this) {
+      delete this.win[CONTROLLER_OWNER_KEY];
+    }
+  }
+
+  private installContextItem(): void {
+    if (this.destroyed || this.contextItem) {
+      return;
+    }
+
+    const menu = this.deps.contextMenu;
+    if (!menu) {
+      if (
+        this.win.document.readyState === "loading" &&
+        !this.waitingForDOMContentLoaded
+      ) {
+        this.waitingForDOMContentLoaded = true;
+        this.win.document.addEventListener(
+          "DOMContentLoaded",
+          this.handleDOMContentLoaded,
+          { once: true },
+        );
+      }
+      return;
+    }
+
+    this.win.document.getElementById(TAB_INLINE_EDIT_CONTEXT_ITEM_ID)?.remove();
+    const chromeDocument = this.win.document as Document & {
+      createXULElement?: (tagName: string) => Element;
+    };
+    const item = chromeDocument.createXULElement?.("menuitem") ??
+      this.win.document.createElement("menuitem");
+    item.id = TAB_INLINE_EDIT_CONTEXT_ITEM_ID;
+    item.addEventListener("command", this.handleContextCommand);
+
+    const marker = this.win.document.getElementById("context_duplicateTab") ??
+      this.win.document.getElementById("context_reloadTab");
+    if (marker?.parentElement === menu) {
+      menu.insertBefore(item, marker);
+    } else {
+      menu.appendChild(item);
+    }
+
+    this.contextItem = item;
+    menu.addEventListener("popupshowing", this.handleContextMenuShowing);
+    this.updateLocalizedLabels();
+    this.updateContextItemState();
+  }
+
+  private updateContextItemState(): void {
+    if (!this.contextItem) {
+      return;
+    }
+    if (this.canEditTab(this.deps.getContextTab())) {
+      this.contextItem.removeAttribute("disabled");
+    } else {
+      this.contextItem.setAttribute("disabled", "true");
+    }
+  }
+
+  private canEditTab(tab: InlineTab | null | undefined): tab is InlineTab {
+    const gBrowser = this.deps.gBrowser;
+    if (!tab || !gBrowser || tab.closing || tab.hasAttribute("closing")) {
+      return false;
+    }
+    if (!tab.isConnected || !collectionIncludesTab(gBrowser.tabs, tab)) {
+      return false;
+    }
+    if (
+      tab.multiselected ||
+      tab.hasAttribute("multiselected") ||
+      (gBrowser.selectedTabs?.length ?? 0) > 1
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  private createInput(): HTMLInputElement {
+    this.win.document.getElementById(TAB_INLINE_EDIT_INPUT_ID)?.remove();
+    const input = this.win.document.createElementNS(
+      "http://www.w3.org/1999/xhtml",
+      "input",
+    ) as HTMLInputElement;
+    input.id = TAB_INLINE_EDIT_INPUT_ID;
+    input.type = "text";
+    input.autocomplete = "off";
+    input.spellcheck = false;
+    input.setAttribute("role", "textbox");
+    input.style.cssText = [
+      "position: fixed",
+      "z-index: 2147483647",
+      "box-sizing: border-box",
+      "margin: 0",
+      "padding: 2px 8px",
+      "border: 1px solid var(--focus-outline-color, AccentColor)",
+      "border-radius: 4px",
+      "background: var(--toolbar-field-background-color, Field)",
+      "color: var(--toolbar-field-color, FieldText)",
+      "font: menu",
+      "box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35)",
+    ].join(";");
+    this.updateInputLocalizedLabel(input);
+    return input;
+  }
+
+  private updateInputLocalizedLabel(input: HTMLInputElement): void {
+    const label = this.deps.translate(
+      "tabInlineEdit.inputLabel",
+      "Tab URL",
+    );
+    input.setAttribute("aria-label", label);
+    input.setAttribute("placeholder", label);
+  }
+
+  private installEditorListeners(state: EditorState): void {
+    const listen = (
+      target: EventTarget,
+      type: string,
+      listener: EventListener,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      target.addEventListener(type, listener, options);
+      state.cleanups.push(() =>
+        target.removeEventListener(type, listener, options)
+      );
+    };
+
+    const onKeyDown = (event: Event) => {
+      const keyboardEvent = event as KeyboardEvent;
+      if (keyboardEvent.key === "Enter") {
+        keyboardEvent.preventDefault();
+        keyboardEvent.stopPropagation();
+        this.submitEditor();
+      } else if (keyboardEvent.key === "Escape") {
+        keyboardEvent.preventDefault();
+        keyboardEvent.stopPropagation();
+        this.navigationEpoch++;
+        this.closeEditor(true);
+      }
+    };
+    const onBlur = () => {
+      if (!state.submitting) {
+        this.navigationEpoch++;
+        this.closeEditor(true);
+      }
+    };
+    const onReposition = () => this.scheduleReposition();
+    const onTabEvent = (event: Event) => {
+      if (event.type === "TabClose" && event.target === state.targetTab) {
+        this.navigationEpoch++;
+        this.closeEditor(true);
+        return;
+      }
+      this.scheduleReposition();
+    };
+
+    listen(state.input, "keydown", onKeyDown);
+    listen(state.input, "blur", onBlur);
+    listen(this.win, "resize", onReposition);
+    listen(this.win, "scroll", onReposition, true);
+
+    const tabContainer = this.deps.gBrowser?.tabContainer;
+    if (tabContainer) {
+      listen(tabContainer, "scroll", onReposition, true);
+      for (
+        const eventName of [
+          "TabMove",
+          "TabClose",
+          "TabPinned",
+          "TabUnpinned",
+          "TabAttrModified",
+          "TabGroupCollapse",
+          "TabGroupExpand",
+        ]
+      ) {
+        listen(tabContainer, eventName, onTabEvent);
+      }
+    }
+
+    const resizeObserverConstructor = (
+      this.win as Window & { ResizeObserver?: typeof ResizeObserver }
+    ).ResizeObserver;
+    if (resizeObserverConstructor) {
+      const observer = new resizeObserverConstructor(onReposition);
+      observer.observe(state.targetTab);
+      if (tabContainer instanceof Element) {
+        observer.observe(tabContainer);
+      }
+      state.cleanups.push(() => observer.disconnect());
+    }
+
+    const mutationObserverConstructor = (
+      this.win as Window & { MutationObserver?: typeof MutationObserver }
+    ).MutationObserver;
+    if (mutationObserverConstructor) {
+      const observer = new mutationObserverConstructor(() => {
+        if (!state.targetTab.isConnected) {
+          this.navigationEpoch++;
+          this.closeEditor(true);
+          return;
+        }
+        this.scheduleReposition();
+      });
+
+      if (tabContainer instanceof Node) {
+        observer.observe(tabContainer, {
+          attributes: true,
+          childList: true,
+          subtree: true,
+          attributeFilter: [
+            "class",
+            "collapsed",
+            "hidden",
+            "orient",
+            "style",
+            "vertical",
+          ],
+        });
+      }
+
+      let ancestor = state.targetTab.parentElement;
+      while (ancestor && ancestor !== tabContainer) {
+        observer.observe(ancestor, {
+          attributes: true,
+          attributeFilter: [
+            "class",
+            "collapsed",
+            "hidden",
+            "orient",
+            "style",
+            "vertical",
+          ],
+        });
+        ancestor = ancestor.parentElement;
+      }
+      state.cleanups.push(() => observer.disconnect());
+    }
+  }
+
+  private scheduleReposition(): void {
+    const state = this.editor;
+    if (!state || state.animationFrame !== null) {
+      return;
+    }
+    state.animationFrame = this.win.requestAnimationFrame(() => {
+      if (this.editor === state) {
+        state.animationFrame = null;
+        this.repositionEditor();
+      }
+    });
+  }
+
+  private repositionEditor(): void {
+    const state = this.editor;
+    if (!state) {
+      return;
+    }
+    if (!state.targetTab.isConnected || !state.input.isConnected) {
+      this.navigationEpoch++;
+      this.closeEditor(true);
+      return;
+    }
+
+    const rect = state.targetTab.getBoundingClientRect();
+    const viewportWidth = Math.max(
+      this.win.innerWidth,
+      this.win.document.documentElement?.clientWidth ?? 0,
+      1,
+    );
+    const viewportHeight = Math.max(
+      this.win.innerHeight,
+      this.win.document.documentElement?.clientHeight ?? 0,
+      1,
+    );
+    const inset = 4;
+    const width = Math.min(
+      Math.max(rect.width, 240),
+      Math.max(1, viewportWidth - inset * 2),
+    );
+    const height = Math.min(
+      Math.max(rect.height, 28),
+      Math.max(1, viewportHeight - inset * 2),
+    );
+    const left = Math.min(
+      Math.max(rect.left, inset),
+      Math.max(inset, viewportWidth - width - inset),
+    );
+    const top = Math.min(
+      Math.max(rect.top, inset),
+      Math.max(inset, viewportHeight - height - inset),
+    );
+
+    state.input.style.left = `${Math.round(left)}px`;
+    state.input.style.top = `${Math.round(top)}px`;
+    state.input.style.width = `${Math.round(width)}px`;
+    state.input.style.height = `${Math.round(height)}px`;
+  }
+
+  private submitEditor(): void {
+    const state = this.editor;
+    if (!state || state.submitting) {
+      return;
+    }
+    state.submitting = true;
+    const rawInput = state.input.value;
+    const targetTab = state.targetTab;
+    const epoch = ++this.navigationEpoch;
+    this.closeEditor(true);
+    void this.navigateFromInput(rawInput, targetTab, epoch);
+  }
+
+  private async navigateFromInput(
+    rawInput: string,
+    targetTab: InlineTab,
+    epoch: number,
+  ): Promise<void> {
+    try {
+      const fixed = await resolveInlineTabUrlInput(rawInput, this.deps.fixup);
+      if (
+        !fixed ||
+        this.destroyed ||
+        epoch !== this.navigationEpoch ||
+        !this.canEditTab(targetTab)
+      ) {
+        return;
+      }
+
+      const gBrowser = this.deps.gBrowser;
+      if (!gBrowser) {
+        return;
+      }
+      const targetBrowser = gBrowser.getBrowserForTab(targetTab);
+      const options = buildInlineTabLoadOptions(
+        targetBrowser,
+        this.deps.getSystemPrincipal(),
+        fixed.postData,
+      );
+      this.deps.openTrustedLinkIn(fixed.url, "current", options);
+    } catch (error) {
+      console.error(
+        "[TabInlineEdit] Failed to navigate edited tab URL:",
+        error,
+      );
+    }
+  }
+
+  private closeEditor(restoreFocus: boolean): void {
+    const state = this.editor;
+    if (!state) {
+      return;
+    }
+    this.editor = null;
+
+    if (state.animationFrame !== null) {
+      this.win.cancelAnimationFrame(state.animationFrame);
+      state.animationFrame = null;
+    }
+    for (const cleanup of state.cleanups.splice(0).reverse()) {
+      try {
+        cleanup();
+      } catch {
+        // The window or tab may already be closing.
+      }
+    }
+    state.input.remove();
+
+    if (restoreFocus) {
+      this.restoreFocus(state.previousFocus, state.targetTab);
+    }
+  }
+
+  private restoreFocus(
+    previousFocus: Element | null,
+    targetTab: InlineTab,
+  ): void {
+    if (this.focusIfValid(previousFocus)) {
+      return;
+    }
+    if (this.focusIfValid(targetTab)) {
+      return;
+    }
+    this.focusIfValid(this.deps.gBrowser?.selectedBrowser ?? null);
+  }
+
+  private focusIfValid(candidate: Element | InlineBrowser | null): boolean {
+    const focusable = candidate as {
+      focus?: (options?: FocusOptions) => void;
+    } | null;
+    if (!focusable || typeof focusable.focus !== "function") {
+      return false;
+    }
+
+    if (candidate instanceof Element) {
+      if (
+        !candidate.isConnected ||
+        candidate.hasAttribute("disabled") ||
+        candidate.hasAttribute("hidden") ||
+        candidate.getClientRects().length === 0
+      ) {
+        return false;
+      }
+    }
+
+    try {
+      focusable.focus({ preventScroll: true });
+    } catch {
+      try {
+        focusable.focus();
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+export function openInlineTabUrlEditorForSelectedTab(win: Window): boolean {
+  const controller = (win as ControllerWindow)[CONTROLLER_OWNER_KEY];
+  return controller?.openForSelectedTab() ?? false;
+}

--- a/browser-features/chrome/common/tab-inline-edit/index.ts
+++ b/browser-features/chrome/common/tab-inline-edit/index.ts
@@ -1,0 +1,136 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { onCleanup } from "solid-js";
+import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
+import {
+  noraComponent,
+  NoraComponentBase,
+} from "#features-chrome/utils/base.ts";
+import { TAB_INLINE_EDIT_PREF, TabInlineEditController } from "./controller.ts";
+
+const LIFECYCLE_OWNER_KEY = "__floorpTabInlineEditLifecycle";
+
+type LifecycleWindow = Window & {
+  [LIFECYCLE_OWNER_KEY]?: Pick<
+    TabInlineEditLifecycle,
+    "destroy" | "updateLocalizedLabels"
+  >;
+};
+
+export interface TabInlineEditPrefService {
+  getBoolPref: (name: string, fallback: boolean) => boolean;
+  addObserver: (name: string, observer: () => void) => void;
+  removeObserver: (name: string, observer: () => void) => void;
+}
+
+export interface TabInlineEditLifecycleDependencies {
+  prefs: TabInlineEditPrefService;
+  createController: (win: Window) => TabInlineEditController;
+}
+
+function createDefaultLifecycleDependencies(): TabInlineEditLifecycleDependencies {
+  return {
+    prefs: {
+      getBoolPref: (name, fallback) =>
+        Services.prefs.getBoolPref(name, fallback),
+      addObserver: (name, observer) =>
+        Services.prefs.addObserver(name, observer),
+      removeObserver: (name, observer) =>
+        Services.prefs.removeObserver(name, observer),
+    },
+    createController: (win) => new TabInlineEditController(win),
+  };
+}
+
+export function isTabInlineEditEnabled(
+  prefs: Pick<TabInlineEditPrefService, "getBoolPref"> =
+    createDefaultLifecycleDependencies().prefs,
+): boolean {
+  try {
+    return prefs.getBoolPref(TAB_INLINE_EDIT_PREF, false) === true;
+  } catch {
+    return false;
+  }
+}
+
+export class TabInlineEditLifecycle {
+  private readonly win: LifecycleWindow;
+  private readonly deps: TabInlineEditLifecycleDependencies;
+  private controller: TabInlineEditController | null = null;
+  private destroyed = false;
+  private readonly prefObserver = () => this.syncFromPref();
+  private readonly unloadObserver = () => this.destroy();
+
+  constructor(
+    win: Window,
+    dependencies: Partial<TabInlineEditLifecycleDependencies> = {},
+  ) {
+    this.win = win as LifecycleWindow;
+    this.deps = {
+      ...createDefaultLifecycleDependencies(),
+      ...dependencies,
+    };
+    const existing = this.win[LIFECYCLE_OWNER_KEY];
+    if (existing && existing !== this) {
+      existing.destroy();
+    }
+    this.win[LIFECYCLE_OWNER_KEY] = this;
+
+    this.deps.prefs.addObserver(TAB_INLINE_EDIT_PREF, this.prefObserver);
+    this.win.addEventListener("unload", this.unloadObserver, { once: true });
+    this.syncFromPref();
+  }
+
+  public updateLocalizedLabels(): void {
+    this.controller?.updateLocalizedLabels();
+  }
+
+  public destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+
+    try {
+      this.deps.prefs.removeObserver(TAB_INLINE_EDIT_PREF, this.prefObserver);
+    } catch {
+      // Preference service may already be shutting down with the window.
+    }
+    this.win.removeEventListener("unload", this.unloadObserver);
+    this.controller?.destroy();
+    this.controller = null;
+
+    if (this.win[LIFECYCLE_OWNER_KEY] === this) {
+      delete this.win[LIFECYCLE_OWNER_KEY];
+    }
+  }
+
+  private syncFromPref(): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    if (isTabInlineEditEnabled(this.deps.prefs)) {
+      if (!this.controller) {
+        this.controller = this.deps.createController(this.win);
+      }
+    } else {
+      this.controller?.destroy();
+      this.controller = null;
+    }
+  }
+}
+
+@noraComponent(import.meta.hot)
+export default class TabInlineEdit extends NoraComponentBase {
+  init(): void {
+    const lifecycle = new TabInlineEditLifecycle(
+      globalThis as unknown as Window,
+    );
+    addI18nObserver(() => lifecycle.updateLocalizedLabels());
+    onCleanup(() => lifecycle.destroy());
+  }
+}

--- a/browser-features/chrome/common/tab-inline-edit/test/tabInlineEditController.test.ts
+++ b/browser-features/chrome/common/tab-inline-edit/test/tabInlineEditController.test.ts
@@ -1,0 +1,623 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import {
+  buildInlineTabLoadOptions,
+  getSafeInlineTabPrefill,
+  type InlineBrowser,
+  type InlineGBrowser,
+  type InlineTab,
+  isDangerousInlineUrl,
+  normalizeInlineTabPrefill,
+  openInlineTabUrlEditorForSelectedTab,
+  resolveInlineTabUrlInput,
+  TAB_INLINE_EDIT_CONTEXT_ITEM_ID,
+  TAB_INLINE_EDIT_INPUT_ID,
+  TabInlineEditController,
+  type TabInlineEditControllerDependencies,
+} from "../controller.ts";
+import {
+  isTabInlineEditEnabled,
+  TabInlineEditLifecycle,
+  type TabInlineEditPrefService,
+} from "../index.ts";
+
+type RectState = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type ControllerHarness = {
+  controller: TabInlineEditController;
+  root: HTMLElement;
+  menu: HTMLElement;
+  tabContainer: HTMLElement;
+  selectedTab: InlineTab;
+  contextTab: InlineTab;
+  gBrowser: InlineGBrowser;
+  selectedBrowser: InlineBrowser;
+  contextBrowser: InlineBrowser;
+  dependencies: Partial<TabInlineEditControllerDependencies>;
+  setContextTab: (tab: InlineTab | null) => void;
+  setFixup: (fixup: TabInlineEditControllerDependencies["fixup"]) => void;
+  loads: Array<{
+    url: string;
+    where: "current";
+    options: Parameters<
+      TabInlineEditControllerDependencies["openTrustedLinkIn"]
+    >[2];
+  }>;
+  cleanup: () => void;
+};
+
+function createHtmlElement<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+): HTMLElementTagNameMap[K] {
+  return document.createElementNS(
+    "http://www.w3.org/1999/xhtml",
+    tagName,
+  ) as HTMLElementTagNameMap[K];
+}
+
+function createTab(url: string, rect: RectState): InlineTab {
+  const tab = createHtmlElement("div") as InlineTab;
+  tab.setAttribute("data-test-url", url);
+  Object.assign(tab, { linkedPanel: `panel-${Math.random()}` });
+  Object.defineProperty(tab, "getBoundingClientRect", {
+    configurable: true,
+    value: () =>
+      DOMRect.fromRect({
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      }),
+  });
+  return tab;
+}
+
+function createHarness(): ControllerHarness {
+  const root = createHtmlElement("div");
+  const menu = createHtmlElement("div");
+  menu.id = `test-${TAB_INLINE_EDIT_CONTEXT_ITEM_ID}`;
+  const tabContainer = createHtmlElement("div");
+  root.append(menu, tabContainer);
+  const documentElement = document.documentElement;
+  assert(documentElement, "browser test document should have a root element");
+  documentElement.appendChild(root);
+
+  const selectedRect = { left: 20, top: 30, width: 140, height: 32 };
+  const contextRect = { left: 180, top: 30, width: 150, height: 32 };
+  const selectedTab = createTab("https://selected.example/", selectedRect);
+  const contextTab = createTab("https://context.example/", contextRect);
+  tabContainer.append(selectedTab, contextTab);
+
+  const selectedBrowser: InlineBrowser = {
+    currentURI: { spec: "https://selected.example/" },
+    focus: () => {},
+  };
+  const contextBrowser: InlineBrowser = {
+    currentURI: { spec: "https://context.example/" },
+    focus: () => {},
+  };
+  const browserByTab = new Map<InlineTab, InlineBrowser>([
+    [selectedTab, selectedBrowser],
+    [contextTab, contextBrowser],
+  ]);
+  const gBrowser: InlineGBrowser = {
+    tabs: [selectedTab, contextTab],
+    selectedTab,
+    selectedTabs: [selectedTab],
+    selectedBrowser,
+    tabContainer,
+    getBrowserForTab: (tab) => {
+      const browser = browserByTab.get(tab);
+      if (!browser) {
+        throw new Error("unexpected test tab");
+      }
+      return browser;
+    },
+  };
+
+  let currentContextTab: InlineTab | null = contextTab;
+  let currentFixup: TabInlineEditControllerDependencies["fixup"] = (input) =>
+    Promise.resolve({ url: input });
+  const loads: ControllerHarness["loads"] = [];
+  const principal = { isSystemPrincipal: true };
+  const dependencies: Partial<TabInlineEditControllerDependencies> = {
+    gBrowser,
+    contextMenu: menu,
+    overlayParent: root,
+    getContextTab: () => currentContextTab,
+    sessionStore: {
+      getLazyTabValue: (tab) => tab.getAttribute("data-test-url") ?? undefined,
+    },
+    fixup: (input) => currentFixup(input),
+    openTrustedLinkIn: (url, where, options) => {
+      loads.push({ url, where, options });
+    },
+    getSystemPrincipal: () => principal,
+    translate: (_key, fallback) => fallback,
+  };
+  const controller = new TabInlineEditController(window, dependencies);
+
+  return {
+    controller,
+    root,
+    menu,
+    tabContainer,
+    selectedTab,
+    contextTab,
+    gBrowser,
+    selectedBrowser,
+    contextBrowser,
+    dependencies,
+    setContextTab: (tab) => {
+      currentContextTab = tab;
+    },
+    setFixup: (fixup) => {
+      currentFixup = fixup;
+    },
+    loads,
+    cleanup: () => {
+      controller.destroy();
+      root.remove();
+      document.getElementById(TAB_INLINE_EDIT_INPUT_ID)?.remove();
+      document.getElementById(TAB_INLINE_EDIT_CONTEXT_ITEM_ID)?.remove();
+    },
+  };
+}
+
+class TestPrefService implements TabInlineEditPrefService {
+  private readonly observers = new Set<() => void>();
+
+  constructor(private value: boolean) {}
+
+  getBoolPref(_name: string, _fallback: boolean): boolean {
+    return this.value;
+  }
+
+  addObserver(_name: string, observer: () => void): void {
+    this.observers.add(observer);
+  }
+
+  removeObserver(_name: string, observer: () => void): void {
+    this.observers.delete(observer);
+  }
+
+  set(value: boolean): void {
+    this.value = value;
+    for (const observer of this.observers) {
+      observer();
+    }
+  }
+}
+
+function inputElement(): HTMLInputElement | null {
+  return document.getElementById(
+    TAB_INLINE_EDIT_INPUT_ID,
+  ) as HTMLInputElement | null;
+}
+
+function testDangerousSchemeNormalization(): void {
+  const dangerous = [
+    "javascript:alert(1)",
+    "  JaVaScRiPt:alert(1)",
+    "java\tscript:alert(1)",
+    "j a v a s c r i p t:alert(1)",
+    "data:text/html,hello",
+    "da\r\nta:text/html,hello",
+    "\u0000d\u001fa\u007ft\u0009a:text/plain,hello",
+  ];
+  for (const value of dangerous) {
+    assert(
+      isDangerousInlineUrl(value),
+      `should reject ${JSON.stringify(value)}`,
+    );
+  }
+  assert(
+    !isDangerousInlineUrl("https://example.com/javascript:data"),
+    "safe URL containing scheme words should remain allowed",
+  );
+}
+
+async function testRawAndPostFixupRejection(): Promise<void> {
+  let fixupCalls = 0;
+  const rawRejected = await resolveInlineTabUrlInput(
+    " j\tavascript:alert(1) ",
+    (input) => {
+      fixupCalls++;
+      return Promise.resolve({ url: input });
+    },
+  );
+  assertEquals(rawRejected, null, "dangerous raw input should be rejected");
+  assertEquals(fixupCalls, 0, "raw rejection should happen before fixup");
+
+  const fixedRejected = await resolveInlineTabUrlInput(
+    "safe search",
+    () => Promise.resolve({ url: "d\u0000a\tt a:text/html,unsafe" }),
+  );
+  assertEquals(
+    fixedRejected,
+    null,
+    "dangerous post-fixup URL should be rejected",
+  );
+
+  const blankRejected = await resolveInlineTabUrlInput(
+    " \r\n ",
+    () =>
+      Promise.resolve({
+        url: "https://should-not-run.example/",
+      }),
+  );
+  assertEquals(blankRejected, null, "blank input should be rejected");
+}
+
+function testLazySafePrefill(): void {
+  const lazyTab = createTab("https://lazy.example/", {
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 30,
+  });
+  lazyTab.setAttribute("pending", "true");
+  let browserReads = 0;
+  const gBrowser: InlineGBrowser = {
+    getBrowserForTab: () => {
+      browserReads++;
+      throw new Error("lazy browser must not be requested during prefill");
+    },
+  };
+  const prefill = getSafeInlineTabPrefill(lazyTab, gBrowser, {
+    getLazyTabValue: () => "https://lazy.example/session",
+  });
+  assertEquals(prefill, "https://lazy.example/session", "use lazy session URL");
+  assertEquals(browserReads, 0, "lazy prefill must not wake/read the browser");
+
+  assertEquals(
+    normalizeInlineTabPrefill("about:blank"),
+    "",
+    "initial about:blank should be empty",
+  );
+  assertEquals(
+    normalizeInlineTabPrefill("about:config"),
+    "about:config",
+    "other explicit about URLs should remain literal",
+  );
+}
+
+function testExactLoadOptions(): void {
+  const targetBrowser = { currentURI: { spec: "about:blank" } };
+  const principal = { isSystemPrincipal: true };
+  const postData = { marker: "post" };
+  const options = buildInlineTabLoadOptions(
+    targetBrowser,
+    principal,
+    postData,
+  );
+
+  assertEquals(options.targetBrowser, targetBrowser, "targetBrowser is exact");
+  assertEquals(
+    options.triggeringPrincipal,
+    principal,
+    "System Principal is explicit",
+  );
+  assertEquals(
+    options.allowInheritPrincipal,
+    false,
+    "principal cannot inherit",
+  );
+  assertEquals(options.allowThirdPartyFixup, true, "third-party fixup is on");
+  assertEquals(options.indicateErrorPageLoad, true, "error load is indicated");
+  assertEquals(
+    options.allowPinnedTabHostChange,
+    true,
+    "pinned tab host change is allowed in-place",
+  );
+  assertEquals(options.postData, postData, "keyword POST data is preserved");
+  assert(
+    !Object.hasOwn(options, "initiatedByURLBar"),
+    "load must not claim URLbar initiation",
+  );
+  assert(!Object.hasOwn(options, "userContextId"), "container ID is untouched");
+  assert(!Object.hasOwn(options, "private"), "private identity is untouched");
+}
+
+function testContextAndKeyboardTargets(): void {
+  const harness = createHarness();
+  try {
+    assert(
+      harness.controller.openForContextTab(),
+      "context action should open",
+    );
+    assertEquals(
+      inputElement()?.value,
+      "https://context.example/",
+      "context invocation uses exactly contextTab",
+    );
+    assertEquals(
+      harness.gBrowser.selectedTab,
+      harness.selectedTab,
+      "editing inactive context tab must not select it",
+    );
+
+    inputElement()?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    assertEquals(inputElement(), null, "Escape removes the editor");
+
+    assert(
+      harness.controller.openForSelectedTab(),
+      "keyboard action should open",
+    );
+    assertEquals(
+      inputElement()?.value,
+      "https://selected.example/",
+      "keyboard invocation uses exactly selectedTab",
+    );
+
+    inputElement()?.dispatchEvent(new FocusEvent("blur"));
+    assertEquals(
+      inputElement(),
+      null,
+      "blur cancels without leaving an editor",
+    );
+    assertEquals(harness.loads.length, 0, "Escape/blur never navigate");
+  } finally {
+    harness.cleanup();
+  }
+}
+
+function testMissingAndMultiselectNoOp(): void {
+  const harness = createHarness();
+  try {
+    harness.setContextTab(null);
+    assertEquals(
+      harness.controller.openForContextTab(),
+      false,
+      "missing context target should no-op",
+    );
+
+    harness.setContextTab(harness.contextTab);
+    harness.contextTab.setAttribute("multiselected", "true");
+    assertEquals(
+      harness.controller.openForContextTab(),
+      false,
+      "multiselected context target should no-op",
+    );
+    harness.contextTab.removeAttribute("multiselected");
+    harness.gBrowser.selectedTabs = [harness.selectedTab, harness.contextTab];
+    assertEquals(
+      harness.controller.openForSelectedTab(),
+      false,
+      "keyboard action should no-op while tabs are multiselected",
+    );
+    assertEquals(inputElement(), null, "no-op paths create no overlay");
+  } finally {
+    harness.cleanup();
+  }
+}
+
+async function testEnterFixesAndLoadsExactTarget(): Promise<void> {
+  const harness = createHarness();
+  try {
+    const postData = { query: "encoded" };
+    const fixupInputs: string[] = [];
+    harness.setFixup((input) => {
+      fixupInputs.push(input);
+      return Promise.resolve({
+        url: "https://search.example/?q=two%20words",
+        postData,
+      });
+    });
+    assert(
+      harness.controller.openForContextTab(),
+      "context editor should open",
+    );
+    const input = inputElement();
+    assert(input, "editor input should exist");
+    input.value = "  two words  ";
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    assertEquals(inputElement(), null, "Enter removes the editor immediately");
+
+    await Promise.resolve();
+    await Promise.resolve();
+    assertEquals(fixupInputs[0], "two words", "input is trimmed before fixup");
+    assertEquals(harness.loads.length, 1, "Enter performs one navigation");
+    const load = harness.loads[0]!;
+    assertEquals(load.where, "current", "load stays in the target tab");
+    assertEquals(
+      load.url,
+      "https://search.example/?q=two%20words",
+      "post-fixup URL is loaded",
+    );
+    assertEquals(
+      load.options.targetBrowser,
+      harness.contextBrowser,
+      "inactive context browser is the explicit target",
+    );
+    assertEquals(
+      load.options.postData,
+      postData,
+      "keyword POST data is passed",
+    );
+    assertEquals(
+      harness.gBrowser.selectedTab,
+      harness.selectedTab,
+      "current-target load must not select the inactive context tab",
+    );
+  } finally {
+    harness.cleanup();
+  }
+}
+
+function testTabCloseAndDestroyCleanup(): void {
+  const harness = createHarness();
+  try {
+    assert(
+      harness.menu.querySelector(`#${TAB_INLINE_EDIT_CONTEXT_ITEM_ID}`),
+      "enabled controller should create the context item",
+    );
+    assert(harness.controller.openForContextTab(), "editor should open");
+    harness.contextTab.dispatchEvent(
+      new CustomEvent("TabClose", { bubbles: true }),
+    );
+    assertEquals(inputElement(), null, "target TabClose removes the editor");
+
+    assert(harness.controller.openForSelectedTab(), "editor should reopen");
+    harness.controller.destroy();
+    assertEquals(inputElement(), null, "destroy removes an open editor");
+    assertEquals(
+      harness.menu.querySelector(`#${TAB_INLINE_EDIT_CONTEXT_ITEM_ID}`),
+      null,
+      "destroy removes the context item",
+    );
+  } finally {
+    harness.cleanup();
+  }
+}
+
+function testPrefOffAndLiveLifecycle(): void {
+  assertEquals(
+    isTabInlineEditEnabled({
+      getBoolPref: () => {
+        throw new Error("missing or invalid pref");
+      },
+    }),
+    false,
+    "missing or invalid pref should fail closed",
+  );
+
+  const harness = createHarness();
+  harness.controller.destroy();
+  const prefs = new TestPrefService(false);
+  const lifecycle = new TabInlineEditLifecycle(window, {
+    prefs,
+    createController: (win) =>
+      new TabInlineEditController(win, harness.dependencies),
+  });
+  try {
+    assertEquals(
+      harness.menu.querySelector(`#${TAB_INLINE_EDIT_CONTEXT_ITEM_ID}`),
+      null,
+      "pref off should create no context item",
+    );
+    assertEquals(
+      openInlineTabUrlEditorForSelectedTab(window),
+      false,
+      "keyboard action should fail closed while pref is off",
+    );
+
+    prefs.set(true);
+    assert(
+      harness.menu.querySelector(`#${TAB_INLINE_EDIT_CONTEXT_ITEM_ID}`),
+      "live enable should create the controller and context item",
+    );
+    assertEquals(
+      openInlineTabUrlEditorForSelectedTab(window),
+      true,
+      "live enable should make the keyboard action available",
+    );
+    assert(inputElement(), "enabled controller should create an editor");
+
+    prefs.set(false);
+    assertEquals(inputElement(), null, "live disable should remove the editor");
+    assertEquals(
+      harness.menu.querySelector(`#${TAB_INLINE_EDIT_CONTEXT_ITEM_ID}`),
+      null,
+      "live disable should remove the context item",
+    );
+    assertEquals(
+      openInlineTabUrlEditorForSelectedTab(window),
+      false,
+      "keyboard action should fail closed again after live disable",
+    );
+  } finally {
+    lifecycle.destroy();
+    harness.cleanup();
+  }
+}
+
+async function testOverlayRepositionsFromTargetRect(): Promise<void> {
+  const harness = createHarness();
+  try {
+    let rect = { left: 100, top: 80, width: 180, height: 34 };
+    Object.defineProperty(harness.contextTab, "getBoundingClientRect", {
+      configurable: true,
+      value: () =>
+        DOMRect.fromRect({
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+        }),
+    });
+    assert(harness.controller.openForContextTab(), "editor should open");
+    const input = inputElement();
+    assert(input, "editor input should exist");
+    assertEquals(input.style.left, "100px", "left comes from target tab rect");
+    assertEquals(input.style.top, "80px", "top comes from target tab rect");
+
+    rect = { left: 240, top: 160, width: 260, height: 40 };
+    globalThis.dispatchEvent(new Event("resize"));
+    await new Promise<void>((resolve) =>
+      globalThis.requestAnimationFrame(() => resolve())
+    );
+    assertEquals(input.style.left, "240px", "resize updates horizontal anchor");
+    assertEquals(input.style.top, "160px", "resize updates vertical anchor");
+    assertEquals(
+      input.style.width,
+      "260px",
+      "target width drives overlay width",
+    );
+  } finally {
+    harness.cleanup();
+  }
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "dangerous scheme normalization",
+      fn: testDangerousSchemeNormalization,
+    },
+    { name: "raw and post-fixup rejection", fn: testRawAndPostFixupRejection },
+    { name: "lazy-safe prefill and about semantics", fn: testLazySafePrefill },
+    { name: "exact current-tab load options", fn: testExactLoadOptions },
+    {
+      name: "context and keyboard exact targets",
+      fn: testContextAndKeyboardTargets,
+    },
+    {
+      name: "missing and multiselect no-op",
+      fn: testMissingAndMultiselectNoOp,
+    },
+    {
+      name: "Enter fixup and exact target load",
+      fn: testEnterFixesAndLoadsExactTarget,
+    },
+    {
+      name: "tab close and destroy cleanup",
+      fn: testTabCloseAndDestroyCleanup,
+    },
+    {
+      name: "pref-off and live lifecycle",
+      fn: testPrefOffAndLiveLifecycle,
+    },
+    {
+      name: "overlay repositions from target rect",
+      fn: testOverlayRepositionsFromTargetRect,
+    },
+  ];
+  await runTests("tabInlineEditController.test.ts", tests);
+}

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/actionCatalog.ts
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/actionCatalog.ts
@@ -1,0 +1,50 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type {
+  KeyboardShortcutActionDefinition,
+  KeyboardShortcutActionOption,
+  KeyboardShortcutConfig,
+} from "../../types/pref.ts";
+
+export const INLINE_TAB_URL_ACTION_ID = "floorp-edit-tab-url" as const;
+
+export const KEYBOARD_ONLY_ACTION_DEFINITIONS:
+  readonly KeyboardShortcutActionDefinition[] = Object.freeze([
+    Object.freeze({
+      id: INLINE_TAB_URL_ACTION_ID,
+      translationKey:
+        `keyboardShortcut.actionLabels.${INLINE_TAB_URL_ACTION_ID}`,
+    }),
+  ]);
+
+export function getKeyboardShortcutActionOptions(
+  translate: (key: string, fallback: string) => string,
+  existingOptions: readonly KeyboardShortcutActionOption[] = [],
+): KeyboardShortcutActionOption[] {
+  const existingIds = new Set(existingOptions.map((option) => option.id));
+  const keyboardOnlyOptions = KEYBOARD_ONLY_ACTION_DEFINITIONS.map((
+    action,
+  ) => ({
+    id: action.id,
+    name: translate(action.translationKey, action.id),
+  })).filter((action) => !existingIds.has(action.id));
+  return [...existingOptions, ...keyboardOnlyOptions];
+}
+
+export function createDefaultKeyboardShortcutConfig(
+  enabled: boolean,
+): KeyboardShortcutConfig {
+  return {
+    enabled,
+    shortcuts: {
+      "floorp-toggle-command-palette": {
+        key: "F2",
+        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+        action: "floorp-toggle-command-palette",
+      },
+    },
+  };
+}

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutsSettings.tsx
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutsSettings.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { KeyboardShortcutConfig, ShortcutConfig } from "../../../types/pref.ts";
 import { useAvailableActions } from "../../gesture/useAvailableActions.ts";
+import { getKeyboardShortcutActionOptions } from "../actionCatalog.ts";
 import { ShortcutEditor } from "./ShortcutEditor.tsx";
 import {
     Card,
@@ -33,7 +34,11 @@ export const ShortcutsSettings = ({
     deleteShortcut,
 }: ShortcutsSettingsProps) => {
     const { t } = useTranslation();
-    const actions = useAvailableActions();
+    const availableActions = useAvailableActions();
+    const actions = getKeyboardShortcutActionOptions(
+        (key, fallback) => t(key, fallback),
+        availableActions,
+    );
     const [editingAction, setEditingAction] = useState<string | null>(null);
     const [isEditorOpen, setIsEditorOpen] = useState(false);
     const [editingShortcut, setEditingShortcut] = useState<ShortcutConfig | null>(null);

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/dataManager.ts
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/dataManager.ts
@@ -9,6 +9,7 @@ import type {
   KeyboardShortcutConfig,
   ShortcutConfig,
 } from "../../types/pref.ts";
+import { createDefaultKeyboardShortcutConfig } from "./actionCatalog.ts";
 
 const KEYBOARD_SHORTCUT_ENABLED_PREF = "floorp.keyboardshortcut.enabled";
 const KEYBOARD_SHORTCUT_CONFIG_PREF = "floorp.keyboardshortcut.config";
@@ -33,16 +34,7 @@ export const useKeyboardShortcutConfig = () => {
           enabled = true;
         }
 
-        const defaultConfig: KeyboardShortcutConfig = {
-          enabled,
-          shortcuts: {
-            "floorp-toggle-command-palette": {
-              key: "F2",
-              modifiers: { alt: false, ctrl: false, meta: false, shift: false },
-              action: "floorp-toggle-command-palette",
-            },
-          },
-        };
+        const defaultConfig = createDefaultKeyboardShortcutConfig(enabled);
 
         try {
           const configStr = await rpc.getStringPref(

--- a/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
@@ -676,6 +676,9 @@
         "action": "Action",
         "shortcut": "Shortcut",
         "actions": "Actions",
+        "actionLabels": {
+            "floorp-edit-tab-url": "Edit Tab URL"
+        },
         "notSet": "Not set",
         "add": "Add",
         "edit": "Edit",

--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -676,6 +676,9 @@
         "action": "アクション",
         "shortcut": "ショートカット",
         "actions": "アクション",
+        "actionLabels": {
+            "floorp-edit-tab-url": "タブの URL を編集"
+        },
         "notSet": "設定なし",
         "add": "追加",
         "edit": "編集",

--- a/browser-features/pages-settings/src/types/pref.ts
+++ b/browser-features/pages-settings/src/types/pref.ts
@@ -227,6 +227,16 @@ export type ShortcutModifiers = t.TypeOf<typeof zShortcutModifiers>;
 export type ShortcutConfig = t.TypeOf<typeof zShortcutConfig>;
 export type KeyboardShortcutConfig = t.TypeOf<typeof zKeyboardShortcutConfig>;
 
+export interface KeyboardShortcutActionDefinition {
+  id: string;
+  translationKey: string;
+}
+
+export interface KeyboardShortcutActionOption {
+  id: string;
+  name: string;
+}
+
 export const zKeyboardShortcutFormData = zKeyboardShortcutConfig;
 export type KeyboardShortcutFormData = t.TypeOf<
   typeof zKeyboardShortcutFormData

--- a/browser-features/pages-settings/test/app/keyboard-shortcut/inlineUrlAction.test.ts
+++ b/browser-features/pages-settings/test/app/keyboard-shortcut/inlineUrlAction.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import enUS from "../../../src/lib/i18n/locales/en-US.json" with {
+  type: "json",
+};
+import jaJP from "../../../src/lib/i18n/locales/ja-JP.json" with {
+  type: "json",
+};
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+import {
+  createDefaultKeyboardShortcutConfig,
+  getKeyboardShortcutActionOptions,
+  INLINE_TAB_URL_ACTION_ID,
+  KEYBOARD_ONLY_ACTION_DEFINITIONS,
+} from "../../../src/app/keyboard-shortcut/actionCatalog.ts";
+
+function testKeyboardCatalogPreservesExistingOrderAndAddsInlineAction(): void {
+  const labels: Record<string, string> = {
+    [`keyboardShortcut.actionLabels.${INLINE_TAB_URL_ACTION_ID}`]:
+      "localized inline action",
+  };
+  const existingOptions = [
+    { id: "gecko-back", name: "localized back" },
+    { id: "floorp-toggle-command-palette", name: "localized palette" },
+  ];
+  const actions = getKeyboardShortcutActionOptions(
+    (key, fallback) => labels[key] ?? fallback,
+    existingOptions,
+  );
+  assertEquals(
+    JSON.stringify(actions),
+    JSON.stringify([
+      ...existingOptions,
+      { id: INLINE_TAB_URL_ACTION_ID, name: "localized inline action" },
+    ]),
+    "existing actions should keep their order before keyboard-only actions",
+  );
+  assert(
+    Object.isFrozen(KEYBOARD_ONLY_ACTION_DEFINITIONS),
+    "mirrored keyboard-only metadata should be frozen",
+  );
+}
+
+function testKeyboardCatalogDeduplicatesExistingAction(): void {
+  const existingOptions = [
+    { id: "gecko-back", name: "localized back" },
+    { id: INLINE_TAB_URL_ACTION_ID, name: "existing inline action" },
+  ];
+  const actions = getKeyboardShortcutActionOptions(
+    (_key, fallback) => fallback,
+    existingOptions,
+  );
+  assertEquals(
+    JSON.stringify(actions),
+    JSON.stringify(existingOptions),
+    "an existing action should not be appended a second time",
+  );
+}
+
+function testPagesDefaultConfigIsUnchanged(): void {
+  const firstEnabledDefault = createDefaultKeyboardShortcutConfig(true);
+  const secondEnabledDefault = createDefaultKeyboardShortcutConfig(true);
+  assertEquals(
+    JSON.stringify(firstEnabledDefault),
+    JSON.stringify({
+      enabled: true,
+      shortcuts: {
+        "floorp-toggle-command-palette": {
+          key: "F2",
+          modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+          action: "floorp-toggle-command-palette",
+        },
+      },
+    }),
+    "enabled default config should retain the existing F2 binding only",
+  );
+  assertEquals(
+    JSON.stringify(createDefaultKeyboardShortcutConfig(false)),
+    JSON.stringify({
+      enabled: false,
+      shortcuts: {
+        "floorp-toggle-command-palette": {
+          key: "F2",
+          modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+          action: "floorp-toggle-command-palette",
+        },
+      },
+    }),
+    "disabled default config should differ only by its enabled state",
+  );
+  assert(
+    firstEnabledDefault !== secondEnabledDefault &&
+      firstEnabledDefault.shortcuts !== secondEnabledDefault.shortcuts &&
+      firstEnabledDefault.shortcuts["floorp-toggle-command-palette"] !==
+        secondEnabledDefault.shortcuts["floorp-toggle-command-palette"],
+    "each default config call should return fresh nested objects",
+  );
+}
+
+function testPagesLocales(): void {
+  assertEquals(
+    enUS.keyboardShortcut.actionLabels[INLINE_TAB_URL_ACTION_ID],
+    "Edit Tab URL",
+    "English pages label should exist",
+  );
+  assertEquals(
+    jaJP.keyboardShortcut.actionLabels[INLINE_TAB_URL_ACTION_ID],
+    "タブの URL を編集",
+    "Japanese pages label should exist",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "keyboard catalog preserves existing order and adds inline action",
+      fn: testKeyboardCatalogPreservesExistingOrderAndAddsInlineAction,
+    },
+    {
+      name: "keyboard catalog deduplicates existing action",
+      fn: testKeyboardCatalogDeduplicatesExistingAction,
+    },
+    {
+      name: "pages default config is unchanged",
+      fn: testPagesDefaultConfigIsUnchanged,
+    },
+    { name: "EN/JA pages locales", fn: testPagesLocales },
+  ];
+  await runTests("inlineUrlAction.test.ts", tests);
+}

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Architecture Overview
@@ -58,7 +58,7 @@ Window Actors are registered from `browser-features/modules/modules/BrowserGlue.
 
 ## Chrome UI Features
 
-Common chrome features are discovered from `browser-features/chrome/common/mod.ts:4` with the glob pattern `./*/index.ts`. The current inventory lists 31 common features:
+Common chrome features are discovered from `browser-features/chrome/common/mod.ts:4` with the glob pattern `./*/index.ts`. The current inventory lists 32 common features:
 
 - `addons`
 - `browser-share-mode`
@@ -83,6 +83,7 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 - `split-view`
 - `statusbar`
 - `tab`
+- `tab-inline-edit`
 - `tab-refresh`
 - `tab-sleep-exclusion`
 - `tab-stacks`

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Common Chrome Features
@@ -10,7 +10,7 @@ The `browser-features/chrome/common/` directory contains loader-managed browser 
 
 ## Discovery And Loading
 
-Common features are discovered by `browser-features/chrome/common/mod.ts:4` using the glob pattern `./*/index.ts`. The current inventory contains 31 common feature entries.
+Common features are discovered by `browser-features/chrome/common/mod.ts:4` using the glob pattern `./*/index.ts`. The current inventory contains 32 common feature entries.
 
 The bridge loader turns discovered entries into loadable modules, while each feature entrypoint remains responsible for its own component, services, styles, context menus, or lifecycle hooks.
 
@@ -96,6 +96,7 @@ Small chrome utilities and action helpers that do not own a broader feature fami
 
 | Feature | Source | Entrypoints | Description |
 |---|---|---|---|
+| tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
 | tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
 
 ## Relationship To Other Layers

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Common Chrome Feature Catalog
@@ -35,6 +35,7 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 | split-view | `browser-features/chrome/common/split-view/index.ts` | `default class SplitView`, `init` | Owns the split view feature through the SplitView chrome component and wires `split-view-manager`. |
 | statusbar | `browser-features/chrome/common/statusbar/index.ts` | `default class StatusBar`, `init` | Owns the statusbar feature through the StatusBar chrome component and wires `context-menu`, `statusbar`, `statusbar-manager`. |
 | tab | `browser-features/chrome/common/tab/index.ts` | `default class Tab`, `init` | Owns the tab feature through the Tab chrome component and wires `scroll`, `openPosition`, `sizeSpecification`. |
+| tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
 | tab-refresh | `browser-features/chrome/common/tab-refresh/index.ts` | `default class TabRefresh`, `init` | Owns the tab refresh feature through the TabRefresh chrome component and wires `controller`. |
 | tab-sleep-exclusion | `browser-features/chrome/common/tab-sleep-exclusion/index.ts` | `default class TabSleepExclusion`, `init` | Owns the tab sleep exclusion feature through the TabSleepExclusion chrome component. |
 | tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Browser UI Customization

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Common Chrome Feature Categories
@@ -18,10 +18,11 @@ This nested catalog is generated from `browser-features/chrome/common`. It group
 | [Input & Shortcuts](./input-and-shortcuts) | 4 | Keyboard, mouse gesture, context menu, and command palette interaction features. |
 | [Web Apps & Integration](./webapps-and-integration) | 6 | PWA, profile, add-on, external browser, share mode, and container integration features. |
 | [Utilities & Actions](./utilities-and-actions) | 2 | Small chrome utilities and action helpers that do not own a broader feature family. |
-| Uncategorized | 1 | Entries discovered from `browser-features/chrome/common` that do not yet have a docs category. |
+| Uncategorized | 2 | Entries discovered from `browser-features/chrome/common` that do not yet have a docs category. |
 
 ## Uncategorized Entries
 
 | Feature | Source | Entrypoints | Description |
 |---|---|---|---|
+| tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
 | tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Window Actor Categories

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Settings & Internal Page Actors

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Web Content & Store Actors

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Browser Features Catalog
@@ -10,7 +10,7 @@ This catalog is generated from loader-discovered chrome feature entrypoints, the
 
 ## Catalog Sections
 
-- Common chrome features: 31 entries from `browser-features/chrome/common`.
+- Common chrome features: 32 entries from `browser-features/chrome/common`.
 - Static chrome features: 3 entries from `browser-features/chrome/static`.
 - Settings page routes: 14 routes from `browser-features/pages-settings/src/App.tsx`.
 - Window Actors: 23 actors from `browser-features/modules/modules/BrowserGlue.sys.mts`.

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Window Actor Catalog

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "89512cb30d94bdc984f14c7d199440b911885dea"
+floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `89512cb30d94bdc984f14c7d199440b911885dea`.
+Inventory generated from Floorp commit `7b6ff3ea8076b5a48575264ff0df6a3a14019280`.
 
 ## Source Precedence
 
@@ -52,7 +52,7 @@ Inventory generated from Floorp commit `89512cb30d94bdc984f14c7d199440b911885dea
 
 ## Feature Catalog Sources
 
-- Common chrome features: `browser-features/chrome/common` (31 entries)
+- Common chrome features: `browser-features/chrome/common` (32 entries)
 - Static chrome features: `browser-features/chrome/static` (3 entries)
 - Settings routes: `browser-features/pages-settings/src/App.tsx` (14 routes)
 - Window Actors: `browser-features/modules/modules/BrowserGlue.sys.mts` (23 actors)

--- a/i18n/en-US/browser-chrome.json
+++ b/i18n/en-US/browser-chrome.json
@@ -136,6 +136,11 @@
     "reopenInPrivateContainer": "Reopen in Private Container",
     "name": "Private Container"
   },
+  "tabInlineEdit": {
+    "contextMenu": "Edit Tab URL",
+    "inputLabel": "Tab URL",
+    "keyboardAction": "Edit Tab URL"
+  },
   "mouseGesture": {
     "actions": {
       "gecko-back": "Back",

--- a/i18n/ja-JP/browser-chrome.json
+++ b/i18n/ja-JP/browser-chrome.json
@@ -136,6 +136,11 @@
     "reopenInPrivateContainer": "プライベートコンテナーで再度開く",
     "name": "プライベートコンテナー"
   },
+  "tabInlineEdit": {
+    "contextMenu": "タブの URL を編集",
+    "inputLabel": "タブの URL",
+    "keyboardAction": "タブの URL を編集"
+  },
   "mouseGesture": {
     "actions": {
       "gecko-back": "戻る",

--- a/static/gecko/pref/override.ini
+++ b/static/gecko/pref/override.ini
@@ -73,6 +73,7 @@ browser.profiles.forceEnableRefresh = true
 browser.tabs.splitView.enabled = true
 floorp.splitView.dragToSplitCreate.enabled = true
 floorp.tabs.hoverReload.enabled = false
+floorp.tabs.inlineUrlEdit.enabled = false
 
 floorp.splitView.config = "{\"layout\":\"horizontal\",\"maxPanes\":4}"
 floorp.splitView.paneSizes = "{\"flexRatios\":[0.5,0.5],\"gridColRatio\":0.5,\"gridRowRatio\":0.5}"


### PR DESCRIPTION
## Summary

This is a redesigned replacement for the abandoned #2577 contribution in the
#2569 batch, rebuilt on current `main`.

- add a default-off inline tab URL editor gated by
  `floorp.tabs.inlineUrlEdit.enabled`
- expose it only through the target tab's context menu and a user-assignable,
  no-default keyboard action
- keep the action out of mouse gestures and the command palette
- preserve inactive-tab selection, lazy/discarded state on open, container
  identity, and private-window isolation
- use the locked Firefox 153 URLbar fixup/current-tab load contract and reject
  blank, `javascript:`, and `data:` input before and after fixup
- cover per-window lifecycle, focus restoration, horizontal/vertical anchoring,
  localization, Settings catalog wiring, and deterministic docs

The abandoned patch used default-on double-click activation and woke lazy tabs.
Those behaviors are intentionally not carried forward.

## Provenance

- Tracking issue: #2569
- Original PR: https://github.com/Floorp-Projects/Floorp/pull/2577
- Original head: `00a244f4ab56e93626064f90ab7492f32f21b90c`
- Original head branch: `feat/tab-inline-url-edit`
- Original PR state: closed and unmerged (`merged=false`, `merged_at=null`)
- Original GitHub author identity now resolves to `ghost` after the account was
  removed
- Original commit author: `100mountains <nobody@nowhere.com>`
- Original commit co-author trailer: `Claude Fable 5
  <noreply@anthropic.com>`
- Replacement base: `410c211c202012631159d1bce1f3ab208305d2b7`

The replacement was reimplemented rather than cherry-picked so it could satisfy
the current Floorp lifecycle, safety, vertical-tabs, and test contracts while
preserving the original feature idea and pref identity.

## Verification

- locked Runtime: Firefox/Floorp `153.0`, BuildID `20260725075208`
- focused browser tests: tab-inline 1/1, keyboard 4/4, mouse-gesture regression
  5/5, Pages 2/2, workspace open-link regression 1/1
- full smoke: all six stages passed, including 41 runner tests, discovery,
  broad source checking, and lint across 8,735 files
- Settings production Vite build: 5,286 modules
- docs pipeline tests: 49/49; deterministic docs verification also passed in a
  clean-LF checkout (the native Windows verifier has the existing CRLF-only
  byte-comparison issue)
- real locked-browser matrix: pref off/on/off, context and keyboard targets,
  multiselect no-op, horizontal and vertical layouts, real tab-strip scroll,
  resize, Enter/Escape/blur/tab-close cleanup, grouped/about/lazy/discarded
  tabs, container and private windows, exact load options, dangerous-input
  rejection, command-palette exclusion, controller replacement, HMR cleanup,
  and exact pref/window/global restoration
- independent Tier 1 review: no P0/P1 finding

### Packaged Settings fidelity gap

`FLOORP_RUNTIME_LOCKED=1 deno task feles-build stage --marionette` selected the
exact locked Runtime but stopped before browser launch in the unrelated
`browser-features/pages-newtab` build. Rolldown reported the existing
`lucide-react` chart-no-axes-gantt missing-default-export failure. No dependency,
CSP, loader, or out-of-scope workaround is included here.

As a result, the final packaged `about:hub` Settings routes were not rendered in
that attempt. The Settings catalog is covered by its successful production Vite
build, Pages tests, locale/source checks, and negative gesture/palette tests,
but this Draft does not claim packaged Settings UI runtime proof.

## Scope guardrails

This Draft intentionally does not add double-click activation, a default
shortcut, a mouse-gesture action, a command-palette command, or package/lock
changes. It does not close the original contribution or tracking issue.
