### PR TITLE
feat(workspaces): add canonical icon registry and searchable icon picker

### DIFF
--- a/browser-features/chrome/common/modal-parent/test/modalParent.test.ts
+++ b/browser-features/chrome/common/modal-parent/test/modalParent.test.ts
@@ -10,6 +10,7 @@ import {
 import ModalParent from "../index.ts";
 import { isModalVisible, setModalVisible } from "../data/data.ts";
 import { attachModalBackdropListener } from "../modalElement.tsx";
+import type { TFormItem } from "../utils/type.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers – save/restore modal visibility state
@@ -201,12 +202,13 @@ function testTFormItemAllTypes(): void {
     "textarea",
     "select",
     "dropdown",
+    "workspace-icon-picker",
     "checkbox",
     "radio",
     "url",
   ] as const;
 
-  assertEquals(types.length, 8, "TFormItem should support 8 types");
+  assertEquals(types.length, 9, "TFormItem should support 9 types");
   for (const t of types) {
     assert(typeof t === "string", `type ${t} should be a string`);
   }
@@ -273,12 +275,52 @@ function testTFormItemAllTypesWithStructure(): void {
     { type: "textarea", appropriateFields: ["rows", "maxLength"] },
     { type: "select", appropriateFields: ["options"] },
     { type: "dropdown", appropriateFields: ["options"] },
+    {
+      type: "workspace-icon-picker",
+      appropriateFields: ["options", "displayValue", "value"],
+    },
     { type: "checkbox", appropriateFields: ["value"] },
     { type: "radio", appropriateFields: ["options"] },
     { type: "url", appropriateFields: ["placeholder"] },
   ];
 
-  assertEquals(types.length, 8, "all 8 types covered");
+  assertEquals(types.length, 9, "all 9 types covered");
+}
+
+function testWorkspaceIconPickerTransportIsCanonicalOnly(): void {
+  const rawStoredValue = "https://example.invalid/raw-workspace-icon.svg";
+  const item: TFormItem = {
+    type: "workspace-icon-picker",
+    id: "icon",
+    label: "Icon",
+    value: "__private_no_change__",
+    displayValue: "floorp-icon:v1:fingerprint",
+    options: [
+      {
+        value: "floorp-icon:v1:fingerprint",
+        label: "Fingerprint",
+        icon: "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+        keywords: ["identity", "default"],
+      },
+    ],
+  };
+  const transported = JSON.parse(JSON.stringify(item)) as TFormItem;
+  assertEquals(transported.type, "workspace-icon-picker", "dedicated type");
+  assertEquals(transported.value, "__private_no_change__", "sentinel survives");
+  assertEquals(
+    transported.displayValue,
+    "floorp-icon:v1:fingerprint",
+    "safe display ID survives",
+  );
+  assertEquals(
+    transported.options?.[0].value,
+    "floorp-icon:v1:fingerprint",
+    "only canonical option is transported",
+  );
+  assert(
+    !JSON.stringify(transported).includes(rawStoredValue),
+    "raw stored value is not transported to the child",
+  );
 }
 
 function testTFormResultEmpty(): void {
@@ -499,7 +541,7 @@ const tests: TestCase[] = [
     name: "TForm with submit/cancel labels",
     fn: testTFormWithSubmitCancelLabels,
   },
-  { name: "TFormItem supports 8 types", fn: testTFormItemAllTypes },
+  { name: "TFormItem supports 9 types", fn: testTFormItemAllTypes },
   { name: "TFormResult key-value", fn: testTFormResultKeyValue },
   {
     name: "TFormItem all optional fields",
@@ -509,6 +551,10 @@ const tests: TestCase[] = [
   {
     name: "TFormItem all types with structure",
     fn: testTFormItemAllTypesWithStructure,
+  },
+  {
+    name: "workspace icon picker transport is canonical only",
+    fn: testWorkspaceIconPickerTransportIsCanonicalOnly,
   },
   { name: "TFormResult empty", fn: testTFormResultEmpty },
   { name: "TFormResult multiple fields", fn: testTFormResultMultipleFields },

--- a/browser-features/chrome/common/modal-parent/utils/type.ts
+++ b/browser-features/chrome/common/modal-parent/utils/type.ts
@@ -1,3 +1,10 @@
+export interface TFormOption {
+  label: string;
+  value: string;
+  icon?: string;
+  keywords?: string[];
+}
+
 export interface TFormItem {
   type:
     | "text"
@@ -5,22 +12,20 @@ export interface TFormItem {
     | "textarea"
     | "select"
     | "dropdown"
+    | "workspace-icon-picker"
     | "checkbox"
     | "radio"
     | "url";
   id: string;
   label?: string;
   value?: string | number;
+  displayValue?: string;
   required?: boolean;
   classList?: string;
   placeholder?: string;
   rows?: number;
   maxLength?: number;
-  options?: Array<{
-    label: string;
-    value: string;
-    icon?: string;
-  }>;
+  options?: TFormOption[];
   when?: {
     id: string;
     value: string | string[];

--- a/browser-features/chrome/common/workspaces/test/workspaceIconRawValue.test.ts
+++ b/browser-features/chrome/common/workspaces/test/workspaceIconRawValue.test.ts
@@ -1,0 +1,614 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  applyWorkspaceIconSelection,
+  isCanonicalWorkspaceIconId,
+  WorkspaceIcons,
+} from "../utils/workspace-icons.ts";
+import { setWorkspacesDataStore, workspacesDataStore } from "../data/data.ts";
+import type {
+  TWorkspace,
+  TWorkspaceID,
+  TWorkspacesStoreData,
+} from "../utils/type.ts";
+import {
+  applyWorkspaceModalResult,
+  createWorkspaceIconPickerFormItem,
+} from "../workspace-modal.tsx";
+import { WorkspacesService } from "../workspacesService.ts";
+import { WORKSPACE_DATA_PREF_NAME } from "../utils/workspaces-static-names.ts";
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+
+const makeWorkspace = (): Omit<TWorkspace, "icon"> => ({
+  name: "Raw icon",
+  userContextId: 0,
+  isSelected: null,
+  isDefault: null,
+});
+
+const assertSameRawIconSlot = (
+  expected: TWorkspace,
+  actual: TWorkspace,
+  label: string,
+): void => {
+  assertEquals(
+    Object.hasOwn(actual, "icon"),
+    Object.hasOwn(expected, "icon"),
+    `${label} presence`,
+  );
+  if (Object.hasOwn(expected, "icon")) {
+    assertEquals(actual.icon, expected.icon, `${label} value`);
+  }
+};
+
+function testNoChangePreservesEveryRawCategory(): void {
+  const cases: Array<[string, TWorkspace]> = [
+    ["absent", makeWorkspace()],
+    ["own undefined", { ...makeWorkspace(), icon: undefined }],
+    ["null", { ...makeWorkspace(), icon: null }],
+    ["alias", { ...makeWorkspace(), icon: "article" }],
+    ["canonical", { ...makeWorkspace(), icon: "floorp-icon:v1:article" }],
+    ["opaque", { ...makeWorkspace(), icon: "future:workspace-icon" }],
+    ["URI", { ...makeWorkspace(), icon: "https://example.invalid/icon.svg" }],
+    ["raw data URI", { ...makeWorkspace(), icon: "data:image/svg+xml,<svg/>" }],
+  ];
+  for (const [label, workspace] of cases) {
+    const unchanged = applyWorkspaceIconSelection(
+      workspace,
+      "__floorp_workspace_icon_picker_no_change__",
+    );
+    assertSameRawIconSlot(workspace, unchanged, label);
+  }
+}
+
+function testInvalidPickerResultsPreserveRawSlot(): void {
+  const workspace: TWorkspace = { ...makeWorkspace(), icon: "article" };
+  for (
+    const candidate of [
+      null,
+      undefined,
+      "article",
+      "floorp-icon:v1:unknown",
+      "https://example.invalid/icon.svg",
+    ]
+  ) {
+    assertSameRawIconSlot(
+      workspace,
+      applyWorkspaceIconSelection(workspace, candidate),
+      `invalid ${String(candidate)}`,
+    );
+  }
+}
+
+function testExplicitCanonicalSelectionOverwritesEveryCategory(): void {
+  const selected = "floorp-icon:v1:music";
+  assert(isCanonicalWorkspaceIconId(selected), "selection is canonical");
+  const cases: TWorkspace[] = [
+    makeWorkspace(),
+    { ...makeWorkspace(), icon: undefined },
+    { ...makeWorkspace(), icon: null },
+    { ...makeWorkspace(), icon: "article" },
+    { ...makeWorkspace(), icon: "floorp-icon:v1:article" },
+    { ...makeWorkspace(), icon: "opaque" },
+  ];
+  for (const workspace of cases) {
+    const changed = applyWorkspaceIconSelection(workspace, selected);
+    assert(
+      Object.hasOwn(changed, "icon"),
+      "explicit selection creates icon slot",
+    );
+    assertEquals(
+      changed.icon,
+      selected,
+      "explicit selection stores canonical ID",
+    );
+  }
+}
+
+function testJsonCategoriesDoNotCollapseToNull(): void {
+  const absent = JSON.parse(JSON.stringify(makeWorkspace())) as Record<
+    string,
+    unknown
+  >;
+  const ownUndefined = JSON.parse(
+    JSON.stringify({ ...makeWorkspace(), icon: undefined }),
+  ) as Record<string, unknown>;
+  const explicitNull = JSON.parse(
+    JSON.stringify({ ...makeWorkspace(), icon: null }),
+  ) as Record<string, unknown>;
+  const opaque = JSON.parse(
+    JSON.stringify({ ...makeWorkspace(), icon: "future:value" }),
+  ) as Record<string, unknown>;
+  assert(!Object.hasOwn(absent, "icon"), "absent icon stays omitted in JSON");
+  assert(
+    !Object.hasOwn(ownUndefined, "icon"),
+    "own undefined becomes absent in JSON, not null",
+  );
+  assertEquals(explicitNull.icon, null, "explicit null stays null in JSON");
+  assertEquals(
+    opaque.icon,
+    "future:value",
+    "opaque strings round-trip exactly",
+  );
+}
+
+function testModalFormNeverTransportsRawStoredValue(): void {
+  const icons = new WorkspaceIcons();
+  const base = makeWorkspace();
+  const cases: Array<[string, TWorkspace, string]> = [
+    ["absent", base, "floorp-icon:v1:fingerprint"],
+    [
+      "own undefined",
+      { ...base, icon: undefined },
+      "floorp-icon:v1:fingerprint",
+    ],
+    ["null", { ...base, icon: null }, "floorp-icon:v1:fingerprint"],
+    ["alias", { ...base, icon: "article" }, "floorp-icon:v1:article"],
+    [
+      "canonical",
+      { ...base, icon: "floorp-icon:v1:article" },
+      "floorp-icon:v1:article",
+    ],
+    ["opaque", { ...base, icon: "future:value" }, "floorp-icon:v1:fingerprint"],
+    [
+      "URI",
+      { ...base, icon: "https://example.invalid/raw.svg" },
+      "floorp-icon:v1:fingerprint",
+    ],
+  ];
+  for (const [label, workspace, expectedDisplay] of cases) {
+    const field = createWorkspaceIconPickerFormItem(
+      workspace,
+      icons,
+      (alias) => `label:${alias}`,
+      "Icon",
+    );
+    assertEquals(
+      field.type,
+      "workspace-icon-picker",
+      `${label} dedicated type`,
+    );
+    assertEquals(field.displayValue, expectedDisplay, `${label} safe display`);
+    assertEquals(field.options?.length, 34, `${label} has exactly 34 options`);
+    assert(
+      field.options?.every((option) =>
+        option.value.startsWith("floorp-icon:v1:") &&
+        option.icon?.startsWith("data:image/svg+xml;base64,")
+      ),
+      `${label} options are canonical with bundled previews`,
+    );
+    if (typeof workspace.icon === "string") {
+      assert(
+        field.value !== workspace.icon,
+        `${label} raw string is not the submitted initial value`,
+      );
+    }
+    if (workspace.icon?.includes("://")) {
+      assert(
+        !JSON.stringify(field).includes(workspace.icon),
+        `${label} raw URI is not transported anywhere`,
+      );
+    }
+  }
+}
+
+function testModalResultTransportCoversCancelNoChangeInvalidAndSelection(): void {
+  const rawCases: TWorkspace[] = [
+    makeWorkspace(),
+    { ...makeWorkspace(), icon: undefined },
+    { ...makeWorkspace(), icon: null },
+    { ...makeWorkspace(), icon: "article" },
+    { ...makeWorkspace(), icon: "floorp-icon:v1:article" },
+    { ...makeWorkspace(), icon: "future:value" },
+    { ...makeWorkspace(), icon: "https://example.invalid/icon.svg" },
+    { ...makeWorkspace(), icon: "data:image/svg+xml,<svg/>" },
+  ];
+  for (const workspace of rawCases) {
+    assertEquals(
+      applyWorkspaceModalResult(workspace, null),
+      null,
+      "cancel produces no workspace update",
+    );
+
+    const noChange = applyWorkspaceModalResult(workspace, {
+      name: "Edited",
+      userContextId: "4",
+      icon: "__floorp_workspace_icon_picker_no_change__",
+    });
+    assert(noChange !== null, "no-change submit returns edited workspace");
+    assertSameRawIconSlot(workspace, noChange, "no-change submit");
+    assertEquals(noChange.name, "Edited", "no-change still applies name edit");
+    assertEquals(noChange.userContextId, 4, "no-change applies container edit");
+
+    for (
+      const invalid of [
+        "article",
+        "floorp-icon:v1:unknown",
+        "https://example.invalid/icon.svg",
+        42,
+      ]
+    ) {
+      const invalidResult = applyWorkspaceModalResult(workspace, {
+        name: workspace.name,
+        userContextId: workspace.userContextId,
+        icon: invalid,
+      });
+      assert(invalidResult !== null, "invalid submit returns workspace");
+      assertSameRawIconSlot(
+        workspace,
+        invalidResult,
+        `invalid ${String(invalid)}`,
+      );
+    }
+
+    const selected = applyWorkspaceModalResult(workspace, {
+      name: workspace.name,
+      userContextId: workspace.userContextId,
+      icon: "floorp-icon:v1:music",
+    });
+    assert(selected !== null, "explicit selection returns workspace");
+    assertEquals(
+      selected.icon,
+      "floorp-icon:v1:music",
+      "explicit selection stores canonical ID",
+    );
+  }
+}
+
+type RawServiceCase = {
+  label: string;
+  hasOwn: boolean;
+  value?: TWorkspace["icon"];
+  persistedHasOwn: boolean;
+  persistedValue?: TWorkspace["icon"];
+};
+
+type ConcurrentWorkspace = TWorkspace & {
+  concurrentMarker?: string;
+};
+
+const createCollisionCheckedTestID = (
+  data: ReadonlyMap<TWorkspaceID, TWorkspace>,
+  order: readonly TWorkspaceID[],
+): TWorkspaceID => {
+  for (let counter = 1; counter <= 999; counter++) {
+    const candidate = `00000000-0000-4000-8000-${
+      counter.toString().padStart(12, "0")
+    }` as TWorkspaceID;
+    if (!data.has(candidate) && !order.includes(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error("Unable to allocate a collision-free workspace test UUID");
+};
+
+const cloneLiveWorkspaceMap = (): Map<TWorkspaceID, TWorkspace> =>
+  new Map(
+    workspacesDataStore.data as unknown as Map<TWorkspaceID, TWorkspace>,
+  );
+
+const replaceWorkspaceStore = (
+  data: Map<TWorkspaceID, TWorkspace>,
+  order: readonly TWorkspaceID[],
+  defaultID: TWorkspaceID,
+): void => {
+  setWorkspacesDataStore({
+    data: data as unknown as TWorkspacesStoreData["data"],
+    order: [...order] as TWorkspacesStoreData["order"],
+    defaultID,
+  });
+};
+
+const setRawIconSlot = (
+  workspace: ConcurrentWorkspace,
+  rawCase: Pick<RawServiceCase, "hasOwn" | "value">,
+): ConcurrentWorkspace => {
+  const next: ConcurrentWorkspace = { ...workspace };
+  if (rawCase.hasOwn) {
+    next.icon = rawCase.value;
+  } else {
+    delete next.icon;
+  }
+  return next;
+};
+
+const flushWorkspacePersistence = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+async function testServiceUsesLatestWorkspaceWithoutResurrection(): Promise<
+  void
+> {
+  const originalData = cloneLiveWorkspaceMap();
+  const originalOrder = [...workspacesDataStore.order] as TWorkspaceID[];
+  const originalDefaultID = workspacesDataStore.defaultID as TWorkspaceID;
+  const hadWorkspacePref = Services.prefs.prefHasUserValue(
+    WORKSPACE_DATA_PREF_NAME,
+  );
+  const originalWorkspacePref = hadWorkspacePref
+    ? Services.prefs.getStringPref(WORKSPACE_DATA_PREF_NAME)
+    : null;
+  const targetID = createCollisionCheckedTestID(originalData, originalOrder);
+  const testOrder = [...originalOrder, targetID];
+  let visibilityUpdates = 0;
+  let onShow: () => Promise<Record<string, unknown> | null> = () =>
+    Promise.resolve(null);
+  const service = Object.create(
+    WorkspacesService.prototype,
+  ) as WorkspacesService;
+  service.dataManagerCtx = {
+    getRawWorkspace: (id: TWorkspaceID) => cloneLiveWorkspaceMap().get(id),
+  } as WorkspacesService["dataManagerCtx"];
+  service.modalCtx = {
+    showWorkspacesModal: async () => await onShow(),
+  } as unknown as WorkspacesService["modalCtx"];
+  service.tabManagerCtx = {
+    updateTabsVisibility: () => {
+      visibilityUpdates++;
+    },
+  } as unknown as WorkspacesService["tabManagerCtx"];
+
+  const rawCases: RawServiceCase[] = [
+    { label: "absent", hasOwn: false, persistedHasOwn: false },
+    {
+      label: "own undefined",
+      hasOwn: true,
+      value: undefined,
+      persistedHasOwn: false,
+    },
+    {
+      label: "null",
+      hasOwn: true,
+      value: null,
+      persistedHasOwn: true,
+      persistedValue: null,
+    },
+    {
+      label: "alias",
+      hasOwn: true,
+      value: "article",
+      persistedHasOwn: true,
+      persistedValue: "article",
+    },
+    {
+      label: "canonical",
+      hasOwn: true,
+      value: "floorp-icon:v1:article",
+      persistedHasOwn: true,
+      persistedValue: "floorp-icon:v1:article",
+    },
+    {
+      label: "opaque",
+      hasOwn: true,
+      value: "future:concurrent-icon",
+      persistedHasOwn: true,
+      persistedValue: "future:concurrent-icon",
+    },
+    {
+      label: "URI",
+      hasOwn: true,
+      value: "https://example.invalid/concurrent.svg",
+      persistedHasOwn: true,
+      persistedValue: "https://example.invalid/concurrent.svg",
+    },
+    {
+      label: "raw data URI",
+      hasOwn: true,
+      value: "data:image/svg+xml,<svg id='concurrent'/>",
+      persistedHasOwn: true,
+      persistedValue: "data:image/svg+xml,<svg id='concurrent'/>",
+    },
+  ];
+
+  const installOpenWorkspace = (): void => {
+    const data = cloneLiveWorkspaceMap();
+    data.set(targetID, {
+      ...makeWorkspace(),
+      name: "Open-time workspace",
+      icon: "floorp-icon:v1:book",
+    });
+    replaceWorkspaceStore(data, testOrder, originalDefaultID);
+  };
+
+  try {
+    for (const rawCase of rawCases) {
+      installOpenWorkspace();
+      visibilityUpdates = 0;
+      onShow = async () => {
+        const data = cloneLiveWorkspaceMap();
+        const current = data.get(targetID);
+        assert(current, `${rawCase.label}: test workspace disappeared`);
+        const concurrent = setRawIconSlot(
+          {
+            ...current,
+            isSelected: true,
+            isDefault: false,
+            concurrentMarker: `latest:${rawCase.label}`,
+          },
+          rawCase,
+        );
+        data.set(targetID, concurrent);
+        replaceWorkspaceStore(data, testOrder, originalDefaultID);
+        await flushWorkspacePersistence();
+        return {
+          name: `Submitted ${rawCase.label}`,
+          userContextId: "7",
+          icon: "__floorp_workspace_icon_picker_no_change__",
+        };
+      };
+
+      const result = await service.manageWorkspaceFromDialog(targetID);
+      assert(result, `${rawCase.label}: modal result was not returned`);
+      await flushWorkspacePersistence();
+      const actual = cloneLiveWorkspaceMap().get(targetID) as
+        | ConcurrentWorkspace
+        | undefined;
+      assert(actual, `${rawCase.label}: workspace was not retained`);
+      assertEquals(
+        actual.name,
+        `Submitted ${rawCase.label}`,
+        `${rawCase.label}: submitted name`,
+      );
+      assertEquals(actual.userContextId, 7, `${rawCase.label}: container`);
+      assertEquals(
+        actual.isSelected,
+        true,
+        `${rawCase.label}: latest selected`,
+      );
+      assertEquals(actual.isDefault, false, `${rawCase.label}: latest default`);
+      assertEquals(
+        actual.concurrentMarker,
+        `latest:${rawCase.label}`,
+        `${rawCase.label}: future metadata`,
+      );
+      assertEquals(
+        Object.hasOwn(actual, "icon"),
+        rawCase.persistedHasOwn,
+        `${rawCase.label}: persisted icon presence`,
+      );
+      if (rawCase.persistedHasOwn) {
+        assertEquals(
+          actual.icon,
+          rawCase.persistedValue,
+          `${rawCase.label}: persisted icon value`,
+        );
+      } else {
+        assert(actual.icon !== null, `${rawCase.label}: did not become null`);
+      }
+      assertEquals(
+        visibilityUpdates,
+        1,
+        `${rawCase.label}: visibility update count`,
+      );
+    }
+
+    installOpenWorkspace();
+    visibilityUpdates = 0;
+    onShow = async () => {
+      const data = cloneLiveWorkspaceMap();
+      const current = data.get(targetID);
+      assert(current, "canonical selection: test workspace disappeared");
+      data.set(targetID, {
+        ...current,
+        icon: "future:latest-before-selection",
+        isSelected: true,
+        isDefault: false,
+        concurrentMarker: "latest:canonical-selection",
+      } as ConcurrentWorkspace);
+      replaceWorkspaceStore(data, testOrder, originalDefaultID);
+      await flushWorkspacePersistence();
+      return {
+        name: "Canonical selection",
+        userContextId: "9",
+        icon: "floorp-icon:v1:music",
+      };
+    };
+    await service.manageWorkspaceFromDialog(targetID);
+    await flushWorkspacePersistence();
+    const selected = cloneLiveWorkspaceMap().get(targetID) as
+      | ConcurrentWorkspace
+      | undefined;
+    assert(selected, "canonical selection: workspace was not retained");
+    assertEquals(
+      selected.icon,
+      "floorp-icon:v1:music",
+      "canonical selection overwrites latest raw icon",
+    );
+    assertEquals(selected.isSelected, true, "canonical latest selected");
+    assertEquals(selected.isDefault, false, "canonical latest default");
+    assertEquals(
+      selected.concurrentMarker,
+      "latest:canonical-selection",
+      "canonical future metadata",
+    );
+    assertEquals(visibilityUpdates, 1, "canonical visibility update count");
+
+    installOpenWorkspace();
+    visibilityUpdates = 0;
+    onShow = async () => {
+      const data = cloneLiveWorkspaceMap();
+      data.delete(targetID);
+      replaceWorkspaceStore(
+        data,
+        testOrder.filter((id) => id !== targetID),
+        originalDefaultID,
+      );
+      await flushWorkspacePersistence();
+      return {
+        name: "Must not resurrect",
+        userContextId: "0",
+        icon: "__floorp_workspace_icon_picker_no_change__",
+      };
+    };
+    const deletedResult = await service.manageWorkspaceFromDialog(targetID);
+    await flushWorkspacePersistence();
+    assertEquals(deletedResult, undefined, "deleted workspace result");
+    assert(
+      !cloneLiveWorkspaceMap().has(targetID),
+      "deleted workspace was resurrected",
+    );
+    assert(
+      !workspacesDataStore.order.includes(targetID),
+      "deleted workspace order entry returned",
+    );
+    assertEquals(visibilityUpdates, 0, "deleted visibility update count");
+  } finally {
+    replaceWorkspaceStore(
+      new Map(originalData),
+      originalOrder,
+      originalDefaultID,
+    );
+    await flushWorkspacePersistence();
+    if (hadWorkspacePref) {
+      Services.prefs.setStringPref(
+        WORKSPACE_DATA_PREF_NAME,
+        originalWorkspacePref!,
+      );
+    } else if (Services.prefs.prefHasUserValue(WORKSPACE_DATA_PREF_NAME)) {
+      Services.prefs.clearUserPref(WORKSPACE_DATA_PREF_NAME);
+    }
+    await flushWorkspacePersistence();
+  }
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "no-change preserves every raw category",
+      fn: testNoChangePreservesEveryRawCategory,
+    },
+    {
+      name: "invalid picker results preserve raw slot",
+      fn: testInvalidPickerResultsPreserveRawSlot,
+    },
+    {
+      name: "explicit canonical selection overwrites every category",
+      fn: testExplicitCanonicalSelectionOverwritesEveryCategory,
+    },
+    {
+      name: "JSON categories do not collapse to null",
+      fn: testJsonCategoriesDoNotCollapseToNull,
+    },
+    {
+      name: "modal form never transports raw stored value",
+      fn: testModalFormNeverTransportsRawStoredValue,
+    },
+    {
+      name: "modal result covers cancel no-change invalid and selection",
+      fn: testModalResultTransportCoversCancelNoChangeInvalidAndSelection,
+    },
+    {
+      name:
+        "service applies modal result to latest workspace without resurrection",
+      fn: testServiceUsesLatestWorkspaceWithoutResurrection,
+    },
+  ];
+  await runTests("workspaceIconRawValue.test.ts", tests);
+}

--- a/browser-features/chrome/common/workspaces/test/workspaceIcons.test.ts
+++ b/browser-features/chrome/common/workspaces/test/workspaceIcons.test.ts
@@ -1,125 +1,204 @@
 // SPDX-License-Identifier: MPL-2.0
 // @colocated-env browser
 
-import { WorkspaceIcons } from "../utils/workspace-icons.ts";
 import {
-  type TestCase,
+  WORKSPACE_ICON_REGISTRY,
+  WorkspaceIcons,
+} from "../utils/workspace-icons.ts";
+import { workspaceIconTranslationKeys } from "../utils/icon-translations.ts";
+import {
   assert,
   assertEquals,
+  type TestCase,
 } from "../../../test/utils/test_harness.ts";
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const EXPECTED_ALIASES = [
+  "article",
+  "book",
+  "briefcase",
+  "cart",
+  "chat",
+  "chill",
+  "circle",
+  "compass",
+  "code",
+  "dollar",
+  "fence",
+  "fingerprint",
+  "food",
+  "fruit",
+  "game",
+  "gear",
+  "gift",
+  "key",
+  "lightning",
+  "network",
+  "notes",
+  "paint",
+  "photo",
+  "pin",
+  "pet",
+  "question",
+  "smartphone",
+  "star",
+  "tree",
+  "vacation",
+  "love",
+  "moon",
+  "music",
+  "user",
+] as const;
 
-let icons: WorkspaceIcons;
-
-function setup(): void {
-  icons = new WorkspaceIcons();
-}
-
-function testWorkspaceIconsSetNotEmpty(): void {
-  setup();
-  assert(icons.workspaceIcons.size > 0, "icon set should not be empty");
-}
-
-function testWorkspaceIconsArrayLength(): void {
-  setup();
+function testRegistryIsExactAndUnique(): void {
+  assertEquals(WORKSPACE_ICON_REGISTRY.length, 34, "registry has 34 entries");
   assertEquals(
-    icons.workspaceIconsArray.length,
-    icons.workspaceIcons.size,
-    "array length should match set size",
+    new Set(WORKSPACE_ICON_REGISTRY.map((entry) => entry.slug)).size,
+    34,
+    "slugs are unique",
+  );
+  assertEquals(
+    new Set(WORKSPACE_ICON_REGISTRY.map((entry) => entry.alias)).size,
+    34,
+    "aliases are unique",
+  );
+  assertEquals(
+    new Set(WORKSPACE_ICON_REGISTRY.map((entry) => entry.canonicalId)).size,
+    34,
+    "canonical IDs are unique",
+  );
+  assertEquals(
+    new Set(WORKSPACE_ICON_REGISTRY.map((entry) => entry.assetPath)).size,
+    34,
+    "bundled assets are one-to-one",
+  );
+  assertEquals(
+    JSON.stringify(WORKSPACE_ICON_REGISTRY.map((entry) => entry.alias)),
+    JSON.stringify(EXPECTED_ALIASES),
+    "all legacy aliases are preserved exactly",
   );
 }
 
-function testKnownIconsExist(): void {
-  setup();
-  const expected = ["briefcase", "star", "fingerprint", "code", "book"];
-  for (const name of expected) {
-    assert(icons.workspaceIcons.has(name), `"${name}" should be in icon set`);
+function testRegistryMetadataMatchesSlugs(): void {
+  assertEquals(
+    Object.keys(workspaceIconTranslationKeys).length,
+    34,
+    "translation map has 34 keys",
+  );
+  for (const entry of WORKSPACE_ICON_REGISTRY) {
+    assertEquals(entry.alias, entry.slug, `${entry.slug} alias`);
+    assertEquals(
+      entry.canonicalId,
+      `floorp-icon:v1:${entry.slug}`,
+      `${entry.slug} canonical ID`,
+    );
+    assertEquals(
+      entry.assetPath,
+      `../icons/${entry.slug}.svg`,
+      `${entry.slug} bundled asset`,
+    );
+    assertEquals(
+      entry.labelKey,
+      workspaceIconTranslationKeys[entry.slug],
+      `${entry.slug} translation key`,
+    );
+    assert(entry.keywords.length > 0, `${entry.slug} has keywords`);
   }
 }
 
-function testGetWorkspaceIconUrlValid(): void {
-  setup();
-  const url = icons.getWorkspaceIconUrl("fingerprint");
-  assert(
-    typeof url === "string" && url.startsWith("data:image/svg+xml;base64,"),
-    "valid icon should return data URL",
+function testAliasesAndCanonicalIdsResolveIdentically(): void {
+  const icons = new WorkspaceIcons();
+  assertEquals(
+    icons.workspaceIconsArray.length,
+    34,
+    "legacy set has 34 aliases",
   );
-}
-
-function testGetWorkspaceIconUrlNull(): void {
-  setup();
-  const url = icons.getWorkspaceIconUrl(null);
-  assert(
-    typeof url === "string" && url.length > 0,
-    "null icon should return fallback (fingerprint)",
-  );
-}
-
-function testGetWorkspaceIconUrlUndefined(): void {
-  setup();
-  const url = icons.getWorkspaceIconUrl(undefined);
-  assert(
-    typeof url === "string" && url.length > 0,
-    "undefined icon should return fallback",
-  );
-}
-
-function testGetWorkspaceIconUrlInvalid(): void {
-  setup();
-  const url = icons.getWorkspaceIconUrl("nonexistent-icon");
-  assert(
-    typeof url === "string",
-    "invalid icon name should return fallback string",
-  );
-}
-
-function testAllIconsResolveToDataUrls(): void {
-  setup();
-  for (const name of icons.workspaceIconsArray) {
-    const url = icons.getWorkspaceIconUrl(name);
+  for (const entry of WORKSPACE_ICON_REGISTRY) {
+    const aliasUrl = icons.getWorkspaceIconUrl(entry.alias);
+    const canonicalUrl = icons.getWorkspaceIconUrl(entry.canonicalId);
+    assertEquals(
+      aliasUrl,
+      canonicalUrl,
+      `${entry.slug} forms resolve identically`,
+    );
     assert(
-      typeof url === "string" && url.startsWith("data:"),
-      `icon "${name}" should resolve to a data URL`,
+      canonicalUrl.startsWith("data:image/svg+xml;base64,"),
+      `${entry.slug} resolves to a bundled SVG data URL`,
+    );
+    assertEquals(
+      icons.getWorkspaceIconCanonicalId(entry.alias),
+      entry.canonicalId,
+      `${entry.slug} alias canonicalizes only for display`,
     );
   }
 }
 
-// ---------------------------------------------------------------------------
-// Runner
-// ---------------------------------------------------------------------------
+function testUnsafeAndNonExactValuesUseFallback(): void {
+  const icons = new WorkspaceIcons();
+  const fallback = icons.getWorkspaceIconUrl("fingerprint");
+  const invalidValues: unknown[] = [
+    null,
+    undefined,
+    "",
+    "Article",
+    " article",
+    "article ",
+    "floorp-icon:v1:Article",
+    "floorp-icon:v1:article ",
+    "floorp-icon:v2:article",
+    "floorp-icon:v1:unknown",
+    "https://example.invalid/icon.svg",
+    "chrome://browser/content/icon.svg",
+    "data:text/html;base64,PHNjcmlwdD4=",
+    "data:image/svg+xml,<svg onload='fetch(1)'></svg>",
+  ];
+  for (const value of invalidValues) {
+    const resolved = icons.getWorkspaceIconUrl(value);
+    assertEquals(
+      resolved,
+      fallback,
+      `${String(value)} uses fingerprint fallback`,
+    );
+    assert(
+      resolved.startsWith("data:image/svg+xml;base64,"),
+      "fallback is always a bundled SVG data URL",
+    );
+  }
+  assertEquals(
+    icons.getWorkspaceIconCanonicalId("https://example.invalid/icon.svg"),
+    "floorp-icon:v1:fingerprint",
+    "unsafe raw value maps only to the fallback display ID",
+  );
+}
 
 export function runAllTests(): void {
   const tests: TestCase[] = [
-    { name: "icon set not empty", fn: testWorkspaceIconsSetNotEmpty },
-    { name: "array length matches set", fn: testWorkspaceIconsArrayLength },
-    { name: "known icons exist", fn: testKnownIconsExist },
-    { name: "getWorkspaceIconUrl valid", fn: testGetWorkspaceIconUrlValid },
-    { name: "getWorkspaceIconUrl null", fn: testGetWorkspaceIconUrlNull },
+    { name: "registry is exact and unique", fn: testRegistryIsExactAndUnique },
     {
-      name: "getWorkspaceIconUrl undefined",
-      fn: testGetWorkspaceIconUrlUndefined,
+      name: "registry metadata matches slugs",
+      fn: testRegistryMetadataMatchesSlugs,
     },
-    { name: "getWorkspaceIconUrl invalid", fn: testGetWorkspaceIconUrlInvalid },
     {
-      name: "all icons resolve to data URLs",
-      fn: testAllIconsResolveToDataUrls,
+      name: "aliases and canonical IDs resolve identically",
+      fn: testAliasesAndCanonicalIdsResolveIdentically,
+    },
+    {
+      name: "unsafe and non-exact values use fallback",
+      fn: testUnsafeAndNonExactValuesUseFallback,
     },
   ];
 
   const failures: string[] = [];
-
   for (const test of tests) {
     try {
       test.fn();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      failures.push(`${test.name}: ${message}`);
+      failures.push(
+        `${test.name}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
-
   if (failures.length > 0) {
     throw new Error(`workspaceIcons.test.ts failures: ${failures.join(" | ")}`);
   }

--- a/browser-features/chrome/common/workspaces/test/workspaceSnapshotUtils.test.ts
+++ b/browser-features/chrome/common/workspaces/test/workspaceSnapshotUtils.test.ts
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 // @colocated-env browser
 
-import { toNumber, extractUrlFromState } from "../utils/workspace-snapshot.ts";
 import {
+  createWorkspaceSnapshotMetadata,
+  extractUrlFromState,
+  toNumber,
+} from "../utils/workspace-snapshot.ts";
+import type { TWorkspaceID } from "../utils/type.ts";
+import {
+  assert,
   assertEquals,
   type TestCase,
 } from "../../../test/utils/test_harness.ts";
@@ -172,6 +178,44 @@ function testExtractUrlComplexEntries(): void {
   );
 }
 
+function testSnapshotMetadataPreservesRawIconCategories(): void {
+  const workspaceId = "00000000-0000-4000-8000-000000000001" as TWorkspaceID;
+  const base = { name: "Snapshot", userContextId: 7 };
+  const cases: Array<
+    [string, { name: string; userContextId: number; icon?: string | null }]
+  > = [
+    ["absent", base],
+    ["own undefined", { ...base, icon: undefined }],
+    ["null", { ...base, icon: null }],
+    ["alias", { ...base, icon: "article" }],
+    ["canonical", { ...base, icon: "floorp-icon:v1:article" }],
+    ["opaque", { ...base, icon: "future:value" }],
+    ["URI", { ...base, icon: "https://example.invalid/icon.svg" }],
+  ];
+  for (const [label, workspace] of cases) {
+    const metadata = createWorkspaceSnapshotMetadata(workspaceId, workspace);
+    assertEquals(
+      Object.hasOwn(metadata, "icon"),
+      Object.hasOwn(workspace, "icon"),
+      `${label} presence`,
+    );
+    if (Object.hasOwn(workspace, "icon")) {
+      assertEquals(metadata.icon, workspace.icon, `${label} value`);
+    }
+    assertEquals(metadata.userContextId, 7, `${label} user context`);
+  }
+
+  const ownUndefined = createWorkspaceSnapshotMetadata(workspaceId, {
+    ...base,
+    icon: undefined,
+  });
+  const json = JSON.parse(JSON.stringify(ownUndefined)) as Record<string, unknown>;
+  assert(
+    !Object.hasOwn(json, "icon"),
+    "snapshot JSON omits own undefined instead of producing null",
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
@@ -199,6 +243,10 @@ export function runAllTests(): void {
     { name: "extractUrl null entries", fn: testExtractUrlNullEntries },
     { name: "extractUrl entry with null URL", fn: testExtractUrlEntryWithNullUrl },
     { name: "extractUrl complex entries", fn: testExtractUrlComplexEntries },
+    {
+      name: "snapshot metadata preserves raw icon categories",
+      fn: testSnapshotMetadataPreservesRawIconCategories,
+    },
   ];
 
   const failures: string[] = [];

--- a/browser-features/chrome/common/workspaces/test/workspacesArchiveHelpers.test.ts
+++ b/browser-features/chrome/common/workspaces/test/workspacesArchiveHelpers.test.ts
@@ -2,7 +2,9 @@
 // @colocated-env browser
 
 import {
+  applyWorkspaceSnapshotMetadata,
   buildSummary,
+  createArchiveFile,
   filterJsonFiles,
   isRecord,
 } from "../utils/workspaces-archive-service.ts";
@@ -228,6 +230,104 @@ function testBuildSummaryWithMultipleTabs(): void {
   assertEquals(summary.icon, "folder", "should preserve workspace icon");
 }
 
+const makeRawIconSnapshot = (
+  workspace: TWorkspaceSnapshot["workspace"],
+): TWorkspaceSnapshot => ({
+  capturedAt: 1700000000000,
+  workspace,
+  tabs: [],
+});
+
+function testArchiveSummaryPreservesRawIconCategories(): void {
+  const workspaceId = "ws-raw" as unknown as TWorkspaceID;
+  const base = { workspaceId, name: "Raw", userContextId: 0 };
+  const cases: Array<[string, TWorkspaceSnapshot["workspace"]]> = [
+    ["absent", base],
+    ["own undefined", { ...base, icon: undefined }],
+    ["null", { ...base, icon: null }],
+    ["alias", { ...base, icon: "article" }],
+    ["canonical", { ...base, icon: "floorp-icon:v1:article" }],
+    ["opaque", { ...base, icon: "future:value" }],
+    ["URI", { ...base, icon: "https://example.invalid/icon.svg" }],
+  ];
+  for (const [label, workspace] of cases) {
+    const summary = buildSummary("archive", makeRawIconSnapshot(workspace), "/p");
+    assertEquals(
+      Object.hasOwn(summary, "icon"),
+      Object.hasOwn(workspace, "icon"),
+      `${label} summary presence`,
+    );
+    if (Object.hasOwn(workspace, "icon")) {
+      assertEquals(summary.icon, workspace.icon, `${label} summary value`);
+    }
+  }
+}
+
+function testArchiveJsonKeepsVersionAndRawCategories(): void {
+  const workspaceId = "ws-json" as unknown as TWorkspaceID;
+  const base = { workspaceId, name: "JSON", userContextId: 0 };
+  const absent = JSON.parse(
+    JSON.stringify(createArchiveFile(makeRawIconSnapshot(base))),
+  ) as Record<string, unknown>;
+  const ownUndefined = JSON.parse(
+    JSON.stringify(
+      createArchiveFile(
+        makeRawIconSnapshot({ ...base, icon: undefined }),
+      ),
+    ),
+  ) as Record<string, unknown>;
+  const explicitNull = JSON.parse(
+    JSON.stringify(createArchiveFile(makeRawIconSnapshot({ ...base, icon: null }))),
+  ) as Record<string, unknown>;
+  const opaque = JSON.parse(
+    JSON.stringify(
+      createArchiveFile(makeRawIconSnapshot({ ...base, icon: "future:value" })),
+    ),
+  ) as Record<string, unknown>;
+  const getWorkspace = (file: Record<string, unknown>) =>
+    ((file.snapshot as Record<string, unknown>).workspace as Record<string, unknown>);
+  assertEquals(absent.version, 1, "archive schema remains v1");
+  assert(!Object.hasOwn(getWorkspace(absent), "icon"), "absent icon stays absent");
+  assert(
+    !Object.hasOwn(getWorkspace(ownUndefined), "icon"),
+    "undefined icon is omitted, not changed to null",
+  );
+  assertEquals(getWorkspace(explicitNull).icon, null, "null stays explicit");
+  assertEquals(getWorkspace(opaque).icon, "future:value", "opaque stays exact");
+}
+
+function testRestoreReplacesDefaultNullWithExactRawSlot(): void {
+  const workspaceId = "ws-restore" as unknown as TWorkspaceID;
+  const created = {
+    name: "Created",
+    icon: null,
+    userContextId: 0,
+    isSelected: null,
+    isDefault: null,
+  };
+  const base = { workspaceId, name: "Restored", userContextId: 8 };
+  const absent = applyWorkspaceSnapshotMetadata(created, base);
+  assert(!Object.hasOwn(absent, "icon"), "absent snapshot removes created null");
+
+  const ownUndefined = applyWorkspaceSnapshotMetadata(created, {
+    ...base,
+    icon: undefined,
+  });
+  assert(Object.hasOwn(ownUndefined, "icon"), "in-memory undefined stays own");
+  assertEquals(ownUndefined.icon, undefined, "in-memory undefined stays undefined");
+
+  for (const icon of [
+    null,
+    "article",
+    "floorp-icon:v1:article",
+    "future:value",
+    "https://example.invalid/icon.svg",
+  ]) {
+    const restored = applyWorkspaceSnapshotMetadata(created, { ...base, icon });
+    assertEquals(restored.icon, icon, `${String(icon)} restores exactly`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
@@ -260,6 +360,18 @@ export function runAllTests(): void {
     {
       name: "buildSummary with multiple tabs",
       fn: testBuildSummaryWithMultipleTabs,
+    },
+    {
+      name: "archive summary preserves raw icon categories",
+      fn: testArchiveSummaryPreservesRawIconCategories,
+    },
+    {
+      name: "archive JSON keeps version and raw categories",
+      fn: testArchiveJsonKeepsVersionAndRawCategories,
+    },
+    {
+      name: "restore replaces default null with exact raw slot",
+      fn: testRestoreReplacesDefaultNullWithExactRawSlot,
     },
   ];
 

--- a/browser-features/chrome/common/workspaces/utils/archive-types.ts
+++ b/browser-features/chrome/common/workspaces/utils/archive-types.ts
@@ -14,7 +14,7 @@ export interface WorkspaceArchiveSummary {
   archiveId: string;
   workspaceId: TWorkspaceID;
   name: string;
-  icon: string | null;
+  icon?: string | null | undefined;
   userContextId: number;
   capturedAt: number;
   filePath: string;

--- a/browser-features/chrome/common/workspaces/utils/type.ts
+++ b/browser-features/chrome/common/workspaces/utils/type.ts
@@ -6,13 +6,17 @@
 import * as t from "io-ts";
 
 /* io-ts codecs */
-export const zWorkspace = t.type({
-  name: t.string,
-  icon: t.union([t.string, t.null, t.undefined]),
-  userContextId: t.number,
-  isSelected: t.union([t.boolean, t.null, t.undefined]),
-  isDefault: t.union([t.boolean, t.null, t.undefined]),
-});
+export const zWorkspace = t.intersection([
+  t.type({
+    name: t.string,
+    userContextId: t.number,
+    isSelected: t.union([t.boolean, t.null, t.undefined]),
+    isDefault: t.union([t.boolean, t.null, t.undefined]),
+  }),
+  t.partial({
+    icon: t.union([t.string, t.null, t.undefined]),
+  }),
+]);
 
 // Brand type for WorkspaceID
 export type WorkspaceIDBrand = { readonly WorkspaceID: unique symbol };
@@ -73,12 +77,16 @@ export const zWorkspaceSnapshotTab = t.type({
 
 export const zWorkspaceSnapshot = t.type({
   capturedAt: t.number,
-  workspace: t.type({
-    workspaceId: zWorkspaceID,
-    name: t.string,
-    icon: t.union([t.string, t.null]),
-    userContextId: t.number,
-  }),
+  workspace: t.intersection([
+    t.type({
+      workspaceId: zWorkspaceID,
+      name: t.string,
+      userContextId: t.number,
+    }),
+    t.partial({
+      icon: t.union([t.string, t.null, t.undefined]),
+    }),
+  ]),
   tabs: t.array(zWorkspaceSnapshotTab),
 });
 

--- a/browser-features/chrome/common/workspaces/utils/workspace-icons.ts
+++ b/browser-features/chrome/common/workspaces/utils/workspace-icons.ts
@@ -9,6 +9,14 @@ type ModuleStrings = Record<string, string>;
 
 export const WORKSPACE_ICON_CANONICAL_PREFIX = "floorp-icon:v1:" as const;
 
+/**
+ * Form value used by the workspace modal to signal "keep the current icon".
+ * A pure constant (no modal/component imports) so pages-layer tests can
+ * import it without pulling in chrome components.
+ */
+export const WORKSPACE_ICON_NO_CHANGE_SENTINEL =
+  "__floorp_workspace_icon_picker_no_change__";
+
 export interface WorkspaceIconRegistryEntry {
   readonly slug: string;
   readonly canonicalId: `${typeof WORKSPACE_ICON_CANONICAL_PREFIX}${string}`;

--- a/browser-features/chrome/common/workspaces/utils/workspace-icons.ts
+++ b/browser-features/chrome/common/workspaces/utils/workspace-icons.ts
@@ -3,85 +3,182 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-type ModuleStrings = {
-  [key: string]: string;
+import type { TWorkspace } from "./type.ts";
+
+type ModuleStrings = Record<string, string>;
+
+export const WORKSPACE_ICON_CANONICAL_PREFIX = "floorp-icon:v1:" as const;
+
+export interface WorkspaceIconRegistryEntry {
+  readonly slug: string;
+  readonly canonicalId: `${typeof WORKSPACE_ICON_CANONICAL_PREFIX}${string}`;
+  readonly alias: string;
+  readonly assetPath: `../icons/${string}.svg`;
+  readonly labelKey: `workspaces.icons.${string}`;
+  readonly keywords: readonly string[];
+}
+
+const defineWorkspaceIcon = (
+  slug: string,
+  keywords: readonly string[],
+): WorkspaceIconRegistryEntry => ({
+  slug,
+  canonicalId: `${WORKSPACE_ICON_CANONICAL_PREFIX}${slug}`,
+  alias: slug,
+  assetPath: `../icons/${slug}.svg`,
+  labelKey: `workspaces.icons.${slug}`,
+  keywords: [slug, ...keywords],
+});
+
+export const WORKSPACE_ICON_REGISTRY: readonly WorkspaceIconRegistryEntry[] =
+  Object.freeze([
+    defineWorkspaceIcon("article", ["document", "news", "read"]),
+    defineWorkspaceIcon("book", ["library", "reading", "study"]),
+    defineWorkspaceIcon("briefcase", ["business", "job", "work"]),
+    defineWorkspaceIcon("cart", ["buy", "shop", "shopping"]),
+    defineWorkspaceIcon("chat", ["conversation", "message", "talk"]),
+    defineWorkspaceIcon("chill", ["break", "relax", "rest"]),
+    defineWorkspaceIcon("circle", ["dot", "round", "simple"]),
+    defineWorkspaceIcon("compass", ["direction", "explore", "travel"]),
+    defineWorkspaceIcon("code", ["developer", "programming", "software"]),
+    defineWorkspaceIcon("dollar", ["finance", "money", "payment"]),
+    defineWorkspaceIcon("fence", ["boundary", "garden", "outdoor"]),
+    defineWorkspaceIcon("fingerprint", ["default", "identity", "security"]),
+    defineWorkspaceIcon("food", ["eat", "meal", "restaurant"]),
+    defineWorkspaceIcon("fruit", ["apple", "fresh", "healthy"]),
+    defineWorkspaceIcon("game", ["gaming", "play", "controller"]),
+    defineWorkspaceIcon("gear", ["configuration", "settings", "tools"]),
+    defineWorkspaceIcon("gift", ["birthday", "present", "surprise"]),
+    defineWorkspaceIcon("key", ["access", "lock", "password"]),
+    defineWorkspaceIcon("lightning", ["energy", "fast", "power"]),
+    defineWorkspaceIcon("network", ["connection", "internet", "nodes"]),
+    defineWorkspaceIcon("notes", ["memo", "notebook", "write"]),
+    defineWorkspaceIcon("paint", ["art", "color", "creative"]),
+    defineWorkspaceIcon("photo", ["camera", "image", "picture"]),
+    defineWorkspaceIcon("pin", ["location", "map", "place"]),
+    defineWorkspaceIcon("pet", ["animal", "cat", "dog"]),
+    defineWorkspaceIcon("question", ["help", "support", "unknown"]),
+    defineWorkspaceIcon("smartphone", ["device", "mobile", "phone"]),
+    defineWorkspaceIcon("star", ["favorite", "featured", "special"]),
+    defineWorkspaceIcon("tree", ["forest", "nature", "plant"]),
+    defineWorkspaceIcon("vacation", ["holiday", "trip", "travel"]),
+    defineWorkspaceIcon("love", ["heart", "like", "romance"]),
+    defineWorkspaceIcon("moon", ["dark", "night", "sleep"]),
+    defineWorkspaceIcon("music", ["audio", "song", "sound"]),
+    defineWorkspaceIcon("user", ["account", "person", "profile"]),
+  ]);
+
+const FALLBACK_ENTRY = WORKSPACE_ICON_REGISTRY.find(
+  (entry) => entry.slug === "fingerprint",
+)!;
+const ENTRY_BY_ALIAS: ReadonlyMap<string, WorkspaceIconRegistryEntry> = new Map(
+  WORKSPACE_ICON_REGISTRY.map((entry) => [entry.alias, entry] as const),
+);
+const ENTRY_BY_CANONICAL_ID: ReadonlyMap<string, WorkspaceIconRegistryEntry> =
+  new Map(
+    WORKSPACE_ICON_REGISTRY.map((entry) => [entry.canonicalId, entry] as const),
+  );
+
+const getExactRegistryEntry = (
+  value: unknown,
+): WorkspaceIconRegistryEntry | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return ENTRY_BY_CANONICAL_ID.get(value) ?? ENTRY_BY_ALIAS.get(value);
+};
+
+export const isCanonicalWorkspaceIconId = (
+  value: unknown,
+): value is WorkspaceIconRegistryEntry["canonicalId"] =>
+  typeof value === "string" && ENTRY_BY_CANONICAL_ID.has(value);
+
+export const applyWorkspaceIconSelection = (
+  workspace: TWorkspace,
+  selection: unknown,
+): TWorkspace =>
+  isCanonicalWorkspaceIconId(selection)
+    ? { ...workspace, icon: selection }
+    : { ...workspace };
+
+const encodeSvgAsDataUrl = (svgContent: string): string => {
+  const svgBytes = new TextEncoder().encode(svgContent);
+  let binString = "";
+  for (const byte of svgBytes) {
+    binString += String.fromCharCode(byte);
+  }
+  return `data:image/svg+xml;base64,${btoa(binString)}`;
 };
 
 export class WorkspaceIcons {
-  private moduleStrings: ModuleStrings;
-  private resolvedIcons: { [key: string]: string } = {};
-  public workspaceIcons = new Set([
-    "article",
-    "book",
-    "briefcase",
-    "cart",
-    "chat",
-    "chill",
-    "circle",
-    "compass",
-    "code",
-    "dollar",
-    "fence",
-    "fingerprint",
-    "food",
-    "fruit",
-    "game",
-    "gear",
-    "gift",
-    "key",
-    "lightning",
-    "network",
-    "notes",
-    "paint",
-    "photo",
-    "pin",
-    "pet",
-    "question",
-    "smartphone",
-    "star",
-    "tree",
-    "vacation",
-    "love",
-    "moon",
-    "music",
-    "user",
-  ]);
+  private readonly resolvedIcons = new Map<string, string>();
+  public readonly workspaceIcons = new Set(
+    WORKSPACE_ICON_REGISTRY.map((entry) => entry.alias),
+  );
 
   get workspaceIconsArray(): string[] {
     return Array.from(this.workspaceIcons);
   }
 
+  get registry(): readonly WorkspaceIconRegistryEntry[] {
+    return WORKSPACE_ICON_REGISTRY;
+  }
+
   constructor() {
-    this.moduleStrings = import.meta.glob("../icons/*.svg", {
+    const moduleStrings = import.meta.glob("../icons/*.svg", {
       query: "?raw",
       import: "default",
       eager: true,
     }) as ModuleStrings;
 
-    for (const path in this.moduleStrings) {
-      const iconName = path.split("/").pop()?.replace(".svg", "") ?? "";
-      if (iconName) {
-        try {
-          const svgContent = this.moduleStrings[path];
-          const svgBytes = new TextEncoder().encode(svgContent);
-          let binString = "";
-          svgBytes.forEach((byte) => {
-            binString += String.fromCharCode(byte);
-          });
-          this.resolvedIcons[iconName] = `data:image/svg+xml;base64,${btoa(
-            binString,
-          )}`;
-        } catch (e) {
-          console.error(`Failed to process and encode icon: ${iconName}`, e);
-        }
+    const registeredAssetPaths = new Set<string>(
+      WORKSPACE_ICON_REGISTRY.map((entry) => entry.assetPath),
+    );
+    const bundledAssetPaths = Object.keys(moduleStrings);
+    if (
+      bundledAssetPaths.length !== WORKSPACE_ICON_REGISTRY.length ||
+      bundledAssetPaths.some((path) => !registeredAssetPaths.has(path))
+    ) {
+      throw new Error(
+        "Bundled workspace SVGs do not match the 34-entry icon registry",
+      );
+    }
+
+    for (const entry of WORKSPACE_ICON_REGISTRY) {
+      const svgContent = moduleStrings[entry.assetPath];
+      if (typeof svgContent !== "string") {
+        throw new Error(`Missing bundled workspace icon: ${entry.assetPath}`);
       }
+      this.resolvedIcons.set(
+        entry.canonicalId,
+        encodeSvgAsDataUrl(svgContent),
+      );
     }
   }
 
-  public getWorkspaceIconUrl(icon: string | null | undefined): string {
-    if (!icon || !this.workspaceIcons.has(icon)) {
-      return this.resolvedIcons.fingerprint;
+  public getWorkspaceIconCanonicalId(
+    icon: unknown,
+  ): WorkspaceIconRegistryEntry["canonicalId"] {
+    return (getExactRegistryEntry(icon) ?? FALLBACK_ENTRY).canonicalId;
+  }
+
+  public isCanonicalWorkspaceIconId(
+    icon: unknown,
+  ): icon is WorkspaceIconRegistryEntry["canonicalId"] {
+    return isCanonicalWorkspaceIconId(icon);
+  }
+
+  public getWorkspaceIconUrl(icon: unknown): string {
+    const entry = getExactRegistryEntry(icon) ?? FALLBACK_ENTRY;
+    const resolved = this.resolvedIcons.get(entry.canonicalId);
+    if (resolved) {
+      return resolved;
     }
-    return this.resolvedIcons[icon];
+
+    const fallback = this.resolvedIcons.get(FALLBACK_ENTRY.canonicalId);
+    if (!fallback) {
+      throw new Error("Bundled fingerprint workspace icon is unavailable");
+    }
+    return fallback;
   }
 }

--- a/browser-features/chrome/common/workspaces/utils/workspace-icons.ts
+++ b/browser-features/chrome/common/workspaces/utils/workspace-icons.ts
@@ -131,21 +131,34 @@ export class WorkspaceIcons {
       eager: true,
     }) as ModuleStrings;
 
+    const normalizeGlobKey = (key: string): string => {
+      return key.split("/").pop()?.replace(/\?raw$/, "") ?? key;
+    };
+
     const registeredAssetPaths = new Set<string>(
-      WORKSPACE_ICON_REGISTRY.map((entry) => entry.assetPath),
+      WORKSPACE_ICON_REGISTRY.map((entry) => normalizeGlobKey(entry.assetPath)),
     );
-    const bundledAssetPaths = Object.keys(moduleStrings);
+    const bundledAssetPaths = new Set(
+      Object.keys(moduleStrings).map(normalizeGlobKey),
+    );
     if (
-      bundledAssetPaths.length !== WORKSPACE_ICON_REGISTRY.length ||
-      bundledAssetPaths.some((path) => !registeredAssetPaths.has(path))
+      bundledAssetPaths.size !== WORKSPACE_ICON_REGISTRY.length ||
+      [...bundledAssetPaths].some((path) => !registeredAssetPaths.has(path))
     ) {
       throw new Error(
         "Bundled workspace SVGs do not match the 34-entry icon registry",
       );
     }
 
+    const moduleStringsByBasename = new Map<string, string>();
+    for (const [key, value] of Object.entries(moduleStrings)) {
+      const basename = normalizeGlobKey(key);
+      moduleStringsByBasename.set(basename, value as string);
+    }
+
     for (const entry of WORKSPACE_ICON_REGISTRY) {
-      const svgContent = moduleStrings[entry.assetPath];
+      const basename = normalizeGlobKey(entry.assetPath);
+      const svgContent = moduleStringsByBasename.get(basename);
       if (typeof svgContent !== "string") {
         throw new Error(`Missing bundled workspace icon: ${entry.assetPath}`);
       }

--- a/browser-features/chrome/common/workspaces/utils/workspace-snapshot.ts
+++ b/browser-features/chrome/common/workspaces/utils/workspace-snapshot.ts
@@ -93,6 +93,25 @@ export const extractUrlFromState = (state: Record<string, unknown>): string | nu
   return null;
 };
 
+export const createWorkspaceSnapshotMetadata = (
+  workspaceId: TWorkspaceID,
+  workspace: {
+    name: string;
+    icon?: string | null | undefined;
+    userContextId: number;
+  },
+): TWorkspaceSnapshot["workspace"] => {
+  const metadata: TWorkspaceSnapshot["workspace"] = {
+    workspaceId,
+    name: workspace.name,
+    userContextId: workspace.userContextId ?? 0,
+  };
+  if (Object.hasOwn(workspace, "icon")) {
+    metadata.icon = workspace.icon;
+  }
+  return metadata;
+};
+
 const extractTitleFromTab = (
   tab: XULElement,
   state: Record<string, unknown> | null,
@@ -225,12 +244,7 @@ export const createWorkspaceSnapshot = async (
 
   return {
     capturedAt: Date.now(),
-    workspace: {
-      workspaceId,
-      name: workspace.name,
-      icon: workspace.icon ?? null,
-      userContextId: workspace.userContextId ?? 0,
-    },
+    workspace: createWorkspaceSnapshotMetadata(workspaceId, workspace),
     tabs,
   };
 };

--- a/browser-features/chrome/common/workspaces/utils/workspaces-archive-service.ts
+++ b/browser-features/chrome/common/workspaces/utils/workspaces-archive-service.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { TWorkspaceSnapshot } from "./type.ts";
+import type { TWorkspace, TWorkspaceSnapshot } from "./type.ts";
 import type {
   WorkspaceArchiveFile,
   WorkspaceArchiveSummary,
@@ -34,16 +34,45 @@ export const buildSummary = (
   archiveId: string,
   snapshot: TWorkspaceSnapshot,
   filePath: string,
-): WorkspaceArchiveSummary => ({
-  archiveId,
-  workspaceId: snapshot.workspace.workspaceId,
-  name: snapshot.workspace.name,
-  icon: snapshot.workspace.icon ?? null,
-  userContextId: snapshot.workspace.userContextId,
-  capturedAt: snapshot.capturedAt,
-  filePath,
-  tabCount: snapshot.tabs.length,
+): WorkspaceArchiveSummary => {
+  const summary: WorkspaceArchiveSummary = {
+    archiveId,
+    workspaceId: snapshot.workspace.workspaceId,
+    name: snapshot.workspace.name,
+    userContextId: snapshot.workspace.userContextId,
+    capturedAt: snapshot.capturedAt,
+    filePath,
+    tabCount: snapshot.tabs.length,
+  };
+  if (Object.hasOwn(snapshot.workspace, "icon")) {
+    summary.icon = snapshot.workspace.icon;
+  }
+  return summary;
+};
+
+export const createArchiveFile = (
+  snapshot: TWorkspaceSnapshot,
+): WorkspaceArchiveFile => ({
+  version: 1,
+  snapshot,
 });
+
+export const applyWorkspaceSnapshotMetadata = (
+  workspace: TWorkspace,
+  snapshotWorkspace: TWorkspaceSnapshot["workspace"],
+): TWorkspace => {
+  const restoredWorkspace: TWorkspace = {
+    ...workspace,
+    name: snapshotWorkspace.name,
+    userContextId: snapshotWorkspace.userContextId,
+  };
+  if (Object.hasOwn(snapshotWorkspace, "icon")) {
+    restoredWorkspace.icon = snapshotWorkspace.icon;
+  } else {
+    delete restoredWorkspace.icon;
+  }
+  return restoredWorkspace;
+};
 
 export const filterJsonFiles = (paths: string[]) =>
   paths.filter((path) => path.toLowerCase().endsWith(SNAPSHOT_FILE_EXTENSION));
@@ -141,10 +170,7 @@ export class WorkspacesArchiveService {
     const archiveId = createArchiveId();
     const path = getSnapshotPath(archiveId);
 
-    await safeWriteJSON(path, {
-      version: 1,
-      snapshot,
-    });
+    await safeWriteJSON(path, createArchiveFile(snapshot));
 
     return archiveId;
   }

--- a/browser-features/chrome/common/workspaces/workspace-modal.tsx
+++ b/browser-features/chrome/common/workspaces/workspace-modal.tsx
@@ -21,7 +21,7 @@ import { createRootHMR } from "@nora/solid-xul";
 import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
 import { IconTranslationsHandler } from "./utils/icon-translations-handler.ts";
 
-const WORKSPACE_ICON_NO_CHANGE_SENTINEL =
+export const WORKSPACE_ICON_NO_CHANGE_SENTINEL =
   "__floorp_workspace_icon_picker_no_change__";
 
 export const createWorkspaceIconPickerFormItem = (

--- a/browser-features/chrome/common/workspaces/workspace-modal.tsx
+++ b/browser-features/chrome/common/workspaces/workspace-modal.tsx
@@ -5,6 +5,7 @@
 
 import {
   applyWorkspaceIconSelection,
+  WORKSPACE_ICON_NO_CHANGE_SENTINEL,
   type WorkspaceIcons,
 } from "./utils/workspace-icons.ts";
 import type { TWorkspace, TWorkspaceID } from "./utils/type.ts";
@@ -21,8 +22,9 @@ import { createRootHMR } from "@nora/solid-xul";
 import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
 import { IconTranslationsHandler } from "./utils/icon-translations-handler.ts";
 
-export const WORKSPACE_ICON_NO_CHANGE_SENTINEL =
-  "__floorp_workspace_icon_picker_no_change__";
+export {
+  WORKSPACE_ICON_NO_CHANGE_SENTINEL,
+} from "./utils/workspace-icons.ts";
 
 export const createWorkspaceIconPickerFormItem = (
   workspace: TWorkspace,

--- a/browser-features/chrome/common/workspaces/workspace-modal.tsx
+++ b/browser-features/chrome/common/workspaces/workspace-modal.tsx
@@ -3,12 +3,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { WorkspaceIcons } from "./utils/workspace-icons.ts";
+import {
+  applyWorkspaceIconSelection,
+  type WorkspaceIcons,
+} from "./utils/workspace-icons.ts";
 import type { TWorkspace, TWorkspaceID } from "./utils/type.ts";
 import type { WorkspacesService } from "./workspacesService.ts";
 import ModalParent from "../modal-parent/index.ts";
 import type {
   TForm,
+  TFormItem,
   TFormResult,
 } from "#features-chrome/common/modal-parent/utils/type.ts";
 import i18next from "i18next";
@@ -16,6 +20,45 @@ import { type Accessor, createSignal } from "solid-js";
 import { createRootHMR } from "@nora/solid-xul";
 import { addI18nObserver } from "#i18n/config-browser-chrome.ts";
 import { IconTranslationsHandler } from "./utils/icon-translations-handler.ts";
+
+const WORKSPACE_ICON_NO_CHANGE_SENTINEL =
+  "__floorp_workspace_icon_picker_no_change__";
+
+export const createWorkspaceIconPickerFormItem = (
+  workspace: TWorkspace,
+  iconCtx: WorkspaceIcons,
+  getTranslatedIconName: (alias: string) => string,
+  label: string,
+): TFormItem => ({
+  id: "icon",
+  type: "workspace-icon-picker",
+  label,
+  value: WORKSPACE_ICON_NO_CHANGE_SENTINEL,
+  displayValue: iconCtx.getWorkspaceIconCanonicalId(workspace.icon),
+  options: iconCtx.registry.map((entry) => ({
+    value: entry.canonicalId,
+    label: getTranslatedIconName(entry.alias),
+    icon: iconCtx.getWorkspaceIconUrl(entry.canonicalId),
+    keywords: [...entry.keywords],
+  })),
+});
+
+export const applyWorkspaceModalResult = (
+  workspace: TWorkspace,
+  result: TFormResult | null,
+): TWorkspace | null => {
+  if (result === null) {
+    return null;
+  }
+  return applyWorkspaceIconSelection(
+    {
+      ...workspace,
+      name: result.name as string,
+      userContextId: Number(result.userContextId),
+    },
+    result.icon,
+  );
+};
 
 const { ContextualIdentityService } = ChromeUtils.importESModule(
   "resource://gre/modules/ContextualIdentityService.sys.mjs",
@@ -136,18 +179,12 @@ export class WorkspaceManageModal {
             })),
           ],
         },
-        {
-          id: "icon",
-          type: "dropdown",
-          label: texts.icon,
-          value: workspace.icon || "fingerprint",
-          required: true,
-          options: this.iconCtx.workspaceIconsArray.map((iconName) => ({
-            value: iconName,
-            label: this.iconTranslationsHandler.getTranslatedIconName(iconName),
-            icon: this.iconCtx.getWorkspaceIconUrl(iconName),
-          })),
-        },
+        createWorkspaceIconPickerFormItem(
+          workspace,
+          this.iconCtx,
+          (alias) => this.iconTranslationsHandler.getTranslatedIconName(alias),
+          texts.icon,
+        ),
       ],
       title: texts.editTitle,
       submitLabel: texts.save,

--- a/browser-features/chrome/common/workspaces/workspacesService.ts
+++ b/browser-features/chrome/common/workspaces/workspacesService.ts
@@ -16,13 +16,19 @@ import type {
 } from "./workspacesDataManagerBase";
 import type { WorkspacesTabManager } from "./workspacesTabManager";
 import type { WorkspaceIcons } from "./utils/workspace-icons";
-import { WorkspaceManageModal } from "./workspace-modal";
+import {
+  applyWorkspaceModalResult,
+  WorkspaceManageModal,
+} from "./workspace-modal";
 import i18next from "i18next";
 import {
   createWorkspaceSnapshot,
   ensureSessionStore,
 } from "./utils/workspace-snapshot";
-import { WorkspacesArchiveService } from "./utils/workspaces-archive-service";
+import {
+  applyWorkspaceSnapshotMetadata,
+  WorkspacesArchiveService,
+} from "./utils/workspaces-archive-service";
 import type { TWorkspaceSnapshotTab } from "./utils/type";
 import type { WorkspaceArchiveSummary } from "./utils/archive-types";
 import {
@@ -319,22 +325,21 @@ export class WorkspacesService implements WorkspacesDataManagerBase {
    */
   public async manageWorkspaceFromDialog(id?: TWorkspaceID) {
     const targetWorkspaceID = id ?? this.getSelectedWorkspaceID();
+    if (!this.getRawWorkspace(targetWorkspaceID)) return;
     const result = await this.modalCtx.showWorkspacesModal(targetWorkspaceID);
     if (result === null) return;
-    const { name, icon, userContextId } = result;
-    const workspace = this.getRawWorkspace(targetWorkspaceID);
-    if (!workspace) return;
-    const newWorkspace: TWorkspace = {
-      ...workspace,
-      name: name as string,
-      icon: icon as string,
-      userContextId: Number(userContextId),
-    };
+    let didApply = false;
     setWorkspacesDataStore("data", (prev) => {
       const temp = this.cloneWorkspaceMap(prev);
+      const latestWorkspace = temp.get(targetWorkspaceID);
+      if (!latestWorkspace) return prev;
+      const newWorkspace = applyWorkspaceModalResult(latestWorkspace, result);
+      if (!newWorkspace) return prev;
       temp.set(targetWorkspaceID, newWorkspace);
+      didApply = true;
       return temp as unknown as TWorkspacesStoreData["data"];
     });
+    if (!didApply) return;
     this.tabManagerCtx.updateTabsVisibility();
     return result;
   }
@@ -414,11 +419,10 @@ export class WorkspacesService implements WorkspacesDataManagerBase {
       const temp = this.cloneWorkspaceMap(prev);
       const workspace = temp.get(restoredWorkspaceId);
       if (workspace) {
-        temp.set(restoredWorkspaceId, {
-          ...workspace,
-          icon: snapshot.workspace.icon,
-          userContextId: snapshot.workspace.userContextId,
-        });
+        temp.set(
+          restoredWorkspaceId,
+          applyWorkspaceSnapshotMetadata(workspace, snapshot.workspace),
+        );
       }
       return temp as unknown as TWorkspacesStoreData["data"];
     });

--- a/browser-features/modules/modules/os-apis/workspaces/WorkspacesApiService.sys.mts
+++ b/browser-features/modules/modules/os-apis/workspaces/WorkspacesApiService.sys.mts
@@ -12,10 +12,37 @@
 export interface WorkspaceInfo {
   id: string;
   name: string;
-  icon: string | null;
+  icon?: string | null | undefined;
   userContextId: number;
   isDefault: boolean;
   isSelected: boolean;
+}
+
+export interface StoredWorkspaceInfo {
+  name: string;
+  icon?: string | null | undefined;
+  userContextId: number;
+  isDefault?: boolean;
+  isSelected?: boolean;
+}
+
+export function buildWorkspaceInfo(
+  id: string,
+  workspace: StoredWorkspaceInfo,
+  defaultId: string,
+  currentId: string | null,
+): WorkspaceInfo {
+  const info: WorkspaceInfo = {
+    id,
+    name: workspace.name,
+    userContextId: workspace.userContextId,
+    isDefault: id === defaultId,
+    isSelected: id === currentId,
+  };
+  if (Object.hasOwn(workspace, "icon")) {
+    info.icon = workspace.icon;
+  }
+  return info;
 }
 
 export interface WorkspacesApiServiceType {
@@ -57,13 +84,7 @@ interface WorkspacesFuncs {
 function getWorkspaceData(): {
   data: Map<
     string,
-    {
-      name: string;
-      icon?: string | null;
-      userContextId: number;
-      isDefault?: boolean;
-      isSelected?: boolean;
-    }
+    StoredWorkspaceInfo
   >;
   order: string[];
   defaultID: string;
@@ -123,14 +144,7 @@ export const WorkspacesApiService: WorkspacesApiServiceType = {
     for (const id of wsData.order) {
       const ws = wsData.data.get(id);
       if (ws) {
-        workspaces.push({
-          id,
-          name: ws.name,
-          icon: ws.icon ?? null,
-          userContextId: ws.userContextId,
-          isDefault: id === wsData.defaultID,
-          isSelected: id === currentId,
-        });
+        workspaces.push(buildWorkspaceInfo(id, ws, wsData.defaultID, currentId));
       }
     }
 

--- a/browser-features/modules/modules/os-apis/workspaces/WorkspacesApiService.test.mts
+++ b/browser-features/modules/modules/os-apis/workspaces/WorkspacesApiService.test.mts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  buildWorkspaceInfo,
+  type StoredWorkspaceInfo,
+} from "./WorkspacesApiService.sys.mts";
+import {
+  assert,
+  assertEquals,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+
+const makeWorkspace = (): Omit<StoredWorkspaceInfo, "icon"> => ({
+  name: "API workspace",
+  userContextId: 3,
+});
+
+function testApiPreservesRawIconCategories(): void {
+  const cases: Array<[string, StoredWorkspaceInfo]> = [
+    ["absent", makeWorkspace()],
+    ["own undefined", { ...makeWorkspace(), icon: undefined }],
+    ["null", { ...makeWorkspace(), icon: null }],
+    ["alias", { ...makeWorkspace(), icon: "article" }],
+    ["canonical", { ...makeWorkspace(), icon: "floorp-icon:v1:article" }],
+    ["opaque", { ...makeWorkspace(), icon: "future:value" }],
+    ["URI", { ...makeWorkspace(), icon: "https://example.invalid/icon.svg" }],
+  ];
+  for (const [label, workspace] of cases) {
+    const result = buildWorkspaceInfo("id", workspace, "id", "id");
+    assertEquals(
+      Object.hasOwn(result, "icon"),
+      Object.hasOwn(workspace, "icon"),
+      `${label} presence`,
+    );
+    if (Object.hasOwn(workspace, "icon")) {
+      assertEquals(result.icon, workspace.icon, `${label} value`);
+    }
+    assertEquals(result.isDefault, true, `${label} default flag`);
+    assertEquals(result.isSelected, true, `${label} selected flag`);
+  }
+}
+
+function testApiJsonOmitsUndefinedWithoutCreatingNull(): void {
+  const absent = JSON.parse(
+    JSON.stringify(buildWorkspaceInfo("id", makeWorkspace(), "other", null)),
+  ) as Record<string, unknown>;
+  const ownUndefined = JSON.parse(
+    JSON.stringify(
+      buildWorkspaceInfo(
+        "id",
+        { ...makeWorkspace(), icon: undefined },
+        "other",
+        null,
+      ),
+    ),
+  ) as Record<string, unknown>;
+  const explicitNull = JSON.parse(
+    JSON.stringify(
+      buildWorkspaceInfo(
+        "id",
+        { ...makeWorkspace(), icon: null },
+        "other",
+        null,
+      ),
+    ),
+  ) as Record<string, unknown>;
+  assert(!Object.hasOwn(absent, "icon"), "absent API icon is omitted");
+  assert(
+    !Object.hasOwn(ownUndefined, "icon"),
+    "undefined API icon is omitted, never converted to null",
+  );
+  assertEquals(explicitNull.icon, null, "explicit API null remains null");
+}
+
+export function runAllTests(): void {
+  const tests: TestCase[] = [
+    {
+      name: "API preserves raw icon categories",
+      fn: testApiPreservesRawIconCategories,
+    },
+    {
+      name: "API JSON omits undefined without creating null",
+      fn: testApiJsonOmitsUndefinedWithoutCreatingNull,
+    },
+  ];
+  const failures: string[] = [];
+  for (const test of tests) {
+    try {
+      test.fn();
+    } catch (error) {
+      failures.push(
+        `${test.name}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `WorkspacesApiService.test.mts failures: ${failures.join(" | ")}`,
+    );
+  }
+}

--- a/browser-features/pages-modal-child/src/App.tsx
+++ b/browser-features/pages-modal-child/src/App.tsx
@@ -20,6 +20,7 @@ import {
   type ModalPageState,
   type NoraModalSubmitMessage,
 } from "./modalProtocol.ts";
+import { WorkspaceIconPickerField } from "./components/WorkspaceIconPickerField.tsx";
 
 interface FormValues {
   [key: string]: string;
@@ -288,6 +289,22 @@ const FormField = ({ item, control }: FormFieldProps) => {
             )}
           />
         </div>
+      );
+
+    case "workspace-icon-picker":
+      return (
+        <Controller
+          name={item.id}
+          control={control}
+          defaultValue={String(item.value || "")}
+          render={({ field: { onChange, value } }) => (
+            <WorkspaceIconPickerField
+              item={item}
+              value={String(value)}
+              onChange={onChange}
+            />
+          )}
+        />
       );
 
     case "checkbox":

--- a/browser-features/pages-modal-child/src/components/WorkspaceIconPickerField.tsx
+++ b/browser-features/pages-modal-child/src/components/WorkspaceIconPickerField.tsx
@@ -1,0 +1,123 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useId, useMemo, useState } from "react";
+import type { TFormItem } from "../../../chrome/common/modal-parent/utils/type.ts";
+import {
+  filterWorkspaceIconPickerOptions,
+  getSafeWorkspaceIconPickerOptions,
+  resolveWorkspaceIconPickerDisplayValue,
+  selectWorkspaceIconPickerValue,
+} from "../workspaceIconPickerModel.ts";
+
+interface WorkspaceIconPickerFieldProps {
+  item: TFormItem;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function WorkspaceIconPickerField({
+  item,
+  value,
+  onChange,
+}: WorkspaceIconPickerFieldProps) {
+  const [query, setQuery] = useState("");
+  const radioGroupName = useId();
+  const options = useMemo(
+    () => getSafeWorkspaceIconPickerOptions(item.options ?? []),
+    [item.options],
+  );
+  const visibleOptions = useMemo(
+    () => filterWorkspaceIconPickerOptions(options, query),
+    [options, query],
+  );
+  const displayValue = resolveWorkspaceIconPickerDisplayValue(
+    value,
+    item.displayValue,
+    options,
+  );
+  const selectedOption = options.find((option) =>
+    option.value === displayValue
+  );
+  const fieldLabel = item.label ?? item.id;
+  const commitSelection = (candidate: string) => {
+    const nextValue = selectWorkspaceIconPickerValue(
+      value,
+      candidate,
+      options,
+    );
+    if (nextValue !== value) {
+      onChange(nextValue);
+    }
+  };
+
+  return (
+    <fieldset className="mb-4 w-full">
+      <legend className="block text-sm font-medium mb-2 text-gray-900 dark:text-white">
+        {fieldLabel}
+      </legend>
+
+      {selectedOption?.icon && (
+        <div className="mb-2 flex items-center gap-2 text-sm text-gray-900 dark:text-white">
+          <img
+            src={selectedOption.icon}
+            className="h-5 w-5"
+            alt=""
+          />
+          <span>{selectedOption.label}</span>
+        </div>
+      )}
+
+      <input
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        aria-label={fieldLabel}
+        placeholder={fieldLabel}
+        className="mb-2 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#0061E0] dark:border-[#42414D] dark:bg-[#42414D] dark:text-white"
+      />
+
+      <div
+        role="radiogroup"
+        aria-label={fieldLabel}
+        className="grid max-h-48 grid-cols-6 gap-2 overflow-y-auto rounded-md border border-gray-300 p-2 dark:border-[#42414D]"
+      >
+        {visibleOptions.map((option) => (
+          <label
+            key={option.value}
+            className="block h-10 w-full cursor-pointer"
+          >
+            <input
+              type="radio"
+              name={radioGroupName}
+              value={option.value}
+              checked={displayValue === option.value}
+              aria-label={option.label}
+              className="peer sr-only"
+              onChange={() => commitSelection(option.value)}
+              onClick={() => {
+                if (
+                  displayValue === option.value && value !== option.value
+                ) {
+                  commitSelection(option.value);
+                }
+              }}
+            />
+            <span
+              title={option.label}
+              className={`flex h-full w-full items-center justify-center rounded-md border p-2 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-[#0061E0] ${
+                displayValue === option.value
+                  ? "border-[#0061E0] bg-blue-50 dark:bg-[#42414D]"
+                  : "border-transparent hover:bg-gray-100 dark:hover:bg-gray-600"
+              }`}
+            >
+              <img src={option.icon} className="h-5 w-5" alt="" />
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/browser-features/pages-modal-child/src/workspaceIconPickerModel.ts
+++ b/browser-features/pages-modal-child/src/workspaceIconPickerModel.ts
@@ -1,0 +1,94 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { TFormOption } from "../../chrome/common/modal-parent/utils/type.ts";
+
+const CANONICAL_ICON_ID_PATTERN = /^floorp-icon:v1:[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const BUNDLED_SVG_DATA_URL_PREFIX = "data:image/svg+xml;base64,";
+const BASE64_PAYLOAD_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+export const isCanonicalWorkspaceIconPickerValue = (
+  value: unknown,
+): value is string =>
+  typeof value === "string" && CANONICAL_ICON_ID_PATTERN.test(value);
+
+export const isSafeWorkspaceIconPreview = (value: unknown): value is string => {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith(BUNDLED_SVG_DATA_URL_PREFIX)
+  ) {
+    return false;
+  }
+  return BASE64_PAYLOAD_PATTERN.test(
+    value.slice(BUNDLED_SVG_DATA_URL_PREFIX.length),
+  );
+};
+
+export const getSafeWorkspaceIconPickerOptions = (
+  options: readonly TFormOption[],
+): TFormOption[] => {
+  const seen = new Set<string>();
+  return options.filter((option) => {
+    if (
+      !isCanonicalWorkspaceIconPickerValue(option.value) ||
+      !isSafeWorkspaceIconPreview(option.icon) ||
+      seen.has(option.value)
+    ) {
+      return false;
+    }
+    seen.add(option.value);
+    return true;
+  });
+};
+
+const normalizeSearchTerm = (value: string): string =>
+  value.trim().toLocaleLowerCase();
+
+export const filterWorkspaceIconPickerOptions = (
+  options: readonly TFormOption[],
+  query: string,
+): TFormOption[] => {
+  const normalizedQuery = normalizeSearchTerm(query);
+  if (!normalizedQuery) {
+    return [...options];
+  }
+
+  return options.filter((option) => {
+    const searchable = [
+      option.label,
+      option.value.slice("floorp-icon:v1:".length),
+      ...(option.keywords ?? []),
+    ];
+    return searchable.some((value) =>
+      normalizeSearchTerm(value).includes(normalizedQuery)
+    );
+  });
+};
+
+const hasOption = (
+  options: readonly TFormOption[],
+  value: unknown,
+): value is string =>
+  typeof value === "string" && options.some((option) => option.value === value);
+
+export const resolveWorkspaceIconPickerDisplayValue = (
+  formValue: unknown,
+  initialDisplayValue: unknown,
+  options: readonly TFormOption[],
+): string | null => {
+  if (hasOption(options, formValue)) {
+    return formValue;
+  }
+  if (hasOption(options, initialDisplayValue)) {
+    return initialDisplayValue;
+  }
+  return null;
+};
+
+export const selectWorkspaceIconPickerValue = (
+  currentValue: string,
+  candidate: unknown,
+  options: readonly TFormOption[],
+): string => hasOption(options, candidate) ? candidate : currentValue;

--- a/browser-features/pages-modal-child/test/workspaceIconPickerModel.test.ts
+++ b/browser-features/pages-modal-child/test/workspaceIconPickerModel.test.ts
@@ -9,6 +9,9 @@ import {
 } from "../src/workspaceIconPickerModel.ts";
 import type { TFormOption } from "../../chrome/common/modal-parent/utils/type.ts";
 import {
+  WORKSPACE_ICON_NO_CHANGE_SENTINEL,
+} from "../../chrome/common/workspaces/workspace-modal.tsx";
+import {
   assert,
   assertEquals,
   type TestCase,
@@ -79,7 +82,7 @@ function testFilterUsesLabelSlugAndKeywords(): void {
 }
 
 function testNoChangeAndInvalidSelectionPreserveSentinel(): void {
-  const sentinel = "__private_no_change__";
+  const sentinel = WORKSPACE_ICON_NO_CHANGE_SENTINEL;
   assertEquals(
     selectWorkspaceIconPickerValue(sentinel, "article", options),
     sentinel,
@@ -102,7 +105,7 @@ function testNoChangeAndInvalidSelectionPreserveSentinel(): void {
 }
 
 function testDisplayValueDoesNotChangeFormValue(): void {
-  const sentinel = "__private_no_change__";
+  const sentinel = WORKSPACE_ICON_NO_CHANGE_SENTINEL;
   assertEquals(
     resolveWorkspaceIconPickerDisplayValue(
       sentinel,
@@ -129,7 +132,7 @@ function testDisplayValueDoesNotChangeFormValue(): void {
 }
 
 function testDisplayedFallbackCanBeExplicitlyCanonicalized(): void {
-  const sentinel = "__private_no_change__";
+  const sentinel = WORKSPACE_ICON_NO_CHANGE_SENTINEL;
   const displayValue = resolveWorkspaceIconPickerDisplayValue(
     sentinel,
     "floorp-icon:v1:article",

--- a/browser-features/pages-modal-child/test/workspaceIconPickerModel.test.ts
+++ b/browser-features/pages-modal-child/test/workspaceIconPickerModel.test.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  filterWorkspaceIconPickerOptions,
+  getSafeWorkspaceIconPickerOptions,
+  resolveWorkspaceIconPickerDisplayValue,
+  selectWorkspaceIconPickerValue,
+} from "../src/workspaceIconPickerModel.ts";
+import type { TFormOption } from "../../chrome/common/modal-parent/utils/type.ts";
+import {
+  assert,
+  assertEquals,
+  type TestCase,
+} from "../../chrome/test/utils/test_harness.ts";
+
+const SAFE_PREVIEW = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+const options: TFormOption[] = [
+  {
+    label: "Article",
+    value: "floorp-icon:v1:article",
+    icon: SAFE_PREVIEW,
+    keywords: ["document", "news"],
+  },
+  {
+    label: "Music",
+    value: "floorp-icon:v1:music",
+    icon: SAFE_PREVIEW,
+    keywords: ["audio", "song"],
+  },
+];
+
+function testSafeOptionsRejectNetworkAndMalformedValues(): void {
+  const filtered = getSafeWorkspaceIconPickerOptions([
+    ...options,
+    { ...options[0], icon: "https://example.invalid/icon.svg" },
+    { ...options[0], value: "article" },
+    { ...options[0], value: "floorp-icon:v1:Article" },
+    { ...options[0], value: "floorp-icon:v1:article " },
+    { ...options[0], icon: "data:text/html;base64,PHNjcmlwdD4=" },
+  ]);
+  assertEquals(
+    filtered.length,
+    2,
+    "only unique canonical bundled options remain",
+  );
+  assert(
+    filtered.every((option) => option.icon === SAFE_PREVIEW),
+    "no network or non-SVG preview survives",
+  );
+}
+
+function testFilterUsesLabelSlugAndKeywords(): void {
+  assertEquals(
+    filterWorkspaceIconPickerOptions(options, "MUSIC").length,
+    1,
+    "label",
+  );
+  assertEquals(
+    filterWorkspaceIconPickerOptions(options, "article").length,
+    1,
+    "slug",
+  );
+  assertEquals(
+    filterWorkspaceIconPickerOptions(options, "document").length,
+    1,
+    "keyword",
+  );
+  assertEquals(
+    filterWorkspaceIconPickerOptions(options, "missing").length,
+    0,
+    "miss",
+  );
+  assertEquals(
+    filterWorkspaceIconPickerOptions(options, "  ").length,
+    2,
+    "empty query",
+  );
+}
+
+function testNoChangeAndInvalidSelectionPreserveSentinel(): void {
+  const sentinel = "__private_no_change__";
+  assertEquals(
+    selectWorkspaceIconPickerValue(sentinel, "article", options),
+    sentinel,
+    "alias cannot be emitted",
+  );
+  assertEquals(
+    selectWorkspaceIconPickerValue(
+      sentinel,
+      "https://example.invalid/icon.svg",
+      options,
+    ),
+    sentinel,
+    "URI cannot be emitted",
+  );
+  assertEquals(
+    selectWorkspaceIconPickerValue(sentinel, "floorp-icon:v1:music", options),
+    "floorp-icon:v1:music",
+    "explicit listed canonical selection is emitted",
+  );
+}
+
+function testDisplayValueDoesNotChangeFormValue(): void {
+  const sentinel = "__private_no_change__";
+  assertEquals(
+    resolveWorkspaceIconPickerDisplayValue(
+      sentinel,
+      "floorp-icon:v1:article",
+      options,
+    ),
+    "floorp-icon:v1:article",
+    "safe initial display is independent of sentinel",
+  );
+  assertEquals(
+    resolveWorkspaceIconPickerDisplayValue(
+      "floorp-icon:v1:music",
+      "floorp-icon:v1:article",
+      options,
+    ),
+    "floorp-icon:v1:music",
+    "explicit selection becomes display value",
+  );
+  assertEquals(
+    resolveWorkspaceIconPickerDisplayValue(sentinel, "opaque", options),
+    null,
+    "opaque initial value is never displayed",
+  );
+}
+
+function testDisplayedFallbackCanBeExplicitlyCanonicalized(): void {
+  const sentinel = "__private_no_change__";
+  const displayValue = resolveWorkspaceIconPickerDisplayValue(
+    sentinel,
+    "floorp-icon:v1:article",
+    options,
+  );
+  assertEquals(
+    displayValue,
+    "floorp-icon:v1:article",
+    "safe fallback is displayed without changing the sentinel",
+  );
+  assertEquals(
+    selectWorkspaceIconPickerValue(sentinel, displayValue, options),
+    "floorp-icon:v1:article",
+    "activating the displayed fallback emits its canonical value",
+  );
+  assertEquals(
+    selectWorkspaceIconPickerValue(sentinel, "article", options),
+    sentinel,
+    "fallback activation still rejects an alias",
+  );
+  assertEquals(
+    selectWorkspaceIconPickerValue(
+      sentinel,
+      "floorp-icon:v1:unknown",
+      options,
+    ),
+    sentinel,
+    "fallback activation still rejects an unknown canonical-looking value",
+  );
+  assertEquals(
+    selectWorkspaceIconPickerValue(
+      sentinel,
+      "https://example.invalid/icon.svg",
+      options,
+    ),
+    sentinel,
+    "fallback activation still rejects a URI",
+  );
+}
+
+export function runAllTests(): void {
+  const tests: TestCase[] = [
+    {
+      name: "safe options reject network and malformed values",
+      fn: testSafeOptionsRejectNetworkAndMalformedValues,
+    },
+    {
+      name: "filter uses label slug and keywords",
+      fn: testFilterUsesLabelSlugAndKeywords,
+    },
+    {
+      name: "no-change and invalid selection preserve sentinel",
+      fn: testNoChangeAndInvalidSelectionPreserveSentinel,
+    },
+    {
+      name: "display value does not change form value",
+      fn: testDisplayValueDoesNotChangeFormValue,
+    },
+    {
+      name: "displayed fallback can be explicitly canonicalized",
+      fn: testDisplayedFallbackCanBeExplicitlyCanonicalized,
+    },
+  ];
+  const failures: string[] = [];
+  for (const test of tests) {
+    try {
+      test.fn();
+    } catch (error) {
+      failures.push(
+        `${test.name}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `workspaceIconPickerModel.test.ts failures: ${failures.join(" | ")}`,
+    );
+  }
+}

--- a/browser-features/pages-modal-child/test/workspaceIconPickerModel.test.ts
+++ b/browser-features/pages-modal-child/test/workspaceIconPickerModel.test.ts
@@ -10,7 +10,7 @@ import {
 import type { TFormOption } from "../../chrome/common/modal-parent/utils/type.ts";
 import {
   WORKSPACE_ICON_NO_CHANGE_SENTINEL,
-} from "../../chrome/common/workspaces/workspace-modal.tsx";
+} from "../../chrome/common/workspaces/utils/workspace-icons.ts";
 import {
   assert,
   assertEquals,

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Architecture Overview

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Common Chrome Features

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Common Chrome Feature Catalog

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Browser UI Customization

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Common Chrome Feature Categories

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Window Actor Categories

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Settings & Internal Page Actors

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Web Content & Store Actors

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Browser Features Catalog

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Window Actor Catalog

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "94fbc9c258f5d412c4c43506b51702f3bdc7ba47"
+floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `94fbc9c258f5d412c4c43506b51702f3bdc7ba47`.
+Inventory generated from Floorp commit `ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64`.
 
 ## Source Precedence
 


### PR DESCRIPTION
Reimplements and deepens derp fork PR #2579 for issue #2569.

The workspace icon field becomes a searchable picker backed by a canonical icon registry instead of a flat dropdown of bundled glyphs.

- **Canonical icon IDs** — \loorp-icon:v1:<slug>\ stored as the workspace icon; legacy bare names (\ingerprint\) still resolve via alias for display and are preserved on no-change saves
- **Registry** — 34 icons with keywords in \workspace-icons.ts\, label keys, and base64 data-URL previews (context-fill tintable)
- **Pure picker model** — \workspaceIconPickerModel.ts\ (safe option filtering, search, display-value resolution) with its own test suite
- **Form integration** — new \workspace-icon-picker\ item type + \WorkspaceIconPickerField\ rendered through the current modal protocol (reconciled with the #2603 modal-parent rewrite)
- **Round-trip coverage** — archive/snapshot/api service tests preserve canonical IDs byte-for-byte
- Regenerated deterministic docs

Note: \WorkspaceInfo.icon\ is now optional in the os-server wire shape (key omitted instead of \
ull\) — JSON passthrough only consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable workspace icon picker with accessible icon-grid selection.
  * Expanded workspace icon support with canonical identifiers, aliases, labels, and keywords.
  * Added safer handling for custom, invalid, and missing workspace icon values.

* **Bug Fixes**
  * Workspace snapshots and archives now preserve icon values accurately, including explicit null and absent values.
  * Invalid or unsafe icons now fall back to the default fingerprint icon.

* **Documentation**
  * Updated generated documentation references to the latest source revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->