### PR TITLE
feat(shortcuts): add chord-drag window move

### DIFF
--- a/browser-features/chrome/common/window-drag/drag-session.ts
+++ b/browser-features/chrome/common/window-drag/drag-session.ts
@@ -1,0 +1,89 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure drag-session state for the chord-drag window move. Kept free of DOM
+ * so the gesture rules are unit-testable in the browser harness.
+ */
+
+export interface DragSessionState {
+  active: boolean;
+  lastScreenX: number;
+  lastScreenY: number;
+}
+
+export type DragSessionAction =
+  | { type: "down"; screenX: number; screenY: number }
+  | { type: "move"; screenX: number; screenY: number; chordHeld: boolean }
+  | { type: "end" }
+  | { type: "cancel" };
+
+export type DragSessionResult =
+  | { type: "start"; state: DragSessionState }
+  | { type: "move"; deltaX: number; deltaY: number; state: DragSessionState }
+  | { type: "noop"; state: DragSessionState }
+  | { type: "cancel"; state: DragSessionState };
+
+export const emptyDragSession = (): DragSessionState => ({
+  active: false,
+  lastScreenX: 0,
+  lastScreenY: 0,
+});
+
+/**
+ * Reduce a pointer/keys event into the next drag-session state.
+ *
+ * - A `down` with the chord held starts a drag anchored at that point.
+ * - A `move` while active re-verifies the chord (a mouseup released outside
+ *   the window never reaches us; without this a latched drag flag would
+ *   relocate the window on every later move).
+ * - `end`, or any `cancel` (key-up, blur), stops the drag.
+ */
+export const reduceDragSession = (
+  state: DragSessionState,
+  action: DragSessionAction,
+): DragSessionResult => {
+  switch (action.type) {
+    case "down":
+      return {
+        type: "start",
+        state: {
+          active: true,
+          lastScreenX: action.screenX,
+          lastScreenY: action.screenY,
+        },
+      };
+    case "move":
+      if (!state.active) {
+        return { type: "noop", state };
+      }
+      if (!action.chordHeld) {
+        return {
+          type: "cancel",
+          state: { ...state, active: false },
+        };
+      }
+      return {
+        type: "move",
+        deltaX: action.screenX - state.lastScreenX,
+        deltaY: action.screenY - state.lastScreenY,
+        state: {
+          active: true,
+          lastScreenX: action.screenX,
+          lastScreenY: action.screenY,
+        },
+      };
+    case "end":
+      return {
+        type: "cancel",
+        state: { ...state, active: false },
+      };
+    case "cancel":
+      return {
+        type: "cancel",
+        state: { ...state, active: false },
+      };
+  }
+};

--- a/browser-features/chrome/common/window-drag/index.ts
+++ b/browser-features/chrome/common/window-drag/index.ts
@@ -1,0 +1,115 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { onCleanup } from "solid-js";
+import {
+  noraComponent,
+  NoraComponentBase,
+} from "#features-chrome/utils/base.ts";
+import {
+  emptyDragSession,
+  type DragSessionState,
+  reduceDragSession,
+} from "./drag-session.ts";
+
+const IS_MAC = /mac/i.test(navigator.platform ?? "");
+
+/**
+ * Move the window by holding a modifier chord and dragging anywhere —
+ * toolbars, tab strip, or web content. Most useful in zen mode and
+ * multirow tabs, where the draggable titlebar is hidden or crowded, but
+ * always active.
+ *
+ * macOS: Alt+Cmd+drag. Windows/Linux: Ctrl+Alt+drag.
+ * Plain Cmd cannot be used on its own: Cmd+click opens links in new tabs,
+ * toggles tab multi-selection, and web apps (Figma, Miro, maps) use
+ * Cmd+drag for canvas panning — a bare-Cmd drag start is ambiguous.
+ */
+@noraComponent(import.meta.hot)
+export default class WindowDrag extends NoraComponentBase {
+  init(): void {
+    // The loader instantiates this class once per browser window, so the
+    // module globals resolve to the owning window's context.
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    let session: DragSessionState = emptyDragSession();
+
+    const chordHeld = (e: MouseEvent): boolean =>
+      IS_MAC ? e.metaKey && e.altKey : e.ctrlKey && e.altKey;
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.button !== 0 || !chordHeld(e)) return;
+      const result = reduceDragSession(session, {
+        type: "down",
+        screenX: e.screenX,
+        screenY: e.screenY,
+      });
+      if (result.type === "start") {
+        session = result.state;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      // Re-verify the chord on every event: a mouseup released outside the
+      // window (or over a popup) never reaches us, and a latched drag flag
+      // would otherwise keep relocating the window on every later mouse
+      // move until it sits offscreen with only an edge visible.
+      const result = reduceDragSession(session, {
+        type: "move",
+        screenX: e.screenX,
+        screenY: e.screenY,
+        chordHeld: chordHeld(e),
+      });
+      session = result.state;
+      if (result.type === "move") {
+        if (result.deltaX !== 0 || result.deltaY !== 0) {
+          window.moveBy(result.deltaX, result.deltaY);
+        }
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    };
+
+    const endDrag = (e: MouseEvent) => {
+      const result = reduceDragSession(session, { type: "end" });
+      if (result.type === "cancel" && session.active) {
+        session = result.state;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    };
+
+    // Releasing any part of the chord cancels the drag so the window
+    // never sticks to the pointer.
+    const onKeyUp = () => {
+      const result = reduceDragSession(session, { type: "cancel" });
+      session = result.state;
+    };
+    const onBlur = () => {
+      const result = reduceDragSession(session, { type: "cancel" });
+      session = result.state;
+    };
+
+    addEventListener("mousedown", onMouseDown, true);
+    addEventListener("mousemove", onMouseMove, true);
+    addEventListener("mouseup", endDrag, true);
+    addEventListener("keyup", onKeyUp, true);
+    addEventListener("blur", onBlur);
+
+    onCleanup(() => {
+      removeEventListener("mousedown", onMouseDown, true);
+      removeEventListener("mousemove", onMouseMove, true);
+      removeEventListener("mouseup", endDrag, true);
+      removeEventListener("keyup", onKeyUp, true);
+      removeEventListener("blur", onBlur);
+    });
+
+    this.logger.debug("WindowDrag attached (chord-drag window move)");
+  }
+}

--- a/browser-features/chrome/common/window-drag/test/windowDragSession.test.ts
+++ b/browser-features/chrome/common/window-drag/test/windowDragSession.test.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  emptyDragSession,
+  reduceDragSession,
+} from "../drag-session.ts";
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+
+function testDownStartsDragAnchored(): void {
+  const result = reduceDragSession(emptyDragSession(), {
+    type: "down",
+    screenX: 10,
+    screenY: 20,
+  });
+  assertEquals(result.type, "start", "chord down should start a drag");
+  if (result.type !== "start") return;
+  assert(result.state.active, "drag should be active after start");
+  assertEquals(result.state.lastScreenX, 10, "anchor x recorded");
+  assertEquals(result.state.lastScreenY, 20, "anchor y recorded");
+}
+
+function testMoveComputesDeltaAndAdvancesAnchor(): void {
+  const started = reduceDragSession(emptyDragSession(), {
+    type: "down",
+    screenX: 10,
+    screenY: 20,
+  });
+  if (started.type !== "start") return;
+  const moved = reduceDragSession(started.state, {
+    type: "move",
+    screenX: 25,
+    screenY: 35,
+    chordHeld: true,
+  });
+  assertEquals(moved.type, "move", "move while active should move");
+  if (moved.type !== "move") return;
+  assertEquals(moved.deltaX, 15, "delta x computed from anchor");
+  assertEquals(moved.deltaY, 15, "delta y computed from anchor");
+  assertEquals(moved.state.lastScreenX, 25, "anchor advances on move");
+  assertEquals(moved.state.lastScreenY, 35, "anchor advances on move");
+}
+
+function testChordReleaseCancelsDrag(): void {
+  const started = reduceDragSession(emptyDragSession(), {
+    type: "down",
+    screenX: 0,
+    screenY: 0,
+  });
+  if (started.type !== "start") return;
+  const cancelled = reduceDragSession(started.state, {
+    type: "move",
+    screenX: 5,
+    screenY: 5,
+    chordHeld: false,
+  });
+  assertEquals(cancelled.type, "cancel", "released chord should cancel drag");
+  if (cancelled.type !== "cancel") return;
+  assert(!cancelled.state.active, "drag should be inactive after cancel");
+}
+
+function testMoveWithoutDragIsNoop(): void {
+  const result = reduceDragSession(emptyDragSession(), {
+    type: "move",
+    screenX: 5,
+    screenY: 5,
+    chordHeld: true,
+  });
+  assertEquals(result.type, "noop", "move without active drag is a noop");
+}
+
+function testKeyUpAndBlurCancelDrag(): void {
+  const started = reduceDragSession(emptyDragSession(), {
+    type: "down",
+    screenX: 0,
+    screenY: 0,
+  });
+  if (started.type !== "start") return;
+
+  const keyUp = reduceDragSession(started.state, { type: "cancel" });
+  assertEquals(keyUp.type, "cancel", "key-up should cancel");
+  if (keyUp.type !== "cancel") return;
+  assert(!keyUp.state.active, "inactive after key-up");
+
+  const restarted = reduceDragSession(emptyDragSession(), {
+    type: "down",
+    screenX: 0,
+    screenY: 0,
+  });
+  if (restarted.type !== "start") return;
+  const blur = reduceDragSession(restarted.state, { type: "end" });
+  assertEquals(blur.type, "cancel", "mouseup/blur should cancel");
+  assert(blur.type === "cancel" && !blur.state.active, "inactive after end");
+}
+
+function testEndThenMoveStaysInactive(): void {
+  const started = reduceDragSession(emptyDragSession(), {
+    type: "down",
+    screenX: 0,
+    screenY: 0,
+  });
+  if (started.type !== "start") return;
+  const ended = reduceDragSession(started.state, { type: "end" });
+  if (ended.type !== "cancel") return;
+  const afterEnd = reduceDragSession(ended.state, {
+    type: "move",
+    screenX: 10,
+    screenY: 10,
+    chordHeld: true,
+  });
+  assertEquals(afterEnd.type, "noop", "no drag after end");
+}
+
+const tests: TestCase[] = [
+  { name: "chord down starts a drag anchored at the point", fn: testDownStartsDragAnchored },
+  { name: "move computes delta and advances anchor", fn: testMoveComputesDeltaAndAdvancesAnchor },
+  { name: "released chord cancels the drag", fn: testChordReleaseCancelsDrag },
+  { name: "move without active drag is a noop", fn: testMoveWithoutDragIsNoop },
+  { name: "key-up and blur cancel the drag", fn: testKeyUpAndBlurCancelDrag },
+  { name: "end then move stays inactive", fn: testEndThenMoveStaysInactive },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("windowDragSession.test.ts", tests);
+}

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Architecture Overview
@@ -58,7 +58,7 @@ Window Actors are registered from `browser-features/modules/modules/BrowserGlue.
 
 ## Chrome UI Features
 
-Common chrome features are discovered from `browser-features/chrome/common/mod.ts:4` with the glob pattern `./*/index.ts`. The current inventory lists 33 common features:
+Common chrome features are discovered from `browser-features/chrome/common/mod.ts:4` with the glob pattern `./*/index.ts`. The current inventory lists 34 common features:
 
 - `addons`
 - `browser-share-mode`
@@ -91,6 +91,7 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 - `tabbar`
 - `ui-custom`
 - `undo-closed-tab`
+- `window-drag`
 - `workspaces`
 - `zen-mode`
 

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Common Chrome Features
@@ -10,7 +10,7 @@ The `browser-features/chrome/common/` directory contains loader-managed browser 
 
 ## Discovery And Loading
 
-Common features are discovered by `browser-features/chrome/common/mod.ts:4` using the glob pattern `./*/index.ts`. The current inventory contains 33 common feature entries.
+Common features are discovered by `browser-features/chrome/common/mod.ts:4` using the glob pattern `./*/index.ts`. The current inventory contains 34 common feature entries.
 
 The bridge loader turns discovered entries into loadable modules, while each feature entrypoint remains responsible for its own component, services, styles, context menus, or lifecycle hooks.
 
@@ -99,6 +99,7 @@ Small chrome utilities and action helpers that do not own a broader feature fami
 | tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
 | tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
 | tab-strip-wheel-guard | `browser-features/chrome/common/tab-strip-wheel-guard/index.ts` | `default class TabStripWheelGuard`, `init` | Owns the tab strip wheel guard feature through the TabStripWheelGuard chrome component and wires `classifier`. |
+| window-drag | `browser-features/chrome/common/window-drag/index.ts` | `default class WindowDrag`, `init` | Owns the window drag feature through the WindowDrag chrome component and wires `drag-session`. |
 
 ## Relationship To Other Layers
 

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Common Chrome Feature Catalog
@@ -43,5 +43,6 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 | tabbar | `browser-features/chrome/common/tabbar/index.ts` | `default class TabBar`, `init` | Owns the tabbar feature through the TabBar chrome component and wires `multirow-tabbar/multirow-tabbar`, `tabbbar-style/tabbar-style`. |
 | ui-custom | `browser-features/chrome/common/ui-custom/index.ts` | `default class UICustomization`, `init`, `initBeforeSessionStoreInit` | Owns the ui custom feature through the UICustomization chrome component and wires `styles/style-manager`, `layout/dom-manipulator`. |
 | undo-closed-tab | `browser-features/chrome/common/undo-closed-tab/index.ts` | `default class UndoClosedTab`, `init` | Owns the undo closed tab feature through the UndoClosedTab chrome component and wires `styleElem`. |
+| window-drag | `browser-features/chrome/common/window-drag/index.ts` | `default class WindowDrag`, `init` | Owns the window drag feature through the WindowDrag chrome component and wires `drag-session`. |
 | workspaces | `browser-features/chrome/common/workspaces/index.ts` | `default class Workspaces`, `init` | Owns the workspaces feature through the Workspaces chrome component and wires `workspacesTabManager`, `utils/workspace-icons`, `workspacesService`. |
 | zen-mode | `browser-features/chrome/common/zen-mode/index.ts` | `default class ZenMode`, `init` | Owns the zen mode feature through the ZenMode chrome component and wires `zen-mode`, `icon.css?inline`. |

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Browser UI Customization

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Common Chrome Feature Categories
@@ -18,7 +18,7 @@ This nested catalog is generated from `browser-features/chrome/common`. It group
 | [Input & Shortcuts](./input-and-shortcuts) | 4 | Keyboard, mouse gesture, context menu, and command palette interaction features. |
 | [Web Apps & Integration](./webapps-and-integration) | 6 | PWA, profile, add-on, external browser, share mode, and container integration features. |
 | [Utilities & Actions](./utilities-and-actions) | 2 | Small chrome utilities and action helpers that do not own a broader feature family. |
-| Uncategorized | 3 | Entries discovered from `browser-features/chrome/common` that do not yet have a docs category. |
+| Uncategorized | 4 | Entries discovered from `browser-features/chrome/common` that do not yet have a docs category. |
 
 ## Uncategorized Entries
 
@@ -27,3 +27,4 @@ This nested catalog is generated from `browser-features/chrome/common`. It group
 | tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
 | tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
 | tab-strip-wheel-guard | `browser-features/chrome/common/tab-strip-wheel-guard/index.ts` | `default class TabStripWheelGuard`, `init` | Owns the tab strip wheel guard feature through the TabStripWheelGuard chrome component and wires `classifier`. |
+| window-drag | `browser-features/chrome/common/window-drag/index.ts` | `default class WindowDrag`, `init` | Owns the window drag feature through the WindowDrag chrome component and wires `drag-session`. |

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Window Actor Categories

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Settings & Internal Page Actors

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Web Content & Store Actors

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Browser Features Catalog
@@ -10,7 +10,7 @@ This catalog is generated from loader-discovered chrome feature entrypoints, the
 
 ## Catalog Sections
 
-- Common chrome features: 33 entries from `browser-features/chrome/common`.
+- Common chrome features: 34 entries from `browser-features/chrome/common`.
 - Static chrome features: 3 entries from `browser-features/chrome/static`.
 - Settings page routes: 14 routes from `browser-features/pages-settings/src/App.tsx`.
 - Window Actors: 23 actors from `browser-features/modules/modules/BrowserGlue.sys.mts`.

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Window Actor Catalog

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "a246c30d65272b03052b6543ea4cd65db6f16239"
+floorp_commit: "ea5bb3140953f994c5295280b4cfd4d52a91245c"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `a246c30d65272b03052b6543ea4cd65db6f16239`.
+Inventory generated from Floorp commit `ea5bb3140953f994c5295280b4cfd4d52a91245c`.
 
 ## Source Precedence
 
@@ -52,7 +52,7 @@ Inventory generated from Floorp commit `a246c30d65272b03052b6543ea4cd65db6f16239
 
 ## Feature Catalog Sources
 
-- Common chrome features: `browser-features/chrome/common` (33 entries)
+- Common chrome features: `browser-features/chrome/common` (34 entries)
 - Static chrome features: `browser-features/chrome/static` (3 entries)
 - Settings routes: `browser-features/pages-settings/src/App.tsx` (14 routes)
 - Window Actors: `browser-features/modules/modules/BrowserGlue.sys.mts` (23 actors)


### PR DESCRIPTION
Reimplements the window-drag part of derp fork PR #2575 for issue #2569.

Move the window by holding a modifier chord and dragging anywhere — toolbars, tab strip, or web content. Most useful in zen mode and multirow tabs where the draggable titlebar is hidden or crowded.

- **macOS**: Alt+Cmd+drag; **Windows/Linux**: Ctrl+Alt+drag
- Plain Cmd is deliberately excluded (Cmd+click opens links in new tabs, toggles tab multi-selection, and web apps use Cmd+drag for canvas panning)
- The chord is re-verified on every mouse-move (a mouseup released outside the window never reaches us) and released via key-up/blur so the window never sticks to the pointer
- Drag session logic extracted as a pure reducer (\drag-session.ts\) with 6 browser-integrated tests

Related: #2614 (zen-mode), #2625 (zen-mode shortcut on the same Alt chord).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added window dragging with Alt+Cmd on macOS or Ctrl+Alt on Windows/Linux while holding the primary mouse button.
  * Dragging follows cursor movement and stops when modifiers are released, focus is lost, or the gesture ends.

* **Documentation**
  * Added window dragging to browser feature catalogs and updated development references.

* **Tests**
  * Added coverage for drag initiation, movement, cancellation, and inactive states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->