### PR TITLE
fix(os-api): keep TabManager instances alive when ownerGlobal is transiently null

### DIFF
--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -299,11 +299,11 @@ class TabManager {
       // Gecko 153 it can transiently be null (e.g. during process swaps or
       // for panel windows), and deleting the instance here would permanently
       // orphan it, breaking every subsequent per-instance operation
-      // (Floorp issue #2608). Use the element's connectedness instead: a
-      // closed tab is removed from the tab strip, so `isConnected` is the
+      // (Floorp issue #2608). Use the tab element's connectedness instead: a
+      // closed tab is removed from the tab strip, so `tab.isConnected` is the
       // reliable liveness signal.
       const browser = entry.tab.linkedBrowser;
-      if (!browser || !browser.isConnected) {
+      if (!browser || !entry.tab.isConnected) {
         this._browserInstances.delete(instanceId);
         this._tabToInstanceId.delete(entry.tab);
         TAB_MANAGER_ACTOR_SETS.delete(entry.browser);
@@ -572,7 +572,7 @@ class TabManager {
     const currentBrowser = tab.linkedBrowser;
     if (
       !currentBrowser ||
-      !currentBrowser.isConnected ||
+      !tab.isConnected ||
       (currentBrowser.ownerGlobal as Window | null)?.closed
     ) {
       throw new Error("Tab was closed during load");

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -294,9 +294,23 @@ class TabManager {
     }
 
     if (entry) {
-      // Verify tab is still alive and in a window
+      // Verify tab is still alive.
+      // NOTE: a null `ownerGlobal` is NOT treated as "tab closed" — on
+      // Gecko 153 it can transiently be null (e.g. during process swaps or
+      // for panel windows), and deleting the instance here would permanently
+      // orphan it, breaking every subsequent per-instance operation
+      // (Floorp issue #2608). Use the element's connectedness instead: a
+      // closed tab is removed from the tab strip, so `isConnected` is the
+      // reliable liveness signal.
       const browser = entry.tab.linkedBrowser;
-      if (!browser || !browser.ownerGlobal || browser.ownerGlobal.closed) {
+      if (!browser || !browser.isConnected) {
+        this._browserInstances.delete(instanceId);
+        this._tabToInstanceId.delete(entry.tab);
+        TAB_MANAGER_ACTOR_SETS.delete(entry.browser);
+        return null;
+      }
+      const ownerWin = browser.ownerGlobal;
+      if (ownerWin?.closed) {
         this._browserInstances.delete(instanceId);
         this._tabToInstanceId.delete(entry.tab);
         TAB_MANAGER_ACTOR_SETS.delete(entry.browser);
@@ -557,8 +571,9 @@ class TabManager {
     // Check tab is still alive (user may have closed it during load)
     const currentBrowser = tab.linkedBrowser;
     if (
-      !currentBrowser?.ownerGlobal ||
-      (currentBrowser.ownerGlobal as Window).closed
+      !currentBrowser ||
+      !currentBrowser.isConnected ||
+      (currentBrowser.ownerGlobal as Window | null)?.closed
     ) {
       throw new Error("Tab was closed during load");
     }


### PR DESCRIPTION
Fixes #2608

## What

`TabManagerServices._getEntry()` treated a transiently-null `browser.ownerGlobal` as "tab closed" and permanently removed the instance from its tracker. On Gecko 153 `ownerGlobal` can be transiently null (e.g. during process swaps or for panel windows), so every subsequent per-instance HTTP API operation (`/title`, `/uri`, `/html`, `/screenshot`) returned `null` or `404` — breaking all automation backends (MCP clients, Selenium, geckodriver) in v12.16.4.

## Changes

- `_getEntry()`: use the tab element's `isConnected` as the liveness signal instead of `ownerGlobal`. A closed tab is removed from the tab strip, so `isConnected` is the reliable indicator.
- Keep the `ownerGlobal.closed` check only when a window actually exists.
- `createInstance()`: same relaxation (fixes `POST /tabs/instances` returning 500 after load).

## Verification (macOS, Gecko 153.0 runtime via `feles-build test`)

Issue #2608 reproduction steps against the local HTTP API (port 58261):

| Step | Before | After |
|---|---|---|
| `POST /tabs/attach` | 200 + uuid | ✅ 200 + uuid |
| `GET /tabs/instances/:id/title` | `null` | ✅ `"Example Domain"` |
| `GET /tabs/instances/:id/uri` | 404 | ✅ `"https://example.com/"` |
| `GET /tabs/instances/:id/html` | `null` | ✅ HTML returned |
| `GET /tabs/instances/:id/screenshot` | `null` | ✅ image returned |
| `POST /tabs/instances` (create tab) | 500 | ✅ 200 + instanceId |

Note: `/tabs/active` is not implemented (route does not exist) — the 404 there is expected behavior, not a regression.

## Notes

- The Marionette backend was verified working on macOS with the correct protocol framing (`<len>:<json>`); the reporter's Windows-specific reproduction remains to be confirmed.
- No new type errors (`deno check` baseline unchanged: 5 pre-existing errors in `CookieHelper.sys.mts` etc. are untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab liveness detection to more accurately identify disconnected tabs.
  * Prevented tabs associated with closed browser windows from being treated as active.
  * Applied the same validation when restoring tabs after loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->