### PR TITLE
fix(os-api): declare BrowserTab isConnected

### DIFF
--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -25,6 +25,7 @@ interface WebScraperActor {
 // Type for browser tab element
 interface BrowserTab {
   linkedBrowser: XULBrowserElement & { browserId: number };
+  readonly isConnected: boolean;
   label: string;
   selected: boolean;
   pinned: boolean;


### PR DESCRIPTION
## Summary
- Follow-up to #2630.
- Declare `BrowserTab.isConnected` in the local TabManager type so the merged `tab.isConnected` liveness checks type-check cleanly.
- Type-only change; no runtime behavior changes.

## Verification
- `deno lint browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts`
- `git diff --check -- browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts`
- `deno check browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts`
  - Expected existing baseline only: five diagnostics in `shared/CookieHelper.sys.mts`.
  - No diagnostics mentioning `isConnected`.
- Prior runtime proof for #2630 on isolated Windows Gecko 153 BuildID `20260725075208`: HTTP health/list/attach/title/URI/HTML/screenshot, cross-origin navigation, create/close/exists cleanup, and Marionette protocol v3 multi-command same connection passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only connection status indicator for browser tabs, enabling tab liveness tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->