### PR TITLE
fix(i18n): restore Noraneko about strings in ja-JP

### DIFF
--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -300,7 +300,13 @@
         "openSourceLicense": "{{productName}} は、 Mozilla Public License 2.0 の下で利用可能なオープンソースソフトウェアです。 Firefox オープンソースプロジェクトやその他のオープンソースソフトウェアによって実現されています。",
         "openSourceLicenseNotice": "オープンソースライセンス",
         "versionInfo": "バージョン",
-        "license": "ライセンス"
+        "license": "ライセンス",
+        "noraneko": {
+            "logoAlt": "ブラウザーのロゴ",
+            "description": "Noraneko は Floorp 12 のテストベッドとして使用されるブラウザーです。Floorp は Firefox と Noraneko をベースにしています。",
+            "communityCredit": "Noraneko Community が ❤ を込めて開発しています",
+            "repositoryLabel": "GitHub リポジトリ: Floorp-Projects/Floorp"
+        }
     },
     "updates": {
         "title": "更新と実験",


### PR DESCRIPTION
The translation sync (bot commit 410c211c) dropped the about.noraneko subtree from ja-JP.json. The smoke test `localization_targets.test.ts` asserts it exists, so every PR based on current main fails the parity check (7 of the issue #2569 reimplementation PRs are currently blocked by this).

Restore the missing keys. This is a pure main-regression fix — no PR is responsible for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Japanese translations for the Noraneko section in About settings, including its description, community credit, logo text, and repository label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->