### PR TITLE
chore(runtime): pin Floorp-Runtime nora-0.2.0 with Floorp Notes tests

### DIFF
--- a/floorp-runtime.lock.json
+++ b/floorp-runtime.lock.json
@@ -3,7 +3,7 @@
   "source": {
     "repository": "Floorp-Projects/Floorp-Runtime",
     "trackingRef": "nora-0.2.0",
-    "ref": "nora-0.2.0",
+    "ref": "daily-998",
     "commit": "ca3d0003976321fd67061d463ab56958b0f38cd9",
     "tree": "a524742367f62767f607764cb5944ec3d613a77c",
     "release": {

--- a/floorp-runtime.lock.json
+++ b/floorp-runtime.lock.json
@@ -3,16 +3,16 @@
   "source": {
     "repository": "Floorp-Projects/Floorp-Runtime",
     "trackingRef": "nora-0.2.0",
-    "ref": "daily-998",
-    "commit": "2d38da4d11be1e0e615f4ddd785ad5e77c95e18d",
-    "tree": "e555a371e1a24f18c8085058461f92c06e0b997d",
+    "ref": "nora-0.2.0",
+    "commit": "ca3d0003976321fd67061d463ab56958b0f38cd9",
+    "tree": "a524742367f62767f607764cb5944ec3d613a77c",
     "release": {
       "id": 359773143,
       "immutable": false
     },
     "materials": {
-      "count": 53,
-      "totalBytes": 220264,
+      "count": 58,
+      "totalBytes": 250737,
       "entries": [
         {
           "path": "browser/base/content/test/caps/browser.toml",
@@ -431,6 +431,46 @@
           "sha256": "9ee35758add99d9dd20c8d20ec26baffa1787401876e205a436015e6d9f00b57"
         },
         {
+          "path": "services/sync/tests/tps/test_floorp_notes.js",
+          "role": "test",
+          "bytes": 2641,
+          "mode": "100644",
+          "gitBlob": "ce928fb13957b688974eef6d14b09543e3d10b5d",
+          "sha256": "7a24eea46d9a418b9089d0f4e6a99ed99d9aaa872682761a403de44932b90ef7"
+        },
+        {
+          "path": "services/sync/tests/tps/tps-floorp-notes.toml",
+          "role": "manifest",
+          "bytes": 736,
+          "mode": "100644",
+          "gitBlob": "895fc3fd7f2b6181438b3eece5c1b517463c1c86",
+          "sha256": "c5b20254de2c5fce8c0dec655a425dbe304bb906dcd293f079d928779a0820a2"
+        },
+        {
+          "path": "services/sync/tests/unit/floorp-notes-merge-v1.json",
+          "role": "support",
+          "bytes": 17256,
+          "mode": "100644",
+          "gitBlob": "fef8f5a0e0e303a3f9106e3ac5ac36a7a67cc6ad",
+          "sha256": "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd"
+        },
+        {
+          "path": "services/sync/tests/unit/test_floorp_notes_prefs.js",
+          "role": "test",
+          "bytes": 9403,
+          "mode": "100644",
+          "gitBlob": "14f2188dad5ae0ca88042800d147839ec552f73c",
+          "sha256": "5a27903dcd166458f0134f61d2ec48cf7322f94d07bc22a3933a96f79d4f5dec"
+        },
+        {
+          "path": "services/sync/tests/unit/xpcshell-floorp-notes.toml",
+          "role": "manifest",
+          "bytes": 437,
+          "mode": "100644",
+          "gitBlob": "881f3e3018af6c05d33e99b92fdebc0b90f51e6b",
+          "sha256": "04439bd4cd0253331e291023ba2bbffead1f15d6104c5ebe6ea5108f4f82d929"
+        },
+        {
           "path": "toolkit/content/tests/browser/common/mockTransfer.js",
           "role": "support",
           "bytes": 2765,
@@ -441,9 +481,9 @@
       ]
     },
     "tests": {
-      "count": 8,
-      "totalTasks": 15,
-      "supportDependencyEdges": 93,
+      "count": 10,
+      "totalTasks": 23,
+      "supportDependencyEdges": 94,
       "entries": [
         {
           "path": "browser/base/content/test/caps/browser_principalSerialization_version1.js",
@@ -498,6 +538,20 @@
           "path": "browser/components/urlbar/tests/browser-UrlbarInput/browser_a11y.js",
           "manifest": "browser/components/urlbar/tests/browser-UrlbarInput/browser.toml",
           "expectedTasks": 1,
+          "headPolicy": "harness-replaced",
+          "supportPolicy": "locked-not-loaded"
+        },
+        {
+          "path": "services/sync/tests/tps/test_floorp_notes.js",
+          "manifest": "services/sync/tests/tps/tps-floorp-notes.toml",
+          "expectedTasks": 3,
+          "headPolicy": "harness-replaced",
+          "supportPolicy": "locked-not-loaded"
+        },
+        {
+          "path": "services/sync/tests/unit/test_floorp_notes_prefs.js",
+          "manifest": "services/sync/tests/unit/xpcshell-floorp-notes.toml",
+          "expectedTasks": 5,
           "headPolicy": "harness-replaced",
           "supportPolicy": "locked-not-loaded"
         }
@@ -648,6 +702,18 @@
           "supportPaths": [
             "browser/components/urlbar/tests/browser-UrlbarInput/head.js",
             "browser/components/urlbar/tests/browser/head-common.js"
+          ]
+        },
+        {
+          "path": "services/sync/tests/tps/tps-floorp-notes.toml",
+          "preferences": [],
+          "supportPaths": []
+        },
+        {
+          "path": "services/sync/tests/unit/xpcshell-floorp-notes.toml",
+          "preferences": [],
+          "supportPaths": [
+            "services/sync/tests/unit/floorp-notes-merge-v1.json"
           ]
         }
       ]

--- a/tools/src/runtime_lock.test.ts
+++ b/tools/src/runtime_lock.test.ts
@@ -62,7 +62,7 @@ Deno.test("canonical Runtime lock pins the complete reviewed source closure", ()
   assertEquals(canonicalLock.schemaVersion, 1);
   assertEquals(canonicalLock.source.repository, RUNTIME_REPOSITORY);
   assertEquals(canonicalLock.source.trackingRef, "nora-0.2.0");
-  assertEquals(canonicalLock.source.ref, "nora-0.2.0");
+  assertEquals(canonicalLock.source.ref, "daily-998");
   assertEquals(
     canonicalLock.source.commit,
     "ca3d0003976321fd67061d463ab56958b0f38cd9",

--- a/tools/src/runtime_lock.test.ts
+++ b/tools/src/runtime_lock.test.ts
@@ -62,7 +62,7 @@ Deno.test("canonical Runtime lock pins the complete reviewed source closure", ()
   assertEquals(canonicalLock.schemaVersion, 1);
   assertEquals(canonicalLock.source.repository, RUNTIME_REPOSITORY);
   assertEquals(canonicalLock.source.trackingRef, "nora-0.2.0");
-  assertEquals(canonicalLock.source.ref, "daily-998");
+  assertEquals(canonicalLock.source.ref, "nora-0.2.0");
   assertEquals(
     canonicalLock.source.commit,
     "ca3d0003976321fd67061d463ab56958b0f38cd9",

--- a/tools/src/runtime_lock.test.ts
+++ b/tools/src/runtime_lock.test.ts
@@ -65,30 +65,30 @@ Deno.test("canonical Runtime lock pins the complete reviewed source closure", ()
   assertEquals(canonicalLock.source.ref, "daily-998");
   assertEquals(
     canonicalLock.source.commit,
-    "2d38da4d11be1e0e615f4ddd785ad5e77c95e18d",
+    "ca3d0003976321fd67061d463ab56958b0f38cd9",
   );
   assertEquals(
     canonicalLock.source.tree,
-    "e555a371e1a24f18c8085058461f92c06e0b997d",
+    "a524742367f62767f607764cb5944ec3d613a77c",
   );
   assertEquals(canonicalLock.source.release, {
     id: 359773143,
     immutable: false,
   });
-  assertEquals(canonicalLock.source.materials.count, 53);
-  assertEquals(canonicalLock.source.materials.totalBytes, 220264);
-  assertEquals(canonicalLock.source.tests.count, 8);
-  assertEquals(canonicalLock.source.tests.totalTasks, 15);
-  assertEquals(canonicalLock.source.tests.supportDependencyEdges, 93);
+  assertEquals(canonicalLock.source.materials.count, 58);
+  assertEquals(canonicalLock.source.materials.totalBytes, 250737);
+  assertEquals(canonicalLock.source.tests.count, 10);
+  assertEquals(canonicalLock.source.tests.totalTasks, 23);
+  assertEquals(canonicalLock.source.tests.supportDependencyEdges, 94);
 
   const roleCounts = Object.groupBy(
     canonicalLock.source.materials.entries,
     (entry) => entry.role,
   );
-  assertEquals(roleCounts.test?.length, 8);
-  assertEquals(roleCounts.manifest?.length, 6);
+  assertEquals(roleCounts.test?.length, 10);
+  assertEquals(roleCounts.manifest?.length, 8);
   assertEquals(roleCounts["head-support"]?.length, 5);
-  assertEquals(roleCounts.support?.length, 34);
+  assertEquals(roleCounts.support?.length, 35);
 
   assertEquals(
     Object.fromEntries(
@@ -110,6 +110,8 @@ Deno.test("canonical Runtime lock pins the complete reviewed source closure", ()
       "browser/components/tabbrowser/test/browser/tabs/browser_pinned_and_hidden_tabs.js":
         1,
       "browser/components/urlbar/tests/browser-UrlbarInput/browser_a11y.js": 1,
+      "services/sync/tests/tps/test_floorp_notes.js": 3,
+      "services/sync/tests/unit/test_floorp_notes_prefs.js": 5,
     },
   );
 });


### PR DESCRIPTION
## Summary
Updates `floorp-runtime.lock.json` to the merged Floorp-Runtime commit `ca3d000397` (nora-0.2.0, tree `a524742367`) which adds Floorp Notes prefs-engine xpcshell/TPS coverage in `services/sync`.

## Changes
- Lock source: `ref: nora-0.2.0`, `commit: ca3d0003976321fd67061d463ab56958b0f38cd9`, `tree: a524742367f62767f607764cb5944ec3d613a77c`.
- New locked materials (5): `xpcshell-floorp-notes.toml`, `test_floorp_notes_prefs.js`, `tps-floorp-notes.toml`, `test_floorp_notes.js`, `floorp-notes-merge-v1.json` (fixture digest 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd).
- Materials 53 -> 58; tests 8 -> 10; totalTasks 15 -> 23; supportDependencyEdges 93 -> 94.
- `tools/src/runtime_lock.test.ts` canonical pins updated.

## Verification
- `deno run -A tools/runtime-lock/runtime_lock_cli.ts validate-lock`: OK.
- `deno task test:firefox-tests`: 16/16 pass.
- `deno task firefox-tests:collect` against the locked commit: 58 files, 10 candidates, deterministic projection matches.
- `deno task firefox-tests:triage-browser`: all 10 already-allowed.
- `deno task firefox-tests:prepare-browser`: wrappers generated (incl. the two new test files).
- `deno test tools/firefox-tests/test_runtime_lock.ts`: OK.

## Notes
- No changes to browser-chrome manifests or unrelated lock materials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated runtime validation checks to reflect the latest bundled materials and source revision.
  * Added coverage for two Floorp Notes synchronization test tasks.
  * Expanded verification of test metadata, dependencies, and material counts.
  * Updated runtime metadata to include additional Floorp Notes test and support files.
  * Registered the new test suites and manifests, with revised aggregate task and test counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->