### PR TITLE
fix(workspaces): keep last-shown tab marker unique per workspace

### DIFF
--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -690,9 +690,8 @@ export class WorkspacesTabManager {
     //
     // The marker must be unique per workspace: stale markers accumulate when
     // the user switches tabs within the workspace without switching
-    // workspaces (the marker is only refreshed on workspace changes), and
-    // Priority 2 below restores the *first* matching tab in DOM order —
-    // making the restored selection history-dependent and seemingly random
+    // workspaces (the marker is only refreshed on workspace changes), which
+    // made the restored selection history-dependent and seemingly random
     // (Floorp issue #2616). Remove stale markers before persisting the new
     // one, mirroring the remove-then-set pattern in updateTabsVisibility().
     try {
@@ -733,9 +732,13 @@ export class WorkspacesTabManager {
         // already chose the correct tab for this workspace.
       } else {
         // Priority 2: Use the last-shown tab for this workspace.
-        // Pick the most recently persisted marker (last in DOM order) so
-        // the restored tab matches the one the user last had selected,
-        // even if stale markers were left behind (Floorp issue #2616).
+        // The persist step above guarantees at most one marker per
+        // workspace, so this normally matches the user's last-selected tab.
+        // If duplicate markers from older versions remain, pick the last
+        // one in DOM order as a deterministic fallback rather than the
+        // first (which made the selection history-dependent — Floorp issue
+        // #2616). Note: DOM order reflects tab position, not write order;
+        // it is only a deterministic fallback for legacy duplicates.
         const willChangeWorkspaceLastShowTabs = document?.querySelectorAll(
           `[${WORKSPACE_LAST_SHOW_ID}="${workspaceId}"]`,
         );

--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -687,6 +687,14 @@ export class WorkspacesTabManager {
     // previously selected workspace before switching. This ensures we can
     // restore focus when returning to that workspace instead of creating
     // a new tab each time.
+    //
+    // The marker must be unique per workspace: stale markers accumulate when
+    // the user switches tabs within the workspace without switching
+    // workspaces (the marker is only refreshed on workspace changes), and
+    // Priority 2 below restores the *first* matching tab in DOM order —
+    // making the restored selection history-dependent and seemingly random
+    // (Floorp issue #2616). Remove stale markers before persisting the new
+    // one, mirroring the remove-then-set pattern in updateTabsVisibility().
     try {
       const prevWorkspaceId = this.dataManagerCtx.getSelectedWorkspaceID();
       const currentlySelectedTab = globalThis.gBrowser
@@ -696,6 +704,9 @@ export class WorkspacesTabManager {
         this.getWorkspaceIdFromAttribute(currentlySelectedTab) ===
           prevWorkspaceId
       ) {
+        document
+          ?.querySelectorAll(`[${WORKSPACE_LAST_SHOW_ID}="${prevWorkspaceId}"]`)
+          .forEach((tab) => tab.removeAttribute(WORKSPACE_LAST_SHOW_ID));
         currentlySelectedTab.setAttribute(
           WORKSPACE_LAST_SHOW_ID,
           prevWorkspaceId,
@@ -722,9 +733,17 @@ export class WorkspacesTabManager {
         // already chose the correct tab for this workspace.
       } else {
         // Priority 2: Use the last-shown tab for this workspace.
-        const willChangeWorkspaceLastShowTab = document?.querySelector(
+        // Pick the most recently persisted marker (last in DOM order) so
+        // the restored tab matches the one the user last had selected,
+        // even if stale markers were left behind (Floorp issue #2616).
+        const willChangeWorkspaceLastShowTabs = document?.querySelectorAll(
           `[${WORKSPACE_LAST_SHOW_ID}="${workspaceId}"]`,
-        ) as XULElement;
+        );
+        const willChangeWorkspaceLastShowTab = willChangeWorkspaceLastShowTabs
+          ? (willChangeWorkspaceLastShowTabs[
+              willChangeWorkspaceLastShowTabs.length - 1
+            ] as XULElement | undefined)
+          : undefined;
 
         if (willChangeWorkspaceLastShowTab) {
           globalThis.gBrowser.selectedTab = willChangeWorkspaceLastShowTab;


### PR DESCRIPTION
Fixes #2616

## What

Workspace switching restored a "seemingly random" tab instead of the one the user last had selected.

## Root cause

The `floorpWorkspaceLastShowId` (LAST_SHOW) marker was only ever appended, never cleaned up. Switching tabs *within* a workspace (without switching workspaces) left stale markers behind because the marker is only refreshed on workspace changes. On the next workspace switch, Priority 2 restored the **first** matching tab in DOM order via `querySelector`, making the restored selection history-dependent and random-looking.

## Changes (`workspacesTabManager.tsx`)

1. **Persist step**: remove all stale LAST_SHOW markers for the previous workspace before setting the new one — mirrors the existing remove-then-set pattern in `updateTabsVisibility()`.
2. **Restore step (defensive)**: pick the **last** matching tab in DOM order (most recently persisted) instead of the first, in case stale markers are ever left behind by other code paths.

## Verification

- No new type errors.
- This file has no direct unit tests; the change follows the existing `updateTabsVisibility()` pattern. Manual verification on a real workspace switch flow is recommended (requires two workspaces + new tabs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace switching by preserving the most recently selected tab.
  * Removed outdated workspace selection markers to ensure tabs restore correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->