### PR TITLE
feat(zen-mode): make chrome overlays and state window-scoped

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/test/zenModeAction.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/zenModeAction.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import { executeGestureAction } from "../utils/gestures.ts";
+import {
+  attachZenModeToWindow,
+  destroyZenModeForWindow,
+  ZEN_MODE_PREF,
+} from "#features-chrome/common/zen-mode/zen-mode.tsx";
+import {
+  assert,
+  assertEquals,
+  runTests,
+} from "../../../test/utils/test_harness.ts";
+
+function createTargetWindow(): Window {
+  const doc = document.implementation.createHTMLDocument(
+    "Zen gesture target",
+  );
+  const eventTarget = new EventTarget();
+  const toolbox = doc.createElement("div");
+  toolbox.id = "navigator-toolbox";
+  doc.body!.appendChild(toolbox);
+
+  return {
+    document: doc,
+    closed: false,
+    innerWidth: 1000,
+    innerHeight: 800,
+    MutationObserver,
+    ResizeObserver,
+    requestAnimationFrame: globalThis.requestAnimationFrame.bind(globalThis),
+    cancelAnimationFrame: globalThis.cancelAnimationFrame.bind(globalThis),
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    addEventListener: eventTarget.addEventListener.bind(eventTarget),
+    removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+    gNavToolbox: toolbox,
+  } as unknown as Window;
+}
+
+function testGestureChangesOnlySuppliedWindow(): void {
+  const hadUserValue = Services.prefs.prefHasUserValue(ZEN_MODE_PREF);
+  const originalSeed = Services.prefs.getBoolPref(ZEN_MODE_PREF, false);
+  const firstWindow = createTargetWindow();
+  const secondWindow = createTargetWindow();
+
+  Services.prefs.setBoolPref(ZEN_MODE_PREF, false);
+  const first = attachZenModeToWindow(firstWindow);
+  const second = attachZenModeToWindow(secondWindow);
+
+  try {
+    assert(first !== null && second !== null, "both controllers should exist");
+    const executed = executeGestureAction(
+      "floorp-toggle-zen-mode",
+      secondWindow,
+    );
+    assertEquals(executed, true, "the Zen gesture should execute");
+    assertEquals(
+      first.enabled(),
+      false,
+      "the non-target window must remain unchanged",
+    );
+    assertEquals(
+      second.enabled(),
+      true,
+      "the supplied gesture window should toggle",
+    );
+    assertEquals(
+      Services.prefs.getBoolPref(ZEN_MODE_PREF, false),
+      true,
+      "the explicit gesture should persist the seed for future windows",
+    );
+  } finally {
+    destroyZenModeForWindow(firstWindow);
+    destroyZenModeForWindow(secondWindow);
+    if (hadUserValue) {
+      Services.prefs.setBoolPref(ZEN_MODE_PREF, originalSeed);
+    } else {
+      Services.prefs.clearUserPref(ZEN_MODE_PREF);
+    }
+  }
+}
+
+export async function runAllTests(): Promise<void> {
+  await runTests("zenModeAction.test.ts", [
+    {
+      name: "gesture changes only its supplied window controller",
+      fn: testGestureChangesOnlySuppliedWindow,
+    },
+  ]);
+}

--- a/browser-features/chrome/common/mouse-gesture/utils/actions.ts
+++ b/browser-features/chrome/common/mouse-gesture/utils/actions.ts
@@ -1,5 +1,6 @@
 import type { GestureActionRegistration } from "./gestures.ts";
 import { setShareModeEnabled } from "#features-chrome/common/browser-share-mode/browser-share-mode.tsx";
+import { toggleZenModeForWindow } from "#features-chrome/common/zen-mode/zen-mode.tsx";
 import {
   setPersistedGroupLayout,
   getSplitViewGroupIdForTabs,
@@ -507,11 +508,8 @@ export const actions: GestureActionRegistration[] = [
   },
   {
     name: "floorp-toggle-zen-mode",
-    fn: (_win) => {
-      Services.prefs.setBoolPref(
-        "floorp.zenmode.enabled",
-        !Services.prefs.getBoolPref("floorp.zenmode.enabled", false),
-      );
+    fn: (win) => {
+      toggleZenModeForWindow(win);
     },
   },
   {

--- a/browser-features/chrome/common/zen-mode/index.ts
+++ b/browser-features/chrome/common/zen-mode/index.ts
@@ -93,12 +93,15 @@ export default class ZenMode extends NoraComponentBase {
         return;
       }
 
-      let tooltip = targetDocument.getElementById(TOOLBAR_TOOLTIP_ID);
+      let tooltip: Element | null = targetDocument.getElementById(
+        TOOLBAR_TOOLTIP_ID,
+      );
       if (!tooltip) {
-        tooltip = targetDocument.createXULElement("tooltip");
-        tooltip.id = TOOLBAR_TOOLTIP_ID;
-        tooltip.setAttribute("hasbeenopened", "false");
-        popupSet.appendChild(tooltip);
+        const createdTooltip = targetDocument.createXULElement("tooltip");
+        createdTooltip.id = TOOLBAR_TOOLTIP_ID;
+        createdTooltip.setAttribute("hasbeenopened", "false");
+        popupSet.appendChild(createdTooltip);
+        tooltip = createdTooltip;
       }
       tooltip.setAttribute("data-floorp-zen-mode-owned", "true");
       tooltip.setAttribute("label", tooltipText);

--- a/browser-features/chrome/common/zen-mode/index.ts
+++ b/browser-features/chrome/common/zen-mode/index.ts
@@ -4,108 +4,265 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { render } from "@nora/solid-xul";
-import { createRootHMR } from "@nora/solid-xul";
-import { createSignal } from "solid-js";
-import { noraComponent, NoraComponentBase } from "#features-chrome/utils/base";
+import { createRoot, onCleanup } from "solid-js";
+import {
+  noraComponent,
+  NoraComponentBase,
+} from "#features-chrome/utils/base.ts";
 import { BrowserActionUtils } from "../../utils/browser-action.tsx";
 import {
+  attachZenModeToWindow,
+  destroyZenModeForWindow,
+  toggleZenModeForWindow,
   ZenModeMenuElement,
-  setZenModeEnabled,
-  initZenModeState,
 } from "./zen-mode.tsx";
-import { StyleElement } from "./styleElem.tsx";
 import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
 import i18next from "i18next";
+import iconStyle from "./icon.css?inline";
+
+const TOOLBAR_BUTTON_ID = "zen-mode-button";
+const TOOLBAR_TOOLTIP_ID = "zen-mode-button-tooltip";
+const TOOLBAR_ICON_STYLE_ID = "floorp-zen-mode-icon-style";
 
 @noraComponent(import.meta.hot)
 export default class ZenMode extends NoraComponentBase {
   init() {
     this.logger.info("Initializing Zen Mode");
 
-    if (typeof document === "undefined") {
+    const targetDocument = typeof document === "undefined" ? null : document;
+    const targetWindow = targetDocument?.defaultView as Window | null;
+    const targetRoot = targetDocument?.documentElement;
+    if (!targetDocument || !targetWindow || !targetRoot) {
       this.logger.warn("Document is unavailable; skip initializing Zen Mode.");
       return;
     }
 
-    // Initialize state management and hover detection
-    initZenModeState();
-
-    const tryInit = () => {
-      this.injectMenu();
-      this.createToolbarButton();
-    };
-
-    if (document?.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", tryInit, { once: true });
-    } else {
-      tryInit();
-    }
-  }
-
-  private injectMenu() {
-    const menuPopup = document!.getElementById("menu_ToolsPopup");
-    if (!menuPopup) {
-      this.logger.warn(
-        "Failed to locate #menu_ToolsPopup; Zen Mode menu item will not be injected.",
-      );
+    const controller = attachZenModeToWindow(targetWindow);
+    if (!controller) {
+      this.logger.error("Failed to create the Zen Mode window controller.");
       return;
     }
 
-    const marker = document!.getElementById("menu_openFirefoxView");
+    let disposed = false;
+    let domReadyListenerAttached = false;
+    let menuDispose: (() => void) | null = null;
+    let uiObserver: MutationObserver | null = null;
+    let iconStyleElement: HTMLStyleElement | null = null;
+    let toolbarNode: Element | null = null;
+    let tooltipElement: Element | null = null;
+    let buttonLabel = "Zen Mode";
+    let tooltipText = "Toggle Zen Mode";
 
-    try {
-      render(ZenModeMenuElement, menuPopup, {
-        marker: marker?.parentElement === menuPopup ? marker : undefined,
-        hotCtx: import.meta.hot,
-      });
-      this.logger.info("Zen Mode menu item rendered successfully.");
-    } catch (error) {
-      const reason = error instanceof Error ? error : new Error(String(error));
-      this.logger.error("Failed to render Zen Mode menu item", reason);
-    }
-  }
+    const ensureIconStyle = () => {
+      if (iconStyleElement?.isConnected) {
+        return;
+      }
 
-  private createToolbarButton() {
-    BrowserActionUtils.createToolbarClickActionButton(
-      "zen-mode-button",
-      null,
-      () => setZenModeEnabled((prev) => !prev),
-      StyleElement(),
-      null,
-      null,
-      (aNode: XULElement) => {
-        const tooltip = document!.createXULElement("tooltip") as XULElement;
-        tooltip.id = "zen-mode-button-tooltip";
+      const existing = targetDocument.getElementById(TOOLBAR_ICON_STYLE_ID);
+      if (existing?.localName === "style") {
+        iconStyleElement = existing as HTMLStyleElement;
+        iconStyleElement.textContent = iconStyle;
+        return;
+      }
+
+      const style = targetDocument.createElement("style");
+      style.id = TOOLBAR_ICON_STYLE_ID;
+      style.setAttribute("data-floorp-zen-mode-owned", "true");
+      style.textContent = iconStyle;
+      (targetDocument.head ?? targetRoot).appendChild(style);
+      iconStyleElement = style;
+    };
+
+    const syncToolbarPresentation = () => {
+      if (disposed) {
+        return;
+      }
+
+      const currentNode = targetDocument.getElementById(TOOLBAR_BUTTON_ID);
+      if (toolbarNode !== currentNode) {
+        if (toolbarNode?.getAttribute("tooltip") === TOOLBAR_TOOLTIP_ID) {
+          toolbarNode.removeAttribute("tooltip");
+        }
+        toolbarNode = currentNode;
+      }
+
+      toolbarNode?.setAttribute("label", buttonLabel);
+
+      const popupSet = targetDocument.getElementById("mainPopupSet");
+      if (!popupSet || !toolbarNode) {
+        return;
+      }
+
+      let tooltip = targetDocument.getElementById(TOOLBAR_TOOLTIP_ID);
+      if (!tooltip) {
+        tooltip = targetDocument.createXULElement("tooltip");
+        tooltip.id = TOOLBAR_TOOLTIP_ID;
         tooltip.setAttribute("hasbeenopened", "false");
-        document!.getElementById("mainPopupSet")?.appendChild(tooltip);
-        aNode.setAttribute("tooltip", "zen-mode-button-tooltip");
+        popupSet.appendChild(tooltip);
+      }
+      tooltip.setAttribute("data-floorp-zen-mode-owned", "true");
+      tooltip.setAttribute("label", tooltipText);
+      toolbarNode.setAttribute("tooltip", TOOLBAR_TOOLTIP_ID);
+      tooltipElement = tooltip;
+    };
 
-        createRootHMR(
-          () => {
-            const [texts, setTexts] = createSignal({
-              buttonLabel: "Zen Mode",
-              tooltipText: "Toggle Zen Mode",
-            });
+    const findToolbarButton = (target: EventTarget | null): Element | null => {
+      let node = target as Node | null;
+      while (node && node !== targetDocument) {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          const element = node as Element;
+          if (element.id === TOOLBAR_BUTTON_ID) {
+            return element.ownerDocument === targetDocument ? element : null;
+          }
+        }
+        node = node.parentNode;
+      }
+      return null;
+    };
 
-            aNode.setAttribute("label", texts().buttonLabel);
-            tooltip.setAttribute("label", texts().tooltipText);
+    const handleToolbarCommand = (event: Event) => {
+      const button = findToolbarButton(event.target);
+      if (!button) {
+        return;
+      }
 
-            addI18nObserver(() => {
-              setTexts({
-                buttonLabel: i18next.t("zen-mode.label", {
-                  defaultValue: "Zen Mode",
-                }),
-                tooltipText: i18next.t("zen-mode.tooltiptext", {
-                  defaultValue: "Toggle Zen Mode",
-                }),
-              });
-              aNode.setAttribute("label", texts().buttonLabel);
-              tooltip.setAttribute("label", texts().tooltipText);
-            });
-          },
-          import.meta.hot,
+      const owningWindow = button.ownerDocument?.defaultView as Window | null;
+      if (owningWindow) {
+        toggleZenModeForWindow(owningWindow);
+      }
+    };
+
+    const injectMenu = () => {
+      const menuPopup = targetDocument.getElementById("menu_ToolsPopup");
+      if (!menuPopup) {
+        this.logger.warn(
+          "Failed to locate #menu_ToolsPopup; Zen Mode menu item will not be injected.",
         );
-      },
-    );
+        return;
+      }
+
+      targetDocument.getElementById("toggle_zenmode")?.remove();
+      const marker = targetDocument.getElementById("menu_openFirefoxView");
+
+      try {
+        menuDispose = createRoot((dispose) => {
+          render(
+            () => ZenModeMenuElement({ targetWindow }),
+            menuPopup,
+            {
+              marker: marker?.parentElement === menuPopup ? marker : undefined,
+            },
+          );
+          return dispose;
+        });
+        this.logger.info("Zen Mode menu item rendered successfully.");
+      } catch (error) {
+        const reason = error instanceof Error
+          ? error
+          : new Error(String(error));
+        this.logger.error("Failed to render Zen Mode menu item", reason);
+      }
+    };
+
+    const createToolbarButton = () => {
+      ensureIconStyle();
+
+      // BrowserActionUtils does not forward the command event. Its callback is
+      // intentionally inert; the owning document listener above performs the
+      // window-stable routing for every widget instance and across HMR.
+      BrowserActionUtils.createToolbarClickActionButton(
+        TOOLBAR_BUTTON_ID,
+        null,
+        () => {},
+        null,
+        null,
+        null,
+        null,
+      );
+      syncToolbarPresentation();
+    };
+
+    const tryInit = () => {
+      if (disposed) {
+        return;
+      }
+      domReadyListenerAttached = false;
+      injectMenu();
+      createToolbarButton();
+    };
+
+    targetDocument.addEventListener("command", handleToolbarCommand, true);
+
+    const MutationObserverConstructor = targetWindow.MutationObserver;
+    if (typeof MutationObserverConstructor === "function") {
+      const observer = new MutationObserverConstructor(() => {
+        syncToolbarPresentation();
+      });
+      observer.observe(targetRoot, {
+        childList: true,
+        subtree: true,
+      });
+      uiObserver = observer;
+    }
+
+    const disposeI18n = createRoot((dispose) => {
+      addI18nObserver(() => {
+        buttonLabel = i18next.t("zen-mode.label", {
+          defaultValue: "Zen Mode",
+        });
+        tooltipText = i18next.t("zen-mode.tooltiptext", {
+          defaultValue: "Toggle Zen Mode",
+        });
+        syncToolbarPresentation();
+      });
+      return dispose;
+    });
+
+    if (targetDocument.readyState === "loading") {
+      domReadyListenerAttached = true;
+      targetDocument.addEventListener("DOMContentLoaded", tryInit, {
+        once: true,
+      });
+    } else {
+      tryInit();
+    }
+
+    const cleanup = () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+
+      if (domReadyListenerAttached) {
+        targetDocument.removeEventListener("DOMContentLoaded", tryInit);
+        domReadyListenerAttached = false;
+      }
+      targetWindow.removeEventListener("unload", cleanup);
+      targetDocument.removeEventListener("command", handleToolbarCommand, true);
+      uiObserver?.disconnect();
+      uiObserver = null;
+
+      menuDispose?.();
+      menuDispose = null;
+      disposeI18n();
+
+      if (toolbarNode?.getAttribute("tooltip") === TOOLBAR_TOOLTIP_ID) {
+        toolbarNode.removeAttribute("tooltip");
+      }
+      toolbarNode = null;
+
+      tooltipElement?.remove();
+      tooltipElement = null;
+      targetDocument.getElementById(TOOLBAR_TOOLTIP_ID)?.remove();
+
+      iconStyleElement?.remove();
+      iconStyleElement = null;
+      targetDocument.getElementById(TOOLBAR_ICON_STYLE_ID)?.remove();
+
+      destroyZenModeForWindow(targetWindow, controller);
+    };
+
+    targetWindow.addEventListener("unload", cleanup, { once: true });
+    onCleanup(cleanup);
   }
 }

--- a/browser-features/chrome/common/zen-mode/test/zenMode.test.ts
+++ b/browser-features/chrome/common/zen-mode/test/zenMode.test.ts
@@ -1,515 +1,511 @@
 // SPDX-License-Identifier: MPL-2.0
 // @colocated-env browser
 
+import { createRoot } from "solid-js";
+import { render } from "@nora/solid-xul";
 import {
-  initZenModeState,
-  setZenModeEnabled,
-  zenModeEnabled,
+  attachZenModeToWindow,
+  destroyZenModeForWindow,
+  getZenModeController,
+  toggleZenModeForWindow,
+  ZEN_MODE_HIDE_DELAY_MS,
+  ZEN_MODE_PREF,
+  ZEN_MODE_STYLE_ID,
   ZenModeMenuElement,
 } from "../zen-mode.tsx";
-
 import {
   assert,
   assertEquals,
   runTests,
+  type TestCase,
 } from "../../../test/utils/test_harness.ts";
-import { render } from "@nora/solid-xul";
 
-const ZENMODE_PREF = "floorp.zenmode.enabled";
+type TestWindowBundle = {
+  win: Window;
+  doc: Document;
+  toolbox: Element;
+  dispatchWindowEvent: (event: Event) => boolean;
+};
 
-function temporarilyRemoveElementById(id: string): () => void {
-  const element = document!.getElementById(id);
-  const parent = element?.parentNode ?? null;
-  const nextSibling = element?.nextSibling ?? null;
-  if (!element || !parent) {
-    return () => {};
-  }
+function makeRect(
+  width: number,
+  height: number,
+  left = 0,
+  top = 0,
+): DOMRect {
+  return {
+    x: left,
+    y: top,
+    width,
+    height,
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({ width, height, left, top }),
+  } as DOMRect;
+}
 
-  parent.removeChild(element);
-  return () => {
-    if (element.parentNode) {
-      return;
-    }
-    parent.insertBefore(
-      element,
-      nextSibling?.parentNode === parent ? nextSibling : null,
-    );
+function setRect(
+  element: Element,
+  width: number,
+  height: number,
+  left = 0,
+  top = 0,
+): void {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => makeRect(width, height, left, top),
+  });
+}
+
+function createTestWindow(): TestWindowBundle {
+  const doc = document.implementation.createHTMLDocument("Zen test window");
+  const windowEvents = new EventTarget();
+  const toolbox = doc.createElement("div");
+  toolbox.id = "navigator-toolbox";
+  setRect(toolbox, 1000, 100, 0, 0);
+  doc.body!.appendChild(toolbox);
+
+  const hostWindow = window;
+  const win = {
+    document: doc,
+    closed: false,
+    innerWidth: 1000,
+    innerHeight: 800,
+    MutationObserver,
+    ResizeObserver,
+    requestAnimationFrame: hostWindow.requestAnimationFrame.bind(hostWindow),
+    cancelAnimationFrame: hostWindow.cancelAnimationFrame.bind(hostWindow),
+    setTimeout: hostWindow.setTimeout.bind(hostWindow),
+    clearTimeout: hostWindow.clearTimeout.bind(hostWindow),
+    addEventListener: windowEvents.addEventListener.bind(windowEvents),
+    removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
+    gNavToolbox: toolbox,
+  } as unknown as Window;
+
+  return {
+    win,
+    doc,
+    toolbox,
+    dispatchWindowEvent: (event) => windowEvents.dispatchEvent(event),
   };
 }
 
-function testZenModeSignalReadable(): void {
-  const value = zenModeEnabled();
-  assert(typeof value === "boolean", "zenModeEnabled should return a boolean");
-}
-
-function testSetZenModeEnabledToggles(): void {
-  const original = zenModeEnabled();
+async function withSeed<T>(
+  seed: boolean,
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  const hadUserValue = Services.prefs.prefHasUserValue(ZEN_MODE_PREF);
+  const original = Services.prefs.getBoolPref(ZEN_MODE_PREF, false);
+  Services.prefs.setBoolPref(ZEN_MODE_PREF, seed);
   try {
-    setZenModeEnabled(true);
-    assertEquals(
-      zenModeEnabled(),
-      true,
-      "zenModeEnabled should be true after setting true",
-    );
-
-    setZenModeEnabled(false);
-    assertEquals(
-      zenModeEnabled(),
-      false,
-      "zenModeEnabled should be false after setting false",
-    );
+    return await callback();
   } finally {
-    setZenModeEnabled(original);
+    if (hadUserValue) {
+      Services.prefs.setBoolPref(ZEN_MODE_PREF, original);
+    } else {
+      Services.prefs.clearUserPref(ZEN_MODE_PREF);
+    }
   }
 }
 
-function testZenModePrefSync(): void {
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-  const originalSignal = zenModeEnabled();
-
-  try {
-    initZenModeState();
-
-    setZenModeEnabled(true);
-    assertEquals(
-      Services.prefs.getBoolPref(ZENMODE_PREF, false),
-      true,
-      "Pref should be true after setZenModeEnabled(true)",
-    );
-
-    setZenModeEnabled(false);
-    assertEquals(
-      Services.prefs.getBoolPref(ZENMODE_PREF, false),
-      false,
-      "Pref should be false after setZenModeEnabled(false)",
-    );
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
-function testZenModeAttributeOnDocumentElement(): void {
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-  const originalSignal = zenModeEnabled();
+const tests: TestCase[] = [
+  {
+    name: "one controller and one owned stylesheet are created per window",
+    async fn() {
+      await withSeed(false, () => {
+        const bundle = createTestWindow();
+        const first = attachZenModeToWindow(bundle.win);
+        const second = attachZenModeToWindow(bundle.win);
+        assert(first !== null, "first controller should be created");
+        assertEquals(second, first, "the window registry should be idempotent");
+        assertEquals(
+          bundle.doc.querySelectorAll(`#${ZEN_MODE_STYLE_ID}`).length,
+          1,
+          "the window should own exactly one Zen stylesheet",
+        );
 
-  try {
-    initZenModeState();
+        const css = bundle.doc.getElementById(ZEN_MODE_STYLE_ID)?.textContent ??
+          "";
+        assert(
+          css.includes("translateY(-100%)"),
+          "toolbox retraction should use its own current height",
+        );
+        assert(
+          css.includes("translateY(100%)"),
+          "statusbar retraction should use its own current height",
+        );
+        assert(
+          css.includes("prefers-reduced-motion: reduce"),
+          "the owned stylesheet should honor reduced motion",
+        );
 
-    setZenModeEnabled(true);
-    assert(
-      document?.documentElement?.hasAttribute("zenmode"),
-      "documentElement should have 'zenmode' attribute when zen mode is enabled",
-    );
+        destroyZenModeForWindow(bundle.win);
+        assertEquals(
+          bundle.doc.getElementById(ZEN_MODE_STYLE_ID),
+          null,
+          "destroy should remove the owned stylesheet",
+        );
+      });
+    },
+  },
+  {
+    name:
+      "existing controllers ignore external pref writes and new ones snapshot them",
+    async fn() {
+      await withSeed(false, () => {
+        const firstWindow = createTestWindow();
+        const first = attachZenModeToWindow(firstWindow.win);
+        assert(first !== null, "first controller should be created");
+        assertEquals(first.enabled(), false, "first window should seed false");
 
-    setZenModeEnabled(false);
-    assert(
-      !document?.documentElement?.hasAttribute("zenmode"),
-      "documentElement should not have 'zenmode' attribute when zen mode is disabled",
-    );
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-    document?.documentElement?.removeAttribute("zenmode");
-    document?.documentElement?.removeAttribute("zenmode-reveal-top");
-    document?.documentElement?.removeAttribute("zenmode-reveal-bottom");
-    document?.documentElement?.removeAttribute("zenmode-reveal-side");
-  }
-}
+        Services.prefs.setBoolPref(ZEN_MODE_PREF, true);
+        assertEquals(
+          first.enabled(),
+          false,
+          "external writes must not mutate an existing controller",
+        );
 
-function testZenModePrefObserverUpdatesSignal(): void {
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-  const originalSignal = zenModeEnabled();
+        const secondWindow = createTestWindow();
+        const second = attachZenModeToWindow(secondWindow.win);
+        assert(second !== null, "second controller should be created");
+        assertEquals(second.enabled(), true, "new window should seed true");
 
-  try {
-    initZenModeState();
+        Services.prefs.setBoolPref(ZEN_MODE_PREF, false);
+        assertEquals(
+          first.enabled(),
+          false,
+          "first window should remain false",
+        );
+        assertEquals(
+          second.enabled(),
+          true,
+          "second window should remain true",
+        );
 
-    Services.prefs.setBoolPref(ZENMODE_PREF, true);
-    assertEquals(
-      zenModeEnabled(),
-      true,
-      "Signal should be true after pref set to true externally",
-    );
+        destroyZenModeForWindow(firstWindow.win);
+        destroyZenModeForWindow(secondWindow.win);
+      });
+    },
+  },
+  {
+    name: "explicit target-window toggles persist without changing peers",
+    async fn() {
+      await withSeed(false, () => {
+        const firstWindow = createTestWindow();
+        const secondWindow = createTestWindow();
+        const first = attachZenModeToWindow(firstWindow.win);
+        const second = attachZenModeToWindow(secondWindow.win);
+        assert(first !== null && second !== null, "controllers should exist");
 
-    Services.prefs.setBoolPref(ZENMODE_PREF, false);
-    assertEquals(
-      zenModeEnabled(),
-      false,
-      "Signal should be false after pref set to false externally",
-    );
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
+        assertEquals(toggleZenModeForWindow(secondWindow.win), true, "toggle");
+        assertEquals(
+          first.enabled(),
+          false,
+          "untargeted window must not change",
+        );
+        assertEquals(second.enabled(), true, "targeted window should change");
+        assertEquals(
+          Services.prefs.getBoolPref(ZEN_MODE_PREF, false),
+          true,
+          "explicit toggle should persist the future-window seed",
+        );
 
-function testMeasureAndSetCSSVariablesSetsToolboxHeight(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
+        destroyZenModeForWindow(firstWindow.win);
+        destroyZenModeForWindow(secondWindow.win);
+      });
+    },
+  },
+  {
+    name: "owning gNavToolbox customization disables locally without restore",
+    async fn() {
+      await withSeed(true, () => {
+        const bundle = createTestWindow();
+        const controller = attachZenModeToWindow(bundle.win);
+        assert(controller !== null, "controller should exist");
+        assertEquals(controller.enabled(), true, "window should seed enabled");
 
-  try {
-    // Create a mock toolbox element
-    const mockToolbox = document!.createElement("div") as unknown as XULElement;
-    mockToolbox.id = "navigator-toolbox";
-    (
-      (mockToolbox as unknown as HTMLElement).style as unknown as Record<
-        string,
-        string
-      >
-    ).height = "100px";
-    document!.body?.appendChild(mockToolbox as unknown as Node);
+        bundle.toolbox.dispatchEvent(new Event("customizationstarting"));
+        assertEquals(
+          controller.enabled(),
+          false,
+          "customization should disable only this controller",
+        );
+        assertEquals(
+          Services.prefs.getBoolPref(ZEN_MODE_PREF, false),
+          true,
+          "customization must not persist the temporary disable",
+        );
 
-    // Enable zen mode and measure
-    setZenModeEnabled(true);
+        bundle.toolbox.dispatchEvent(new Event("aftercustomization"));
+        assertEquals(
+          controller.enabled(),
+          false,
+          "leaving customization must not auto-restore Zen",
+        );
 
-    const root = document!.documentElement as HTMLElement;
-    const toolboxHeight = root.style.getPropertyValue(
-      "--zenmode-toolbox-height",
-    );
+        destroyZenModeForWindow(bundle.win);
+      });
+    },
+  },
+  {
+    name: "late sidebar mounts use only positive rendered measurements",
+    async fn() {
+      await withSeed(true, async () => {
+        const bundle = createTestWindow();
+        const controller = attachZenModeToWindow(bundle.win);
+        assert(controller !== null, "controller should exist");
 
-    assert(
-      toolboxHeight === "100px" || toolboxHeight !== "",
-      "CSS variable --zenmode-toolbox-height should be set after enabling zen mode",
-    );
+        const sidebar = bundle.doc.createElement("div");
+        sidebar.id = "panel-sidebar-box";
+        setRect(sidebar, 284, 600);
+        bundle.doc.body!.appendChild(sidebar);
 
-    document!.body?.removeChild(mockToolbox as unknown as Node);
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
+        const selectBox = bundle.doc.createElement("div");
+        selectBox.id = "panel-sidebar-select-box";
+        setRect(selectBox, 44, 600);
+        bundle.doc.body!.appendChild(selectBox);
 
-function testMeasureAndSetCSSVariablesHandlesMissingToolbox(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-  const restoreToolbox = temporarilyRemoveElementById("navigator-toolbox");
+        const statusbar = bundle.doc.createElement("div");
+        statusbar.id = "nora-statusbar";
+        setRect(statusbar, 1000, 32, 0, 768);
+        bundle.doc.body!.appendChild(statusbar);
 
-  try {
-    // Should not throw when toolbox is missing
-    setZenModeEnabled(true);
+        await wait(0);
+        const root = bundle.doc.documentElement as HTMLElement;
+        assertEquals(
+          root.style.getPropertyValue("--zenmode-sidebar-width"),
+          "284px",
+          "late sidebar should establish a rendered width",
+        );
+        assertEquals(
+          root.style.getPropertyValue("--zenmode-selectbox-width"),
+          "44px",
+          "late select box should establish a rendered width",
+        );
 
-    const root = document!.documentElement as HTMLElement;
-    const toolboxHeight = root.style.getPropertyValue(
-      "--zenmode-toolbox-height",
-    );
+        setRect(sidebar, 0, 0);
+        sidebar.remove();
+        bundle.doc.body!.appendChild(sidebar);
+        await wait(0);
+        assertEquals(
+          root.style.getPropertyValue("--zenmode-sidebar-width"),
+          "284px",
+          "a zero-sized render must not poison the last positive width",
+        );
 
-    // Environment may already have a toolbox or preexisting value; main contract is no throw.
-    assert(
-      typeof toolboxHeight === "string",
-      "CSS variable read should succeed even when toolbox is missing",
-    );
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-    restoreToolbox();
-  }
-}
+        const css = bundle.doc.getElementById(ZEN_MODE_STYLE_ID)?.textContent ??
+          "";
+        assert(
+          css.includes(":root[zenmode] #nora-statusbar"),
+          "late statusbar should already be covered by owned Zen CSS",
+        );
 
-function testTopEdgeHoverRevealSetsAttribute(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
+        destroyZenModeForWindow(bundle.win);
+      });
+    },
+  },
+  {
+    name: "sibling mainPopupSet app-menu keeps the owning window revealed",
+    async fn() {
+      await withSeed(true, async () => {
+        const bundle = createTestWindow();
+        const popupSet = bundle.doc.createElement("div");
+        popupSet.id = "mainPopupSet";
+        const appMenu = bundle.doc.createElement("panel");
+        appMenu.setAttribute("open", "true");
+        popupSet.appendChild(appMenu);
+        bundle.doc.body!.appendChild(popupSet);
 
-  try {
-    setZenModeEnabled(true);
+        const controller = attachZenModeToWindow(bundle.win);
+        assert(controller !== null, "controller should exist");
 
-    // Create a mock toolbox
-    const mockToolbox = document!.createElement("div") as unknown as XULElement;
-    mockToolbox.id = "navigator-toolbox";
-    (
-      (mockToolbox as unknown as HTMLElement).style as unknown as Record<
-        string,
-        string
-      >
-    ).height = "100px";
-    (
-      (mockToolbox as unknown as HTMLElement).style as unknown as Record<
-        string,
-        string
-      >
-    ).position = "absolute";
-    (
-      (mockToolbox as unknown as HTMLElement).style as unknown as Record<
-        string,
-        string
-      >
-    ).top = "0px";
-    document!.body?.appendChild(mockToolbox as unknown as Node);
+        bundle.dispatchWindowEvent(
+          new MouseEvent("mousemove", { clientX: 100, clientY: 5 }),
+        );
+        bundle.dispatchWindowEvent(
+          new MouseEvent("mousemove", { clientX: 100, clientY: 200 }),
+        );
+        await wait(ZEN_MODE_HIDE_DELAY_MS + 60);
+        assert(
+          bundle.doc.documentElement!.hasAttribute("zenmode-reveal-top"),
+          "an app-menu in the owning document should hold the reveal open",
+        );
 
-    // Simulate mouse move to top edge
-    const mouseEvent = new MouseEvent("mousemove", {
-      clientX: 100,
-      clientY: 5, // Within EDGE_THRESHOLD (10)
-    });
-    globalThis.dispatchEvent(mouseEvent);
+        appMenu.removeAttribute("open");
+        await wait(ZEN_MODE_HIDE_DELAY_MS + 60);
+        assert(
+          !bundle.doc.documentElement!.hasAttribute("zenmode-reveal-top"),
+          "closing the owning app-menu should allow the reveal to retract",
+        );
 
-    assert(
-      document!.documentElement?.hasAttribute("zenmode-reveal-top"),
-      "zenmode-reveal-top attribute should be set when hovering top edge",
-    );
+        destroyZenModeForWindow(bundle.win);
+      });
+    },
+  },
+  {
+    name: "late urlbar focus and open state preserve the top reveal",
+    async fn() {
+      await withSeed(true, async () => {
+        const bundle = createTestWindow();
+        const controller = attachZenModeToWindow(bundle.win);
+        assert(controller !== null, "controller should exist");
 
-    document!.body?.removeChild(mockToolbox as unknown as Node);
-    document!.documentElement?.removeAttribute("zenmode-reveal-top");
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
+        const urlbar = bundle.doc.createElement("div");
+        urlbar.id = "urlbar";
+        bundle.doc.body!.appendChild(urlbar);
+        urlbar.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+        assert(
+          bundle.doc.documentElement!.hasAttribute("zenmode-reveal-top"),
+          "a late-mounted urlbar should reveal on focus",
+        );
 
-function testBottomEdgeHoverRevealSetsAttribute(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
+        urlbar.setAttribute("open", "true");
+        urlbar.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+        await wait(ZEN_MODE_HIDE_DELAY_MS + 60);
+        assert(
+          bundle.doc.documentElement!.hasAttribute("zenmode-reveal-top"),
+          "an open urlbar view should hold the reveal open",
+        );
 
-  try {
-    setZenModeEnabled(true);
+        urlbar.removeAttribute("open");
+        await wait(ZEN_MODE_HIDE_DELAY_MS + 60);
+        assert(
+          !bundle.doc.documentElement!.hasAttribute("zenmode-reveal-top"),
+          "closing the urlbar view should allow retraction",
+        );
 
-    // Simulate mouse move to bottom edge
-    const mouseEvent = new MouseEvent("mousemove", {
-      clientX: 100,
-      clientY: globalThis.innerHeight - 5, // Within EDGE_THRESHOLD of bottom
-    });
-    globalThis.dispatchEvent(mouseEvent);
+        destroyZenModeForWindow(bundle.win);
+      });
+    },
+  },
+  {
+    name:
+      "destroy removes attributes variables observers listeners and registry state",
+    async fn() {
+      await withSeed(false, () => {
+        const bundle = createTestWindow();
+        const controller = attachZenModeToWindow(bundle.win);
+        assert(controller !== null, "controller should exist");
+        controller.setEnabledFromUser(true);
 
-    assert(
-      document!.documentElement?.hasAttribute("zenmode-reveal-bottom"),
-      "zenmode-reveal-bottom attribute should be set when hovering bottom edge",
-    );
+        const root = bundle.doc.documentElement as HTMLElement;
+        root.setAttribute("zenmode-reveal-top", "");
+        root.setAttribute("zenmode-reveal-bottom", "");
+        root.setAttribute("zenmode-reveal-side", "");
+        root.setAttribute("zenmode-rebase", "");
+        root.style.setProperty("--zenmode-sidebar-width", "300px");
+        root.style.setProperty("--zenmode-statusbar-height", "30px");
 
-    document!.documentElement?.removeAttribute("zenmode-reveal-bottom");
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
+        destroyZenModeForWindow(bundle.win);
+        for (
+          const attribute of [
+            "zenmode",
+            "zenmode-reveal-top",
+            "zenmode-reveal-bottom",
+            "zenmode-reveal-side",
+            "zenmode-rebase",
+          ]
+        ) {
+          assert(
+            !root.hasAttribute(attribute),
+            `destroy should remove ${attribute}`,
+          );
+        }
+        for (
+          const property of [
+            "--zenmode-toolbox-height",
+            "--zenmode-sidebar-width",
+            "--zenmode-selectbox-width",
+            "--zenmode-statusbar-height",
+          ]
+        ) {
+          assertEquals(
+            root.style.getPropertyValue(property),
+            "",
+            `destroy should remove ${property}`,
+          );
+        }
+        assertEquals(
+          getZenModeController(bundle.win),
+          undefined,
+          "destroy should remove the registry entry",
+        );
+        assertEquals(
+          (bundle.win as unknown as { __floorpZenModeController?: unknown })
+            .__floorpZenModeController,
+          undefined,
+          "destroy should remove the cross-context window marker",
+        );
+        assertEquals(
+          bundle.doc.getElementById(ZEN_MODE_STYLE_ID),
+          null,
+          "destroy should remove Zen CSS",
+        );
 
-function testSideEdgeHoverRevealSetsAttribute(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
+        bundle.dispatchWindowEvent(
+          new MouseEvent("mousemove", { clientX: 100, clientY: 5 }),
+        );
+        bundle.toolbox.dispatchEvent(new Event("customizationstarting"));
+        assert(
+          !root.hasAttribute("zenmode-reveal-top"),
+          "destroyed listeners must not mutate the document",
+        );
+      });
+    },
+  },
+  {
+    name: "menu reflects and toggles its owning window controller",
+    async fn() {
+      await withSeed(false, () => {
+        const controller = attachZenModeToWindow(window);
+        assert(controller !== null, "real window controller should exist");
+        const originalEnabled = controller.enabled();
+        controller.setEnabledFromUser(false);
 
-  try {
-    setZenModeEnabled(true);
+        const container = document.createElement("div");
+        document.body?.appendChild(container);
+        const dispose = createRoot((rootDispose) => {
+          render(
+            () => ZenModeMenuElement({ targetWindow: window }),
+            container,
+          );
+          return rootDispose;
+        });
 
-    // Simulate mouse move to left edge
-    const mouseEvent = new MouseEvent("mousemove", {
-      clientX: 5, // Within EDGE_THRESHOLD
-      clientY: 100,
-    });
-    globalThis.dispatchEvent(mouseEvent);
-
-    assert(
-      document!.documentElement?.hasAttribute("zenmode-reveal-side"),
-      "zenmode-reveal-side attribute should be set when hovering left edge",
-    );
-
-    document!.documentElement?.removeAttribute("zenmode-reveal-side");
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
-
-function testHoverRevealDoesNotTriggerWhenDisabled(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-
-  try {
-    setZenModeEnabled(false);
-
-    // Simulate mouse move to top edge
-    const mouseEvent = new MouseEvent("mousemove", {
-      clientX: 100,
-      clientY: 5,
-    });
-    globalThis.dispatchEvent(mouseEvent);
-
-    assert(
-      !document!.documentElement?.hasAttribute("zenmode-reveal-top"),
-      "zenmode-reveal-top attribute should NOT be set when zen mode is disabled",
-    );
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
-
-function testZenModeDisablingRemovesAllRevealAttributes(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-
-  try {
-    setZenModeEnabled(true);
-
-    // Manually set all reveal attributes
-    document!.documentElement?.setAttribute("zenmode-reveal-top", "");
-    document!.documentElement?.setAttribute("zenmode-reveal-bottom", "");
-    document!.documentElement?.setAttribute("zenmode-reveal-side", "");
-
-    // Disable zen mode
-    setZenModeEnabled(false);
-
-    assert(
-      !document!.documentElement?.hasAttribute("zenmode-reveal-top"),
-      "zenmode-reveal-top should be removed when zen mode is disabled",
-    );
-    assert(
-      !document!.documentElement?.hasAttribute("zenmode-reveal-bottom"),
-      "zenmode-reveal-bottom should be removed when zen mode is disabled",
-    );
-    assert(
-      !document!.documentElement?.hasAttribute("zenmode-reveal-side"),
-      "zenmode-reveal-side should be removed when zen mode is disabled",
-    );
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
-
-function testZenModeMenuElementHasCorrectId(): void {
-  const container = document!.createElement("div");
-  render(() => ZenModeMenuElement(), container);
-
-  const menuitem = container.querySelector("#toggle_zenmode");
-  assert(
-    menuitem !== null,
-    "ZenModeMenuElement should render a menuitem with id 'toggle_zenmode'",
-  );
-
-  menuitem?.remove();
-}
-
-function testZenModeMenuElementCheckedStateSyncs(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-
-  try {
-    setZenModeEnabled(true);
-
-    const container = document!.createElement("div");
-    render(() => ZenModeMenuElement(), container);
-
-    const menuitem = container.querySelector("#toggle_zenmode");
-    const checked = menuitem?.getAttribute("checked");
-
-    assert(
-      checked === "true" || checked === "",
-      "menuitem checked attribute should be set when zen mode is enabled",
-    );
-
-    menuitem?.remove();
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
-
-function testZenModeMenuElementHasCorrectAccesskey(): void {
-  const container = document!.createElement("div");
-  render(() => ZenModeMenuElement(), container);
-
-  const menuitem = container.querySelector("#toggle_zenmode");
-  const accesskey = menuitem?.getAttribute("accesskey");
-
-  assertEquals(accesskey, "Z", "menuitem should have accesskey 'Z'");
-
-  menuitem?.remove();
-}
-
-function testZenModeMenuElementConditionallyRendersStyle(): void {
-  const originalSignal = zenModeEnabled();
-  const originalPref = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-
-  try {
-    // Test with zen mode disabled
-    setZenModeEnabled(false);
-    let container = document!.createElement("div");
-    render(() => ZenModeMenuElement(), container);
-    let styleElement = container.querySelector("style");
-
-    assert(
-      styleElement === null,
-      "style element should not be rendered when zen mode is disabled",
-    );
-
-    // Test with zen mode enabled
-    setZenModeEnabled(true);
-    container = document!.createElement("div");
-    render(() => ZenModeMenuElement(), container);
-    styleElement = container.querySelector("style");
-
-    assert(
-      styleElement !== null,
-      "style element should be rendered when zen mode is enabled",
-    );
-
-    container.remove();
-  } finally {
-    setZenModeEnabled(originalSignal);
-    Services.prefs.setBoolPref(ZENMODE_PREF, originalPref);
-  }
-}
+        try {
+          const menuitem = container.querySelector("#toggle_zenmode");
+          assert(menuitem !== null, "menu item should render");
+          assertEquals(
+            menuitem.getAttribute("accesskey"),
+            "Z",
+            "menu item should retain its access key",
+          );
+          menuitem.dispatchEvent(new Event("command", { bubbles: true }));
+          assertEquals(
+            controller.enabled(),
+            true,
+            "menu command should toggle its owning window",
+          );
+          assert(
+            menuitem.hasAttribute("checked"),
+            "menu checked state should react to its controller",
+          );
+        } finally {
+          dispose();
+          container.remove();
+          controller.setEnabledFromUser(originalEnabled);
+        }
+      });
+    },
+  },
+];
 
 export async function runAllTests(): Promise<void> {
-  await runTests("zenMode.test.ts", [
-    {
-      name: "zenModeEnabled signal is readable",
-      fn: testZenModeSignalReadable,
-    },
-    {
-      name: "setZenModeEnabled toggles value",
-      fn: testSetZenModeEnabledToggles,
-    },
-    { name: "zen mode pref sync", fn: testZenModePrefSync },
-    {
-      name: "zen mode attribute on documentElement",
-      fn: testZenModeAttributeOnDocumentElement,
-    },
-    {
-      name: "pref observer updates signal",
-      fn: testZenModePrefObserverUpdatesSignal,
-    },
-    {
-      name: "measureAndSetCSSVariables sets toolbox height",
-      fn: testMeasureAndSetCSSVariablesSetsToolboxHeight,
-    },
-    {
-      name: "measureAndSetCSSVariables handles missing toolbox",
-      fn: testMeasureAndSetCSSVariablesHandlesMissingToolbox,
-    },
-    {
-      name: "top edge hover reveal sets attribute",
-      fn: testTopEdgeHoverRevealSetsAttribute,
-    },
-    {
-      name: "bottom edge hover reveal sets attribute",
-      fn: testBottomEdgeHoverRevealSetsAttribute,
-    },
-    {
-      name: "side edge hover reveal sets attribute",
-      fn: testSideEdgeHoverRevealSetsAttribute,
-    },
-    {
-      name: "hover reveal does not trigger when disabled",
-      fn: testHoverRevealDoesNotTriggerWhenDisabled,
-    },
-    {
-      name: "zen mode disabling removes all reveal attributes",
-      fn: testZenModeDisablingRemovesAllRevealAttributes,
-    },
-    {
-      name: "ZenModeMenuElement has correct id",
-      fn: testZenModeMenuElementHasCorrectId,
-    },
-    {
-      name: "ZenModeMenuElement checked state syncs",
-      fn: testZenModeMenuElementCheckedStateSyncs,
-    },
-    {
-      name: "ZenModeMenuElement has correct accesskey",
-      fn: testZenModeMenuElementHasCorrectAccesskey,
-    },
-    {
-      name: "ZenModeMenuElement conditionally renders style",
-      fn: testZenModeMenuElementConditionallyRendersStyle,
-    },
-  ]);
+  await runTests("zenMode.test.ts", tests);
 }

--- a/browser-features/chrome/common/zen-mode/test/zenModeStyleElement.test.ts
+++ b/browser-features/chrome/common/zen-mode/test/zenModeStyleElement.test.ts
@@ -2,6 +2,11 @@
 // @colocated-env browser
 
 import { StyleElement } from "../styleElem.tsx";
+import {
+  attachZenModeToWindow,
+  destroyZenModeForWindow,
+  ZEN_MODE_STYLE_ID,
+} from "../zen-mode.tsx";
 import { render } from "@nora/solid-xul";
 import {
   assert,
@@ -10,6 +15,32 @@ import {
   type TestCase,
 } from "../../../test/utils/test_harness.ts";
 
+function createDisposableWindow(): Window {
+  const doc = document.implementation.createHTMLDocument(
+    "Zen style ownership test",
+  );
+  const eventTarget = new EventTarget();
+  const toolbox = doc.createElement("div");
+  toolbox.id = "navigator-toolbox";
+  doc.body!.appendChild(toolbox);
+
+  return {
+    document: doc,
+    closed: false,
+    innerWidth: 1000,
+    innerHeight: 800,
+    MutationObserver,
+    ResizeObserver,
+    requestAnimationFrame: globalThis.requestAnimationFrame.bind(globalThis),
+    cancelAnimationFrame: globalThis.cancelAnimationFrame.bind(globalThis),
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    addEventListener: eventTarget.addEventListener.bind(eventTarget),
+    removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+    gNavToolbox: toolbox,
+  } as unknown as Window;
+}
+
 function testStyleElementReturnsNode(): void {
   const node = StyleElement();
   assert(node !== null, "StyleElement should return a JSX node");
@@ -17,14 +48,6 @@ function testStyleElementReturnsNode(): void {
     typeof node,
     "object",
     "StyleElement result should be object-like",
-  );
-}
-
-function testStyleElementCanBeCalledRepeatedly(): void {
-  const nodes = [StyleElement(), StyleElement(), StyleElement()];
-  assert(
-    nodes.every((node) => node !== null),
-    "repeated calls should continue returning nodes",
   );
 }
 
@@ -97,38 +120,25 @@ function testStyleElementTargetsCorrectButtonId(): void {
   }
 }
 
-function testStyleElementCanBeRenderedMultipleTimes(): void {
-  const head = document?.head;
-  assert(head !== null && head !== undefined, "document.head should exist");
-
-  const initialCount = head.querySelectorAll("style").length;
-
-  // Render multiple times
-  render(() => StyleElement(), head);
-  render(() => StyleElement(), head);
-  render(() => StyleElement(), head);
-
-  const styleNodes = head.querySelectorAll("style");
+function testControllerOwnsSingleZenStylePerWindow(): void {
+  const testWindow = createDisposableWindow();
+  const first = attachZenModeToWindow(testWindow);
 
   try {
-    assert(
-      styleNodes.length >= initialCount + 3,
-      "should add at least 3 style elements after rendering 3 times",
+    const second = attachZenModeToWindow(testWindow);
+    assert(first !== null, "the test window should have a Zen controller");
+    assertEquals(
+      second,
+      first,
+      "the controller registry should be idempotent",
     );
-
-    // Verify only newly rendered style nodes have content
-    for (let i = initialCount; i < styleNodes.length; i++) {
-      const style = styleNodes.item(i);
-      assert(
-        (style.textContent ?? "").length > 0,
-        "each rendered style should have content",
-      );
-    }
+    assertEquals(
+      testWindow.document!.querySelectorAll(`#${ZEN_MODE_STYLE_ID}`).length,
+      1,
+      "Zen behavior CSS should be owned once per window, independent of menu rendering",
+    );
   } finally {
-    // Cleanup only styles rendered by this test
-    for (let i = initialCount; i < styleNodes.length; i++) {
-      styleNodes.item(i)?.remove();
-    }
+    destroyZenModeForWindow(testWindow, first ?? undefined);
   }
 }
 
@@ -164,10 +174,6 @@ export async function runAllTests(): Promise<void> {
   const tests: TestCase[] = [
     { name: "StyleElement returns node", fn: testStyleElementReturnsNode },
     {
-      name: "StyleElement can be called repeatedly",
-      fn: testStyleElementCanBeCalledRepeatedly,
-    },
-    {
       name: "rendered style contains zen mode selector",
       fn: testRenderedStyleContainsZenModeSelector,
     },
@@ -180,8 +186,8 @@ export async function runAllTests(): Promise<void> {
       fn: testStyleElementTargetsCorrectButtonId,
     },
     {
-      name: "StyleElement can be rendered multiple times",
-      fn: testStyleElementCanBeRenderedMultipleTimes,
+      name: "controller owns one Zen style per window",
+      fn: testControllerOwnsSingleZenStylePerWindow,
     },
     {
       name: "StyleElement SVG contains zen mode icon",

--- a/browser-features/chrome/common/zen-mode/zen-mode.css
+++ b/browser-features/chrome/common/zen-mode/zen-mode.css
@@ -4,27 +4,23 @@
 
 /* ===== Zen Mode: Hide all browser chrome ===== */
 
-/* Navigator toolbox (tab bar + navigation bar)
-   transform visually slides the toolbox up WITHOUT changing its layout position
-   → Firefox still calculates urlbarView / popup positions against the correct origin.
-   margin-bottom collapses the space so the browser content fills the gap. */
+/* The toolbox is an overlay and retracts by its own current height. This
+   avoids both content reflow on reveal and a stale measured-height cache. */
 :root[zenmode] #navigator-toolbox {
-  position: relative !important;
-  transform: translateY(
-    calc(-1 * var(--zenmode-toolbox-height, 80px))
-  ) !important;
-  margin-bottom: calc(-1 * var(--zenmode-toolbox-height, 80px)) !important;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  transform: translateY(-100%) !important;
   opacity: 0 !important;
   pointer-events: none !important;
   transition:
     transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    margin-bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1),
     opacity 0.25s ease !important;
-  z-index: 1 !important;
+  z-index: 101 !important;
 }
 
-/* URL bar is rendered in the top layer via the Popover API (popover="manual"),
-   so ancestor opacity/transform do NOT affect it. Hide it directly. */
+/* The urlbar is rendered in the top layer and must be hidden directly. */
 :root[zenmode] #urlbar {
   opacity: 0 !important;
   pointer-events: none !important;
@@ -38,11 +34,11 @@
   display: none !important;
 }
 
-/* Floorp panel sidebar — slide out via negative margin */
+/* The two Floorp sidebar boxes share an edge, so they retain positive,
+   rendered-element measurements and are rebased without animation. */
 :root[zenmode] #panel-sidebar-box {
-  margin-inline-start: calc(
-    -1 * var(--zenmode-sidebar-width, 250px)
-  ) !important;
+  margin-inline-start: calc(-1 * var(--zenmode-sidebar-width, 250px))
+    !important;
   opacity: 0 !important;
   pointer-events: none !important;
   transition:
@@ -51,9 +47,8 @@
 }
 
 :root[zenmode] #panel-sidebar-select-box {
-  margin-inline-start: calc(
-    -1 * var(--zenmode-selectbox-width, 40px)
-  ) !important;
+  margin-inline-start: calc(-1 * var(--zenmode-selectbox-width, 40px))
+    !important;
   opacity: 0 !important;
   pointer-events: none !important;
   transition:
@@ -61,18 +56,32 @@
     opacity 0.25s ease !important;
 }
 
-/* Status bar — slide down via negative margin */
+:root[zenmode]:not([zenmode-reveal-side]) #panel-sidebar-splitter {
+  display: none !important;
+}
+
+:root[zenmode][zenmode-rebase] #panel-sidebar-box,
+:root[zenmode][zenmode-rebase] #panel-sidebar-select-box {
+  transition: none !important;
+}
+
+/* The status bar also retracts by its own current height. */
 :root[zenmode] #nora-statusbar {
-  margin-bottom: calc(-1 * var(--zenmode-statusbar-height, 30px)) !important;
+  position: absolute !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  transform: translateY(100%) !important;
   opacity: 0 !important;
   pointer-events: none !important;
   transition:
-    margin-bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
     opacity 0.25s ease !important;
+  z-index: 101 !important;
 }
 
 /* ===== Window drag region ===== */
-/* Transparent draggable area at top so the window can still be moved */
+
 :root[zenmode] #browser {
   position: relative !important;
 }
@@ -91,38 +100,38 @@
 
 /* ===== Hover Reveal ===== */
 
-/* Reveal top chrome — slide back in via transform and restore spacing */
 :root[zenmode][zenmode-reveal-top] #navigator-toolbox {
-  transform: translateY(0) !important;
-  margin-bottom: 0 !important;
+  transform: none !important;
   opacity: 1 !important;
   pointer-events: auto !important;
-  z-index: 101 !important;
 }
 
-/* Reveal urlbar (top-layer element is not affected by ancestor styles) */
 :root[zenmode][zenmode-reveal-top] #urlbar {
   opacity: 1 !important;
   pointer-events: auto !important;
   transition-delay: 0.15s !important;
 }
 
-/* Reveal panel sidebar on edge hover — slide back in */
-:root[zenmode][zenmode-reveal-side] #panel-sidebar-box {
-  margin-inline-start: 0 !important;
-  opacity: 1 !important;
-  pointer-events: auto !important;
-}
-
+:root[zenmode][zenmode-reveal-side] #panel-sidebar-box,
 :root[zenmode][zenmode-reveal-side] #panel-sidebar-select-box {
   margin-inline-start: 0 !important;
   opacity: 1 !important;
   pointer-events: auto !important;
 }
 
-/* Reveal status bar on hover — slide back in */
 :root[zenmode][zenmode-reveal-bottom] #nora-statusbar {
-  margin-bottom: 0 !important;
+  transform: none !important;
   opacity: 1 !important;
   pointer-events: auto !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[zenmode] #navigator-toolbox,
+  :root[zenmode] #urlbar,
+  :root[zenmode] #panel-sidebar-box,
+  :root[zenmode] #panel-sidebar-select-box,
+  :root[zenmode] #nora-statusbar {
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
 }

--- a/browser-features/chrome/common/zen-mode/zen-mode.tsx
+++ b/browser-features/chrome/common/zen-mode/zen-mode.tsx
@@ -3,340 +3,677 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createEffect, createSignal, onCleanup } from "solid-js";
-import { Show } from "solid-js";
-import { createRootHMR } from "@nora/solid-xul";
+import { type Accessor, createSignal, type Setter } from "solid-js";
 import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
 import i18next from "i18next";
 import zenModeStyle from "./zen-mode.css?inline";
 
-const ZENMODE_PREF = "floorp.zenmode.enabled";
+export const ZEN_MODE_PREF = "floorp.zenmode.enabled";
+export const ZEN_MODE_STYLE_ID = "floorp-zen-mode-style";
 
 const EDGE_THRESHOLD = 10;
-const HIDE_DELAY_MS = 500;
+export const ZEN_MODE_HIDE_DELAY_MS = 500;
 
-export const [zenModeEnabled, setZenModeEnabled] = createRootHMR(
-  () =>
-    createSignal(
-      typeof Services !== "undefined"
-        ? Services.prefs.getBoolPref(ZENMODE_PREF, false)
-        : false,
-    ),
-  import.meta.hot,
-);
+const ZEN_MODE_ATTRIBUTES = [
+  "zenmode",
+  "zenmode-reveal-top",
+  "zenmode-reveal-bottom",
+  "zenmode-reveal-side",
+  "zenmode-rebase",
+] as const;
 
-function measureAndSetCSSVariables() {
-  const root = document!.documentElement as HTMLElement;
+const ZEN_MODE_CSS_VARIABLES = [
+  "--zenmode-toolbox-height",
+  "--zenmode-sidebar-width",
+  "--zenmode-selectbox-width",
+  "--zenmode-statusbar-height",
+] as const;
 
-  const toolbox = document!.getElementById("navigator-toolbox");
-  if (toolbox) {
-    root.style.setProperty(
-      "--zenmode-toolbox-height",
-      `${toolbox.getBoundingClientRect().height}px`,
-    );
-  }
+const MEASURED_ELEMENTS = [
+  {
+    id: "panel-sidebar-box",
+    property: "--zenmode-sidebar-width",
+  },
+  {
+    id: "panel-sidebar-select-box",
+    property: "--zenmode-selectbox-width",
+  },
+] as const;
 
-  const sidebar = document!.getElementById("panel-sidebar-box");
-  if (sidebar) {
-    root.style.setProperty(
-      "--zenmode-sidebar-width",
-      `${sidebar.getBoundingClientRect().width}px`,
-    );
-  }
+type MeasuredElement = (typeof MEASURED_ELEMENTS)[number];
 
-  const selectBox = document!.getElementById("panel-sidebar-select-box");
-  if (selectBox) {
-    root.style.setProperty(
-      "--zenmode-selectbox-width",
-      `${selectBox.getBoundingClientRect().width}px`,
-    );
-  }
+type BrowserWindowWithToolbox = Window & {
+  gNavToolbox?: EventTarget | null;
+};
 
-  const statusbar = document!.getElementById("nora-statusbar");
-  if (statusbar) {
-    root.style.setProperty(
-      "--zenmode-statusbar-height",
-      `${statusbar.getBoundingClientRect().height}px`,
-    );
+type BrowserWindowWithZenController = Window & {
+  __floorpZenModeController?: ZenModeController;
+};
+
+type ControllerDestroyedCallback = (controller: ZenModeController) => void;
+
+function readPersistedSeed(): boolean {
+  try {
+    return typeof Services !== "undefined"
+      ? Services.prefs.getBoolPref(ZEN_MODE_PREF, false)
+      : false;
+  } catch {
+    return false;
   }
 }
 
-function setupPrefSync() {
-  createEffect(() => {
-    const enabled = zenModeEnabled();
-    Services.prefs.setBoolPref(ZENMODE_PREF, enabled);
-
-    if (enabled) {
-      // Measure element sizes before hiding so animations have correct distances
-      measureAndSetCSSVariables();
-      document!.documentElement!.setAttribute("zenmode", "");
-    } else {
-      document!.documentElement!.removeAttribute("zenmode");
-      document!.documentElement!.removeAttribute("zenmode-reveal-top");
-      document!.documentElement!.removeAttribute("zenmode-reveal-bottom");
-      document!.documentElement!.removeAttribute("zenmode-reveal-side");
-    }
-  });
-
-  const observer = () => {
-    const prefValue = Services.prefs.getBoolPref(ZENMODE_PREF, false);
-    if (prefValue !== zenModeEnabled()) {
-      setZenModeEnabled(prefValue);
-    }
-  };
-  Services.prefs.addObserver(ZENMODE_PREF, observer);
-  onCleanup(() => {
-    Services.prefs.removeObserver(ZENMODE_PREF, observer);
-  });
+function persistSeed(enabled: boolean): void {
+  try {
+    Services.prefs.setBoolPref(ZEN_MODE_PREF, enabled);
+  } catch (error) {
+    console.error("[zen-mode] Failed to persist Zen mode seed:", error);
+  }
 }
 
 /**
- * Check whether a menupopup inside the navigator-toolbox (e.g. a menu-bar
- * dropdown) is currently open.  These popups are rendered as native OS-level
- * overlays, so they stay visible even after the toolbox is hidden with
- * opacity/pointer-events — producing the "ghost dropdown" artifact described
- * in issue #2374.
+ * Owns every piece of Zen state and chrome integration for one browser window.
+ * The preference is read once, at construction, and is never observed.
  */
-function isToolbarPopupOpen(): boolean {
-  const toolbox = document!.getElementById("navigator-toolbox");
-  if (!toolbox) return false;
-  // menupopup: menu-bar dropdowns (File, Edit, View…)
-  // panel: toolbar button popups (appMenu, hamburger menu, etc.)
-  return (
-    toolbox.querySelector("menupopup[open]") !== null ||
-    toolbox.querySelector("panel[open]") !== null
-  );
-}
+export class ZenModeController {
+  public readonly enabled: Accessor<boolean>;
 
-function setupHoverReveal() {
-  let topHideTimer: ReturnType<typeof setTimeout> | null = null;
-  let bottomHideTimer: ReturnType<typeof setTimeout> | null = null;
-  let sideHideTimer: ReturnType<typeof setTimeout> | null = null;
-  let urlbarObserver: MutationObserver | null = null;
+  private readonly setEnabledSignal: Setter<boolean>;
+  private readonly document: Document;
+  private readonly root: HTMLElement;
+  private readonly onDestroyed: ControllerDestroyedCallback;
 
-  const clearTopTimer = () => {
-    if (topHideTimer !== null) {
-      clearTimeout(topHideTimer);
-      topHideTimer = null;
+  private destroyed = false;
+  private styleElement: HTMLStyleElement | null = null;
+  private domObserver: MutationObserver | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  private readonly observedElements = new Map<string, Element>();
+  private customizationTarget: EventTarget | null = null;
+
+  private topHideTimer: number | null = null;
+  private bottomHideTimer: number | null = null;
+  private sideHideTimer: number | null = null;
+  private rebaseRafOne: number | null = null;
+  private rebaseRafTwo: number | null = null;
+
+  constructor(
+    public readonly targetWindow: Window,
+    onDestroyed: ControllerDestroyedCallback,
+  ) {
+    const targetDocument = targetWindow.document;
+    const root = targetDocument?.documentElement as HTMLElement | null;
+    if (!targetDocument || !root) {
+      throw new Error("Zen mode requires a browser window document");
     }
-  };
 
-  const clearBottomTimer = () => {
-    if (bottomHideTimer !== null) {
-      clearTimeout(bottomHideTimer);
-      bottomHideTimer = null;
+    this.document = targetDocument;
+    this.root = root;
+    this.onDestroyed = onDestroyed;
+
+    const [enabled, setEnabled] = createSignal(readPersistedSeed());
+    this.enabled = enabled;
+    this.setEnabledSignal = setEnabled;
+
+    try {
+      this.initialize();
+    } catch (error) {
+      this.destroy();
+      throw error;
     }
-  };
+  }
 
-  const clearSideTimer = () => {
-    if (sideHideTimer !== null) {
-      clearTimeout(sideHideTimer);
-      sideHideTimer = null;
+  public isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  /** Toggle from a menu, toolbar button, or mouse gesture. */
+  public toggleFromUser(): boolean {
+    return this.setEnabledFromUser(!this.enabled());
+  }
+
+  /** Set from an explicit user action and persist only the future-window seed. */
+  public setEnabledFromUser(enabled: boolean): boolean {
+    if (this.destroyed) {
+      return this.enabled();
     }
-  };
 
-  /** Whether the urlbar is currently open (showing the urlbarView dropdown). */
-  const isUrlbarOpen = (): boolean => {
-    const urlbar = document!.getElementById("urlbar");
-    return urlbar !== null && urlbar.hasAttribute("open");
-  };
+    this.setLocalEnabled(enabled);
+    persistSeed(enabled);
+    return enabled;
+  }
 
-  /** Attempt to hide the top chrome; reschedule while a menupopup or urlbar is open. */
-  const tryHideTop = () => {
-    if (!zenModeEnabled()) {
-      topHideTimer = null;
+  /** Toolbar customization is intentionally local and non-persistent. */
+  public disableForCustomization(): void {
+    if (!this.destroyed) {
+      this.setLocalEnabled(false);
+    }
+  }
+
+  public destroy(): void {
+    if (this.destroyed) {
       return;
     }
-    if (isToolbarPopupOpen() || isUrlbarOpen()) {
-      // A menupopup or urlbarView is still open — keep the toolbox visible
-      // and re-check after another delay.
-      topHideTimer = setTimeout(tryHideTop, HIDE_DELAY_MS);
+    this.destroyed = true;
+
+    this.targetWindow.removeEventListener("mousemove", this.handleMouseMove);
+    this.targetWindow.removeEventListener("unload", this.handleWindowUnload);
+    this.document.removeEventListener("focusin", this.handleUrlbarFocusIn);
+    this.document.removeEventListener("focusout", this.handleUrlbarFocusOut);
+
+    this.setCustomizationTarget(null);
+
+    this.domObserver?.disconnect();
+    this.domObserver = null;
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    this.observedElements.clear();
+
+    this.clearTopTimer();
+    this.clearBottomTimer();
+    this.clearSideTimer();
+    this.cancelRebaseFrames();
+
+    for (const attribute of ZEN_MODE_ATTRIBUTES) {
+      this.root.removeAttribute(attribute);
+    }
+    for (const property of ZEN_MODE_CSS_VARIABLES) {
+      this.root.style.removeProperty(property);
+    }
+
+    this.styleElement?.remove();
+    this.styleElement = null;
+
+    this.onDestroyed(this);
+  }
+
+  private initialize(): void {
+    this.ensureStyleElement();
+
+    this.targetWindow.addEventListener("mousemove", this.handleMouseMove);
+    this.targetWindow.addEventListener("unload", this.handleWindowUnload, {
+      once: true,
+    });
+    this.document.addEventListener("focusin", this.handleUrlbarFocusIn);
+    this.document.addEventListener("focusout", this.handleUrlbarFocusOut);
+
+    const ResizeObserverConstructor = this.targetWindow.ResizeObserver;
+    if (typeof ResizeObserverConstructor === "function") {
+      this.resizeObserver = new ResizeObserverConstructor(
+        this.handleMeasuredElementResize,
+      );
+    }
+
+    const MutationObserverConstructor = this.targetWindow.MutationObserver;
+    if (typeof MutationObserverConstructor === "function") {
+      const observer = new MutationObserverConstructor(
+        this.handleDocumentMutation,
+      );
+      observer.observe(this.root, {
+        attributes: true,
+        attributeFilter: ["open"],
+        childList: true,
+        subtree: true,
+      });
+      this.domObserver = observer;
+    }
+
+    this.syncOwnedElements();
+    this.applyEnabledState(this.enabled());
+  }
+
+  private setLocalEnabled(enabled: boolean): void {
+    this.setEnabledSignal(enabled);
+    this.applyEnabledState(enabled);
+  }
+
+  private applyEnabledState(enabled: boolean): void {
+    if (enabled) {
+      this.measureCurrentElements(false);
+      this.root.setAttribute("zenmode", "");
       return;
     }
-    document!.documentElement!.removeAttribute("zenmode-reveal-top");
-    topHideTimer = null;
+
+    this.clearTopTimer();
+    this.clearBottomTimer();
+    this.clearSideTimer();
+    this.cancelRebaseFrames();
+    this.root.removeAttribute("zenmode");
+    this.root.removeAttribute("zenmode-reveal-top");
+    this.root.removeAttribute("zenmode-reveal-bottom");
+    this.root.removeAttribute("zenmode-reveal-side");
+    this.root.removeAttribute("zenmode-rebase");
+  }
+
+  private ensureStyleElement(): void {
+    if (this.styleElement?.isConnected) {
+      return;
+    }
+
+    const existing = this.document.getElementById(ZEN_MODE_STYLE_ID);
+    if (existing?.localName === "style") {
+      this.styleElement = existing as HTMLStyleElement;
+      this.styleElement.textContent = zenModeStyle;
+      return;
+    }
+
+    const style = this.document.createElement("style");
+    style.id = ZEN_MODE_STYLE_ID;
+    style.setAttribute("data-floorp-zen-mode-owned", "true");
+    style.textContent = zenModeStyle;
+    (this.document.head ?? this.root).appendChild(style);
+    this.styleElement = style;
+  }
+
+  private readonly handleWindowUnload = (): void => {
+    destroyZenModeForWindow(this.targetWindow, this);
   };
 
-  const handleMouseMove = (event: MouseEvent) => {
-    if (!zenModeEnabled()) return;
+  private readonly handleCustomizationStarting = (): void => {
+    this.disableForCustomization();
+  };
+
+  private setCustomizationTarget(target: EventTarget | null): void {
+    if (this.customizationTarget === target) {
+      return;
+    }
+
+    this.customizationTarget?.removeEventListener(
+      "customizationstarting",
+      this.handleCustomizationStarting,
+    );
+    this.customizationTarget = target;
+    this.customizationTarget?.addEventListener(
+      "customizationstarting",
+      this.handleCustomizationStarting,
+    );
+  }
+
+  private syncOwnedElements(): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.ensureStyleElement();
+
+    const explicitToolbox = (this.targetWindow as BrowserWindowWithToolbox)
+      .gNavToolbox;
+    const toolbox = explicitToolbox ??
+      this.document.getElementById("navigator-toolbox");
+    this.setCustomizationTarget(toolbox);
+
+    for (const measured of MEASURED_ELEMENTS) {
+      const previous = this.observedElements.get(measured.id) ?? null;
+      const current = this.document.getElementById(measured.id);
+
+      if (previous && previous !== current) {
+        this.resizeObserver?.unobserve(previous);
+        this.observedElements.delete(measured.id);
+      }
+
+      if (current && previous !== current) {
+        this.observedElements.set(measured.id, current);
+        this.resizeObserver?.observe(current);
+      }
+    }
+
+    this.measureCurrentElements(this.enabled());
+  }
+
+  private readonly handleDocumentMutation: MutationCallback = (mutations) => {
+    if (this.destroyed) {
+      return;
+    }
+
+    let shouldSyncElements = false;
+    for (const mutation of mutations) {
+      if (mutation.type === "childList") {
+        shouldSyncElements = true;
+        continue;
+      }
+
+      if (
+        mutation.type === "attributes" &&
+        mutation.attributeName === "open" &&
+        mutation.target === this.document.getElementById("urlbar") &&
+        !(mutation.target as Element).hasAttribute("open") &&
+        this.enabled()
+      ) {
+        this.scheduleTopHide();
+      }
+    }
+
+    if (shouldSyncElements) {
+      this.syncOwnedElements();
+    }
+  };
+
+  private readonly handleMeasuredElementResize: ResizeObserverCallback = (
+    entries,
+  ) => {
+    if (this.destroyed) {
+      return;
+    }
+
+    const elements = entries
+      .map((entry) => entry.target)
+      .filter((element) => element.ownerDocument === this.document);
+    this.applyMeasurements(elements, this.enabled());
+  };
+
+  private measureCurrentElements(rebase: boolean): void {
+    const elements = MEASURED_ELEMENTS.map((measured) =>
+      this.document.getElementById(measured.id)
+    ).filter((element): element is Element => element !== null);
+    this.applyMeasurements(elements, rebase);
+  }
+
+  private applyMeasurements(elements: Element[], rebase: boolean): void {
+    const updates: Array<{ measured: MeasuredElement; value: string }> = [];
+
+    for (const element of elements) {
+      const measured = MEASURED_ELEMENTS.find(({ id }) => id === element.id);
+      if (!measured || this.document.getElementById(measured.id) !== element) {
+        continue;
+      }
+
+      const width = element.getBoundingClientRect().width;
+      if (!Number.isFinite(width) || width <= 0) {
+        continue;
+      }
+
+      const value = `${width}px`;
+      if (this.root.style.getPropertyValue(measured.property) !== value) {
+        updates.push({ measured, value });
+      }
+    }
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    if (rebase) {
+      this.beginRebase();
+    }
+    for (const update of updates) {
+      this.root.style.setProperty(update.measured.property, update.value);
+    }
+  }
+
+  private beginRebase(): void {
+    if (!this.enabled() || this.destroyed) {
+      return;
+    }
+
+    this.cancelRebaseFrames(false);
+    this.root.setAttribute("zenmode-rebase", "");
+    this.rebaseRafOne = this.targetWindow.requestAnimationFrame(() => {
+      this.rebaseRafOne = null;
+      if (this.destroyed) {
+        return;
+      }
+      this.rebaseRafTwo = this.targetWindow.requestAnimationFrame(() => {
+        this.rebaseRafTwo = null;
+        if (!this.destroyed) {
+          this.root.removeAttribute("zenmode-rebase");
+        }
+      });
+    });
+  }
+
+  private cancelRebaseFrames(removeAttribute = true): void {
+    if (this.rebaseRafOne !== null) {
+      this.targetWindow.cancelAnimationFrame(this.rebaseRafOne);
+      this.rebaseRafOne = null;
+    }
+    if (this.rebaseRafTwo !== null) {
+      this.targetWindow.cancelAnimationFrame(this.rebaseRafTwo);
+      this.rebaseRafTwo = null;
+    }
+    if (removeAttribute) {
+      this.root.removeAttribute("zenmode-rebase");
+    }
+  }
+
+  private isOwnedTopPopupOpen(): boolean {
+    const selectors = [
+      "#navigator-toolbox menupopup[open]",
+      "#navigator-toolbox panel[open]",
+      "#mainPopupSet menupopup[open]",
+      "#mainPopupSet panel[open]",
+    ];
+    return selectors.some((selector) => {
+      const popup = this.document.querySelector(selector) as Element | null;
+      return popup?.ownerDocument === this.document;
+    });
+  }
+
+  private isUrlbarOpen(): boolean {
+    return this.document.getElementById("urlbar")?.hasAttribute("open") ??
+      false;
+  }
+
+  private isOrContainsUrlbar(target: EventTarget | null): boolean {
+    const node = target as Node | null;
+    if (!node || node.ownerDocument !== this.document) {
+      return false;
+    }
+
+    const urlbar = this.document.getElementById("urlbar");
+    return urlbar !== null && (urlbar === node || urlbar.contains(node));
+  }
+
+  private readonly tryHideTop = (): void => {
+    if (!this.enabled() || this.destroyed) {
+      this.topHideTimer = null;
+      return;
+    }
+
+    if (this.isOwnedTopPopupOpen() || this.isUrlbarOpen()) {
+      this.topHideTimer = this.targetWindow.setTimeout(
+        this.tryHideTop,
+        ZEN_MODE_HIDE_DELAY_MS,
+      );
+      return;
+    }
+
+    this.root.removeAttribute("zenmode-reveal-top");
+    this.topHideTimer = null;
+  };
+
+  private scheduleTopHide(): void {
+    this.clearTopTimer();
+    this.topHideTimer = this.targetWindow.setTimeout(
+      this.tryHideTop,
+      ZEN_MODE_HIDE_DELAY_MS,
+    );
+  }
+
+  private readonly handleMouseMove = (event: MouseEvent): void => {
+    if (!this.enabled() || this.destroyed) {
+      return;
+    }
 
     const { clientX, clientY } = event;
-    const windowWidth = innerWidth;
-    const windowHeight = innerHeight;
+    const windowWidth = this.targetWindow.innerWidth;
+    const windowHeight = this.targetWindow.innerHeight;
 
-    // Top edge detection
     if (clientY <= EDGE_THRESHOLD) {
-      clearTopTimer();
-      document!.documentElement!.setAttribute("zenmode-reveal-top", "");
-    } else if (
-      document!.documentElement!.hasAttribute("zenmode-reveal-top")
-    ) {
-      const navigatorToolbox = document!.getElementById("navigator-toolbox");
-      if (navigatorToolbox) {
-        const rect = navigatorToolbox.getBoundingClientRect();
-        if (clientY > rect.bottom) {
-          clearTopTimer();
-          topHideTimer = setTimeout(tryHideTop, HIDE_DELAY_MS);
-        } else {
-          clearTopTimer();
-        }
+      this.clearTopTimer();
+      this.root.setAttribute("zenmode-reveal-top", "");
+    } else if (this.root.hasAttribute("zenmode-reveal-top")) {
+      const toolbox = this.document.getElementById("navigator-toolbox");
+      if (!toolbox || clientY > toolbox.getBoundingClientRect().bottom) {
+        this.scheduleTopHide();
+      } else {
+        this.clearTopTimer();
       }
     }
 
-    // Bottom edge detection
     if (clientY >= windowHeight - EDGE_THRESHOLD) {
-      clearBottomTimer();
-      document!.documentElement!.setAttribute("zenmode-reveal-bottom", "");
-    } else if (
-      document!.documentElement!.hasAttribute("zenmode-reveal-bottom")
-    ) {
-      const statusbar = document!.getElementById("nora-statusbar");
-      if (statusbar) {
-        const rect = statusbar.getBoundingClientRect();
-        if (clientY < rect.top) {
-          clearBottomTimer();
-          bottomHideTimer = setTimeout(() => {
-            document!.documentElement!.removeAttribute("zenmode-reveal-bottom");
-            bottomHideTimer = null;
-          }, HIDE_DELAY_MS);
-        } else {
-          clearBottomTimer();
-        }
+      this.clearBottomTimer();
+      this.root.setAttribute("zenmode-reveal-bottom", "");
+    } else if (this.root.hasAttribute("zenmode-reveal-bottom")) {
+      const statusbar = this.document.getElementById("nora-statusbar");
+      if (!statusbar || clientY < statusbar.getBoundingClientRect().top) {
+        this.clearBottomTimer();
+        this.bottomHideTimer = this.targetWindow.setTimeout(() => {
+          this.root.removeAttribute("zenmode-reveal-bottom");
+          this.bottomHideTimer = null;
+        }, ZEN_MODE_HIDE_DELAY_MS);
+      } else {
+        this.clearBottomTimer();
       }
     }
 
-    // Left/right edge detection for panel sidebar
     if (clientX <= EDGE_THRESHOLD || clientX >= windowWidth - EDGE_THRESHOLD) {
-      clearSideTimer();
-      document!.documentElement!.setAttribute("zenmode-reveal-side", "");
-    } else if (
-      document!.documentElement!.hasAttribute("zenmode-reveal-side")
-    ) {
-      const panelSidebar = document!.getElementById("panel-sidebar-box");
-      const panelSelectBox = document!.getElementById(
+      this.clearSideTimer();
+      this.root.setAttribute("zenmode-reveal-side", "");
+    } else if (this.root.hasAttribute("zenmode-reveal-side")) {
+      const panelSidebar = this.document.getElementById("panel-sidebar-box");
+      const panelSelectBox = this.document.getElementById(
         "panel-sidebar-select-box",
       );
-      const insideSidebar = (panelSidebar &&
-        clientX >= panelSidebar.getBoundingClientRect().left &&
-        clientX <= panelSidebar.getBoundingClientRect().right) ||
-        (panelSelectBox &&
-          clientX >= panelSelectBox.getBoundingClientRect().left &&
-          clientX <= panelSelectBox.getBoundingClientRect().right);
+      const insideSidebar = [panelSidebar, panelSelectBox].some((element) => {
+        if (!element) {
+          return false;
+        }
+        const rect = element.getBoundingClientRect();
+        return clientX >= rect.left && clientX <= rect.right;
+      });
 
       if (!insideSidebar) {
-        clearSideTimer();
-        sideHideTimer = setTimeout(() => {
-          document!.documentElement!.removeAttribute("zenmode-reveal-side");
-          sideHideTimer = null;
-        }, HIDE_DELAY_MS);
+        this.clearSideTimer();
+        this.sideHideTimer = this.targetWindow.setTimeout(() => {
+          this.root.removeAttribute("zenmode-reveal-side");
+          this.sideHideTimer = null;
+        }, ZEN_MODE_HIDE_DELAY_MS);
       } else {
-        clearSideTimer();
+        this.clearSideTimer();
       }
     }
   };
 
-  // ===== URL bar focus / open handling =====
-  // Reveal the toolbox when the URL bar gains focus (e.g. Ctrl+L) and keep
-  // it visible while the urlbarView dropdown is open.
-  // Use focusin/focusout (bubbling) on the document so we also catch focus on
-  // the inner <input> element inside html:moz-urlbar.
-
-  const isOrContainsUrlbar = (target: EventTarget | null): boolean => {
-    if (!(target instanceof Element)) return false;
-    const urlbar = document!.getElementById("urlbar");
-    return urlbar !== null && (urlbar === target || urlbar.contains(target));
+  private readonly handleUrlbarFocusIn = (event: FocusEvent): void => {
+    if (!this.enabled() || !this.isOrContainsUrlbar(event.target)) {
+      return;
+    }
+    this.clearTopTimer();
+    this.root.setAttribute("zenmode-reveal-top", "");
   };
 
-  const handleUrlbarFocusIn = (event: FocusEvent) => {
-    if (!zenModeEnabled()) return;
-    if (!isOrContainsUrlbar(event.target)) return;
-    clearTopTimer();
-    document!.documentElement!.setAttribute("zenmode-reveal-top", "");
+  private readonly handleUrlbarFocusOut = (event: FocusEvent): void => {
+    if (!this.enabled() || !this.isOrContainsUrlbar(event.target)) {
+      return;
+    }
+    this.scheduleTopHide();
   };
 
-  const handleUrlbarFocusOut = (event: FocusEvent) => {
-    if (!zenModeEnabled()) return;
-    if (!isOrContainsUrlbar(event.target)) return;
-    // Don't hide immediately — the urlbarView may still be open.  Schedule
-    // a delayed hide; tryHideTop will keep rescheduling while [open] is set.
-    clearTopTimer();
-    topHideTimer = setTimeout(tryHideTop, HIDE_DELAY_MS);
-  };
+  private clearTopTimer(): void {
+    if (this.topHideTimer !== null) {
+      this.targetWindow.clearTimeout(this.topHideTimer);
+      this.topHideTimer = null;
+    }
+  }
 
-  const setupUrlbarListeners = () => {
-    const urlbar = document!.getElementById("urlbar");
-    if (!urlbar) return;
+  private clearBottomTimer(): void {
+    if (this.bottomHideTimer !== null) {
+      this.targetWindow.clearTimeout(this.bottomHideTimer);
+      this.bottomHideTimer = null;
+    }
+  }
 
-    // Listen on document so bubbling focusin/focusout from the inner <input>
-    // are captured even when focus lands on a descendant of #urlbar.
-    document!.addEventListener("focusin", handleUrlbarFocusIn);
-    document!.addEventListener("focusout", handleUrlbarFocusOut);
+  private clearSideTimer(): void {
+    if (this.sideHideTimer !== null) {
+      this.targetWindow.clearTimeout(this.sideHideTimer);
+      this.sideHideTimer = null;
+    }
+  }
+}
 
-    // Watch for the [open] attribute so we can schedule a hide when the
-    // urlbarView dropdown closes while the input itself stays focused.
-    urlbarObserver = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "open"
-        ) {
-          // [open] was removed → urlbarView closed
-          if (!urlbar.hasAttribute("open") && zenModeEnabled()) {
-            clearTopTimer();
-            topHideTimer = setTimeout(tryHideTop, HIDE_DELAY_MS);
-          }
+const zenModeControllers = new Map<Window, ZenModeController>();
+
+function getAttachedWindowController(
+  win: Window,
+): ZenModeController | undefined {
+  const controller = (win as BrowserWindowWithZenController)
+    .__floorpZenModeController;
+  if (!controller || controller.isDestroyed()) {
+    return undefined;
+  }
+  return controller;
+}
+
+export function attachZenModeToWindow(win: Window): ZenModeController | null {
+  if (!win || win.closed === true || !win.document?.documentElement) {
+    return null;
+  }
+
+  // Mouse gestures may be owned by the first browser window's module context.
+  // Keep the authoritative controller on the addressed Window so another
+  // context routes to the same signal instead of creating a duplicate.
+  const attached = getAttachedWindowController(win);
+  if (attached) {
+    return attached;
+  }
+
+  const existing = zenModeControllers.get(win);
+  if (existing && !existing.isDestroyed()) {
+    return existing;
+  }
+
+  let controller: ZenModeController;
+  try {
+    controller = new ZenModeController(win, (destroyedController) => {
+      if (zenModeControllers.get(win) === destroyedController) {
+        zenModeControllers.delete(win);
+      }
+      const markedWindow = win as BrowserWindowWithZenController;
+      if (markedWindow.__floorpZenModeController === destroyedController) {
+        try {
+          delete markedWindow.__floorpZenModeController;
+        } catch {
+          markedWindow.__floorpZenModeController = undefined;
         }
       }
     });
-    urlbarObserver.observe(urlbar, {
-      attributes: true,
-      attributeFilter: ["open"],
-    });
-  };
+  } catch (error) {
+    console.error("[zen-mode] Failed to attach window controller:", error);
+    return null;
+  }
 
-  setupUrlbarListeners();
-
-  addEventListener("mousemove", handleMouseMove);
-
-  onCleanup(() => {
-    removeEventListener("mousemove", handleMouseMove);
-
-    // Clean up urlbar listeners
-    document!.removeEventListener("focusin", handleUrlbarFocusIn);
-    document!.removeEventListener("focusout", handleUrlbarFocusOut);
-    if (urlbarObserver) {
-      urlbarObserver.disconnect();
-      urlbarObserver = null;
-    }
-
-    clearTopTimer();
-    clearBottomTimer();
-    clearSideTimer();
-    document!.documentElement!.removeAttribute("zenmode");
-    document!.documentElement!.removeAttribute("zenmode-reveal-top");
-    document!.documentElement!.removeAttribute("zenmode-reveal-bottom");
-    document!.documentElement!.removeAttribute("zenmode-reveal-side");
-  });
+  zenModeControllers.set(win, controller);
+  (win as BrowserWindowWithZenController).__floorpZenModeController =
+    controller;
+  return controller;
 }
 
-export function initZenModeState() {
-  setupPrefSync();
-  setupHoverReveal();
-
-  // Disable zen mode when entering toolbar customization
-  const customizeObserver = new MutationObserver(() => {
-    if (document!.documentElement!.hasAttribute("customizing")) {
-      setZenModeEnabled(false);
-    }
-  });
-  customizeObserver.observe(document!.documentElement!, {
-    attributes: true,
-    attributeFilter: ["customizing"],
-  });
-  onCleanup(() => customizeObserver.disconnect());
+export function getZenModeController(
+  win: Window,
+): ZenModeController | undefined {
+  const controller = getAttachedWindowController(win) ??
+    zenModeControllers.get(win);
+  return controller?.isDestroyed() ? undefined : controller;
 }
 
-export function ZenModeMenuElement() {
+export function toggleZenModeForWindow(win: Window): boolean | null {
+  return attachZenModeToWindow(win)?.toggleFromUser() ?? null;
+}
+
+export function destroyZenModeForWindow(
+  win: Window,
+  expectedController?: ZenModeController,
+): void {
+  const controller = getAttachedWindowController(win) ??
+    zenModeControllers.get(win);
+  if (
+    !controller || (expectedController && controller !== expectedController)
+  ) {
+    return;
+  }
+  controller.destroy();
+}
+
+export function ZenModeMenuElement(props: { targetWindow: Window }) {
+  const controller = attachZenModeToWindow(props.targetWindow);
   const [label, setLabel] = createSignal(
     i18next.t("zen-mode.menu-label", { defaultValue: "Toggle Zen Mode" }),
   );
@@ -347,20 +684,20 @@ export function ZenModeMenuElement() {
     );
   });
 
-  return (
-    <>
-      <xul:menuitem
-        label={label()}
-        type="checkbox"
-        id="toggle_zenmode"
-        checked={zenModeEnabled() || undefined}
-        onCommand={() => setZenModeEnabled((prev) => !prev)}
-        accesskey="Z"
-      />
+  const handleCommand = (event?: Event) => {
+    const menuitem = event?.currentTarget as Element | null;
+    const owningWindow = menuitem?.ownerDocument?.defaultView as Window | null;
+    toggleZenModeForWindow(owningWindow ?? props.targetWindow);
+  };
 
-      <Show when={zenModeEnabled()}>
-        <style>{zenModeStyle}</style>
-      </Show>
-    </>
+  return (
+    <xul:menuitem
+      label={label()}
+      type="checkbox"
+      id="toggle_zenmode"
+      checked={controller?.enabled() || undefined}
+      onCommand={handleCommand}
+      accesskey="Z"
+    />
   );
 }

--- a/browser-features/chrome/common/zen-mode/zen-mode.tsx
+++ b/browser-features/chrome/common/zen-mode/zen-mode.tsx
@@ -362,7 +362,7 @@ export class ZenModeController {
   private measureCurrentElements(rebase: boolean): void {
     const elements = MEASURED_ELEMENTS.map((measured) =>
       this.document.getElementById(measured.id)
-    ).filter((element): element is Element => element !== null);
+    ).filter((element): element is HTMLElement => element !== null);
     this.applyMeasurements(elements, rebase);
   }
 

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Architecture Overview

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Common Chrome Features
@@ -57,7 +57,7 @@ Chrome CSS, design, ordering, tab color, UI customization, and focused UI mode f
 | designs | `browser-features/chrome/common/designs/index.ts` | `default class Designs`, `init` | Owns the designs feature through the Designs chrome component and wires `browser-design-element`. |
 | flex-order | `browser-features/chrome/common/flex-order/index.ts` | `default class FlexOrder`, `init` | Owns the flex order feature through the FlexOrder chrome component and wires `flex-order`. |
 | ui-custom | `browser-features/chrome/common/ui-custom/index.ts` | `default class UICustomization`, `init`, `initBeforeSessionStoreInit` | Owns the ui custom feature through the UICustomization chrome component and wires `styles/style-manager`, `layout/dom-manipulator`. |
-| zen-mode | `browser-features/chrome/common/zen-mode/index.ts` | `default class ZenMode`, `init` | Owns the zen mode feature through the ZenMode chrome component and wires `zen-mode`, `styleElem`. |
+| zen-mode | `browser-features/chrome/common/zen-mode/index.ts` | `default class ZenMode`, `init` | Owns the zen mode feature through the ZenMode chrome component and wires `zen-mode`, `icon.css?inline`. |
 
 ### Input & Shortcuts
 

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Common Chrome Feature Catalog
@@ -43,4 +43,4 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 | ui-custom | `browser-features/chrome/common/ui-custom/index.ts` | `default class UICustomization`, `init`, `initBeforeSessionStoreInit` | Owns the ui custom feature through the UICustomization chrome component and wires `styles/style-manager`, `layout/dom-manipulator`. |
 | undo-closed-tab | `browser-features/chrome/common/undo-closed-tab/index.ts` | `default class UndoClosedTab`, `init` | Owns the undo closed tab feature through the UndoClosedTab chrome component and wires `styleElem`. |
 | workspaces | `browser-features/chrome/common/workspaces/index.ts` | `default class Workspaces`, `init` | Owns the workspaces feature through the Workspaces chrome component and wires `workspacesTabManager`, `utils/workspace-icons`, `workspacesService`. |
-| zen-mode | `browser-features/chrome/common/zen-mode/index.ts` | `default class ZenMode`, `init` | Owns the zen mode feature through the ZenMode chrome component and wires `zen-mode`, `styleElem`. |
+| zen-mode | `browser-features/chrome/common/zen-mode/index.ts` | `default class ZenMode`, `init` | Owns the zen mode feature through the ZenMode chrome component and wires `zen-mode`, `icon.css?inline`. |

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Browser UI Customization
@@ -17,4 +17,4 @@ Chrome CSS, design, ordering, tab color, UI customization, and focused UI mode f
 | designs | `browser-features/chrome/common/designs/index.ts` | `default class Designs`, `init` | Owns the designs feature through the Designs chrome component and wires `browser-design-element`. |
 | flex-order | `browser-features/chrome/common/flex-order/index.ts` | `default class FlexOrder`, `init` | Owns the flex order feature through the FlexOrder chrome component and wires `flex-order`. |
 | ui-custom | `browser-features/chrome/common/ui-custom/index.ts` | `default class UICustomization`, `init`, `initBeforeSessionStoreInit` | Owns the ui custom feature through the UICustomization chrome component and wires `styles/style-manager`, `layout/dom-manipulator`. |
-| zen-mode | `browser-features/chrome/common/zen-mode/index.ts` | `default class ZenMode`, `init` | Owns the zen mode feature through the ZenMode chrome component and wires `zen-mode`, `styleElem`. |
+| zen-mode | `browser-features/chrome/common/zen-mode/index.ts` | `default class ZenMode`, `init` | Owns the zen mode feature through the ZenMode chrome component and wires `zen-mode`, `icon.css?inline`. |

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Common Chrome Feature Categories

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Window Actor Categories

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Settings & Internal Page Actors

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Web Content & Store Actors

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Browser Features Catalog

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Window Actor Catalog

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "7b6ff3ea8076b5a48575264ff0df6a3a14019280"
+floorp_commit: "b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `7b6ff3ea8076b5a48575264ff0df6a3a14019280`.
+Inventory generated from Floorp commit `b3410330e5b4fdf4ef2d22d0c812b88a10cd0e4c`.
 
 ## Source Precedence
 


### PR DESCRIPTION
## Summary

This is a redesigned replacement for the closed, unmerged #2578 contribution in the open #2569 batch, rebuilt on current `main`.

- make the toolbox and status bar self-sized overlays so Zen Mode reveal/retract does not reflow page content or depend on stale cached heights
- give each browser window its own Zen Mode controller; menu, toolbar, and mouse-gesture commands target the owning window, while `floorp.zenmode.enabled` only seeds future windows
- rebase positive panel-sidebar measurements, hide the stray splitter, respect reduced motion, and clean up observers, timers, styles, attributes, and UI roots on unload/HMR
- add focused browser tests and refresh only the three affected deterministic generated documentation pages

## Provenance

- Tracking issue: #2569
- Original PR: https://github.com/Floorp-Projects/Floorp/pull/2578
- Original head: `63d7210f605dd2091cf4918e211a2e208216e49c`
- Original PR state: closed and unmerged
- Original commit author: `100mountains <nobody@nowhere.com>`
- Original commit co-author trailer: `Claude Fable 5 <noreply@anthropic.com>`
- Replacement base: `410c211c202012631159d1bce1f3ab208305d2b7`
- Replacement head: `2b04ad51864bf6126d1af0b3d793036ff7d604e3`

The replacement preserves the original contribution's authorship and feature intent, but was revised for current Floorp window ownership, lifecycle, cleanup, and test contracts.

## Verification

- locked Runtime identity: Floorp/Firefox `153.0`, BuildID `20260725075208`
- exact Runtime capture: exit 0, timeout false, exact 52-byte stdout, empty stderr, no residual target process
- focused Zen browser tests: 2 passed, 0 failed
- dedicated supplied-window gesture test: 1 passed, 0 failed
- adjacent mouse-gesture regression tests: 6 passed, 0 failed
- locked real-browser proof: three windows, menu and toolbar own-window targeting, external pref writes affecting only future windows, restoration, unload cleanup, graceful quit, and zero scoped process/listener survivors
- generated docs: 23-path clean-LF scan with zero CRLF findings, deterministic verification passed, docs-pipeline tests 49 passed / 0 failed
- `git diff --check 410c211c202012631159d1bce1f3ab208305d2b7..2b04ad51864bf6126d1af0b3d793036ff7d604e3` passed
- independent Tier 1 audit: A/B/C/A all GO for Draft publication, with no P0/P1 finding

Retained verification bundle (local rescue archive): `issue-2569-rescue/20260726T230714JST/stage2/pr2578/final-commit-verification/20260728T062736JST-2b04ad51864b`; ledger SHA-256 `763FD50DD93B6D87EF9E92BCE602EFC0D0903714E16FEAAF3FFF19FB039E7351`.

## Residual validation gaps

- Physical macOS window-transform/compositor behavior has not been verified. The original contribution warned that it had only been daily-driven with `widget.macos.window-transforms.disabled = true`.
- A physical mouse gesture was not replayed; the supplied-window gesture action path is covered by the locked browser harness.
- The retained screenshot proves active-window toolbar rendering; three-window isolation is established by the Marionette state evidence rather than screenshot framing.

This must remain Draft until updated-head CI is reviewed and the macOS compositor risk is checked. This PR does not close #2569.

## Scope guardrails

The replacement changes Zen Mode implementation/tests, one mouse-gesture action/test, and three generated docs pages. It does not add package or lockfile changes, mark the contribution ready, merge it, or close the batch tracker.
