### PR TITLE
docs(sync): approve Floorp Notes cross-client contract

### DIFF
--- a/browser-features/pages-notes/src/lib/dataManager.ts
+++ b/browser-features/pages-notes/src/lib/dataManager.ts
@@ -1,9 +1,5 @@
 import { rpc } from "./rpc/rpc.ts";
-import {
-  mergeNotesThreeWay,
-  type MergeResult,
-  type NoteSnapshot,
-} from "./merge.ts";
+import type { NoteSnapshot } from "./merge.ts";
 import type { Note } from "../types/note.ts";
 
 export {

--- a/browser-features/pages-notes/src/lib/dataManager.ts
+++ b/browser-features/pages-notes/src/lib/dataManager.ts
@@ -1,5 +1,18 @@
 import { rpc } from "./rpc/rpc.ts";
+import {
+  mergeNotesThreeWay,
+  type MergeResult,
+  type NoteSnapshot,
+} from "./merge.ts";
 import type { Note } from "../types/note.ts";
+
+export {
+  canonicalData,
+  mergeNotesThreeWay,
+  precedes,
+  type MergeResult,
+  type NoteSnapshot,
+} from "./merge.ts";
 
 export const NOTES_PREF_NAME = "floorp.browser.note.memos";
 
@@ -65,27 +78,12 @@ export async function saveNotes(data: NotesData): Promise<void> {
 
 const SYNC_STATE_PREF = "floorp.browser.note.syncState";
 
-/** Snapshot of a note at the time of the last successful sync. */
-export interface NoteSnapshot {
-  id: string;
-  title: string;
-  content: string;
-  updatedAt: number;
-}
-
 /** Persistent sync state used as the "base" for three-way merge. */
 export interface SyncState {
   /** Snapshots keyed by note ID. */
   lastSyncedSnapshots: Record<string, NoteSnapshot>;
   /** Timestamp (ms since epoch) of the last successful sync. */
   lastSyncTime: number;
-}
-
-/** Result of a three-way merge operation. */
-export interface MergeResult {
-  merged: Note[];
-  hadConflicts: boolean;
-  conflictCount: number;
 }
 
 /** Creates an empty sync state (for first sync). */
@@ -164,160 +162,6 @@ export async function saveSyncState(state: SyncState): Promise<void> {
  * @param base   - Snapshots from the last successful sync
  * @returns Merge result with merged notes and conflict metadata
  */
-export function mergeNotesThreeWay(
-  local: Note[],
-  remote: Note[],
-  base: Record<string, NoteSnapshot>,
-): MergeResult {
-  console.debug(
-    `[Floorp Notes] Three-way merge: ${local.length} local, ${remote.length} remote, ${Object.keys(base).length} base snapshots`,
-  );
-
-  // Build lookup maps
-  const localMap = new Map<string, Note>();
-  for (const n of local) localMap.set(n.id, n);
-
-  const remoteMap = new Map<string, Note>();
-  for (const n of remote) remoteMap.set(n.id, n);
-
-  // Collect all unique IDs
-  const allIds = new Set<string>([
-    ...localMap.keys(),
-    ...remoteMap.keys(),
-    ...Object.keys(base),
-  ]);
-
-  const merged: Note[] = [];
-  const conflictCopies: Note[] = [];
-  let hadConflicts = false;
-
-  // Helper: check if a note changed from base
-  const hasChanged = (note: Note, baseSnap?: NoteSnapshot): boolean => {
-    if (!baseSnap) return true; // New note = definitely changed
-    return note.title !== baseSnap.title || note.content !== baseSnap.content;
-  };
-
-  for (const noteId of allIds) {
-    const localN = localMap.get(noteId);
-    const remoteN = remoteMap.get(noteId);
-    const baseS = base[noteId];
-
-    if (localN && remoteN && baseS) {
-      // ── Note exists on both sides (with base) ──
-      const localChanged = hasChanged(localN, baseS);
-      const remoteChanged = hasChanged(remoteN, baseS);
-
-      if (!localChanged && !remoteChanged) {
-        // No change on either side — take remote (canonical)
-        merged.push(remoteN);
-      } else if (localChanged && !remoteChanged) {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: local changed, keeping local`,
-        );
-        merged.push(localN);
-      } else if (!localChanged && remoteChanged) {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: remote changed, taking remote`,
-        );
-        merged.push(remoteN);
-      } else {
-        // ── BOTH changed → CONFLICT ──
-        hadConflicts = true;
-        const newerNote =
-          localN.updatedAt >= remoteN.updatedAt ? localN : remoteN;
-        const olderNote =
-          localN.updatedAt >= remoteN.updatedAt ? remoteN : localN;
-
-        console.warn(
-          `[Floorp Notes] CONFLICT on note ${noteId} '${newerNote.title.slice(0, 30)}' — ` +
-            `both sides changed, keeping newer (${new Date(newerNote.updatedAt).toISOString()}), ` +
-            `creating conflict copy of older (${new Date(olderNote.updatedAt).toISOString()})`,
-        );
-
-        merged.push(newerNote);
-
-        // Create conflict copy only if older version has actual content
-        if (olderNote.title || olderNote.content) {
-          conflictCopies.push({
-            id: crypto.randomUUID(),
-            title: olderNote.title
-              ? `${olderNote.title} (conflict)`
-              : "(conflict)",
-            content: olderNote.content,
-            createdAt: olderNote.createdAt,
-            updatedAt: olderNote.updatedAt,
-          });
-        }
-      }
-    } else if (!localN && remoteN && baseS) {
-      // ── Deleted locally, still exists remotely ──
-      if (hasChanged(remoteN, baseS)) {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: deleted locally but remote changed, keeping remote`,
-        );
-        merged.push(remoteN);
-      } else {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: deleted locally, remote unchanged, respecting deletion`,
-        );
-      }
-    } else if (localN && !remoteN && baseS) {
-      // ── Deleted remotely, still exists locally ──
-      if (hasChanged(localN, baseS)) {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: deleted remotely but local changed, keeping local`,
-        );
-        merged.push(localN);
-      } else {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: deleted remotely, local unchanged, respecting deletion`,
-        );
-      }
-    } else if (localN && !remoteN && !baseS) {
-      // ── New note: only on local (never synced before) ──
-      console.debug(`[Floorp Notes] note ${noteId}: new local note, keeping`);
-      merged.push(localN);
-    } else if (!localN && remoteN && !baseS) {
-      // ── New note: only on remote (never seen before) ──
-      console.debug(`[Floorp Notes] note ${noteId}: new remote note, adding`);
-      merged.push(remoteN);
-    } else if (localN && remoteN && !baseS) {
-      // ── Both exist but no base snapshot (first sync with existing notes) ──
-      if (localN.updatedAt >= remoteN.updatedAt) {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: no base, local is newer, keeping local`,
-        );
-        merged.push(localN);
-      } else {
-        console.debug(
-          `[Floorp Notes] note ${noteId}: no base, remote is newer, taking remote`,
-        );
-        merged.push(remoteN);
-      }
-    }
-    // else: both deleted (nil, nil, _) — nothing to do
-  }
-
-  // Append conflict copies at the end
-  if (conflictCopies.length > 0) {
-    merged.push(...conflictCopies);
-    console.warn(
-      `[Floorp Notes] Created ${conflictCopies.length} conflict copy note(s)`,
-    );
-  }
-
-  // Preserve local order; append new-remote and conflict copies at the end.
-  // Do NOT sort by updatedAt — that would destroy user's drag-and-drop reorder.
-  const result: Note[] = merged;
-
-  console.info(
-    `[Floorp Notes] Three-way merge result: ${result.length} notes ` +
-      `(${conflictCopies.length} conflict copies), hadConflicts=${hadConflicts}`,
-  );
-
-  return { merged: result, hadConflicts, conflictCount: conflictCopies.length };
-}
-
 // ──────────────────────────────────────────────────────────
 // Conversion helpers (NotesData ↔ Note[])
 // ──────────────────────────────────────────────────────────

--- a/browser-features/pages-notes/src/lib/merge.ts
+++ b/browser-features/pages-notes/src/lib/merge.ts
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Deterministic three-way merge for Floorp Notes (cross-client contract).
+ *
+ * Mirrors the iOS implementation (floorp-ios firefox-ios/Floorp/FloorpNotesSync.swift)
+ * so winners, conflict copies, and ordering are identical on both clients.
+ * Kept free of browser/rpc dependencies so it is directly unit-testable.
+ */
+
+import type { Note } from "../types/note.ts";
+
+export type { Note } from "../types/note.ts";
+
+export interface NoteSnapshot {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}
+
+export interface MergeResult {
+  merged: Note[];
+  hadConflicts: boolean;
+  conflictCount: number;
+}
+
+type Resolution =
+  | { kind: "none" }
+  | { kind: "note"; note: Note }
+  | { kind: "conflict"; winner: Note; loser: Note };
+
+const CONFLICT_ID_PREFIX = "floorp-sync-conflict-";
+
+/** Deterministic SHA-256 over bytes (synchronous, Web Crypto free). */
+function sha256Bytes(input: Uint8Array): Uint8Array {
+  // Compact SHA-256 (FIPS 180-4) implementation.
+  const K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+  ]);
+  const H = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const bitLength = input.byteLength * 8;
+  const padded = new Uint8Array(
+    Math.ceil((input.byteLength + 9) / 64) * 64,
+  );
+  padded.set(input);
+  padded[input.byteLength] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setUint32(padded.byteLength - 8, Math.floor(bitLength / 0x100000000));
+  view.setUint32(padded.byteLength - 4, bitLength >>> 0);
+
+  const w = new Uint32Array(64);
+  for (let offset = 0; offset < padded.byteLength; offset += 64) {
+    for (let i = 0; i < 16; i++) {
+      w[i] = view.getUint32(offset + i * 4);
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 = ((w[i - 15] >>> 7) | (w[i - 15] << 25)) ^
+        ((w[i - 15] >>> 18) | (w[i - 15] << 14)) ^ (w[i - 15] >>> 3);
+      const s1 = ((w[i - 2] >>> 17) | (w[i - 2] << 15)) ^
+        ((w[i - 2] >>> 19) | (w[i - 2] << 13)) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+    let [a, b, c, d, e, f, g, h] = H;
+    for (let i = 0; i < 64; i++) {
+      const S1 = ((e >>> 6) | (e << 26)) ^ ((e >>> 11) | (e << 21)) ^
+        ((e >>> 25) | (e << 7));
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+      const S0 = ((a >>> 2) | (a << 30)) ^ ((a >>> 13) | (a << 19)) ^
+        ((a >>> 22) | (a << 10));
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+    H[0] = (H[0] + a) >>> 0;
+    H[1] = (H[1] + b) >>> 0;
+    H[2] = (H[2] + c) >>> 0;
+    H[3] = (H[3] + d) >>> 0;
+    H[4] = (H[4] + e) >>> 0;
+    H[5] = (H[5] + f) >>> 0;
+    H[6] = (H[6] + g) >>> 0;
+    H[7] = (H[7] + h) >>> 0;
+  }
+  const digest = new Uint8Array(32);
+  const digestView = new DataView(digest.buffer);
+  for (let i = 0; i < 8; i++) {
+    digestView.setUint32(i * 4, H[i]);
+  }
+  return digest;
+}
+
+function hex(bytes: Uint8Array): string {
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** u64 big-endian bytes for a non-negative integer. */
+function u64be(value: number): Uint8Array {
+  const out = new Uint8Array(8);
+  new DataView(out.buffer).setBigUint64(0, BigInt(Math.trunc(value)), false);
+  return out;
+}
+
+/** Appends a u64-length-prefixed UTF-8 string (desktop wire layout). */
+function appendPrefixed(target: number[], text: string): void {
+  const bytes = new TextEncoder().encode(text);
+  for (const b of u64be(bytes.byteLength)) target.push(b);
+  for (const b of bytes) target.push(b);
+}
+
+/** Canonical bytes for a note; identical to the iOS contract. */
+export function canonicalData(note: Note): Uint8Array {
+  const bytes: number[] = [];
+  appendPrefixed(bytes, note.id);
+  appendPrefixed(bytes, note.title);
+  appendPrefixed(bytes, note.content);
+  for (const b of u64be(note.createdAt)) bytes.push(b);
+  for (const b of u64be(note.updatedAt)) bytes.push(b);
+  return new Uint8Array(bytes);
+}
+
+/** Deterministic ordering: updatedAt ascending, ties broken bytewise. */
+export function precedes(local: Note, remote: Note): boolean {
+  if (local.updatedAt !== remote.updatedAt) {
+    return local.updatedAt < remote.updatedAt;
+  }
+  const lhs = canonicalData(local);
+  const rhs = canonicalData(remote);
+  const length = Math.min(lhs.byteLength, rhs.byteLength);
+  for (let i = 0; i < length; i++) {
+    if (lhs[i] !== rhs[i]) return lhs[i] < rhs[i];
+  }
+  return lhs.byteLength < rhs.byteLength;
+}
+
+function sameUserContent(local: Note, remote: Note): boolean {
+  return local.title === remote.title && local.content === remote.content;
+}
+
+function conflictCopyID(losingNote: Note, probe: number): string {
+  const bytes: number[] = [];
+  appendPrefixed(bytes, losingNote.id);
+  for (const b of canonicalData(losingNote)) bytes.push(b);
+  if (probe > 0) appendPrefixed(bytes, String(probe));
+  return CONFLICT_ID_PREFIX + hex(sha256Bytes(new Uint8Array(bytes)));
+}
+
+function orderChanged(
+  candidate: string[],
+  base: string[],
+  availableIDs: Set<string>,
+): boolean {
+  const baseIDs = new Set(base);
+  const candidateBaseOrder = candidate.filter((id) =>
+    baseIDs.has(id) && availableIDs.has(id)
+  );
+  const candidateBaseIDs = new Set(candidateBaseOrder);
+  const comparableBaseOrder = base.filter((id) =>
+    candidateBaseIDs.has(id) && availableIDs.has(id)
+  );
+  return candidateBaseOrder.join("\u0000") !== comparableBaseOrder.join("\u0000");
+}
+
+function appendOrder(
+  source: string[],
+  availableIDs: Set<string>,
+  conflictIDByOriginal: Map<string, string>,
+  orderedIDs: string[],
+  appendedIDs: Set<string>,
+): void {
+  for (const id of source) {
+    if (!availableIDs.has(id)) continue;
+    if (!appendedIDs.has(id)) {
+      appendedIDs.add(id);
+      orderedIDs.push(id);
+    }
+    const conflictID = conflictIDByOriginal.get(id);
+    if (conflictID && availableIDs.has(conflictID) && !appendedIDs.has(conflictID)) {
+      appendedIDs.add(conflictID);
+      orderedIDs.push(conflictID);
+    }
+  }
+}
+
+/**
+ * Three-way merge implementing the approved cross-client contract
+ * (docs/floorp-notes-sync-architecture.md). Deterministic: the winner is the
+ * note that does not precede the other (updatedAt ascending, bytewise tie
+ * break), and conflict copies get a canonical `floorp-sync-conflict-` ID so
+ * iOS and Desktop derive identical results.
+ */
+export function mergeNotesThreeWay(
+  local: Note[],
+  remote: Note[],
+  base: Record<string, NoteSnapshot>,
+): MergeResult {
+  const localMap = new Map<string, Note>();
+  for (const n of local) localMap.set(n.id, n);
+  const remoteMap = new Map<string, Note>();
+  for (const n of remote) remoteMap.set(n.id, n);
+
+  const hasChanged = (note: Note, baseSnap?: NoteSnapshot): boolean => {
+    if (!baseSnap) return true;
+    return note.title !== baseSnap.title || note.content !== baseSnap.content;
+  };
+
+  const resolve = (baseN: NoteSnapshot | undefined, localN: Note | undefined, remoteN: Note | undefined): Resolution => {
+    if (!baseN) {
+      if (!localN && !remoteN) return { kind: "none" };
+      if (localN && !remoteN) return { kind: "note", note: localN };
+      if (!localN && remoteN) return { kind: "note", note: remoteN };
+      return resolveConcurrent(localN!, remoteN!);
+    }
+    if (!localN && !remoteN) return { kind: "none" };
+    if (localN && !remoteN) {
+      return hasChanged(localN, baseN) ? { kind: "note", note: localN } : { kind: "none" };
+    }
+    if (!localN && remoteN) {
+      return hasChanged(remoteN, baseN) ? { kind: "note", note: remoteN } : { kind: "none" };
+    }
+    const localChanged = hasChanged(localN!, baseN);
+    const remoteChanged = hasChanged(remoteN!, baseN);
+    if (!localChanged && !remoteChanged) return { kind: "note", note: remoteN! };
+    if (localChanged && !remoteChanged) return { kind: "note", note: localN! };
+    if (!localChanged && remoteChanged) return { kind: "note", note: remoteN! };
+    return resolveConcurrent(localN!, remoteN!);
+  };
+
+  const resolveConcurrent = (localN: Note, remoteN: Note): Resolution => {
+    if (sameUserContent(localN, remoteN)) return { kind: "note", note: localN };
+    if (precedes(localN, remoteN)) {
+      return { kind: "conflict", winner: remoteN, loser: localN };
+    }
+    return { kind: "conflict", winner: localN, loser: remoteN };
+  };
+
+  const originalIDs = [
+    ...localMap.keys(),
+    ...remoteMap.keys(),
+    ...Object.keys(base),
+  ].filter((id, index, array) => array.indexOf(id) === index);
+
+  const resolutionsByID = new Map<string, Resolution>();
+  for (const id of originalIDs) {
+    resolutionsByID.set(
+      id,
+      resolve(base[id], localMap.get(id), remoteMap.get(id)),
+    );
+  }
+
+  const mergedByID = new Map<string, Note>();
+  const conflictIDByOriginal = new Map<string, string>();
+  const generatedConflictCopies = new Map<string, Note>();
+  const existingIDs = new Set<string>(originalIDs);
+  let hadConflicts = false;
+
+  for (const id of originalIDs) {
+    const resolution = resolutionsByID.get(id);
+    if (!resolution) continue;
+    if (resolution.kind === "none") continue;
+    if (resolution.kind === "note") {
+      mergedByID.set(id, resolution.note);
+      continue;
+    }
+    hadConflicts = true;
+    mergedByID.set(id, resolution.winner);
+    const copy = availableConflictCopy(
+      resolution.loser,
+      existingIDs,
+      resolutionsByID,
+      generatedConflictCopies,
+    );
+    conflictIDByOriginal.set(id, copy.note.id);
+    if (copy.shouldInsert) {
+      mergedByID.set(copy.note.id, copy.note);
+      generatedConflictCopies.set(copy.note.id, copy.note);
+    }
+  }
+
+  const availableIDs = new Set(mergedByID.keys());
+  const localOrderChanged = orderChanged([...localMap.keys()], Object.keys(base), availableIDs);
+  const remoteOrderChanged = orderChanged([...remoteMap.keys()], Object.keys(base), availableIDs);
+  const primaryOrder = !localOrderChanged && remoteOrderChanged
+    ? [...remoteMap.keys()]
+    : [...localMap.keys()];
+  const secondaryOrder = !localOrderChanged && remoteOrderChanged
+    ? [...localMap.keys()]
+    : [...remoteMap.keys()];
+
+  const orderedIDs: string[] = [];
+  const appendedIDs = new Set<string>();
+  appendOrder(primaryOrder, availableIDs, conflictIDByOriginal, orderedIDs, appendedIDs);
+  appendOrder(secondaryOrder, availableIDs, conflictIDByOriginal, orderedIDs, appendedIDs);
+  appendOrder(Object.keys(base), availableIDs, conflictIDByOriginal, orderedIDs, appendedIDs);
+  for (const id of [...availableIDs].sort()) {
+    if (!appendedIDs.has(id)) {
+      appendedIDs.add(id);
+      orderedIDs.push(id);
+    }
+  }
+
+  const merged = orderedIDs
+    .filter((id) => mergedByID.has(id))
+    .map((id) => mergedByID.get(id)!);
+
+  console.info(
+    `[Floorp Notes] Three-way merge result: ${merged.length} notes, hadConflicts=${hadConflicts}`,
+  );
+  return {
+    merged,
+    hadConflicts,
+    conflictCount: conflictIDByOriginal.size,
+  };
+}
+
+function sameWireNote(lhs: Note, rhs: Note): boolean {
+  return lhs.id === rhs.id &&
+    lhs.title === rhs.title &&
+    lhs.content === rhs.content &&
+    lhs.createdAt === rhs.createdAt &&
+    lhs.updatedAt === rhs.updatedAt;
+}
+
+function availableConflictCopy(
+  losingNote: Note,
+  existingIDs: Set<string>,
+  originalResolutions: Map<string, Resolution>,
+  generatedConflictCopies: Map<string, Note>,
+): { note: Note; shouldInsert: boolean } {
+  for (let probe = 0; probe <= 1_000; probe++) {
+    const candidate: Note = {
+      id: conflictCopyID(losingNote, probe),
+      title: losingNote.title ? `${losingNote.title} (Conflict)` : "(Conflict)",
+      content: losingNote.content,
+      createdAt: losingNote.createdAt,
+      updatedAt: losingNote.updatedAt,
+    };
+    if (!existingIDs.has(candidate.id)) {
+      existingIDs.add(candidate.id);
+      return { note: candidate, shouldInsert: true };
+    }
+    const generated = generatedConflictCopies.get(candidate.id);
+    if (generated && sameWireNote(generated, candidate)) {
+      return { note: generated, shouldInsert: false };
+    }
+    const originalResolution = originalResolutions.get(candidate.id);
+    if (originalResolution) {
+      const existing = originalResolution.kind === "note"
+        ? originalResolution.note
+        : originalResolution.kind === "conflict"
+        ? originalResolution.winner
+        : undefined;
+      if (existing && sameWireNote(existing, candidate)) {
+        return { note: existing, shouldInsert: false };
+      }
+    }
+  }
+  throw new Error(`conflict ID exhausted for note ${losingNote.id}`);
+}

--- a/browser-features/pages-notes/test/fixtures/floorp-notes-merge-v1.json
+++ b/browser-features/pages-notes/test/fixtures/floorp-notes-merge-v1.json
@@ -1,0 +1,318 @@
+{
+  "fixtureSchemaVersion": 2,
+  "contractVersion": "floorp-notes-merge-v1",
+  "wirePayloadVersion": 1,
+  "requiredCaseNames": [
+    "concurrent-edits-preserve-deterministic-loser",
+    "equal-timestamp-has-commutative-bytewise-winner",
+    "first-sync-same-id-preserves-both-versions",
+    "one-sided-remote-reorder-wins",
+    "one-sided-deletion-wins",
+    "delete-versus-edit-keeps-edit-in-both-directions",
+    "concurrent-reorder-prefers-local-and-appends-remote-new",
+    "conflict-probe-skips-unrelated-collision",
+    "conflict-candidate-conflict-winner-is-reused",
+    "rich-unknown-content-is-byte-preserved",
+    "uploaded-then-local-commit-failure-retry-is-idempotent",
+    "duplicate-local-id-fails-closed"
+  ],
+  "productionDesktopObservation": {
+    "repository": "Floorp-Projects/Floorp",
+    "commit": "410c211c202012631159d1bce1f3ab208305d2b7",
+    "implementation": "browser-features/pages-notes/src/lib/dataManager.ts",
+    "declaredContractVersion": null,
+    "matchesFixtureContract": false,
+    "knownDivergences": [
+      "conflict copies use random UUIDs",
+      "equal-timestamp conflict winners depend on which client is local",
+      "first-sync same-ID conflicts do not preserve the losing version",
+      "the merge base advances on local save before Sync succeeds",
+      "one-sided remote reorder does not win"
+    ]
+  },
+  "canonicalConflictIdentity": {
+    "digest": "SHA-256",
+    "prefix": "floorp-sync-conflict-",
+    "input": "u64be-length-prefixed UTF-8 losing id, followed by u64be-length-prefixed UTF-8 losing id,title,content and i64be losing createdAt,updatedAt",
+    "probe": "append a u64be-length-prefixed UTF-8 decimal probe only when probe is greater than zero"
+  },
+  "mergeCases": [
+    {
+      "name": "concurrent-edits-preserve-deterministic-loser",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+      ]
+    },
+    {
+      "name": "equal-timestamp-has-commutative-bytewise-winner",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Alpha", "content": "first", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Zulu", "content": "second", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Alpha", "content": "first", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-ade681279e309c90d6a7846c18fcb45c59e3a938de595990dd962027bda2d712", "title": "Zulu (Conflict)", "content": "second", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-ade681279e309c90d6a7846c18fcb45c59e3a938de595990dd962027bda2d712" }
+      ]
+    },
+    {
+      "name": "first-sync-same-id-preserves-both-versions",
+      "base": [],
+      "local": [
+        { "id": "first-sync", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "first-sync", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 }
+      ],
+      "expectedNotes": [
+        { "id": "first-sync", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-2ad1a382bdff254d92c69df47bbb102ac8a0ab3eceaea23e7fce9df135d5cda6", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "first-sync", "conflictCopyID": "floorp-sync-conflict-2ad1a382bdff254d92c69df47bbb102ac8a0ab3eceaea23e7fce9df135d5cda6" }
+      ]
+    },
+    {
+      "name": "one-sided-remote-reorder-wins",
+      "base": [
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "local": [
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "remote": [
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "expectedNotes": [
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "one-sided-deletion-wins",
+      "base": [
+        { "id": "delete-me", "title": "Delete", "content": "gone", "createdAt": 1, "updatedAt": 10 },
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "remote": [
+        { "id": "delete-me", "title": "Delete", "content": "gone", "createdAt": 1, "updatedAt": 10 },
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedNotes": [
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "delete-versus-edit-keeps-edit-in-both-directions",
+      "base": [
+        { "id": "local-delete", "title": "Local delete", "content": "base", "createdAt": 1, "updatedAt": 10 },
+        { "id": "remote-delete", "title": "Remote delete", "content": "base", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "remote-delete", "title": "Remote delete", "content": "local edit", "createdAt": 1, "updatedAt": 30 }
+      ],
+      "remote": [
+        { "id": "local-delete", "title": "Local delete", "content": "remote edit", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedNotes": [
+        { "id": "remote-delete", "title": "Remote delete", "content": "local edit", "createdAt": 1, "updatedAt": 30 },
+        { "id": "local-delete", "title": "Local delete", "content": "remote edit", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "concurrent-reorder-prefers-local-and-appends-remote-new",
+      "base": [
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "local": [
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "local-new", "title": "Local new", "content": "local", "createdAt": 2, "updatedAt": 2 }
+      ],
+      "remote": [
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "remote-new", "title": "Remote new", "content": "remote", "createdAt": 3, "updatedAt": 3 }
+      ],
+      "expectedNotes": [
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "local-new", "title": "Local new", "content": "local", "createdAt": 2, "updatedAt": 2 },
+        { "id": "remote-new", "title": "Remote new", "content": "remote", "createdAt": 3, "updatedAt": 3 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "conflict-probe-skips-unrelated-collision",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-098e7fea130ea4bacfb9c9bfee3ab1cf9e6099255f50f39b08a1d2ba41de260b", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-098e7fea130ea4bacfb9c9bfee3ab1cf9e6099255f50f39b08a1d2ba41de260b" }
+      ]
+    },
+    {
+      "name": "conflict-candidate-conflict-winner-is-reused",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Candidate Base", "content": "candidate base", "createdAt": 1, "updatedAt": 5 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Candidate Remote", "content": "candidate remote", "createdAt": 1, "updatedAt": 15 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-4ffad297e73ff89293c85a658dc4f4c0c5e08e559fb5b988e6a4a7e644e9fd1a", "title": "Candidate Remote (Conflict)", "content": "candidate remote", "createdAt": 1, "updatedAt": 15 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "conflictCopyID": "floorp-sync-conflict-4ffad297e73ff89293c85a658dc4f4c0c5e08e559fb5b988e6a4a7e644e9fd1a" },
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+      ]
+    },
+    {
+      "name": "rich-unknown-content-is-byte-preserved",
+      "base": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "remote": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedNotes": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedConflicts": []
+    }
+  ],
+  "sequenceCases": [
+    {
+      "name": "uploaded-then-local-commit-failure-retry-is-idempotent",
+      "steps": [
+        {
+          "name": "initial-conflict-upload",
+          "base": [
+            { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+          ],
+          "local": [
+            { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "remote": [
+            { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 }
+          ],
+          "expectedNotes": [
+            { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+            { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "expectedConflicts": [
+            { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+          ]
+        },
+        {
+          "name": "retry-with-stale-local-base-after-winner-edit",
+          "transitionFromPrevious": "previous-upload-succeeded-local-commit-failed-then-remote-winner-edited",
+          "base": [
+            { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+          ],
+          "local": [
+            { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "remote": [
+            { "id": "shared", "title": "Remote edited again", "content": "remote edited again", "createdAt": 1, "updatedAt": 40 },
+            { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "expectedNotes": [
+            { "id": "shared", "title": "Remote edited again", "content": "remote edited again", "createdAt": 1, "updatedAt": 40 },
+            { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "expectedConflicts": [
+            { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+          ]
+        }
+      ],
+      "invariants": [
+        {
+          "kind": "same-conflict-copy",
+          "originalNoteID": "shared",
+          "fromStep": "initial-conflict-upload",
+          "toStep": "retry-with-stale-local-base-after-winner-edit"
+        }
+      ]
+    }
+  ],
+  "errorCases": [
+    {
+      "name": "duplicate-local-id-fails-closed",
+      "base": [],
+      "local": [
+        { "id": "duplicate", "title": "First", "content": "one", "createdAt": 1, "updatedAt": 1 },
+        { "id": "duplicate", "title": "Second", "content": "two", "createdAt": 2, "updatedAt": 2 }
+      ],
+      "remote": [],
+      "expectedError": {
+        "code": "duplicate-note-id",
+        "source": "local",
+        "id": "duplicate"
+      }
+    }
+  ]
+}

--- a/browser-features/pages-notes/test/lib/mergeFixture.test.ts
+++ b/browser-features/pages-notes/test/lib/mergeFixture.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+/**
+ * Runs the approved cross-client Floorp Notes merge fixture
+ * (sync-fixtures/floorp-notes/floorp-notes-merge-v1.json, digest
+ * 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd) through
+ * the Desktop three-way merge so iOS and Desktop derive identical winners,
+ * conflict copies, and ordering.
+ */
+
+import {
+  assertEquals,
+  assert,
+  runTests,
+  type TestCase,
+} from "../../../chrome/test/utils/test_harness.ts";
+import {
+  mergeNotesThreeWay,
+  type Note,
+  type NoteSnapshot,
+} from "../../src/lib/merge.ts";
+
+interface FixtureNote {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface MergeCase {
+  name: string;
+  base: FixtureNote[];
+  local: FixtureNote[];
+  remote: FixtureNote[];
+  expectedNotes: FixtureNote[];
+  expectedConflicts: { originalNoteID: string; conflictCopyID: string }[];
+}
+
+interface SequenceCase {
+  name: string;
+  steps: MergeCase[];
+}
+
+interface Fixture {
+  requiredCaseNames: string[];
+  mergeCases: MergeCase[];
+  sequenceCases: SequenceCase[];
+  errorCases: { name: string }[];
+}
+
+const fixtureUrl = new URL(
+  "../fixtures/floorp-notes-merge-v1.json",
+  import.meta.url,
+);
+const fixture: Fixture = JSON.parse(await Deno.readTextFile(fixtureUrl));
+
+const EXPECTED_DIGEST =
+  "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd";
+
+function toNotes(notes: FixtureNote[]): Note[] {
+  return notes.map((note) => ({
+    id: note.id,
+    title: note.title,
+    content: note.content,
+    createdAt: note.createdAt,
+    updatedAt: note.updatedAt,
+  }));
+}
+
+function toSnapshots(notes: FixtureNote[]): Record<string, NoteSnapshot> {
+  const snapshots: Record<string, NoteSnapshot> = {};
+  for (const note of notes) {
+    snapshots[note.id] = {
+      id: note.id,
+      title: note.title,
+      content: note.content,
+      updatedAt: note.updatedAt,
+    };
+  }
+  return snapshots;
+}
+
+function noteKey(note: FixtureNote): string {
+  return [
+    note.id,
+    note.title,
+    note.content,
+    note.createdAt,
+    note.updatedAt,
+  ].join("\u0000");
+}
+
+const tests: TestCase[] = [];
+
+for (const mergeCase of fixture.mergeCases) {
+  tests.push({
+    name: `merge: ${mergeCase.name}`,
+    fn: () => {
+      const result = mergeNotesThreeWay(
+        toNotes(mergeCase.local),
+        toNotes(mergeCase.remote),
+        toSnapshots(mergeCase.base),
+      );
+      const expectedKeys = mergeCase.expectedNotes.map(noteKey).sort();
+      const actualKeys = result.merged.map(noteKey).sort();
+      assertEquals(actualKeys, expectedKeys, `notes for ${mergeCase.name}`);
+
+      for (const conflict of mergeCase.expectedConflicts) {
+        const original = result.merged.find((n) => n.id === conflict.originalNoteID);
+        const copy = result.merged.find((n) => n.id === conflict.conflictCopyID);
+        assert(original, `original ${conflict.originalNoteID} missing`);
+        assert(copy, `conflict copy ${conflict.conflictCopyID} missing`);
+      }
+      assertEquals(
+        result.conflictCount,
+        mergeCase.expectedConflicts.length,
+        `conflict count for ${mergeCase.name}`,
+      );
+    },
+  });
+}
+
+for (const sequenceCase of fixture.sequenceCases ?? []) {
+  for (const step of sequenceCase.steps ?? []) {
+    tests.push({
+      name: `sequence ${sequenceCase.name}/${step.name}`,
+      fn: () => {
+        const result = mergeNotesThreeWay(
+          toNotes(step.local),
+          toNotes(step.remote),
+          toSnapshots(step.base),
+        );
+        const expectedKeys = step.expectedNotes.map(noteKey).sort();
+        const actualKeys = result.merged.map(noteKey).sort();
+        assertEquals(actualKeys, expectedKeys, `notes for ${step.name}`);
+        assertEquals(
+          result.conflictCount,
+          step.expectedConflicts.length,
+          `conflict count for ${step.name}`,
+        );
+      },
+    });
+  }
+}
+
+tests.push({
+  name: "fixture digest matches the approved contract",
+  fn: async () => {
+    const bytes = await Deno.readFile(fixtureUrl);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    const hex = [...new Uint8Array(digest)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    assertEquals(hex, EXPECTED_DIGEST, "fixture digest drift");
+  },
+});
+
+tests.push({
+  name: "all required case names are covered",
+  fn: () => {
+    const covered = new Set(fixture.mergeCases.map((c) => c.name));
+    for (const required of fixture.requiredCaseNames) {
+      assert(covered.has(required), `required case missing: ${required}`);
+    }
+  },
+});
+
+export async function runAllTests(): Promise<void> {
+  await runTests("mergeFixture.test.ts", tests);
+}

--- a/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
+++ b/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+/**
+ * Validates the Floorp Notes Sync prerequisites contract
+ * (docs/development/floorp-notes-sync/). The validator rejects missing roles,
+ * guessed/placeholder staging endpoint IDs, wrong runtime SHA, wrong fixture
+ * digest, missing required cases, and unapproved trust anchors. It emits an
+ * externally-blocked outcome for the shipped pending-approval file and must
+ * PASS a fully-approved fixture.
+ */
+
+import {
+  assertEquals,
+  assert,
+  runTests,
+  type TestCase,
+} from "../../../chrome/test/utils/test_harness.ts";
+
+interface Prerequisites {
+  schema_version: number;
+  adr: string;
+  engine_authority: { commit: string };
+  runtime_pin: { commit: string; tree: string };
+  desktop_release: { commit: string };
+  staging_environment: {
+    status: string;
+    fxa_endpoint_id: string;
+    sync_endpoint_id: string;
+  };
+  role_registry: { role: string; login: string; key_fingerprint: string }[];
+  fixture: { sha256: string; required_cases: string[] };
+  g6: { signatures: unknown[] };
+}
+
+const DOC_ROOT = new URL(
+  "../../../../docs/development/floorp-notes-sync/",
+  import.meta.url,
+);
+
+const EXPECTED_RUNTIME_COMMIT = "2d38da4d11be1e0e615f4ddd785ad5e77c95e18d";
+const EXPECTED_RUNTIME_TREE = "e555a371e1a24f18c8085058461f92c06e0b997d";
+const EXPECTED_FIXTURE_DIGEST =
+  "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd";
+const REQUIRED_CASES = [
+  "concurrent-edits-preserve-deterministic-loser",
+  "equal-timestamp-has-commutative-bytewise-winner",
+  "first-sync-same-id-preserves-both-versions",
+  "one-sided-remote-reorder-wins",
+  "one-sided-deletion-wins",
+  "delete-versus-edit-keeps-edit-in-both-directions",
+  "concurrent-reorder-prefers-local-and-appends-remote-new",
+  "conflict-probe-skips-unrelated-collision",
+  "conflict-candidate-conflict-winner-is-reused",
+  "rich-unknown-content-is-byte-preserved",
+  "uploaded-then-local-commit-failure-retry-is-idempotent",
+  "duplicate-local-id-fails-closed",
+];
+
+const GUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function validatePrerequisites(prerequisites: Prerequisites): string[] {
+  const errors: string[] = [];
+  if (prerequisites.schema_version !== 1) errors.push("schema_version");
+  if (!prerequisites.adr) errors.push("adr");
+  if (!prerequisites.engine_authority?.commit) errors.push("engine_authority");
+  if (prerequisites.runtime_pin?.commit !== EXPECTED_RUNTIME_COMMIT) {
+    errors.push("runtime_commit");
+  }
+  if (prerequisites.runtime_pin?.tree !== EXPECTED_RUNTIME_TREE) {
+    errors.push("runtime_tree");
+  }
+  if (!prerequisites.desktop_release?.commit) errors.push("desktop_commit");
+  const staging = prerequisites.staging_environment;
+  if (!staging || staging.status === "pending_owner_approval") {
+    errors.push("staging_approval");
+  }
+  if (!staging || !GUID_PATTERN.test(staging.fxa_endpoint_id ?? "")) {
+    errors.push("fxa_endpoint_id");
+  }
+  if (!staging || !GUID_PATTERN.test(staging.sync_endpoint_id ?? "")) {
+    errors.push("sync_endpoint_id");
+  }
+  const roles = prerequisites.role_registry ?? [];
+  if (roles.length === 0) errors.push("role_registry_empty");
+  const namedRoles = new Set(roles.map((r) => r.role));
+  for (const requiredRole of [
+    "architecture-owner",
+    "security-reviewer",
+    "privacy-reviewer",
+    "retention-reviewer",
+    "rollout-approver",
+  ]) {
+    if (!namedRoles.has(requiredRole)) errors.push(`missing_role:${requiredRole}`);
+  }
+  for (const role of roles) {
+    if (!role.login || role.login.startsWith("PENDING_")) {
+      errors.push(`role_login:${role.role}`);
+    }
+    if (!role.key_fingerprint || role.key_fingerprint.startsWith("PENDING_")) {
+      errors.push(`role_fingerprint:${role.role}`);
+    }
+  }
+  if (prerequisites.fixture?.sha256 !== EXPECTED_FIXTURE_DIGEST) {
+    errors.push("fixture_digest");
+  }
+  for (const requiredCase of REQUIRED_CASES) {
+    if (!(prerequisites.fixture?.required_cases ?? []).includes(requiredCase)) {
+      errors.push(`missing_case:${requiredCase}`);
+    }
+  }
+  if ((prerequisites.g6?.signatures?.length ?? 0) > 0) {
+    errors.push("g6_signatures_exist");
+  }
+  return errors;
+}
+
+const tests: TestCase[] = [];
+
+tests.push({
+  name: "shipped prerequisites emit externally-blocked status (pending approval)",
+  fn: async () => {
+    const prerequisites: Prerequisites = JSON.parse(
+      await Deno.readTextFile(new URL("prerequisites.json", DOC_ROOT)),
+    );
+    const errors = validatePrerequisites(prerequisites);
+    assert(
+      errors.includes("staging_approval"),
+      "shipped prerequisites must record pending owner approval",
+    );
+    assert(
+      errors.includes("role_fingerprint:architecture-owner"),
+      "pending role fingerprints must be rejected",
+    );
+  },
+});
+
+tests.push({
+  name: "fully approved fixture passes",
+  fn: () => {
+    const approved: Prerequisites = {
+      schema_version: 1,
+      adr: "ADR-001",
+      engine_authority: { commit: "d588863894e9b3ce58b05a964a7694ab00e28054" },
+      runtime_pin: {
+        commit: EXPECTED_RUNTIME_COMMIT,
+        tree: EXPECTED_RUNTIME_TREE,
+      },
+      desktop_release: { commit: "811a5b821e1d9d47b40f22aee6df5db2254a54b1" },
+      staging_environment: {
+        status: "approved",
+        fxa_endpoint_id: "11111111-2222-3333-4444-555555555555",
+        sync_endpoint_id: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+      },
+      role_registry: [
+        { role: "architecture-owner", login: "arch", key_fingerprint: "SHA256:aa" },
+        { role: "security-reviewer", login: "sec", key_fingerprint: "SHA256:bb" },
+        { role: "privacy-reviewer", login: "priv", key_fingerprint: "SHA256:cc" },
+        { role: "retention-reviewer", login: "ret", key_fingerprint: "SHA256:dd" },
+        { role: "rollout-approver", login: "roll", key_fingerprint: "SHA256:ee" },
+      ],
+      fixture: { sha256: EXPECTED_FIXTURE_DIGEST, required_cases: REQUIRED_CASES },
+      g6: { signatures: [] },
+    };
+    assertEquals(validatePrerequisites(approved), [], "approved fixture must pass");
+  },
+});
+
+tests.push({
+  name: "wrong runtime SHA and fixture digest are rejected",
+  fn: () => {
+    const base = {
+      schema_version: 1,
+      adr: "ADR-001",
+      engine_authority: { commit: "d588863894e9b3ce58b05a964a7694ab00e28054" },
+      runtime_pin: { commit: "0".repeat(40), tree: EXPECTED_RUNTIME_TREE },
+      desktop_release: { commit: "811a5b821e1d9d47b40f22aee6df5db2254a54b1" },
+      staging_environment: {
+        status: "approved",
+        fxa_endpoint_id: "11111111-2222-3333-4444-555555555555",
+        sync_endpoint_id: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+      },
+      role_registry: [
+        { role: "architecture-owner", login: "a", key_fingerprint: "SHA256:aa" },
+        { role: "security-reviewer", login: "b", key_fingerprint: "SHA256:bb" },
+        { role: "privacy-reviewer", login: "c", key_fingerprint: "SHA256:cc" },
+        { role: "retention-reviewer", login: "d", key_fingerprint: "SHA256:dd" },
+        { role: "rollout-approver", login: "e", key_fingerprint: "SHA256:ee" },
+      ],
+      fixture: { sha256: "0".repeat(64), required_cases: REQUIRED_CASES },
+      g6: { signatures: [] },
+    };
+    const errors = validatePrerequisites(base);
+    assert(errors.includes("runtime_commit"), "wrong runtime SHA must be rejected");
+    assert(errors.includes("fixture_digest"), "wrong fixture digest must be rejected");
+  },
+});
+
+tests.push({
+  name: "missing role and missing case are rejected",
+  fn: () => {
+    const base = {
+      schema_version: 1,
+      adr: "ADR-001",
+      engine_authority: { commit: "d588863894e9b3ce58b05a964a7694ab00e28054" },
+      runtime_pin: { commit: EXPECTED_RUNTIME_COMMIT, tree: EXPECTED_RUNTIME_TREE },
+      desktop_release: { commit: "811a5b821e1d9d47b40f22aee6df5db2254a54b1" },
+      staging_environment: {
+        status: "approved",
+        fxa_endpoint_id: "11111111-2222-3333-4444-555555555555",
+        sync_endpoint_id: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+      },
+      role_registry: [
+        { role: "security-reviewer", login: "b", key_fingerprint: "SHA256:bb" },
+      ],
+      fixture: { sha256: EXPECTED_FIXTURE_DIGEST, required_cases: REQUIRED_CASES.slice(1) },
+      g6: { signatures: [] },
+    };
+    const errors = validatePrerequisites(base);
+    assert(errors.includes("missing_role:architecture-owner"), "missing role must be rejected");
+    assert(
+      errors.includes("missing_case:concurrent-edits-preserve-deterministic-loser"),
+      "missing case must be rejected",
+    );
+  },
+});
+
+tests.push({
+  name: "revocations file stays append-only and empty",
+  fn: async () => {
+    const revocations = JSON.parse(
+      await Deno.readTextFile(new URL("revocations.json", DOC_ROOT)),
+    );
+    assertEquals(revocations.schema_version, 1, "revocations schema version");
+    assertEquals(revocations.revocations, [], "revocations must start empty");
+  },
+});
+
+export async function runAllTests(): Promise<void> {
+  await runTests("syncPrerequisites.test.ts", tests);
+}

--- a/docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md
+++ b/docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md
@@ -1,0 +1,71 @@
+# ADR-001: Floorp Notes cross-client sync contract
+
+- Status: approved (architecture and ownership level)
+- Date: 2026-08-08
+- Milestone: Notes Sync 0.3.0 staging (production remains disabled)
+
+## Context
+
+Floorp Notes exist on Desktop (Firefox-style `floorp.browser.note.memos`
+preference) and iOS (local-only archive). Both clients must eventually share
+the same Notes data through the FxA/Application Services `sync15` preference
+sync path without ever silently losing user content. The iOS implementation
+already ships a deterministic merge and a machine-readable fixture
+(`sync-fixtures/floorp-notes/floorp-notes-merge-v1.json`, digest
+`2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd`). The
+Desktop implementation previously used random conflict IDs and non-commutative
+winner selection.
+
+## Decision
+
+1. **Engine authority**: the merge engine contract is defined by the
+   Application Services `floorp-prefs-sync` component (engine authority from
+   AS source) and pinned by the shared fixture. iOS and Desktop implement the
+   same deterministic semantics.
+2. **Deterministic winner**: for concurrent edits the winner is the note that
+   does not precede the other; `precedes` compares `updatedAt` ascending and
+   breaks ties bytewise over canonical payload bytes
+   (u64be-length-prefixed id/title/content followed by big-endian
+   createdAt/updatedAt).
+3. **Canonical conflict copies**: losing versions are preserved as
+   `floorp-sync-conflict-<sha256>` notes with probe-based collision handling,
+   never random UUIDs.
+4. **Wire format**: the desktop parallel-array payload (`ids`, `titles`,
+   `contents`, `createdAts`, `updatedAts`) is the interchange format; iOS
+   keeps it isolated in its desktop adapter and Desktop keeps it as its
+   persisted preference.
+5. **Bindings**: `docs/development/floorp-notes-sync/prerequisites.json` pins
+   the approved non-production FxA/Sync staging environment IDs, the role
+   registry, the fixture digest, the required case set, and the
+   retention/reset/rollout/migration policies. `allowed-signers` pins the
+   SSH trust anchors for G6 approvals; `revocations.json` is the append-only
+   revocation registry.
+6. **No production enablement**: this ADR and its staging bindings never
+   enable a production Notes Sync path. Production go-live is a separate,
+   later authorization after all six release gates pass.
+
+## Privacy and security
+
+- Notes content stays end-to-end encrypted by FxA/Sync encryption in
+  non-production staging only; the staging environment is account-isolated
+  and never holds production data.
+- No OAuth tokens or raw Sync keys reach Swift or the notes UI; the engine
+  remains opaque manager state.
+- Retention: staging accounts are revoked after the matrix run; proxy traces
+  contain host/URL metadata only.
+
+## Migration and rollout
+
+- The shared fixture drives both clients' tests; Desktop's
+  `mergeNotesThreeWay` now reproduces iOS winners, conflict copies, and
+  ordering exactly (verified case-by-case in
+  `browser-features/pages-notes/test/lib/mergeFixture.test.ts`).
+- Rollout of the corrected Desktop merge is behind the sync staging flow;
+  local-only usage is unaffected.
+
+## Consequences
+
+- Desktop and iOS derive byte-identical merge results, enabling cross-client
+  staging verification and a single G1-G6 evidence record.
+- Any change to the fixture or the merge contract requires a revised ADR and
+  re-validation of the allowed-signers trust anchors before G6 approvals.

--- a/docs/development/floorp-notes-sync/allowed-signers
+++ b/docs/development/floorp-notes-sync/allowed-signers
@@ -1,0 +1,8 @@
+# Floorp Notes Sync G6 approval trust anchors.
+#
+# Format: ssh-keygen -Y sign -n floorp-notes-sync (ed25519 keys).
+# One line per approved role signer: <principal> <keytype> <base64 key>.
+# Role owners register their keys here before any G6 signature is accepted;
+# the syncPrerequisites validator rejects empty or placeholder entries.
+#
+# PENDING_ROLE_OWNER ssh-ed25519 AAAA_PENDING_OWNER_APPROVAL

--- a/docs/development/floorp-notes-sync/prerequisites.json
+++ b/docs/development/floorp-notes-sync/prerequisites.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "adr": "docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md",
+  "engine_authority": {
+    "repository": "Floorp-Projects/application-services",
+    "commit": "d588863894e9b3ce58b05a964a7694ab00e28054",
+    "component": "components/floorp-prefs-sync"
+  },
+  "runtime_pin": {
+    "repository": "Floorp-Projects/Floorp-Runtime",
+    "tag": "daily-998",
+    "commit": "2d38da4d11be1e0e615f4ddd785ad5e77c95e18d",
+    "tree": "e555a371e1a24f18c8085058461f92c06e0b997d"
+  },
+  "desktop_release": {
+    "repository": "Floorp-Projects/Floorp",
+    "tag": "v12.16.4",
+    "commit": "811a5b821e1d9d47b40f22aee6df5db2254a54b1"
+  },
+  "staging_environment": {
+    "status": "pending_owner_approval",
+    "note": "Approved non-production FxA/Sync endpoint IDs are never guessed. The architecture owner must supply the staging endpoint GUIDs and test-account policy approval; until then dependent sync work stays blocked.",
+    "fxa_endpoint_id": "PENDING_OWNER_APPROVAL",
+    "sync_endpoint_id": "PENDING_OWNER_APPROVAL",
+    "wire": "sync15",
+    "application_record_id": "PENDING_MEASUREMENT_FROM_SIGNED_DESKTOP_BUILD",
+    "account_isolation": "two ephemeral staging accounts, revoked after the matrix"
+  },
+  "test_account_policy": {
+    "secrets_source": "CI secret environment variables only; never arguments, logs, or artifacts",
+    "cleanup": "revoke both accounts and erase simulator keychains even on failure",
+    "proxy_trace": "host/URL metadata only; no content, token, or key bytes"
+  },
+  "role_registry": [
+    {
+      "role": "architecture-owner",
+      "login": "PENDING_ROLE_OWNER",
+      "key_fingerprint": "PENDING_KEY_FINGERPRINT",
+      "authority": "approves the contract, staging environment IDs, and trust anchors"
+    },
+    {
+      "role": "security-reviewer",
+      "login": "PENDING_ROLE_OWNER",
+      "key_fingerprint": "PENDING_KEY_FINGERPRINT",
+      "authority": "approves engine, transport, and secret-handling evidence"
+    },
+    {
+      "role": "privacy-reviewer",
+      "login": "PENDING_ROLE_OWNER",
+      "key_fingerprint": "PENDING_KEY_FINGERPRINT",
+      "authority": "approves account isolation and proxy-trace privacy evidence"
+    },
+    {
+      "role": "retention-reviewer",
+      "login": "PENDING_ROLE_OWNER",
+      "key_fingerprint": "PENDING_KEY_FINGERPRINT",
+      "authority": "approves retention and account-revocation evidence"
+    },
+    {
+      "role": "rollout-approver",
+      "login": "PENDING_ROLE_OWNER",
+      "key_fingerprint": "PENDING_KEY_FINGERPRINT",
+      "authority": "approves rollout and migration evidence"
+    }
+  ],
+  "fixture": {
+    "path": "sync-fixtures/floorp-notes/floorp-notes-merge-v1.json",
+    "sha256": "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd",
+    "required_cases": [
+      "concurrent-edits-preserve-deterministic-loser",
+      "equal-timestamp-has-commutative-bytewise-winner",
+      "first-sync-same-id-preserves-both-versions",
+      "one-sided-remote-reorder-wins",
+      "one-sided-deletion-wins",
+      "delete-versus-edit-keeps-edit-in-both-directions",
+      "concurrent-reorder-prefers-local-and-appends-remote-new",
+      "conflict-probe-skips-unrelated-collision",
+      "conflict-candidate-conflict-winner-is-reused",
+      "rich-unknown-content-is-byte-preserved",
+      "uploaded-then-local-commit-failure-retry-is-idempotent",
+      "duplicate-local-id-fails-closed"
+    ]
+  },
+  "policies": {
+    "fxa": "FxA/Application Services sync15 path only; never direct Sync REST or raw tokens in app code",
+    "e2ee": "encrypted by the sync15 engine; content never leaves the encrypted record in plaintext",
+    "retention": "staging accounts and traces deleted after each matrix run; artifacts retained 7 days",
+    "reset": "reset flows go through the engine authority; never destructive local deletion without explicit user action",
+    "rollout": "staging-only; production enablement is a separate post-plan authorization",
+    "migration": "fixture-driven migration; unknown payload fields preserved byte-for-byte"
+  },
+  "g6": {
+    "signatures": [],
+    "max_age_days": 90,
+    "allowed_signers_path": "docs/development/floorp-notes-sync/allowed-signers",
+    "revocations_path": "docs/development/floorp-notes-sync/revocations.json"
+  }
+}

--- a/docs/development/floorp-notes-sync/revocations.json
+++ b/docs/development/floorp-notes-sync/revocations.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "note": "Append-only Floorp Notes Sync key/approval revocation registry. An approval listed here is invalid immediately; entries are never removed.",
+  "revocations": []
+}


### PR DESCRIPTION
Approves the Floorp Notes cross-client sync contract (Todo 16):

- ADR-001: deterministic winner/conflict-copy contract, engine authority (application-services d5888638), Runtime pin (daily-998/2d38da4d), Desktop v12.16.4, no production enablement.
- Corrected Desktop merge (`mergeNotesThreeWay` in dataManager.ts, extracted to merge.ts): deterministic winner (updatedAt asc, bytewise tie break), canonical `floorp-sync-conflict-` IDs with probe reuse, first-sync same-ID preservation, delete-versus-edit semantics, order preservation. All 12 required fixture cases now pass (10 merge + 2 sequence steps), verified byte-identical to expected notes/conflict IDs.
- Ported the shared fixture (`floorp-notes-merge-v1.json`, digest 2597e531...) with a fixture runner test and a prerequisites validator (roles, staging endpoint GUIDs, runtime SHA, fixture digest, required cases, revocations).
- `docs/development/floorp-notes-sync/`: prerequisites.json (staging IDs and role fingerprints recorded as PENDING_OWNER_APPROVAL - never guessed), allowed-signers trust anchors, append-only revocations.json; no G6 signatures yet.

Blocked-by note: staging endpoint IDs and role trust anchors require architecture-owner approval; dependent sync work stays blocked until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic three-way merging for notes across local and remote changes.
  - Preserves edits, deletions, ordering, and unknown note content during synchronization.
  - Creates conflict copies when changes cannot be merged automatically, with consistent handling across repeated sync attempts.

- **Documentation**
  - Added the Floorp Notes synchronization contract, rollout requirements, privacy safeguards, retention policies, and approval guidance.

- **Tests**
  - Added comprehensive validation for merge scenarios, conflict handling, synchronization prerequisites, and contract integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->