### PR TITLE
feat(shortcuts): add Alt-chord zen-mode toggle with schema v2 config migration

### DIFF
--- a/browser-features/chrome/common/keyboard-shortcut/config.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/config.ts
@@ -16,63 +16,50 @@ import {
   type ShortcutConfig,
   zKeyboardShortcutConfig,
 } from "./type.ts";
-import { clearLegacyConfig, migrateLegacyConfig } from "./migration.ts";
+import {
+  clearLegacyConfig,
+  migrateConfigToV2,
+  migrateLegacyConfig,
+} from "./migration.ts";
+import { createDefaultConfig } from "./defaults.ts";
 import { isRight } from "fp-ts/Either";
+
+export {
+  COMMAND_PALETTE_ACTION,
+  createDefaultConfig,
+  createDefaultShortcuts,
+  createZenModeShortcut,
+  KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+  ZEN_MODE_ACTION,
+} from "./defaults.ts";
 
 export const KEYBOARD_SHORTCUT_ENABLED_PREF = "floorp.keyboardshortcut.enabled";
 export const KEYBOARD_SHORTCUT_CONFIG_PREF = "floorp.keyboardshortcut.config";
 export const KEYBOARD_SHORTCUT_SAFE_ERROR_HANDLING_PREF =
   "floorp.keyboardshortcut.safeErrorHandling";
 
-/**
- * Returns the default keyboard shortcut map used by the extension.
- *
- * Shape: `Record<string, ShortcutConfig>` where each entry contains
- * `key`, `modifiers`, and `action`.
- *
- * The sole default mapping is the **F2** key for
- * "floorp-toggle-command-palette", with all modifiers set to `false`.
- */
-const createDefaultShortcuts = (): Record<string, ShortcutConfig> => {
-  return {
-    "floorp-toggle-command-palette": {
-      key: "F2",
-      modifiers: { alt: false, ctrl: false, meta: false, shift: false },
-      action: "floorp-toggle-command-palette",
-    },
-  };
-};
-
-export const defaultConfig: KeyboardShortcutConfig = {
-  enabled: true,
-  shortcuts: createDefaultShortcuts(),
-};
+export const defaultConfig: KeyboardShortcutConfig = createDefaultConfig();
 
 export const strDefaultConfig = JSON.stringify(defaultConfig);
 
 const normalizeConfig = (
   config: Record<string, unknown>,
 ): KeyboardShortcutConfig => {
-  return {
-    ...defaultConfig,
-    ...config,
-    shortcuts:
-      (config?.shortcuts as Record<string, ShortcutConfig> | undefined) ??
-      defaultConfig.shortcuts,
-  } as KeyboardShortcutConfig;
+  return migrateConfigToV2(config, defaultConfig);
 };
 
-const parseConfig = (jsonStr: string): KeyboardShortcutConfig => {
+export const parseConfig = (jsonStr: string): KeyboardShortcutConfig => {
   try {
     const parsed = JSON.parse(jsonStr);
-    const result = zKeyboardShortcutConfig.decode(parsed);
+    const normalized = normalizeConfig(parsed);
+    const result = zKeyboardShortcutConfig.decode(normalized);
     if (isRight(result)) {
-      return normalizeConfig(result.right);
+      return result.right;
     }
     console.warn(
       "Keyboard shortcut configuration validation failed, attempting to recover partial data",
     );
-    return normalizeConfig(parsed);
+    return normalized;
   } catch (e) {
     console.error(
       "Failed to parse keyboard shortcut configuration JSON, using default",
@@ -177,7 +164,8 @@ export const [_config, _setConfig] = createRootHMR(
 export const isEnabled = () => _enabled();
 export const setEnabled = (value: boolean) => _setEnabled(value);
 export const getConfig = () => _config();
-export const setConfig = (value: KeyboardShortcutConfig) => _setConfig(value);
+export const setConfig = (value: KeyboardShortcutConfig) =>
+  _setConfig(migrateConfigToV2(value, defaultConfig));
 
 /**
  * Experiment "ks_safe_error_handling" — wraps getAction + fn invocation

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -67,7 +67,7 @@ export class KeyboardShortcutController {
 
   private handleKeyDown = (event: KeyboardEvent): void => {
     if (!isEnabled()) return;
-    if (event.repeat || event.getModifierState("AltGraph")) return;
+    if (event.repeat || event.getModifierState?.("AltGraph")) return;
 
     this.pressedModifiers = {
       alt: event.altKey,

--- a/browser-features/chrome/common/keyboard-shortcut/controller.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/controller.ts
@@ -67,6 +67,7 @@ export class KeyboardShortcutController {
 
   private handleKeyDown = (event: KeyboardEvent): void => {
     if (!isEnabled()) return;
+    if (event.repeat || event.getModifierState("AltGraph")) return;
 
     this.pressedModifiers = {
       alt: event.altKey,

--- a/browser-features/chrome/common/keyboard-shortcut/defaults.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/defaults.ts
@@ -1,0 +1,52 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { KeyboardShortcutConfig, ShortcutConfig } from "./type.ts";
+
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs",
+);
+
+export const KEYBOARD_SHORTCUT_SCHEMA_VERSION = 2 as const;
+export const COMMAND_PALETTE_ACTION = "floorp-toggle-command-palette";
+export const ZEN_MODE_ACTION = "floorp-toggle-zen-mode";
+
+export function createZenModeShortcut(platform: string): ShortcutConfig {
+  const isMac = platform === "macosx";
+
+  return {
+    key: "KeyZ",
+    modifiers: {
+      alt: true,
+      ctrl: !isMac,
+      meta: isMac,
+      shift: false,
+    },
+    action: ZEN_MODE_ACTION,
+  };
+}
+
+export function createDefaultShortcuts(
+  platform: string = AppConstants.platform,
+): Record<string, ShortcutConfig> {
+  return {
+    [COMMAND_PALETTE_ACTION]: {
+      key: "F2",
+      modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+      action: COMMAND_PALETTE_ACTION,
+    },
+    [ZEN_MODE_ACTION]: createZenModeShortcut(platform),
+  };
+}
+
+export function createDefaultConfig(
+  platform: string = AppConstants.platform,
+): KeyboardShortcutConfig {
+  return {
+    schemaVersion: KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+    enabled: true,
+    shortcuts: createDefaultShortcuts(platform),
+  };
+}

--- a/browser-features/chrome/common/keyboard-shortcut/migration.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/migration.ts
@@ -4,6 +4,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { KeyboardShortcutConfig, ShortcutConfig } from "./type.ts";
+import {
+  createDefaultConfig,
+  KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+  ZEN_MODE_ACTION,
+} from "./defaults.ts";
 
 const LEGACY_PREF = "floorp.browser.nora.csk.data";
 
@@ -20,6 +25,47 @@ interface LegacyShortcutConfig {
 }
 
 type LegacyConfig = Record<string, LegacyShortcutConfig>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize the current JSON preference to schema version 2.
+ *
+ * Only schema-less/older configurations receive the Zen shortcut. A version 2
+ * configuration without Zen is an intentional user deletion and is preserved.
+ */
+export function migrateConfigToV2(
+  value: unknown,
+  defaults: KeyboardShortcutConfig = createDefaultConfig(),
+): KeyboardShortcutConfig {
+  const source = isRecord(value) ? value : {};
+  const sourceShortcuts = isRecord(source.shortcuts)
+    ? source.shortcuts as Record<string, ShortcutConfig>
+    : null;
+  const shortcuts = sourceShortcuts
+    ? { ...sourceShortcuts }
+    : { ...defaults.shortcuts };
+
+  if (
+    source.schemaVersion !== KEYBOARD_SHORTCUT_SCHEMA_VERSION &&
+    !Object.values(shortcuts).some((shortcut) =>
+      isRecord(shortcut) && shortcut.action === ZEN_MODE_ACTION
+    )
+  ) {
+    shortcuts[ZEN_MODE_ACTION] = defaults.shortcuts[ZEN_MODE_ACTION];
+  }
+
+  return {
+    ...source,
+    schemaVersion: KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+    enabled: typeof source.enabled === "boolean"
+      ? source.enabled
+      : defaults.enabled,
+    shortcuts,
+  } as KeyboardShortcutConfig;
+}
 
 export function migrateLegacyConfig(): KeyboardShortcutConfig | null {
   try {

--- a/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutConfig.test.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutConfig.test.ts
@@ -4,7 +4,6 @@
 import {
   assertEquals,
   assertNotEquals,
-  assert,
   runTests,
 } from "../../../test/utils/test_harness.ts";
 import type { ShortcutConfig } from "../type.ts";
@@ -17,6 +16,7 @@ import {
   KEYBOARD_SHORTCUT_CONFIG_PREF,
   setEnabled,
   setConfig,
+  parseConfig,
 } from "../config.ts";
 
 // ---------------------------------------------------------------------------
@@ -341,10 +341,11 @@ function testDefaultConfigStructure(): void {
   assertEquals(defaultConfig.enabled, true, "default config should be enabled");
   assertEquals(
     Object.keys(defaultConfig.shortcuts).length,
-    1,
-    "default config should have one shortcut",
+    2,
+    "default config should have command-palette and Zen shortcuts",
   );
-  const shortcut = Object.values(defaultConfig.shortcuts)[0];
+  assertEquals(defaultConfig.schemaVersion, 2, "default config should be v2");
+  const shortcut = defaultConfig.shortcuts["floorp-toggle-command-palette"];
   assertEquals(
     shortcut.action,
     "floorp-toggle-command-palette",
@@ -362,10 +363,13 @@ function testStrDefaultConfigIsParseable(): void {
   );
   assertEquals(
     Object.keys(parsed.shortcuts).length,
-    1,
-    "parsed default config should have one shortcut (command palette)",
+    2,
+    "parsed default config should have command-palette and Zen shortcuts",
   );
-  const parsedShortcut = Object.values(parsed.shortcuts)[0] as ShortcutConfig;
+  assertEquals(parsed.schemaVersion, 2, "parsed default config should be v2");
+  const parsedShortcut = parsed.shortcuts[
+    "floorp-toggle-command-palette"
+  ] as ShortcutConfig;
   assertEquals(
     parsedShortcut.action,
     "floorp-toggle-command-palette",
@@ -435,81 +439,23 @@ function testNormalizeConfigWithPartialConfig(): void {
 // ---------------------------------------------------------------------------
 
 function testParseConfigHandlesInvalidJson(): void {
-  const hadConfig = Services.prefs.prefHasUserValue(
-    KEYBOARD_SHORTCUT_CONFIG_PREF,
+  const parsed = parseConfig("invalid-json{{{");
+  assertEquals(parsed.schemaVersion, 2, "invalid JSON should recover to v2");
+  assertEquals(
+    Object.keys(parsed.shortcuts).length,
+    2,
+    "invalid JSON should recover to fresh F2 and Zen defaults",
   );
-  const savedConfig = hadConfig
-    ? Services.prefs.getStringPref(KEYBOARD_SHORTCUT_CONFIG_PREF)
-    : null;
-
-  try {
-    // Set invalid JSON and apply it via setConfig.
-    // parseConfig catches JSON.parse errors and returns defaultConfig,
-    // then the SolidJS effect writes the normalized default back to the pref.
-    Services.prefs.setStringPref(
-      KEYBOARD_SHORTCUT_CONFIG_PREF,
-      "invalid-json{{{",
-    );
-    setConfig({
-      enabled: true,
-      shortcuts: {},
-    });
-
-    // After setConfig, the pref should contain valid JSON (the default config),
-    // because parseConfig returned defaultConfig and the reactive effect wrote it back.
-    const currentPref = Services.prefs.getStringPref(
-      KEYBOARD_SHORTCUT_CONFIG_PREF,
-      strDefaultConfig,
-    );
-    const parsed = JSON.parse(currentPref);
-    assertEquals(
-      parsed.enabled,
-      true,
-      "invalid JSON should result in default config being written back",
-    );
-    assertEquals(
-      Object.keys(parsed.shortcuts).length,
-      0,
-      "invalid JSON should result in empty shortcuts in default config",
-    );
-  } finally {
-    if (hadConfig && savedConfig !== null) {
-      Services.prefs.setStringPref(KEYBOARD_SHORTCUT_CONFIG_PREF, savedConfig);
-    } else {
-      Services.prefs.clearUserPref(KEYBOARD_SHORTCUT_CONFIG_PREF);
-    }
-  }
 }
 
 function testParseConfigHandlesMalformedObject(): void {
-  const hadConfig = Services.prefs.prefHasUserValue(
-    KEYBOARD_SHORTCUT_CONFIG_PREF,
+  const parsed = parseConfig(JSON.stringify({ invalidField: "test" }));
+  assertEquals(parsed.schemaVersion, 2, "malformed object should migrate to v2");
+  assertEquals(
+    Object.keys(parsed.shortcuts).length,
+    2,
+    "malformed object should recover missing shortcuts from defaults",
   );
-  const savedConfig = hadConfig
-    ? Services.prefs.getStringPref(KEYBOARD_SHORTCUT_CONFIG_PREF)
-    : null;
-
-  try {
-    // Set valid JSON but missing required fields
-    Services.prefs.setStringPref(
-      KEYBOARD_SHORTCUT_CONFIG_PREF,
-      JSON.stringify({ invalidField: "test" }),
-    );
-    const currentPref = Services.prefs.getStringPref(
-      KEYBOARD_SHORTCUT_CONFIG_PREF,
-      strDefaultConfig,
-    );
-    assert(
-      currentPref.includes("invalidField"),
-      "pref should preserve the malformed object",
-    );
-  } finally {
-    if (hadConfig && savedConfig !== null) {
-      Services.prefs.setStringPref(KEYBOARD_SHORTCUT_CONFIG_PREF, savedConfig);
-    } else {
-      Services.prefs.clearUserPref(KEYBOARD_SHORTCUT_CONFIG_PREF);
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutController.test.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutController.test.ts
@@ -79,6 +79,8 @@ function dispatchKeyEvent(
     ctrlKey?: boolean;
     metaKey?: boolean;
     shiftKey?: boolean;
+    repeat?: boolean;
+    altGraph?: boolean;
   },
 ): KeyboardEvent {
   const event = new KeyboardEvent(type, {
@@ -88,9 +90,16 @@ function dispatchKeyEvent(
     ctrlKey: options.ctrlKey ?? false,
     metaKey: options.metaKey ?? false,
     shiftKey: options.shiftKey ?? false,
+    repeat: options.repeat ?? false,
     bubbles: true,
     cancelable: true,
   });
+  if (options.altGraph) {
+    Object.defineProperty(event, "getModifierState", {
+      configurable: true,
+      value: (modifier: string) => modifier === "AltGraph",
+    });
+  }
   target.dispatchEvent(event);
   return event;
 }
@@ -1369,6 +1378,84 @@ function testCapturePhaseBlocksBubbleListener(): void {
   });
 }
 
+function testPhysicalCodeMatchesNonLatinKey(): void {
+  withPrefs(() => {
+    const config: KeyboardShortcutConfig = {
+      enabled: true,
+      shortcuts: {
+        "test-physical-code": {
+          key: "KeyZ",
+          modifiers: { alt: true, ctrl: true, meta: false, shift: false },
+          action: "test-physical-code",
+        },
+      },
+    };
+    applyTestConfig(config);
+    const fakeWin = createFakeWindow();
+    const controller = new KeyboardShortcutController(fakeWin);
+    const event = dispatchKeyEvent(fakeWin, "keydown", {
+      key: "я",
+      code: "KeyZ",
+      ctrlKey: true,
+      altKey: true,
+    });
+
+    assertEquals(
+      event.defaultPrevented,
+      true,
+      "matching uses physical KeyboardEvent.code instead of the layout key",
+    );
+    controller.destroy();
+  });
+}
+
+function testRepeatIsIgnored(): void {
+  withPrefs(() => {
+    applyTestConfig(CTRL_T_CONFIG);
+    const fakeWin = createFakeWindow();
+    const controller = new KeyboardShortcutController(fakeWin);
+    const event = dispatchKeyEvent(fakeWin, "keydown", {
+      code: "KeyT",
+      ctrlKey: true,
+      repeat: true,
+    });
+
+    assertEquals(event.defaultPrevented, false, "repeat keydown is ignored");
+    controller.destroy();
+  });
+}
+
+function testAltGraphIsNotCtrlAlt(): void {
+  withPrefs(() => {
+    const config: KeyboardShortcutConfig = {
+      enabled: true,
+      shortcuts: {
+        "test-ctrl-alt-z": {
+          key: "KeyZ",
+          modifiers: { alt: true, ctrl: true, meta: false, shift: false },
+          action: "test-ctrl-alt-z",
+        },
+      },
+    };
+    applyTestConfig(config);
+    const fakeWin = createFakeWindow();
+    const controller = new KeyboardShortcutController(fakeWin);
+    const event = dispatchKeyEvent(fakeWin, "keydown", {
+      code: "KeyZ",
+      ctrlKey: true,
+      altKey: true,
+      altGraph: true,
+    });
+
+    assertEquals(
+      event.defaultPrevented,
+      false,
+      "AltGraph must not execute a Ctrl+Alt shortcut",
+    );
+    controller.destroy();
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
@@ -1564,6 +1651,12 @@ export async function runAllTests(): Promise<void> {
       name: "capture phase blocks bubble listener",
       fn: testCapturePhaseBlocksBubbleListener,
     },
+    {
+      name: "physical code matches non-Latin key",
+      fn: testPhysicalCodeMatchesNonLatinKey,
+    },
+    { name: "repeat keydown is ignored", fn: testRepeatIsIgnored },
+    { name: "AltGraph is not Ctrl+Alt", fn: testAltGraphIsNotCtrlAlt },
   ];
 
   await runTests("keyboardShortcutController.test.ts", tests);

--- a/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutSchemaV2.test.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/test/keyboardShortcutSchemaV2.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+import {
+  createDefaultConfig,
+  createZenModeShortcut,
+  KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+  ZEN_MODE_ACTION,
+} from "../defaults.ts";
+import { migrateConfigToV2 } from "../migration.ts";
+
+function testPlatformDefaults(): void {
+  const mac = createZenModeShortcut("macosx");
+  assertEquals(mac.key, "KeyZ", "mac default stores physical code");
+  assertEquals(mac.modifiers.alt, true, "mac default uses Alt");
+  assertEquals(mac.modifiers.ctrl, false, "mac default excludes Ctrl");
+  assertEquals(mac.modifiers.meta, true, "mac default uses Meta");
+
+  const windows = createZenModeShortcut("win");
+  assertEquals(windows.key, "KeyZ", "non-mac default stores physical code");
+  assertEquals(windows.modifiers.alt, true, "non-mac default uses Alt");
+  assertEquals(windows.modifiers.ctrl, true, "non-mac default uses Ctrl");
+  assertEquals(windows.modifiers.meta, false, "non-mac default excludes Meta");
+}
+
+function testFreshDefaultsAreV2(): void {
+  const defaults = createDefaultConfig("win");
+  assertEquals(
+    defaults.schemaVersion,
+    KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+    "fresh defaults use schema v2",
+  );
+  assertEquals(
+    Object.keys(defaults.shortcuts).length,
+    2,
+    "fresh defaults include F2 and Zen",
+  );
+  assert(
+    Object.hasOwn(defaults.shortcuts, ZEN_MODE_ACTION),
+    "fresh defaults include Zen",
+  );
+}
+
+function testLegacyAddsOnlyZen(): void {
+  const rebound = {
+    key: "KeyP",
+    modifiers: { alt: false, ctrl: true, meta: false, shift: true },
+    action: "floorp-toggle-command-palette",
+  };
+  const migrated = migrateConfigToV2(
+    {
+      enabled: false,
+      shortcuts: { "floorp-toggle-command-palette": rebound },
+    },
+    createDefaultConfig("win"),
+  );
+
+  assertEquals(migrated.schemaVersion, 2, "legacy config migrates to v2");
+  assertEquals(migrated.enabled, false, "legacy enabled state is preserved");
+  assertEquals(
+    JSON.stringify(migrated.shortcuts["floorp-toggle-command-palette"]),
+    JSON.stringify(rebound),
+    "legacy rebound shortcut is preserved exactly",
+  );
+  assertEquals(
+    Object.keys(migrated.shortcuts).length,
+    2,
+    "migration adds Zen without restoring other defaults",
+  );
+}
+
+function testExistingZenBindingIsPreserved(): void {
+  const reboundZen = {
+    key: "BracketRight",
+    modifiers: { alt: false, ctrl: true, meta: false, shift: true },
+    action: ZEN_MODE_ACTION,
+  };
+  const migrated = migrateConfigToV2(
+    { shortcuts: { "custom-zen-binding": reboundZen } },
+    createDefaultConfig("win"),
+  );
+
+  assertEquals(
+    JSON.stringify(migrated.shortcuts["custom-zen-binding"]),
+    JSON.stringify(reboundZen),
+    "an existing Zen binding under a custom id is not overwritten",
+  );
+  assertEquals(
+    Object.keys(migrated.shortcuts).length,
+    1,
+    "an existing Zen action does not receive a duplicate default binding",
+  );
+}
+
+function testV2DeletionPersists(): void {
+  const deleted = {
+    schemaVersion: 2,
+    enabled: true,
+    shortcuts: {},
+  } as const;
+  const firstLoad = migrateConfigToV2(deleted, createDefaultConfig("win"));
+  const restartLoad = migrateConfigToV2(
+    JSON.parse(JSON.stringify(firstLoad)),
+    createDefaultConfig("win"),
+  );
+
+  assertEquals(
+    Object.hasOwn(firstLoad.shortcuts, ZEN_MODE_ACTION),
+    false,
+    "v2 deletion is preserved on load",
+  );
+  assertEquals(
+    Object.hasOwn(restartLoad.shortcuts, ZEN_MODE_ACTION),
+    false,
+    "v2 deletion is preserved after restart serialization",
+  );
+}
+
+const tests: TestCase[] = [
+  { name: "platform defaults", fn: testPlatformDefaults },
+  { name: "fresh defaults are v2", fn: testFreshDefaultsAreV2 },
+  { name: "legacy migration adds only Zen", fn: testLegacyAddsOnlyZen },
+  {
+    name: "legacy migration preserves existing Zen binding",
+    fn: testExistingZenBindingIsPreserved,
+  },
+  { name: "v2 deletion persists", fn: testV2DeletionPersists },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("keyboardShortcutSchemaV2.test.ts", tests);
+}

--- a/browser-features/chrome/common/keyboard-shortcut/type.ts
+++ b/browser-features/chrome/common/keyboard-shortcut/type.ts
@@ -24,6 +24,9 @@ const zKeyboardShortcutConfigRequired = t.type({
 
 const zKeyboardShortcutConfigOptional = t.partial({
   enabled: t.boolean,
+  // Optional at the API boundary so callers can still supply a legacy config.
+  // All persisted configurations are normalized to version 2 before storage.
+  schemaVersion: t.literal(2),
 });
 
 export const zKeyboardShortcutConfig = t.intersection([

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/actionCatalog.ts
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/actionCatalog.ts
@@ -8,6 +8,7 @@ import type {
   KeyboardShortcutActionOption,
   KeyboardShortcutConfig,
 } from "../../types/pref.ts";
+import { createDefaultKeyboardShortcutConfig as createDefaultKeyboardShortcutConfigWithPlatform } from "../../types/pref.ts";
 
 export const INLINE_TAB_URL_ACTION_ID = "floorp-edit-tab-url" as const;
 
@@ -37,14 +38,12 @@ export function getKeyboardShortcutActionOptions(
 export function createDefaultKeyboardShortcutConfig(
   enabled: boolean,
 ): KeyboardShortcutConfig {
-  return {
-    enabled,
-    shortcuts: {
-      "floorp-toggle-command-palette": {
-        key: "F2",
-        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
-        action: "floorp-toggle-command-palette",
-      },
-    },
-  };
+  // Delegate to the single source of truth in pref.ts, which requires a
+  // platform string. Detect platform the same way the settings hook does.
+  const platform = typeof navigator !== "undefined" &&
+      navigator.platform.toUpperCase().includes("MAC")
+    ? "macosx"
+    : "other";
+
+  return createDefaultKeyboardShortcutConfigWithPlatform(enabled, platform);
 }

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutEditor.tsx
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutEditor.tsx
@@ -50,6 +50,16 @@ export const ShortcutEditor = ({
         return code.replace(/^(Key|Digit|Arrow)/, "");
     };
 
+    const normalizeKeyCode = (code: string): string => {
+        if (/^[A-Z]$/.test(code)) {
+            return `Key${code}`;
+        }
+        if (/^[0-9]$/.test(code)) {
+            return `Digit${code}`;
+        }
+        return code;
+    };
+
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             e.preventDefault();
@@ -80,7 +90,7 @@ export const ShortcutEditor = ({
     const checkDuplicate = (key: string) => {
         const newShortcut = {
             ...shortcut,
-            key,
+            key: normalizeKeyCode(key),
         };
 
         const otherShortcuts = existingShortcuts.filter(
@@ -88,8 +98,9 @@ export const ShortcutEditor = ({
         );
 
         const isDuplicate = otherShortcuts.some((existing) => {
+            const normalizedExistingKey = normalizeKeyCode(existing.key);
             return (
-                existing.key === newShortcut.key &&
+                normalizedExistingKey === newShortcut.key &&
                 existing.modifiers.alt === newShortcut.modifiers.alt &&
                 existing.modifiers.ctrl === newShortcut.modifiers.ctrl &&
                 existing.modifiers.meta === newShortcut.modifiers.meta &&

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutEditor.tsx
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutEditor.tsx
@@ -5,7 +5,10 @@
 
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { ShortcutConfig } from "../../../types/pref.ts";
+import {
+    getRecordedShortcutCode,
+    type ShortcutConfig,
+} from "../../../types/pref.ts";
 import { Input } from "@/components/common/input.tsx";
 import { formatModifierLabel, formatModifierSymbol } from "../platform.ts";
 
@@ -52,24 +55,17 @@ export const ShortcutEditor = ({
             e.preventDefault();
             e.stopPropagation();
 
-            if (
-                e.code.startsWith("Alt") ||
-                e.code.startsWith("Control") ||
-                e.code.startsWith("Meta") ||
-                e.code.startsWith("Shift")
-            ) {
+            const code = getRecordedShortcutCode(e);
+            if (!code) {
                 return;
             }
 
-            const code = e.code;
-            const newKey = code.replace(/^(Key|Digit)/, "");
-
             setShortcut((prev) => ({
                 ...prev,
-                key: newKey,
+                key: code,
             }));
             setIsRecording(false);
-            checkDuplicate(newKey);
+            checkDuplicate(code);
         };
 
         if (isOpen && isRecording) {
@@ -251,4 +247,4 @@ export const ShortcutEditor = ({
             </div>
         </div>
     );
-}; 
+};

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutsSettings.tsx
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/components/ShortcutsSettings.tsx
@@ -20,6 +20,10 @@ import { Keyboard } from "lucide-react";
 import { InfoTip } from "@/components/common/infotip.tsx";
 import { formatModifierSymbol } from "../platform.ts";
 
+function formatKeyCode(code: string): string {
+    return code.replace(/^(Key|Digit|Arrow)/, "").toUpperCase();
+}
+
 interface ShortcutsSettingsProps {
     config: KeyboardShortcutConfig;
     addShortcut: (action: string, shortcut: ShortcutConfig) => void;
@@ -94,7 +98,7 @@ export const ShortcutsSettings = ({
                                                     {shortcut.modifiers.ctrl && <span>{formatModifierSymbol("ctrl")}</span>}
                                                     {shortcut.modifiers.meta && <span>{formatModifierSymbol("meta")}</span>}
                                                     {shortcut.modifiers.shift && <span>{formatModifierSymbol("shift")}</span>}
-                                                    <span>{shortcut.key.toUpperCase()}</span>
+                                                    <span>{formatKeyCode(shortcut.key)}</span>
                                                 </div>
                                             ) : (
                                                 <span className="text-base-content/50">

--- a/browser-features/pages-settings/src/app/keyboard-shortcut/dataManager.ts
+++ b/browser-features/pages-settings/src/app/keyboard-shortcut/dataManager.ts
@@ -5,14 +5,42 @@
 
 import { useEffect, useState } from "react";
 import { rpc } from "../../lib/rpc/rpc.ts";
-import type {
-  KeyboardShortcutConfig,
-  ShortcutConfig,
+import {
+  createDefaultKeyboardShortcutConfig,
+  KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+  parseKeyboardShortcutConfig,
+  serializeKeyboardShortcutConfig,
+  type KeyboardShortcutConfig,
+  type ShortcutConfig,
 } from "../../types/pref.ts";
-import { createDefaultKeyboardShortcutConfig } from "./actionCatalog.ts";
+
+declare const ChromeUtils:
+  | {
+    importESModule: (uri: string) => {
+      AppConstants: { platform: string };
+    };
+  }
+  | undefined;
 
 const KEYBOARD_SHORTCUT_ENABLED_PREF = "floorp.keyboardshortcut.enabled";
 const KEYBOARD_SHORTCUT_CONFIG_PREF = "floorp.keyboardshortcut.config";
+
+export function getKeyboardShortcutPlatform(): string {
+  try {
+    if (typeof ChromeUtils !== "undefined") {
+      return ChromeUtils.importESModule(
+        "resource://gre/modules/AppConstants.sys.mjs",
+      ).AppConstants.platform;
+    }
+  } catch (error) {
+    console.error("Failed to read AppConstants.platform", error);
+  }
+
+  return typeof navigator !== "undefined" &&
+      navigator.platform.toUpperCase().includes("MAC")
+    ? "macosx"
+    : "other";
+}
 
 export const useKeyboardShortcutConfig = () => {
   const [config, setConfig] = useState<KeyboardShortcutConfig>(
@@ -34,25 +62,35 @@ export const useKeyboardShortcutConfig = () => {
           enabled = true;
         }
 
-        const defaultConfig = createDefaultKeyboardShortcutConfig(enabled);
-
         try {
+          const platform = getKeyboardShortcutPlatform();
           const configStr = await rpc.getStringPref(
             KEYBOARD_SHORTCUT_CONFIG_PREF,
           );
-          if (configStr) {
-            const parsedConfig = JSON.parse(configStr);
-            setConfig({
-              ...defaultConfig,
-              ...parsedConfig,
-              enabled,
-            });
-          } else {
-            setConfig(defaultConfig);
+          const loadedConfig = parseKeyboardShortcutConfig(
+            configStr,
+            enabled,
+            platform,
+          );
+          const serializedConfig = serializeKeyboardShortcutConfig(
+            loadedConfig,
+          );
+
+          if (configStr !== serializedConfig) {
+            await rpc.setStringPref(
+              KEYBOARD_SHORTCUT_CONFIG_PREF,
+              serializedConfig,
+            );
           }
+          setConfig(loadedConfig);
         } catch (parseError) {
-          console.error("Failed to parse configuration", parseError);
-          setConfig(defaultConfig);
+          console.error("Failed to load configuration", parseError);
+          setConfig(
+            createDefaultKeyboardShortcutConfig(
+              enabled,
+              getKeyboardShortcutPlatform(),
+            ),
+          );
         }
       } catch (error) {
         console.error("Failed to load configuration", error);
@@ -66,15 +104,20 @@ export const useKeyboardShortcutConfig = () => {
 
   const saveConfig = async (newConfig: KeyboardShortcutConfig) => {
     try {
-      await rpc.setBoolPref(KEYBOARD_SHORTCUT_ENABLED_PREF, newConfig.enabled);
-      const configToSave = { ...newConfig };
-      const { enabled: _, ...configWithoutEnabled } = configToSave;
+      const normalizedConfig: KeyboardShortcutConfig = {
+        ...newConfig,
+        schemaVersion: KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+      };
+      await rpc.setBoolPref(
+        KEYBOARD_SHORTCUT_ENABLED_PREF,
+        normalizedConfig.enabled,
+      );
       await rpc.setStringPref(
         KEYBOARD_SHORTCUT_CONFIG_PREF,
-        JSON.stringify(configWithoutEnabled),
+        serializeKeyboardShortcutConfig(normalizedConfig),
       );
 
-      setConfig(newConfig);
+      setConfig(normalizedConfig);
       return true;
     } catch (error) {
       console.error("Failed to save configuration", error);

--- a/browser-features/pages-settings/src/types/pref.ts
+++ b/browser-features/pages-settings/src/types/pref.ts
@@ -219,6 +219,7 @@ export const zShortcutConfig = t.type({
 });
 
 export const zKeyboardShortcutConfig = t.type({
+  schemaVersion: t.literal(2),
   enabled: t.boolean,
   shortcuts: t.record(t.string, zShortcutConfig),
 });
@@ -235,6 +236,123 @@ export interface KeyboardShortcutActionDefinition {
 export interface KeyboardShortcutActionOption {
   id: string;
   name: string;
+}
+
+export const KEYBOARD_SHORTCUT_SCHEMA_VERSION = 2 as const;
+export const ZEN_MODE_ACTION = "floorp-toggle-zen-mode";
+
+function isKeyboardShortcutRecord(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function createDefaultKeyboardShortcutConfig(
+  enabled: boolean,
+  platform: string,
+): KeyboardShortcutConfig {
+  const isMac = platform === "macosx";
+
+  return {
+    schemaVersion: KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+    enabled,
+    shortcuts: {
+      "floorp-toggle-command-palette": {
+        key: "F2",
+        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+        action: "floorp-toggle-command-palette",
+      },
+      [ZEN_MODE_ACTION]: {
+        key: "KeyZ",
+        modifiers: {
+          alt: true,
+          ctrl: !isMac,
+          meta: isMac,
+          shift: false,
+        },
+        action: ZEN_MODE_ACTION,
+      },
+    },
+  };
+}
+
+export function migrateKeyboardShortcutConfig(
+  value: unknown,
+  enabled: boolean,
+  platform: string,
+): KeyboardShortcutConfig {
+  const defaults = createDefaultKeyboardShortcutConfig(enabled, platform);
+  const source = isKeyboardShortcutRecord(value) ? value : {};
+  const sourceShortcuts = isKeyboardShortcutRecord(source.shortcuts)
+    ? source.shortcuts as Record<string, ShortcutConfig>
+    : null;
+  const shortcuts = sourceShortcuts
+    ? { ...sourceShortcuts }
+    : { ...defaults.shortcuts };
+
+  if (
+    source.schemaVersion !== KEYBOARD_SHORTCUT_SCHEMA_VERSION &&
+    !Object.values(shortcuts).some((shortcut) =>
+      isKeyboardShortcutRecord(shortcut) &&
+      shortcut.action === ZEN_MODE_ACTION
+    )
+  ) {
+    shortcuts[ZEN_MODE_ACTION] = defaults.shortcuts[ZEN_MODE_ACTION];
+  }
+
+  return {
+    ...source,
+    schemaVersion: KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+    enabled,
+    shortcuts,
+  } as KeyboardShortcutConfig;
+}
+
+export function parseKeyboardShortcutConfig(
+  value: string | null,
+  enabled: boolean,
+  platform: string,
+): KeyboardShortcutConfig {
+  if (!value) {
+    return createDefaultKeyboardShortcutConfig(enabled, platform);
+  }
+
+  try {
+    return migrateKeyboardShortcutConfig(JSON.parse(value), enabled, platform);
+  } catch (error) {
+    console.error("Failed to parse configuration", error);
+    return createDefaultKeyboardShortcutConfig(enabled, platform);
+  }
+}
+
+export function serializeKeyboardShortcutConfig(
+  config: KeyboardShortcutConfig,
+): string {
+  const normalized = {
+    ...config,
+    schemaVersion: KEYBOARD_SHORTCUT_SCHEMA_VERSION,
+  };
+  const { enabled: _, ...configWithoutEnabled } = normalized;
+  return JSON.stringify(configWithoutEnabled);
+}
+
+export function getRecordedShortcutCode(
+  event: Pick<KeyboardEvent, "code" | "repeat" | "getModifierState">,
+): string | null {
+  if (event.repeat || event.getModifierState("AltGraph")) {
+    return null;
+  }
+
+  if (
+    event.code.startsWith("Alt") ||
+    event.code.startsWith("Control") ||
+    event.code.startsWith("Meta") ||
+    event.code.startsWith("Shift")
+  ) {
+    return null;
+  }
+
+  return event.code || null;
 }
 
 export const zKeyboardShortcutFormData = zKeyboardShortcutConfig;

--- a/browser-features/pages-settings/test/app/keyboard-shortcut/inlineUrlAction.test.ts
+++ b/browser-features/pages-settings/test/app/keyboard-shortcut/inlineUrlAction.test.ts
@@ -91,6 +91,7 @@ function testPagesDefaultConfigIsUnchanged(): void {
   assertEquals(
     JSON.stringify(createDefaultKeyboardShortcutConfig(false)),
     JSON.stringify({
+      schemaVersion: 2,
       enabled: false,
       shortcuts: {
         "floorp-toggle-command-palette": {

--- a/browser-features/pages-settings/test/app/keyboard-shortcut/inlineUrlAction.test.ts
+++ b/browser-features/pages-settings/test/app/keyboard-shortcut/inlineUrlAction.test.ts
@@ -67,18 +67,26 @@ function testPagesDefaultConfigIsUnchanged(): void {
   const firstEnabledDefault = createDefaultKeyboardShortcutConfig(true);
   const secondEnabledDefault = createDefaultKeyboardShortcutConfig(true);
   assertEquals(
-    JSON.stringify(firstEnabledDefault),
-    JSON.stringify({
-      enabled: true,
-      shortcuts: {
-        "floorp-toggle-command-palette": {
-          key: "F2",
-          modifiers: { alt: false, ctrl: false, meta: false, shift: false },
-          action: "floorp-toggle-command-palette",
-        },
-      },
-    }),
-    "enabled default config should retain the existing F2 binding only",
+    firstEnabledDefault.enabled,
+    true,
+    "enabled default config should be enabled",
+  );
+  assertEquals(
+    Object.keys(firstEnabledDefault.shortcuts).length,
+    2,
+    "enabled default config should have command-palette and Zen shortcuts",
+  );
+  const paletteShortcut = firstEnabledDefault.shortcuts["floorp-toggle-command-palette"];
+  assertEquals(
+    paletteShortcut.action,
+    "floorp-toggle-command-palette",
+    "default shortcut action should be floorp-toggle-command-palette",
+  );
+  assertEquals(paletteShortcut.key, "F2", "default shortcut key should be F2");
+  assertEquals(
+    firstEnabledDefault.shortcuts["floorp-toggle-zen-mode"].action,
+    "floorp-toggle-zen-mode",
+    "default config should include Zen mode shortcut",
   );
   assertEquals(
     JSON.stringify(createDefaultKeyboardShortcutConfig(false)),
@@ -89,6 +97,16 @@ function testPagesDefaultConfigIsUnchanged(): void {
           key: "F2",
           modifiers: { alt: false, ctrl: false, meta: false, shift: false },
           action: "floorp-toggle-command-palette",
+        },
+        "floorp-toggle-zen-mode": {
+          key: "KeyZ",
+          modifiers: {
+            alt: true,
+            ctrl: typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC") ? false : true,
+            meta: typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC") ? true : false,
+            shift: false,
+          },
+          action: "floorp-toggle-zen-mode",
         },
       },
     }),

--- a/browser-features/pages-settings/test/app/keyboard-shortcut/keyboardShortcutEditorPolicy.test.ts
+++ b/browser-features/pages-settings/test/app/keyboard-shortcut/keyboardShortcutEditorPolicy.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+import { getRecordedShortcutCode } from "../../../src/types/pref.ts";
+
+function eventPolicy(
+  code: string,
+  options: { repeat?: boolean; altGraph?: boolean } = {},
+): Pick<KeyboardEvent, "code" | "repeat" | "getModifierState"> {
+  return {
+    code,
+    repeat: options.repeat ?? false,
+    getModifierState: (modifier: string) =>
+      modifier === "AltGraph" && options.altGraph === true,
+  };
+}
+
+const tests: TestCase[] = [
+  {
+    name: "records exact physical code",
+    fn: () =>
+      assertEquals(
+        getRecordedShortcutCode(eventPolicy("KeyZ")),
+        "KeyZ",
+        "recording stores KeyboardEvent.code without layout conversion",
+      ),
+  },
+  {
+    name: "records non-letter physical code",
+    fn: () =>
+      assertEquals(
+        getRecordedShortcutCode(eventPolicy("Semicolon")),
+        "Semicolon",
+        "recording preserves punctuation physical code",
+      ),
+  },
+  {
+    name: "ignores repeat",
+    fn: () =>
+      assertEquals(
+        getRecordedShortcutCode(eventPolicy("KeyZ", { repeat: true })),
+        null,
+        "repeat keydown is ignored while recording",
+      ),
+  },
+  {
+    name: "ignores AltGraph",
+    fn: () =>
+      assertEquals(
+        getRecordedShortcutCode(eventPolicy("KeyZ", { altGraph: true })),
+        null,
+        "AltGraph is not recorded as Ctrl+Alt",
+      ),
+  },
+  {
+    name: "ignores pure modifier",
+    fn: () =>
+      assertEquals(
+        getRecordedShortcutCode(eventPolicy("AltRight")),
+        null,
+        "pure modifiers do not finish recording",
+      ),
+  },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("keyboardShortcutEditorPolicy.test.ts", tests);
+}

--- a/browser-features/pages-settings/test/app/keyboard-shortcut/keyboardShortcutMigration.test.ts
+++ b/browser-features/pages-settings/test/app/keyboard-shortcut/keyboardShortcutMigration.test.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+import {
+  createDefaultKeyboardShortcutConfig,
+  migrateKeyboardShortcutConfig,
+  parseKeyboardShortcutConfig,
+  serializeKeyboardShortcutConfig,
+  ZEN_MODE_ACTION,
+} from "../../../src/types/pref.ts";
+
+function testFreshPlatformDefaults(): void {
+  const mac = createDefaultKeyboardShortcutConfig(true, "macosx");
+  const macZen = mac.shortcuts[ZEN_MODE_ACTION];
+  assertEquals(mac.schemaVersion, 2, "fresh mac config is v2");
+  assertEquals(macZen.key, "KeyZ", "fresh mac config stores physical code");
+  assertEquals(macZen.modifiers.alt, true, "mac Zen uses Alt");
+  assertEquals(macZen.modifiers.meta, true, "mac Zen uses Meta");
+  assertEquals(macZen.modifiers.ctrl, false, "mac Zen excludes Ctrl");
+
+  const windows = createDefaultKeyboardShortcutConfig(true, "win");
+  const windowsZen = windows.shortcuts[ZEN_MODE_ACTION];
+  assertEquals(windowsZen.modifiers.alt, true, "non-mac Zen uses Alt");
+  assertEquals(windowsZen.modifiers.ctrl, true, "non-mac Zen uses Ctrl");
+  assertEquals(windowsZen.modifiers.meta, false, "non-mac Zen excludes Meta");
+}
+
+function testLegacyMigrationPreservesRebinding(): void {
+  const rebound = {
+    key: "KeyP",
+    modifiers: { alt: false, ctrl: true, meta: false, shift: true },
+    action: "floorp-toggle-command-palette",
+  };
+  const migrated = migrateKeyboardShortcutConfig(
+    { shortcuts: { "floorp-toggle-command-palette": rebound } },
+    false,
+    "win",
+  );
+
+  assertEquals(migrated.schemaVersion, 2, "legacy settings migrate to v2");
+  assertEquals(migrated.enabled, false, "separate enabled pref wins");
+  assertEquals(
+    JSON.stringify(migrated.shortcuts["floorp-toggle-command-palette"]),
+    JSON.stringify(rebound),
+    "rebound shortcut is preserved exactly",
+  );
+  assert(
+    Object.hasOwn(migrated.shortcuts, ZEN_MODE_ACTION),
+    "legacy settings receive Zen once",
+  );
+}
+
+function testExistingZenBindingIsPreserved(): void {
+  const reboundZen = {
+    key: "Semicolon",
+    modifiers: { alt: false, ctrl: true, meta: false, shift: true },
+    action: ZEN_MODE_ACTION,
+  };
+  const migrated = migrateKeyboardShortcutConfig(
+    { shortcuts: { "custom-zen-binding": reboundZen } },
+    true,
+    "win",
+  );
+
+  assertEquals(
+    JSON.stringify(migrated.shortcuts["custom-zen-binding"]),
+    JSON.stringify(reboundZen),
+    "legacy migration does not overwrite an existing Zen binding under a custom id",
+  );
+  assertEquals(
+    Object.keys(migrated.shortcuts).length,
+    1,
+    "settings migration does not add a duplicate default Zen binding",
+  );
+}
+
+function testV2DeletionSurvivesRoundTrip(): void {
+  const deleted = {
+    schemaVersion: 2 as const,
+    enabled: true,
+    shortcuts: {
+      "floorp-toggle-command-palette": {
+        key: "F2",
+        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+        action: "floorp-toggle-command-palette",
+      },
+    },
+  };
+  const saved = serializeKeyboardShortcutConfig(deleted);
+  const reopened = parseKeyboardShortcutConfig(saved, true, "win");
+  const restarted = migrateKeyboardShortcutConfig(
+    JSON.parse(serializeKeyboardShortcutConfig(reopened)),
+    true,
+    "win",
+  );
+
+  assertEquals(
+    JSON.parse(saved).schemaVersion,
+    2,
+    "settings save persists schema v2",
+  );
+  assertEquals(
+    Object.hasOwn(reopened.shortcuts, ZEN_MODE_ACTION),
+    false,
+    "settings reopen preserves Zen deletion",
+  );
+  assertEquals(
+    Object.hasOwn(restarted.shortcuts, ZEN_MODE_ACTION),
+    false,
+    "browser restart preserves Zen deletion",
+  );
+}
+
+function testInvalidJsonRecoversToV2Defaults(): void {
+  const recovered = parseKeyboardShortcutConfig("not-json{{", true, "win");
+  assertEquals(recovered.schemaVersion, 2, "invalid JSON recovers to v2");
+  assertEquals(
+    Object.keys(recovered.shortcuts).length,
+    2,
+    "invalid JSON recovers to F2 and Zen defaults",
+  );
+}
+
+const tests: TestCase[] = [
+  { name: "fresh platform defaults", fn: testFreshPlatformDefaults },
+  {
+    name: "legacy migration preserves rebinding",
+    fn: testLegacyMigrationPreservesRebinding,
+  },
+  {
+    name: "legacy migration preserves existing Zen",
+    fn: testExistingZenBindingIsPreserved,
+  },
+  {
+    name: "v2 deletion survives round trip",
+    fn: testV2DeletionSurvivesRoundTrip,
+  },
+  {
+    name: "invalid JSON recovers to v2 defaults",
+    fn: testInvalidJsonRecoversToV2Defaults,
+  },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("keyboardShortcutMigration.test.ts", tests);
+}

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Architecture Overview

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Common Chrome Features

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Common Chrome Feature Catalog

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Browser UI Customization

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Common Chrome Feature Categories

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Window Actor Categories

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Settings & Internal Page Actors

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Web Content & Store Actors

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Browser Features Catalog

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Window Actor Catalog

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
+floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `ea5bb3140953f994c5295280b4cfd4d52a91245c`.
+Inventory generated from Floorp commit `94fbc9c258f5d412c4c43506b51702f3bdc7ba47`.
 
 ## Source Precedence
 


### PR DESCRIPTION
Reimplements the zen-mode key part of derp fork PR #2575 for issue #2569.

Adds a default keyboard shortcut to toggle Zen Mode: **Ctrl+Alt+Z** on Windows/Linux, **Cmd+Alt+Z** on macOS (platform Alt chord, same family as the window-drag chord).

Config schema v2:
- \schemaVersion: 2\ stamped on the persisted config
- New default shortcuts merge into saved configs; a v2 config without Zen is treated as an intentional user deletion (not resurrected)
- \migrateConfigToV2\ in the chrome layer and \migrateKeyboardShortcutConfig\ in settings share identical semantics

Also:
- \vent.repeat\ / AltGraph events are ignored by the shortcut controller (prevents AltGr-as-Ctrl+Alt false positives on non-Latin layouts) — complementary to the typing guard from #2604
- Settings editor records full key codes (\KeyZ\/\Digit1\) with cross-format duplicate detection vs legacy stripped keys
- Unifies \createDefaultKeyboardShortcutConfig\ (single source of truth in \	ypes/pref.ts\)
- Tests: schema migration, editor policy, controller repeat/AltGraph guards

Related: #2614 (zen-mode per-window controller), #2604 (typing guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zen Mode and command palette shortcuts by default.
  * Added platform-specific shortcut defaults, including macOS support.
  * Added automatic migration and recovery for older or invalid configurations.
  * Improved shortcut recording and display for physical key codes.

* **Bug Fixes**
  * Repeated key presses and AltGraph-modified events are now ignored.
  * Improved duplicate shortcut detection and preservation of custom bindings.

* **Tests**
  * Added coverage for migration, platform defaults, shortcut recording, and key-event handling.

* **Documentation**
  * Updated generated documentation references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->