### PR TITLE
fix(ci): restore ja-JP i18n keys and refresh generated docs

### DIFF
--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -300,7 +300,13 @@
         "openSourceLicense": "{{productName}} は、 Mozilla Public License 2.0 の下で利用可能なオープンソースソフトウェアです。 Firefox オープンソースプロジェクトやその他のオープンソースソフトウェアによって実現されています。",
         "openSourceLicenseNotice": "オープンソースライセンス",
         "versionInfo": "バージョン",
-        "license": "ライセンス"
+        "license": "ライセンス",
+        "noraneko": {
+            "logoAlt": "ブラウザのロゴ",
+            "description": "Noraneko は Floorp 12 のテストヘッドとしてのブラウザです。Floorp は Firefox と Noraneko に基づいています。",
+            "communityCredit": "Noraneko コミュニティによって作られました ❤",
+            "repositoryLabel": "GitHub リポジトリ: Floorp-Projects/Floorp"
+        }
     },
     "updates": {
         "title": "更新と実験",

--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -714,6 +714,9 @@
             "saveDescription": "ショートカットを保存",
             "cancel": "キャンセル",
             "cancelDescription": "編集をキャンセル"
+        },
+        "actionLabels": {
+            "floorp-edit-tab-url": "タブの URL を編集"
         }
     }
 }

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Architecture Overview

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Common Chrome Features
@@ -97,7 +97,7 @@ Small chrome utilities and action helpers that do not own a broader feature fami
 | Feature | Source | Entrypoints | Description |
 |---|---|---|---|
 | tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
-| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
+| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacks`, `init` | Owns the tab stacks feature through the TabStacks chrome component and wires `stack-bar`. |
 | tab-strip-wheel-guard | `browser-features/chrome/common/tab-strip-wheel-guard/index.ts` | `default class TabStripWheelGuard`, `init` | Owns the tab strip wheel guard feature through the TabStripWheelGuard chrome component and wires `classifier`. |
 | window-drag | `browser-features/chrome/common/window-drag/index.ts` | `default class WindowDrag`, `init` | Owns the window drag feature through the WindowDrag chrome component and wires `drag-session`. |
 

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Common Chrome Feature Catalog
@@ -38,7 +38,7 @@ Common chrome features are discovered from `browser-features/chrome/common/mod.t
 | tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
 | tab-refresh | `browser-features/chrome/common/tab-refresh/index.ts` | `default class TabRefresh`, `init` | Owns the tab refresh feature through the TabRefresh chrome component and wires `controller`. |
 | tab-sleep-exclusion | `browser-features/chrome/common/tab-sleep-exclusion/index.ts` | `default class TabSleepExclusion`, `init` | Owns the tab sleep exclusion feature through the TabSleepExclusion chrome component. |
-| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
+| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacks`, `init` | Owns the tab stacks feature through the TabStacks chrome component and wires `stack-bar`. |
 | tab-strip-wheel-guard | `browser-features/chrome/common/tab-strip-wheel-guard/index.ts` | `default class TabStripWheelGuard`, `init` | Owns the tab strip wheel guard feature through the TabStripWheelGuard chrome component and wires `classifier`. |
 | tabbar | `browser-features/chrome/common/tabbar/index.ts` | `default class TabBar`, `init` | Owns the tabbar feature through the TabBar chrome component and wires `multirow-tabbar/multirow-tabbar`, `tabbbar-style/tabbar-style`. |
 | ui-custom | `browser-features/chrome/common/ui-custom/index.ts` | `default class UICustomization`, `init`, `initBeforeSessionStoreInit` | Owns the ui custom feature through the UICustomization chrome component and wires `styles/style-manager`, `layout/dom-manipulator`. |

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Browser UI Customization

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Common Chrome Feature Categories
@@ -25,6 +25,6 @@ This nested catalog is generated from `browser-features/chrome/common`. It group
 | Feature | Source | Entrypoints | Description |
 |---|---|---|---|
 | tab-inline-edit | `browser-features/chrome/common/tab-inline-edit/index.ts` | `default class TabInlineEdit`, `init` | Owns the tab inline edit feature through the TabInlineEdit chrome component and wires `controller`. |
-| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacksFoundation`, `init` | Owns the tab stacks feature through the TabStacksFoundation chrome component and wires `stack-bar`. |
+| tab-stacks | `browser-features/chrome/common/tab-stacks/index.ts` | `default class TabStacks`, `init` | Owns the tab stacks feature through the TabStacks chrome component and wires `stack-bar`. |
 | tab-strip-wheel-guard | `browser-features/chrome/common/tab-strip-wheel-guard/index.ts` | `default class TabStripWheelGuard`, `init` | Owns the tab strip wheel guard feature through the TabStripWheelGuard chrome component and wires `classifier`. |
 | window-drag | `browser-features/chrome/common/window-drag/index.ts` | `default class WindowDrag`, `init` | Owns the window drag feature through the WindowDrag chrome component and wires `drag-session`. |

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Window Actor Categories

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Settings & Internal Page Actors

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Web Content & Store Actors

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Browser Features Catalog

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Window Actor Catalog

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64"
+floorp_commit: "92463afd2e9fa2550eb60fe4afdba954c4bad6d9"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `ffd14aa22e9d2a4a1cb7a31d353bfba101fb4b64`.
+Inventory generated from Floorp commit `92463afd2e9fa2550eb60fe4afdba954c4bad6d9`.
 
 ## Source Precedence
 

--- a/i18n/ja-JP/browser-chrome.json
+++ b/i18n/ja-JP/browser-chrome.json
@@ -1,4 +1,7 @@
 {
+  "tab-refresh": {
+    "reload": "タブを再読み込み"
+  },
   "undo-closed-tab": {
     "label": "閉じたタブを元に戻す",
     "tooltiptext": "最後に閉じたタブを開きなおす {{shortcut}}"
@@ -132,6 +135,11 @@
     "openInPrivateContainer": "プライベートコンテナーで開く",
     "reopenInPrivateContainer": "プライベートコンテナーで再度開く",
     "name": "プライベートコンテナー"
+  },
+  "tabInlineEdit": {
+    "contextMenu": "タブの URL を編集",
+    "inputLabel": "タブの URL",
+    "keyboardAction": "タブの URL を編集"
   },
   "mouseGesture": {
     "actions": {


### PR DESCRIPTION
Fixes the two failing CI checks on `main`:

## 1. smoke failure — ja-JP i18n keys missing

`keyboardShortcutActionCatalog.test.ts` failed type-checking because `jaJP.tabInlineEdit` did not exist.

**Root cause**: The 8/4 translated-files sync (`653d48bd062d`) dropped `tabInlineEdit` and `tab-refresh` from `ja-JP/browser-chrome.json` before the en-US source keys had reached f18n-central. The en-US source was subsequently synced (f18n-central `adcff64`, 8/4), but Crowdin translations for the new keys are still pending.

**This PR**: Restores the ja-JP translations (`tabInlineEdit`: タブの URL を編集 / `tab-refresh`: タブを再読み込み) so CI passes now. A companion PR in f18n-central (`add/ja-jp-tab-inline-edit-translation`) adds the same translations to the Crowdin source so future syncs keep them (Crowdin will also pick these up).

## 2. verify failure — stale deterministic docs

`docs-pipeline verify` reported 3 stale deterministic pages (`chrome/common.mdx`, `chrome-common.mdx`, `common/overview.mdx`).

**This PR**: Refreshes all 22 deterministic generated pages from the current inventory via `docs-pipeline codex-seed` + selective copy. Verified: `docs-pipeline:verify` passes.

## Verification

- `deno task test:smoke` ✅ passes
- `deno task docs-pipeline:verify --inventory _dist/docs-pipeline/inventory.json --docs-dir docs` ✅ passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated development documentation to reflect the latest Floorp revision.
  - Corrected the documented tab-stacks entry point name for improved accuracy.

- **Localization**
  - Added Japanese translations for tab refresh actions and inline tab URL editing.
  - Added Japanese branding, description, community credit, repository labels, and a keyboard shortcut label to the settings page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->