### PR TITLE
fix(mouse-gesture): restore multi-tab switching via wheel gestures

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -58,7 +58,10 @@ export class MouseGestureController {
 
     this.targetWindow.addEventListener("mousedown", this.handleMouseDown);
     this.targetWindow.addEventListener("mousemove", this.handleMouseMove);
-    this.targetWindow.addEventListener("mouseup", this.handleMouseUp);
+    // Capture-phase mouseup: content scripts (e.g. video players) may call
+    // stopPropagation() on mouseup, which would prevent the wheel-gesture
+    // cleanup / context-menu suppression from starting (Floorp issue #2586).
+    this.targetWindow.addEventListener("mouseup", this.handleMouseUp, true);
     this.targetWindow.addEventListener(
       "contextmenu",
       this.handleContextMenu,
@@ -82,7 +85,11 @@ export class MouseGestureController {
     if (this.eventListenersAttached) {
       this.targetWindow.removeEventListener("mousedown", this.handleMouseDown);
       this.targetWindow.removeEventListener("mousemove", this.handleMouseMove);
-      this.targetWindow.removeEventListener("mouseup", this.handleMouseUp);
+      this.targetWindow.removeEventListener(
+        "mouseup",
+        this.handleMouseUp,
+        true,
+      );
       this.targetWindow.removeEventListener(
         "contextmenu",
         this.handleContextMenu,
@@ -484,10 +491,12 @@ export class MouseGestureController {
       return;
     }
 
-    // After the first wheel action, consume all remaining wheel events in this
-    // cycle (including momentum/residual events after mouseup) without firing a
-    // second action.
-    if (this.isWheelGestureFired || this.isWheelGestureSuppressionActive) {
+    // Consume residual wheel events only while post-mouseup suppression is
+    // active (momentum / touchpad residual events). While the right button is
+    // still held, each wheel notch must keep switching tabs — the exact-once
+    // latch introduced in #2559 made only a single tab switch possible per
+    // right-button cycle (Floorp issue #2586).
+    if (this.isWheelGestureSuppressionActive) {
       event.preventDefault();
       event.stopPropagation();
       return;
@@ -517,8 +526,10 @@ export class MouseGestureController {
     }
 
     if (action) {
-      // Set the exact-once latch before executing the action so synchronous
-      // re-entrancy cannot execute another wheel action.
+      // Mark the cycle as a wheel gesture so the mouseup handler can start
+      // the context-menu suppression window. This does not latch: subsequent
+      // wheel events while the button is held execute further actions
+      // (multi-tab switching, Floorp issue #2586).
       this.isWheelGestureFired = true;
       this.isContextMenuPrevented = false;
       this.clearPreventionTimeout();

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -259,7 +259,7 @@ async function testWheelGestureSuppressesPostMouseUpContextMenu(): Promise<
   });
 }
 
-async function testWheelGestureIsExactOnceAndConsumesResidualWheel(): Promise<
+async function testWheelGestureChainsWhileHeldAndConsumesResidualWheel(): Promise<
   void
 > {
   await withTrackedActions(async (counts) => {
@@ -268,6 +268,8 @@ async function testWheelGestureIsExactOnceAndConsumesResidualWheel(): Promise<
       dispatchMouse(win, "mousedown", 2);
       const firstWheel = dispatchWheel(win, 120);
       dispatchMouse(win, "mousemove", 0, 100, 0);
+      // While the right button is held, each wheel notch switches tabs
+      // (Floorp issue #2586 regression from the #2559 exact-once latch).
       const heldResidualWheel = dispatchWheel(win, -120);
       dispatchMouse(win, "mouseup", 2);
       const postMouseUpResidualWheel = dispatchWheel(win, 120);
@@ -291,12 +293,12 @@ async function testWheelGestureIsExactOnceAndConsumesResidualWheel(): Promise<
       assertEquals(
         counts[NEXT_TAB_ACTION],
         1,
-        "next-tab action should fire once",
+        "first wheel should execute next-tab once",
       );
       assertEquals(
         counts[PREVIOUS_TAB_ACTION],
-        0,
-        "opposite residual wheel must not execute another action",
+        1,
+        "a subsequent wheel while held must execute its own action (multi-tab switching)",
       );
       assertEquals(
         counts[DRAWN_RIGHT_ACTION],
@@ -710,8 +712,8 @@ const tests: TestCase[] = [
     fn: testWheelGestureSuppressesPostMouseUpContextMenu,
   },
   {
-    name: "wheel gesture is exact-once and consumes residual wheel",
-    fn: testWheelGestureIsExactOnceAndConsumesResidualWheel,
+    name: "wheel gesture chains while held and consumes residual wheel",
+    fn: testWheelGestureChainsWhileHeldAndConsumesResidualWheel,
   },
   {
     name: "normal right click remains allowed",


### PR DESCRIPTION
Fixes #2586

## What

Wheel gestures (right-button held + scroll) only switched tabs **once** per right-button cycle — a regression introduced by the exactly-once latch in #2559.

## Changes (`mouse-gesture/controller.ts`)

1. **Remove the exact-once latch** from `handleMouseWheel`: while the right button is held, each wheel notch executes its own action (multi-tab switching restored, matching pre-#2559 behavior).
   - Momentum / touchpad residual events after `mouseup` are still consumed by the existing post-mouseup suppression window, so the #2559 momentum-runaway protection is preserved.
2. **Move `mouseup` handling to the capture phase**: content scripts that call `stopPropagation()` on `mouseup` (e.g. video players) could previously prevent wheel-gesture cleanup and context-menu suppression from starting.
3. **Test updated**: `testWheelGestureChainsWhileHeldAndConsumesResidualWheel` now asserts a second wheel while held executes its own action, and post-mouseup residual wheel remains consumed (no action).

## Design note (trade-off)

#2559 deliberately made "one physical interaction execute one command" (`isWheelGestureFired` latch). That design conflicts with the long-standing UX of holding right-button and scrolling through several tabs. This PR restores chaining while the button is held and keeps the momentum protection after release. If the maintainers prefer to keep the latch, an alternative would be a config option — happy to adjust.

## Verification

- `mouse-gesture` browser test suite: **6/6 passed** (`mouseGestureController.test.ts` included).
- Full test suite: 157 passed / 5 failed — all 5 failures are pre-existing and unrelated (command palette, locale catalogs, theme color env-dependent, mochitest-compat).
- Requires manual verification on real hardware (reporter: Fedora Linux 43, touchpad) for the context-menu suppression path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse gesture handling so repeated wheel gestures can switch across multiple tabs while the right mouse button remains held.
  * Ensured context-menu suppression and cleanup continue working even when page scripts intercept mouse events.
  * Prevented residual wheel events after mouse release from triggering unintended actions.

* **Tests**
  * Added coverage for chained wheel gestures and multi-tab switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->