### PR TITLE
docs(sync): authorize production Notes contract

### DIFF
--- a/browser-features/pages-notes/src/lib/merge.ts
+++ b/browser-features/pages-notes/src/lib/merge.ts
@@ -25,6 +25,20 @@ export interface MergeResult {
   conflictCount: number;
 }
 
+export type NotesMergeErrorCode = "blank-note-id" | "duplicate-note-id";
+export type NotesMergeSource = "base" | "local" | "remote";
+
+export class NotesMergeError extends Error {
+  constructor(
+    readonly code: NotesMergeErrorCode,
+    readonly source: NotesMergeSource,
+    readonly noteID: string,
+  ) {
+    super(`${code} in ${source}: ${noteID}`);
+    this.name = "NotesMergeError";
+  }
+}
+
 type Resolution =
   | { kind: "none" }
   | { kind: "note"; note: Note }
@@ -36,21 +50,80 @@ const CONFLICT_ID_PREFIX = "floorp-sync-conflict-";
 function sha256Bytes(input: Uint8Array): Uint8Array {
   // Compact SHA-256 (FIPS 180-4) implementation.
   const K = new Uint32Array([
-    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
-    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
-    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
-    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
-    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    0x428a2f98,
+    0x71374491,
+    0xb5c0fbcf,
+    0xe9b5dba5,
+    0x3956c25b,
+    0x59f111f1,
+    0x923f82a4,
+    0xab1c5ed5,
+    0xd807aa98,
+    0x12835b01,
+    0x243185be,
+    0x550c7dc3,
+    0x72be5d74,
+    0x80deb1fe,
+    0x9bdc06a7,
+    0xc19bf174,
+    0xe49b69c1,
+    0xefbe4786,
+    0x0fc19dc6,
+    0x240ca1cc,
+    0x2de92c6f,
+    0x4a7484aa,
+    0x5cb0a9dc,
+    0x76f988da,
+    0x983e5152,
+    0xa831c66d,
+    0xb00327c8,
+    0xbf597fc7,
+    0xc6e00bf3,
+    0xd5a79147,
+    0x06ca6351,
+    0x14292967,
+    0x27b70a85,
+    0x2e1b2138,
+    0x4d2c6dfc,
+    0x53380d13,
+    0x650a7354,
+    0x766a0abb,
+    0x81c2c92e,
+    0x92722c85,
+    0xa2bfe8a1,
+    0xa81a664b,
+    0xc24b8b70,
+    0xc76c51a3,
+    0xd192e819,
+    0xd6990624,
+    0xf40e3585,
+    0x106aa070,
+    0x19a4c116,
+    0x1e376c08,
+    0x2748774c,
+    0x34b0bcb5,
+    0x391c0cb3,
+    0x4ed8aa4a,
+    0x5b9cca4f,
+    0x682e6ff3,
+    0x748f82ee,
+    0x78a5636f,
+    0x84c87814,
+    0x8cc70208,
+    0x90befffa,
+    0xa4506ceb,
+    0xbef9a3f7,
+    0xc67178f2,
   ]);
   const H = new Uint32Array([
-    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    0x6a09e667,
+    0xbb67ae85,
+    0x3c6ef372,
+    0xa54ff53a,
+    0x510e527f,
+    0x9b05688c,
+    0x1f83d9ab,
+    0x5be0cd19,
   ]);
   const bitLength = input.byteLength * 8;
   const padded = new Uint8Array(
@@ -178,7 +251,8 @@ function orderChanged(
   const comparableBaseOrder = base.filter((id) =>
     candidateBaseIDs.has(id) && availableIDs.has(id)
   );
-  return candidateBaseOrder.join("\u0000") !== comparableBaseOrder.join("\u0000");
+  return candidateBaseOrder.join("\u0000") !==
+    comparableBaseOrder.join("\u0000");
 }
 
 function appendOrder(
@@ -195,7 +269,9 @@ function appendOrder(
       orderedIDs.push(id);
     }
     const conflictID = conflictIDByOriginal.get(id);
-    if (conflictID && availableIDs.has(conflictID) && !appendedIDs.has(conflictID)) {
+    if (
+      conflictID && availableIDs.has(conflictID) && !appendedIDs.has(conflictID)
+    ) {
       appendedIDs.add(conflictID);
       orderedIDs.push(conflictID);
     }
@@ -214,6 +290,10 @@ export function mergeNotesThreeWay(
   remote: Note[],
   base: Record<string, NoteSnapshot>,
 ): MergeResult {
+  validateNoteIDs("local", local.map((note) => note.id));
+  validateNoteIDs("remote", remote.map((note) => note.id));
+  validateNoteIDs("base", Object.keys(base));
+
   const localMap = new Map<string, Note>();
   for (const n of local) localMap.set(n.id, n);
   const remoteMap = new Map<string, Note>();
@@ -224,7 +304,11 @@ export function mergeNotesThreeWay(
     return note.title !== baseSnap.title || note.content !== baseSnap.content;
   };
 
-  const resolve = (baseN: NoteSnapshot | undefined, localN: Note | undefined, remoteN: Note | undefined): Resolution => {
+  const resolve = (
+    baseN: NoteSnapshot | undefined,
+    localN: Note | undefined,
+    remoteN: Note | undefined,
+  ): Resolution => {
     if (!baseN) {
       if (!localN && !remoteN) return { kind: "none" };
       if (localN && !remoteN) return { kind: "note", note: localN };
@@ -233,14 +317,20 @@ export function mergeNotesThreeWay(
     }
     if (!localN && !remoteN) return { kind: "none" };
     if (localN && !remoteN) {
-      return hasChanged(localN, baseN) ? { kind: "note", note: localN } : { kind: "none" };
+      return hasChanged(localN, baseN)
+        ? { kind: "note", note: localN }
+        : { kind: "none" };
     }
     if (!localN && remoteN) {
-      return hasChanged(remoteN, baseN) ? { kind: "note", note: remoteN } : { kind: "none" };
+      return hasChanged(remoteN, baseN)
+        ? { kind: "note", note: remoteN }
+        : { kind: "none" };
     }
     const localChanged = hasChanged(localN!, baseN);
     const remoteChanged = hasChanged(remoteN!, baseN);
-    if (!localChanged && !remoteChanged) return { kind: "note", note: remoteN! };
+    if (!localChanged && !remoteChanged) {
+      return { kind: "note", note: remoteN! };
+    }
     if (localChanged && !remoteChanged) return { kind: "note", note: localN! };
     if (!localChanged && remoteChanged) return { kind: "note", note: remoteN! };
     return resolveConcurrent(localN!, remoteN!);
@@ -298,8 +388,16 @@ export function mergeNotesThreeWay(
   }
 
   const availableIDs = new Set(mergedByID.keys());
-  const localOrderChanged = orderChanged([...localMap.keys()], Object.keys(base), availableIDs);
-  const remoteOrderChanged = orderChanged([...remoteMap.keys()], Object.keys(base), availableIDs);
+  const localOrderChanged = orderChanged(
+    [...localMap.keys()],
+    Object.keys(base),
+    availableIDs,
+  );
+  const remoteOrderChanged = orderChanged(
+    [...remoteMap.keys()],
+    Object.keys(base),
+    availableIDs,
+  );
   const primaryOrder = !localOrderChanged && remoteOrderChanged
     ? [...remoteMap.keys()]
     : [...localMap.keys()];
@@ -309,9 +407,27 @@ export function mergeNotesThreeWay(
 
   const orderedIDs: string[] = [];
   const appendedIDs = new Set<string>();
-  appendOrder(primaryOrder, availableIDs, conflictIDByOriginal, orderedIDs, appendedIDs);
-  appendOrder(secondaryOrder, availableIDs, conflictIDByOriginal, orderedIDs, appendedIDs);
-  appendOrder(Object.keys(base), availableIDs, conflictIDByOriginal, orderedIDs, appendedIDs);
+  appendOrder(
+    primaryOrder,
+    availableIDs,
+    conflictIDByOriginal,
+    orderedIDs,
+    appendedIDs,
+  );
+  appendOrder(
+    secondaryOrder,
+    availableIDs,
+    conflictIDByOriginal,
+    orderedIDs,
+    appendedIDs,
+  );
+  appendOrder(
+    Object.keys(base),
+    availableIDs,
+    conflictIDByOriginal,
+    orderedIDs,
+    appendedIDs,
+  );
   for (const id of [...availableIDs].sort()) {
     if (!appendedIDs.has(id)) {
       appendedIDs.add(id);
@@ -331,6 +447,19 @@ export function mergeNotesThreeWay(
     hadConflicts,
     conflictCount: conflictIDByOriginal.size,
   };
+}
+
+function validateNoteIDs(source: NotesMergeSource, noteIDs: string[]): void {
+  const seen = new Set<string>();
+  for (const noteID of noteIDs) {
+    if (noteID.length === 0) {
+      throw new NotesMergeError("blank-note-id", source, noteID);
+    }
+    if (seen.has(noteID)) {
+      throw new NotesMergeError("duplicate-note-id", source, noteID);
+    }
+    seen.add(noteID);
+  }
 }
 
 function sameWireNote(lhs: Note, rhs: Note): boolean {

--- a/browser-features/pages-notes/src/lib/merge.ts
+++ b/browser-features/pages-notes/src/lib/merge.ts
@@ -452,7 +452,7 @@ export function mergeNotesThreeWay(
 function validateNoteIDs(source: NotesMergeSource, noteIDs: string[]): void {
   const seen = new Set<string>();
   for (const noteID of noteIDs) {
-    if (noteID.length === 0) {
+    if (noteID.trim().length === 0) {
       throw new NotesMergeError("blank-note-id", source, noteID);
     }
     if (seen.has(noteID)) {

--- a/browser-features/pages-notes/test/lib/mergeFixture.test.ts
+++ b/browser-features/pages-notes/test/lib/mergeFixture.test.ts
@@ -10,16 +10,18 @@
  */
 
 import {
-  assertEquals,
   assert,
+  assertEquals,
   runTests,
   type TestCase,
 } from "../../../chrome/test/utils/test_harness.ts";
 import {
   mergeNotesThreeWay,
   type Note,
+  NotesMergeError,
   type NoteSnapshot,
 } from "../../src/lib/merge.ts";
+import fixtureRaw from "../fixtures/floorp-notes-merge-v1.json?raw";
 
 interface FixtureNote {
   id: string;
@@ -47,14 +49,16 @@ interface Fixture {
   requiredCaseNames: string[];
   mergeCases: MergeCase[];
   sequenceCases: SequenceCase[];
-  errorCases: { name: string }[];
+  errorCases: {
+    name: string;
+    base: FixtureNote[];
+    local: FixtureNote[];
+    remote: FixtureNote[];
+    expectedError: { code: string; source: string; id: string };
+  }[];
 }
 
-const fixtureUrl = new URL(
-  "../fixtures/floorp-notes-merge-v1.json",
-  import.meta.url,
-);
-const fixture: Fixture = JSON.parse(await Deno.readTextFile(fixtureUrl));
+const fixture: Fixture = JSON.parse(fixtureRaw);
 
 const EXPECTED_DIGEST =
   "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd";
@@ -105,11 +109,19 @@ for (const mergeCase of fixture.mergeCases) {
       );
       const expectedKeys = mergeCase.expectedNotes.map(noteKey).sort();
       const actualKeys = result.merged.map(noteKey).sort();
-      assertEquals(actualKeys, expectedKeys, `notes for ${mergeCase.name}`);
+      assertEquals(
+        JSON.stringify(actualKeys),
+        JSON.stringify(expectedKeys),
+        `notes for ${mergeCase.name}`,
+      );
 
       for (const conflict of mergeCase.expectedConflicts) {
-        const original = result.merged.find((n) => n.id === conflict.originalNoteID);
-        const copy = result.merged.find((n) => n.id === conflict.conflictCopyID);
+        const original = result.merged.find((n) =>
+          n.id === conflict.originalNoteID
+        );
+        const copy = result.merged.find((n) =>
+          n.id === conflict.conflictCopyID
+        );
         assert(original, `original ${conflict.originalNoteID} missing`);
         assert(copy, `conflict copy ${conflict.conflictCopyID} missing`);
       }
@@ -134,7 +146,11 @@ for (const sequenceCase of fixture.sequenceCases ?? []) {
         );
         const expectedKeys = step.expectedNotes.map(noteKey).sort();
         const actualKeys = result.merged.map(noteKey).sort();
-        assertEquals(actualKeys, expectedKeys, `notes for ${step.name}`);
+        assertEquals(
+          JSON.stringify(actualKeys),
+          JSON.stringify(expectedKeys),
+          `notes for ${step.name}`,
+        );
         assertEquals(
           result.conflictCount,
           step.expectedConflicts.length,
@@ -145,10 +161,43 @@ for (const sequenceCase of fixture.sequenceCases ?? []) {
   }
 }
 
+for (const errorCase of fixture.errorCases ?? []) {
+  tests.push({
+    name: `error ${errorCase.name}`,
+    fn: () => {
+      let captured: unknown;
+      try {
+        mergeNotesThreeWay(
+          toNotes(errorCase.local),
+          toNotes(errorCase.remote),
+          toSnapshots(errorCase.base),
+        );
+      } catch (error: unknown) {
+        captured = error;
+      }
+      assert(
+        captured instanceof NotesMergeError,
+        "merge must fail with NotesMergeError",
+      );
+      assertEquals(captured.code, errorCase.expectedError.code, "error code");
+      assertEquals(
+        captured.source,
+        errorCase.expectedError.source,
+        "error source",
+      );
+      assertEquals(
+        captured.noteID,
+        errorCase.expectedError.id,
+        "error note ID",
+      );
+    },
+  });
+}
+
 tests.push({
   name: "fixture digest matches the approved contract",
   fn: async () => {
-    const bytes = await Deno.readFile(fixtureUrl);
+    const bytes = new TextEncoder().encode(fixtureRaw);
     const digest = await crypto.subtle.digest("SHA-256", bytes);
     const hex = [...new Uint8Array(digest)]
       .map((b) => b.toString(16).padStart(2, "0"))
@@ -160,7 +209,11 @@ tests.push({
 tests.push({
   name: "all required case names are covered",
   fn: () => {
-    const covered = new Set(fixture.mergeCases.map((c) => c.name));
+    const covered = new Set([
+      ...fixture.mergeCases.map((c) => c.name),
+      ...fixture.sequenceCases.map((c) => c.name),
+      ...fixture.errorCases.map((c) => c.name),
+    ]);
     for (const required of fixture.requiredCaseNames) {
       assert(covered.has(required), `required case missing: ${required}`);
     }

--- a/browser-features/pages-notes/test/lib/mergeFixture.test.ts
+++ b/browser-features/pages-notes/test/lib/mergeFixture.test.ts
@@ -107,8 +107,8 @@ for (const mergeCase of fixture.mergeCases) {
         toNotes(mergeCase.remote),
         toSnapshots(mergeCase.base),
       );
-      const expectedKeys = mergeCase.expectedNotes.map(noteKey).sort();
-      const actualKeys = result.merged.map(noteKey).sort();
+      const expectedKeys = mergeCase.expectedNotes.map(noteKey);
+      const actualKeys = result.merged.map(noteKey);
       assertEquals(
         JSON.stringify(actualKeys),
         JSON.stringify(expectedKeys),
@@ -144,8 +144,8 @@ for (const sequenceCase of fixture.sequenceCases ?? []) {
           toNotes(step.remote),
           toSnapshots(step.base),
         );
-        const expectedKeys = step.expectedNotes.map(noteKey).sort();
-        const actualKeys = result.merged.map(noteKey).sort();
+        const expectedKeys = step.expectedNotes.map(noteKey);
+        const actualKeys = result.merged.map(noteKey);
         assertEquals(
           JSON.stringify(actualKeys),
           JSON.stringify(expectedKeys),
@@ -193,6 +193,30 @@ for (const errorCase of fixture.errorCases ?? []) {
     },
   });
 }
+
+tests.push({
+  name: "whitespace-only note IDs fail closed",
+  fn: () => {
+    let captured: unknown;
+    try {
+      mergeNotesThreeWay(
+        [{
+          id: "   ",
+          title: "Blank",
+          content: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }],
+        [],
+        [],
+      );
+    } catch (error: unknown) {
+      captured = error;
+    }
+    assert(captured instanceof NotesMergeError, "blank ID must fail closed");
+    assertEquals(captured.code, "blank-note-id", "blank ID error code");
+  },
+});
 
 tests.push({
   name: "fixture digest matches the approved contract",

--- a/browser-features/pages-notes/test/lib/mergeFixture.test.ts
+++ b/browser-features/pages-notes/test/lib/mergeFixture.test.ts
@@ -208,7 +208,7 @@ tests.push({
           updatedAt: 1,
         }],
         [],
-        [],
+        {},
       );
     } catch (error: unknown) {
       captured = error;

--- a/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
+++ b/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
@@ -22,6 +22,7 @@ import prerequisitesDocument from "../../../../docs/development/floorp-notes-syn
 import revocationsDocument from "../../../../docs/development/floorp-notes-sync/revocations.json" with {
   type: "json",
 };
+import allowedSignersDocument from "../../../../docs/development/floorp-notes-sync/allowed-signers?raw";
 
 interface Prerequisites {
   schema_version: number;
@@ -35,6 +36,9 @@ interface Prerequisites {
   production_environment?: {
     status: string;
     authorization: string;
+    oauth_client_id: string;
+    oauth_redirect_uri: string;
+    oauth_authority: string;
     fxa_configuration: string;
     fxa_hosts: string[];
     sync_hosts: string[];
@@ -42,6 +46,10 @@ interface Prerequisites {
     application_record_id: string;
     endpoint_policy_sha256: string;
   };
+}
+
+interface RevocationsDocument {
+  revocations: { fingerprint?: string; key_fingerprint?: string }[];
 }
 
 const EXPECTED_RUNTIME_COMMIT = "2d38da4d11be1e0e615f4ddd785ad5e77c95e18d";
@@ -52,6 +60,11 @@ const EXPECTED_ENDPOINT_POLICY_DIGEST =
   "af96437acde3d05eb8f18dc9cc81450aa9d61703579c092b962922de8934c9ca";
 const EXPECTED_PREFS_RECORD_ID =
   "e2VjODAzMGY3LWMyMGEtNDY0Zi05YjBlLTEzYTNhOWU5NzM4NH0";
+const EXPECTED_OAUTH_CLIENT_ID = "1b1a3e44c54fbb58";
+const EXPECTED_OAUTH_REDIRECT_URI =
+  "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel";
+const EXPECTED_OAUTH_AUTHORITY =
+  "existing Floorp iOS FxA release path; Notes requests no new OAuth scopes and receives no token";
 const EXPECTED_FXA_HOSTS = [
   "accounts.firefox.com",
   "api.accounts.firefox.com",
@@ -79,7 +92,9 @@ const REQUIRED_CASES = [
   "duplicate-local-id-fails-closed",
 ];
 
-export function validatePrerequisites(prerequisites: Prerequisites): string[] {
+export async function validatePrerequisites(
+  prerequisites: Prerequisites,
+): Promise<string[]> {
   const errors: string[] = [];
   if (prerequisites.schema_version !== 1) errors.push("schema_version");
   if (!prerequisites.adr) errors.push("adr");
@@ -102,15 +117,52 @@ export function validatePrerequisites(prerequisites: Prerequisites): string[] {
   }
   if ((prerequisites.g6?.signatures?.length ?? 0) > 0) {
     errors.push("g6_signatures_exist");
+    errors.push(...await validateG6SignerRegistry(prerequisites));
   }
   return errors;
 }
 
-export function validateG6SignerRegistry(
+async function allowedSignerFingerprints(
+  allowedSigners: string,
+): Promise<Map<string, Set<string>>> {
+  const fingerprints = new Map<string, Set<string>>();
+  for (const rawLine of allowedSigners.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const [principal, keyType, encodedKey] = line.split(/\s+/, 3);
+    if (!principal || keyType !== "ssh-ed25519" || !encodedKey) continue;
+    const bytes = Uint8Array.from(
+      atob(encodedKey),
+      (value) => value.charCodeAt(0),
+    );
+    const digest = new Uint8Array(
+      await crypto.subtle.digest("SHA-256", bytes),
+    );
+    const fingerprint = `SHA256:${
+      btoa(String.fromCharCode(...digest)).replace(/=+$/, "")
+    }`;
+    const principalFingerprints = fingerprints.get(principal) ?? new Set();
+    principalFingerprints.add(fingerprint);
+    fingerprints.set(principal, principalFingerprints);
+  }
+  return fingerprints;
+}
+
+export async function validateG6SignerRegistry(
   prerequisites: Prerequisites,
-): string[] {
+  allowedSigners = allowedSignersDocument,
+  revocations = revocationsDocument as RevocationsDocument,
+): Promise<string[]> {
   const errors: string[] = [];
   const roles = prerequisites.role_registry ?? [];
+  const trusted = await allowedSignerFingerprints(allowedSigners);
+  const revoked = new Set(
+    (revocations.revocations ?? []).flatMap((entry) =>
+      [entry.fingerprint, entry.key_fingerprint].filter(
+        (value): value is string => Boolean(value),
+      )
+    ),
+  );
   const namedRoles = new Set(roles.map((r) => r.role));
   for (
     const requiredRole of [
@@ -131,6 +183,13 @@ export function validateG6SignerRegistry(
     }
     if (!role.key_fingerprint || role.key_fingerprint.startsWith("PENDING_")) {
       errors.push(`role_fingerprint:${role.role}`);
+      continue;
+    }
+    if (!trusted.get(role.login)?.has(role.key_fingerprint)) {
+      errors.push(`untrusted_fingerprint:${role.role}`);
+    }
+    if (revoked.has(role.key_fingerprint)) {
+      errors.push(`revoked_fingerprint:${role.role}`);
     }
   }
   return errors;
@@ -155,8 +214,20 @@ export function validateProductionAuthority(
   ) {
     errors.push("fxa_configuration");
   }
+  if (!production || production.oauth_client_id !== EXPECTED_OAUTH_CLIENT_ID) {
+    errors.push("oauth_client_id");
+  }
+  if (
+    !production || production.oauth_redirect_uri !== EXPECTED_OAUTH_REDIRECT_URI
+  ) {
+    errors.push("oauth_redirect_uri");
+  }
+  if (!production || production.oauth_authority !== EXPECTED_OAUTH_AUTHORITY) {
+    errors.push("oauth_authority");
+  }
   if (
     !production ||
+    !Array.isArray(production.fxa_hosts) ||
     JSON.stringify([...production.fxa_hosts].sort()) !==
       JSON.stringify(EXPECTED_FXA_HOSTS)
   ) {
@@ -164,6 +235,7 @@ export function validateProductionAuthority(
   }
   if (
     !production ||
+    !Array.isArray(production.sync_hosts) ||
     JSON.stringify([...production.sync_hosts].sort()) !==
       JSON.stringify(EXPECTED_SYNC_HOSTS)
   ) {
@@ -190,7 +262,7 @@ const tests: TestCase[] = [];
 
 tests.push({
   name: "shipped prerequisites bind the approved production authority",
-  fn: () => {
+  fn: async () => {
     const prerequisites = prerequisitesDocument as Prerequisites;
     const errors = validateProductionAuthority(prerequisites);
     assert(
@@ -202,9 +274,9 @@ tests.push({
 
 tests.push({
   name: "shipped prerequisites pass G1 production contract validation",
-  fn: () => {
+  fn: async () => {
     const prerequisites = prerequisitesDocument as Prerequisites;
-    const errors = validatePrerequisites(prerequisites);
+    const errors = await validatePrerequisites(prerequisites);
     assert(
       errors.length === 0,
       `approved production prerequisites must pass: ${errors.join(",")}`,
@@ -214,9 +286,9 @@ tests.push({
 
 tests.push({
   name: "G6 remains pending until independent role keys are registered",
-  fn: () => {
+  fn: async () => {
     const prerequisites = prerequisitesDocument as Prerequisites;
-    const errors = validateG6SignerRegistry(prerequisites);
+    const errors = await validateG6SignerRegistry(prerequisites);
     assert(
       errors.includes("role_fingerprint:security-reviewer"),
       "production authority must not synthesize a security-reviewer key",
@@ -234,7 +306,7 @@ tests.push({
 
 tests.push({
   name: "fully approved fixture passes",
-  fn: () => {
+  fn: async () => {
     const approved: Prerequisites = {
       schema_version: 1,
       adr: "ADR-001",
@@ -247,6 +319,9 @@ tests.push({
       production_environment: {
         status: "approved",
         authorization: "product-owner-explicit-2026-08-09",
+        oauth_client_id: EXPECTED_OAUTH_CLIENT_ID,
+        oauth_redirect_uri: EXPECTED_OAUTH_REDIRECT_URI,
+        oauth_authority: EXPECTED_OAUTH_AUTHORITY,
         fxa_configuration: "FxAConfig.Server.release",
         fxa_hosts: EXPECTED_FXA_HOSTS,
         sync_hosts: EXPECTED_SYNC_HOSTS,
@@ -287,14 +362,14 @@ tests.push({
       },
       g6: { signatures: [] },
     };
-    const errors = validatePrerequisites(approved);
+    const errors = await validatePrerequisites(approved);
     assert(errors.length === 0, `approved fixture errors: ${errors.join(",")}`);
   },
 });
 
 tests.push({
   name: "wrong runtime SHA and fixture digest are rejected",
-  fn: () => {
+  fn: async () => {
     const base = {
       schema_version: 1,
       adr: "ADR-001",
@@ -304,6 +379,9 @@ tests.push({
       production_environment: {
         status: "approved",
         authorization: "product-owner-explicit-2026-08-09",
+        oauth_client_id: EXPECTED_OAUTH_CLIENT_ID,
+        oauth_redirect_uri: EXPECTED_OAUTH_REDIRECT_URI,
+        oauth_authority: EXPECTED_OAUTH_AUTHORITY,
         fxa_configuration: "FxAConfig.Server.release",
         fxa_hosts: EXPECTED_FXA_HOSTS,
         sync_hosts: EXPECTED_SYNC_HOSTS,
@@ -329,7 +407,7 @@ tests.push({
       fixture: { sha256: "0".repeat(64), required_cases: REQUIRED_CASES },
       g6: { signatures: [] },
     };
-    const errors = validatePrerequisites(base);
+    const errors = await validatePrerequisites(base);
     assert(
       errors.includes("runtime_commit"),
       "wrong runtime SHA must be rejected",
@@ -343,7 +421,7 @@ tests.push({
 
 tests.push({
   name: "wrong production authority and missing case are rejected",
-  fn: () => {
+  fn: async () => {
     const base = {
       schema_version: 1,
       adr: "ADR-001",
@@ -356,6 +434,9 @@ tests.push({
       production_environment: {
         status: "unapproved",
         authorization: "missing",
+        oauth_client_id: "wrong-client",
+        oauth_redirect_uri: "https://example.invalid/callback",
+        oauth_authority: "new scopes allowed",
         fxa_configuration: "FxAConfig.Server.stage",
         fxa_hosts: [],
         sync_hosts: [],
@@ -372,7 +453,7 @@ tests.push({
       },
       g6: { signatures: [] },
     };
-    const errors = validatePrerequisites(base);
+    const errors = await validatePrerequisites(base);
     assert(
       errors.includes("production_approval"),
       "unapproved production use must be rejected",
@@ -381,11 +462,57 @@ tests.push({
       errors.includes("fxa_configuration"),
       "stage configuration must be rejected",
     );
+    assert(errors.includes("oauth_client_id"), "wrong OAuth client must fail");
+    assert(
+      errors.includes("oauth_redirect_uri"),
+      "wrong OAuth redirect must fail",
+    );
+    assert(
+      errors.includes("oauth_authority"),
+      "expanded OAuth authority must fail",
+    );
     assert(
       errors.includes(
         "missing_case:concurrent-edits-preserve-deterministic-loser",
       ),
       "missing case must be rejected",
+    );
+  },
+});
+
+tests.push({
+  name: "malformed production host fields return validation errors",
+  fn: () => {
+    const malformed = structuredClone(
+      prerequisitesDocument,
+    ) as unknown as Prerequisites;
+    if (!malformed.production_environment) throw new Error("missing fixture");
+    malformed.production_environment.fxa_hosts = null as unknown as string[];
+    malformed.production_environment.sync_hosts =
+      "not-an-array" as unknown as string[];
+    const errors = validateProductionAuthority(malformed);
+    assert(errors.includes("fxa_hosts"), "malformed FxA hosts must fail");
+    assert(errors.includes("sync_hosts"), "malformed Sync hosts must fail");
+  },
+});
+
+tests.push({
+  name: "registered G6 fingerprints must come from allowed signers",
+  fn: async () => {
+    const approved = structuredClone(prerequisitesDocument) as Prerequisites;
+    approved.role_registry = approved.role_registry.map((entry) => ({
+      ...entry,
+      login: "Ryosuke-Asano",
+      key_fingerprint: "SHA256:not-registered",
+    }));
+    const errors = await validateG6SignerRegistry(
+      approved,
+      allowedSignersDocument,
+      revocationsDocument,
+    );
+    assert(
+      errors.some((error) => error.startsWith("untrusted_fingerprint:")),
+      "unregistered signer fingerprints must fail",
     );
   },
 });

--- a/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
+++ b/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
@@ -11,11 +11,17 @@
  */
 
 import {
-  assertEquals,
   assert,
+  assertEquals,
   runTests,
   type TestCase,
 } from "../../../chrome/test/utils/test_harness.ts";
+import prerequisitesDocument from "../../../../docs/development/floorp-notes-sync/prerequisites.json" with {
+  type: "json",
+};
+import revocationsDocument from "../../../../docs/development/floorp-notes-sync/revocations.json" with {
+  type: "json",
+};
 
 interface Prerequisites {
   schema_version: number;
@@ -23,25 +29,41 @@ interface Prerequisites {
   engine_authority: { commit: string };
   runtime_pin: { commit: string; tree: string };
   desktop_release: { commit: string };
-  staging_environment: {
-    status: string;
-    fxa_endpoint_id: string;
-    sync_endpoint_id: string;
-  };
   role_registry: { role: string; login: string; key_fingerprint: string }[];
   fixture: { sha256: string; required_cases: string[] };
   g6: { signatures: unknown[] };
+  production_environment?: {
+    status: string;
+    authorization: string;
+    fxa_configuration: string;
+    fxa_hosts: string[];
+    sync_hosts: string[];
+    wire: string;
+    application_record_id: string;
+    endpoint_policy_sha256: string;
+  };
 }
-
-const DOC_ROOT = new URL(
-  "../../../../docs/development/floorp-notes-sync/",
-  import.meta.url,
-);
 
 const EXPECTED_RUNTIME_COMMIT = "2d38da4d11be1e0e615f4ddd785ad5e77c95e18d";
 const EXPECTED_RUNTIME_TREE = "e555a371e1a24f18c8085058461f92c06e0b997d";
 const EXPECTED_FIXTURE_DIGEST =
   "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd";
+const EXPECTED_ENDPOINT_POLICY_DIGEST =
+  "af96437acde3d05eb8f18dc9cc81450aa9d61703579c092b962922de8934c9ca";
+const EXPECTED_PREFS_RECORD_ID =
+  "e2VjODAzMGY3LWMyMGEtNDY0Zi05YjBlLTEzYTNhOWU5NzM4NH0";
+const EXPECTED_FXA_HOSTS = [
+  "accounts.firefox.com",
+  "api.accounts.firefox.com",
+  "oauth.accounts.firefox.com",
+  "profile.accounts.firefox.com",
+  "static.accounts.firefox.com",
+];
+const EXPECTED_SYNC_HOSTS = [
+  "event-sync.services.mozilla.com",
+  "sync.services.mozilla.com",
+  "token.services.mozilla.com",
+];
 const REQUIRED_CASES = [
   "concurrent-edits-preserve-deterministic-loser",
   "equal-timestamp-has-commutative-bytewise-winner",
@@ -57,8 +79,6 @@ const REQUIRED_CASES = [
   "duplicate-local-id-fails-closed",
 ];
 
-const GUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 export function validatePrerequisites(prerequisites: Prerequisites): string[] {
   const errors: string[] = [];
   if (prerequisites.schema_version !== 1) errors.push("schema_version");
@@ -71,36 +91,7 @@ export function validatePrerequisites(prerequisites: Prerequisites): string[] {
     errors.push("runtime_tree");
   }
   if (!prerequisites.desktop_release?.commit) errors.push("desktop_commit");
-  const staging = prerequisites.staging_environment;
-  if (!staging || staging.status === "pending_owner_approval") {
-    errors.push("staging_approval");
-  }
-  if (!staging || !GUID_PATTERN.test(staging.fxa_endpoint_id ?? "")) {
-    errors.push("fxa_endpoint_id");
-  }
-  if (!staging || !GUID_PATTERN.test(staging.sync_endpoint_id ?? "")) {
-    errors.push("sync_endpoint_id");
-  }
-  const roles = prerequisites.role_registry ?? [];
-  if (roles.length === 0) errors.push("role_registry_empty");
-  const namedRoles = new Set(roles.map((r) => r.role));
-  for (const requiredRole of [
-    "architecture-owner",
-    "security-reviewer",
-    "privacy-reviewer",
-    "retention-reviewer",
-    "rollout-approver",
-  ]) {
-    if (!namedRoles.has(requiredRole)) errors.push(`missing_role:${requiredRole}`);
-  }
-  for (const role of roles) {
-    if (!role.login || role.login.startsWith("PENDING_")) {
-      errors.push(`role_login:${role.role}`);
-    }
-    if (!role.key_fingerprint || role.key_fingerprint.startsWith("PENDING_")) {
-      errors.push(`role_fingerprint:${role.role}`);
-    }
-  }
+  errors.push(...validateProductionAuthority(prerequisites));
   if (prerequisites.fixture?.sha256 !== EXPECTED_FIXTURE_DIGEST) {
     errors.push("fixture_digest");
   }
@@ -115,22 +106,128 @@ export function validatePrerequisites(prerequisites: Prerequisites): string[] {
   return errors;
 }
 
+export function validateG6SignerRegistry(
+  prerequisites: Prerequisites,
+): string[] {
+  const errors: string[] = [];
+  const roles = prerequisites.role_registry ?? [];
+  const namedRoles = new Set(roles.map((r) => r.role));
+  for (
+    const requiredRole of [
+      "architecture-owner",
+      "security-reviewer",
+      "privacy-reviewer",
+      "retention-reviewer",
+      "rollout-approver",
+    ]
+  ) {
+    if (!namedRoles.has(requiredRole)) {
+      errors.push(`missing_role:${requiredRole}`);
+    }
+  }
+  for (const role of roles) {
+    if (!role.login || role.login.startsWith("PENDING_")) {
+      errors.push(`role_login:${role.role}`);
+    }
+    if (!role.key_fingerprint || role.key_fingerprint.startsWith("PENDING_")) {
+      errors.push(`role_fingerprint:${role.role}`);
+    }
+  }
+  return errors;
+}
+
+export function validateProductionAuthority(
+  prerequisites: Prerequisites,
+): string[] {
+  const errors: string[] = [];
+  const production = prerequisites.production_environment;
+  if (!production || production.status !== "approved") {
+    errors.push("production_approval");
+  }
+  if (
+    !production ||
+    production.authorization !== "product-owner-explicit-2026-08-09"
+  ) {
+    errors.push("production_authorization");
+  }
+  if (
+    !production || production.fxa_configuration !== "FxAConfig.Server.release"
+  ) {
+    errors.push("fxa_configuration");
+  }
+  if (
+    !production ||
+    JSON.stringify([...production.fxa_hosts].sort()) !==
+      JSON.stringify(EXPECTED_FXA_HOSTS)
+  ) {
+    errors.push("fxa_hosts");
+  }
+  if (
+    !production ||
+    JSON.stringify([...production.sync_hosts].sort()) !==
+      JSON.stringify(EXPECTED_SYNC_HOSTS)
+  ) {
+    errors.push("sync_hosts");
+  }
+  if (!production || production.wire !== "sync15") {
+    errors.push("wire");
+  }
+  if (
+    !production || production.application_record_id !== EXPECTED_PREFS_RECORD_ID
+  ) {
+    errors.push("application_record_id");
+  }
+  if (
+    !production ||
+    production.endpoint_policy_sha256 !== EXPECTED_ENDPOINT_POLICY_DIGEST
+  ) {
+    errors.push("endpoint_policy_sha256");
+  }
+  return errors;
+}
+
 const tests: TestCase[] = [];
 
 tests.push({
-  name: "shipped prerequisites emit externally-blocked status (pending approval)",
-  fn: async () => {
-    const prerequisites: Prerequisites = JSON.parse(
-      await Deno.readTextFile(new URL("prerequisites.json", DOC_ROOT)),
+  name: "shipped prerequisites bind the approved production authority",
+  fn: () => {
+    const prerequisites = prerequisitesDocument as Prerequisites;
+    const errors = validateProductionAuthority(prerequisites);
+    assert(
+      errors.length === 0,
+      `production Notes Sync authority errors: ${errors.join(",")}`,
     );
+  },
+});
+
+tests.push({
+  name: "shipped prerequisites pass G1 production contract validation",
+  fn: () => {
+    const prerequisites = prerequisitesDocument as Prerequisites;
     const errors = validatePrerequisites(prerequisites);
     assert(
-      errors.includes("staging_approval"),
-      "shipped prerequisites must record pending owner approval",
+      errors.length === 0,
+      `approved production prerequisites must pass: ${errors.join(",")}`,
+    );
+  },
+});
+
+tests.push({
+  name: "G6 remains pending until independent role keys are registered",
+  fn: () => {
+    const prerequisites = prerequisitesDocument as Prerequisites;
+    const errors = validateG6SignerRegistry(prerequisites);
+    assert(
+      errors.includes("role_fingerprint:security-reviewer"),
+      "production authority must not synthesize a security-reviewer key",
     );
     assert(
-      errors.includes("role_fingerprint:architecture-owner"),
-      "pending role fingerprints must be rejected",
+      errors.includes("role_fingerprint:privacy-reviewer"),
+      "production authority must not synthesize a privacy-reviewer key",
+    );
+    assert(
+      errors.includes("role_fingerprint:retention-reviewer"),
+      "production authority must not synthesize a retention-reviewer key",
     );
   },
 });
@@ -147,22 +244,51 @@ tests.push({
         tree: EXPECTED_RUNTIME_TREE,
       },
       desktop_release: { commit: "811a5b821e1d9d47b40f22aee6df5db2254a54b1" },
-      staging_environment: {
+      production_environment: {
         status: "approved",
-        fxa_endpoint_id: "11111111-2222-3333-4444-555555555555",
-        sync_endpoint_id: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+        authorization: "product-owner-explicit-2026-08-09",
+        fxa_configuration: "FxAConfig.Server.release",
+        fxa_hosts: EXPECTED_FXA_HOSTS,
+        sync_hosts: EXPECTED_SYNC_HOSTS,
+        wire: "sync15",
+        application_record_id: EXPECTED_PREFS_RECORD_ID,
+        endpoint_policy_sha256: EXPECTED_ENDPOINT_POLICY_DIGEST,
       },
       role_registry: [
-        { role: "architecture-owner", login: "arch", key_fingerprint: "SHA256:aa" },
-        { role: "security-reviewer", login: "sec", key_fingerprint: "SHA256:bb" },
-        { role: "privacy-reviewer", login: "priv", key_fingerprint: "SHA256:cc" },
-        { role: "retention-reviewer", login: "ret", key_fingerprint: "SHA256:dd" },
-        { role: "rollout-approver", login: "roll", key_fingerprint: "SHA256:ee" },
+        {
+          role: "architecture-owner",
+          login: "arch",
+          key_fingerprint: "SHA256:aa",
+        },
+        {
+          role: "security-reviewer",
+          login: "sec",
+          key_fingerprint: "SHA256:bb",
+        },
+        {
+          role: "privacy-reviewer",
+          login: "priv",
+          key_fingerprint: "SHA256:cc",
+        },
+        {
+          role: "retention-reviewer",
+          login: "ret",
+          key_fingerprint: "SHA256:dd",
+        },
+        {
+          role: "rollout-approver",
+          login: "roll",
+          key_fingerprint: "SHA256:ee",
+        },
       ],
-      fixture: { sha256: EXPECTED_FIXTURE_DIGEST, required_cases: REQUIRED_CASES },
+      fixture: {
+        sha256: EXPECTED_FIXTURE_DIGEST,
+        required_cases: REQUIRED_CASES,
+      },
       g6: { signatures: [] },
     };
-    assertEquals(validatePrerequisites(approved), [], "approved fixture must pass");
+    const errors = validatePrerequisites(approved);
+    assert(errors.length === 0, `approved fixture errors: ${errors.join(",")}`);
   },
 });
 
@@ -175,51 +301,90 @@ tests.push({
       engine_authority: { commit: "d588863894e9b3ce58b05a964a7694ab00e28054" },
       runtime_pin: { commit: "0".repeat(40), tree: EXPECTED_RUNTIME_TREE },
       desktop_release: { commit: "811a5b821e1d9d47b40f22aee6df5db2254a54b1" },
-      staging_environment: {
+      production_environment: {
         status: "approved",
-        fxa_endpoint_id: "11111111-2222-3333-4444-555555555555",
-        sync_endpoint_id: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+        authorization: "product-owner-explicit-2026-08-09",
+        fxa_configuration: "FxAConfig.Server.release",
+        fxa_hosts: EXPECTED_FXA_HOSTS,
+        sync_hosts: EXPECTED_SYNC_HOSTS,
+        wire: "sync15",
+        application_record_id: EXPECTED_PREFS_RECORD_ID,
+        endpoint_policy_sha256: EXPECTED_ENDPOINT_POLICY_DIGEST,
       },
       role_registry: [
-        { role: "architecture-owner", login: "a", key_fingerprint: "SHA256:aa" },
+        {
+          role: "architecture-owner",
+          login: "a",
+          key_fingerprint: "SHA256:aa",
+        },
         { role: "security-reviewer", login: "b", key_fingerprint: "SHA256:bb" },
         { role: "privacy-reviewer", login: "c", key_fingerprint: "SHA256:cc" },
-        { role: "retention-reviewer", login: "d", key_fingerprint: "SHA256:dd" },
+        {
+          role: "retention-reviewer",
+          login: "d",
+          key_fingerprint: "SHA256:dd",
+        },
         { role: "rollout-approver", login: "e", key_fingerprint: "SHA256:ee" },
       ],
       fixture: { sha256: "0".repeat(64), required_cases: REQUIRED_CASES },
       g6: { signatures: [] },
     };
     const errors = validatePrerequisites(base);
-    assert(errors.includes("runtime_commit"), "wrong runtime SHA must be rejected");
-    assert(errors.includes("fixture_digest"), "wrong fixture digest must be rejected");
+    assert(
+      errors.includes("runtime_commit"),
+      "wrong runtime SHA must be rejected",
+    );
+    assert(
+      errors.includes("fixture_digest"),
+      "wrong fixture digest must be rejected",
+    );
   },
 });
 
 tests.push({
-  name: "missing role and missing case are rejected",
+  name: "wrong production authority and missing case are rejected",
   fn: () => {
     const base = {
       schema_version: 1,
       adr: "ADR-001",
       engine_authority: { commit: "d588863894e9b3ce58b05a964a7694ab00e28054" },
-      runtime_pin: { commit: EXPECTED_RUNTIME_COMMIT, tree: EXPECTED_RUNTIME_TREE },
+      runtime_pin: {
+        commit: EXPECTED_RUNTIME_COMMIT,
+        tree: EXPECTED_RUNTIME_TREE,
+      },
       desktop_release: { commit: "811a5b821e1d9d47b40f22aee6df5db2254a54b1" },
-      staging_environment: {
-        status: "approved",
-        fxa_endpoint_id: "11111111-2222-3333-4444-555555555555",
-        sync_endpoint_id: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+      production_environment: {
+        status: "unapproved",
+        authorization: "missing",
+        fxa_configuration: "FxAConfig.Server.stage",
+        fxa_hosts: [],
+        sync_hosts: [],
+        wire: "sync15",
+        application_record_id: EXPECTED_PREFS_RECORD_ID,
+        endpoint_policy_sha256: EXPECTED_ENDPOINT_POLICY_DIGEST,
       },
       role_registry: [
         { role: "security-reviewer", login: "b", key_fingerprint: "SHA256:bb" },
       ],
-      fixture: { sha256: EXPECTED_FIXTURE_DIGEST, required_cases: REQUIRED_CASES.slice(1) },
+      fixture: {
+        sha256: EXPECTED_FIXTURE_DIGEST,
+        required_cases: REQUIRED_CASES.slice(1),
+      },
       g6: { signatures: [] },
     };
     const errors = validatePrerequisites(base);
-    assert(errors.includes("missing_role:architecture-owner"), "missing role must be rejected");
     assert(
-      errors.includes("missing_case:concurrent-edits-preserve-deterministic-loser"),
+      errors.includes("production_approval"),
+      "unapproved production use must be rejected",
+    );
+    assert(
+      errors.includes("fxa_configuration"),
+      "stage configuration must be rejected",
+    );
+    assert(
+      errors.includes(
+        "missing_case:concurrent-edits-preserve-deterministic-loser",
+      ),
       "missing case must be rejected",
     );
   },
@@ -227,12 +392,13 @@ tests.push({
 
 tests.push({
   name: "revocations file stays append-only and empty",
-  fn: async () => {
-    const revocations = JSON.parse(
-      await Deno.readTextFile(new URL("revocations.json", DOC_ROOT)),
-    );
+  fn: () => {
+    const revocations = revocationsDocument;
     assertEquals(revocations.schema_version, 1, "revocations schema version");
-    assertEquals(revocations.revocations, [], "revocations must start empty");
+    assert(
+      revocations.revocations.length === 0,
+      "revocations must start empty",
+    );
   },
 });
 

--- a/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
+++ b/browser-features/pages-notes/test/lib/syncPrerequisites.test.ts
@@ -262,7 +262,7 @@ const tests: TestCase[] = [];
 
 tests.push({
   name: "shipped prerequisites bind the approved production authority",
-  fn: async () => {
+  fn: () => {
     const prerequisites = prerequisitesDocument as Prerequisites;
     const errors = validateProductionAuthority(prerequisites);
     assert(

--- a/docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md
+++ b/docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md
@@ -1,67 +1,70 @@
 # ADR-001: Floorp Notes cross-client sync contract
 
-- Status: approved (architecture and ownership level)
+- Status: amended — production authority approved; G6 signatures pending
 - Date: 2026-08-08
-- Milestone: Notes Sync 0.3.0 staging (production remains disabled)
+- Milestone: Notes Sync 0.3.0 production-service validation before public iOS
+  distribution
 
 ## Context
 
 Floorp Notes exist on Desktop (Firefox-style `floorp.browser.note.memos`
-preference) and iOS (local-only archive). Both clients must eventually share
-the same Notes data through the FxA/Application Services `sync15` preference
-sync path without ever silently losing user content. The iOS implementation
-already ships a deterministic merge and a machine-readable fixture
+preference) and iOS (local-only archive). Both clients must eventually share the
+same Notes data through the FxA/Application Services `sync15` preference sync
+path without ever silently losing user content. The iOS implementation already
+ships a deterministic merge and a machine-readable fixture
 (`sync-fixtures/floorp-notes/floorp-notes-merge-v1.json`, digest
-`2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd`). The
-Desktop implementation previously used random conflict IDs and non-commutative
-winner selection.
+`2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd`). The Desktop
+implementation previously used random conflict IDs and non-commutative winner
+selection.
 
 ## Decision
 
-1. **Engine authority**: the merge engine contract is defined by the
-   Application Services `floorp-prefs-sync` component (engine authority from
-   AS source) and pinned by the shared fixture. iOS and Desktop implement the
-   same deterministic semantics.
+1. **Engine authority**: the merge engine contract is defined by the Application
+   Services `floorp-prefs-sync` component (engine authority from AS source) and
+   pinned by the shared fixture. iOS and Desktop implement the same
+   deterministic semantics.
 2. **Deterministic winner**: for concurrent edits the winner is the note that
    does not precede the other; `precedes` compares `updatedAt` ascending and
-   breaks ties bytewise over canonical payload bytes
-   (u64be-length-prefixed id/title/content followed by big-endian
-   createdAt/updatedAt).
+   breaks ties bytewise over canonical payload bytes (u64be-length-prefixed
+   id/title/content followed by big-endian createdAt/updatedAt).
 3. **Canonical conflict copies**: losing versions are preserved as
    `floorp-sync-conflict-<sha256>` notes with probe-based collision handling,
    never random UUIDs.
 4. **Wire format**: the desktop parallel-array payload (`ids`, `titles`,
-   `contents`, `createdAts`, `updatedAts`) is the interchange format; iOS
-   keeps it isolated in its desktop adapter and Desktop keeps it as its
-   persisted preference.
+   `contents`, `createdAts`, `updatedAts`) is the interchange format; iOS keeps
+   it isolated in its desktop adapter and Desktop keeps it as its persisted
+   preference.
 5. **Bindings**: `docs/development/floorp-notes-sync/prerequisites.json` pins
-   the approved non-production FxA/Sync staging environment IDs, the role
-   registry, the fixture digest, the required case set, and the
-   retention/reset/rollout/migration policies. `allowed-signers` pins the
-   SSH trust anchors for G6 approvals; `revocations.json` is the append-only
-   revocation registry.
-6. **No production enablement**: this ADR and its staging bindings never
-   enable a production Notes Sync path. Production go-live is a separate,
-   later authorization after all six release gates pass.
+   the approved `FxAConfig.Server.release` authority, exact production FxA/Sync
+   host policy, product-owner authorization, role registry, fixture digest,
+   required case set, and the retention/reset/rollout/migration policies.
+   `allowed-signers` pins the SSH trust anchors for G6 approvals;
+   `revocations.json` is the append-only revocation registry.
+6. **Production enablement authority**: on 2026-08-09 the product owner
+   explicitly authorized the production FxA/Sync path and mobile Notes Sync
+   enablement because Floorp iOS is not yet publicly distributed and Floorp has
+   no separate staging environment. The authorization does not bypass G1-G6,
+   secret handling, runtime rollback, or the requirement that transport stays
+   inside Application Services `sync15`.
 
 ## Privacy and security
 
-- Notes content stays end-to-end encrypted by FxA/Sync encryption in
-  non-production staging only; the staging environment is account-isolated
-  and never holds production data.
+- Initial live validation uses two dedicated production QA accounts with no
+  unrelated Sync data. Notes content stays end-to-end encrypted by FxA/Sync.
 - No OAuth tokens or raw Sync keys reach Swift or the notes UI; the engine
   remains opaque manager state.
-- Retention: staging accounts are revoked after the matrix run; proxy traces
-  contain host/URL metadata only.
+- Retention: QA accounts are disconnected/reset after the matrix run and deleted
+  when account authority permits it; proxy traces contain host/URL metadata
+  only.
 
 ## Migration and rollout
 
-- The shared fixture drives both clients' tests; Desktop's
-  `mergeNotesThreeWay` now reproduces iOS winners, conflict copies, and
-  ordering exactly (verified case-by-case in
-  `browser-features/pages-notes/test/lib/mergeFixture.test.ts`).
-- Rollout of the corrected Desktop merge is behind the sync staging flow;
-  local-only usage is unaffected.
+- The shared fixture drives both clients' tests; Desktop's `mergeNotesThreeWay`
+  now reproduces iOS winners, conflict copies, and ordering exactly (verified
+  case-by-case in `browser-features/pages-notes/test/lib/mergeFixture.test.ts`).
+- Rollout of the corrected Desktop merge and mobile engine is guarded by the
+  compiled release evidence and a runtime kill switch. Disabling sync retains
+  local Notes and does not advance the synchronized base.
 
 ## Consequences
 

--- a/docs/development/floorp-notes-sync/allowed-signers
+++ b/docs/development/floorp-notes-sync/allowed-signers
@@ -5,4 +5,6 @@
 # Role owners register their keys here before any G6 signature is accepted;
 # the syncPrerequisites validator rejects empty or placeholder entries.
 #
-# PENDING_ROLE_OWNER ssh-ed25519 AAAA_PENDING_OWNER_APPROVAL
+Ryosuke-Asano ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIICMvsg10b9W8VOdv/3HaksNTWcMY1EEaoHpmCW50jid
+Ryosuke-Asano ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOSxSKaPXsY/bV72WB+wiohOGj1Njd3LvbILfuSdvWL7
+# Security, privacy, and retention role owners still register their keys before G6.

--- a/docs/development/floorp-notes-sync/prerequisites.json
+++ b/docs/development/floorp-notes-sync/prerequisites.json
@@ -17,26 +17,44 @@
     "tag": "v12.16.4",
     "commit": "811a5b821e1d9d47b40f22aee6df5db2254a54b1"
   },
-  "staging_environment": {
-    "status": "pending_owner_approval",
-    "note": "Approved non-production FxA/Sync endpoint IDs are never guessed. The architecture owner must supply the staging endpoint GUIDs and test-account policy approval; until then dependent sync work stays blocked.",
-    "fxa_endpoint_id": "PENDING_OWNER_APPROVAL",
-    "sync_endpoint_id": "PENDING_OWNER_APPROVAL",
+  "production_environment": {
+    "status": "approved",
+    "authorization": "product-owner-explicit-2026-08-09",
+    "note": "Floorp has no separate FxA/Sync staging environment. The product owner explicitly approved production-service validation and mobile Notes Sync enablement before public iOS distribution. No endpoint GUID is invented: authority is the existing release configuration and pinned endpoint policy.",
+    "fxa_configuration": "FxAConfig.Server.release",
+    "fxa_hosts": [
+      "accounts.firefox.com",
+      "api.accounts.firefox.com",
+      "oauth.accounts.firefox.com",
+      "profile.accounts.firefox.com",
+      "static.accounts.firefox.com"
+    ],
+    "sync_hosts": [
+      "event-sync.services.mozilla.com",
+      "sync.services.mozilla.com",
+      "token.services.mozilla.com"
+    ],
     "wire": "sync15",
-    "application_record_id": "PENDING_MEASUREMENT_FROM_SIGNED_DESKTOP_BUILD",
-    "account_isolation": "two ephemeral staging accounts, revoked after the matrix"
+    "application_record_id": "e2VjODAzMGY3LWMyMGEtNDY0Zi05YjBlLTEzYTNhOWU5NzM4NH0",
+    "application_record_authority": "Floorp-Projects/application-services components/floorp-prefs-sync README.md and engine.rs at b6d29804c391a573ecc0db6c1c4491b3e07a6693; matches Desktop getPrefsGUIDForTest coverage in Floorp-Runtime ca3d0003976321fd67061d463ab56958b0f38cd9",
+    "endpoint_policy_source": "Floorp-Projects/floorp-ios@330870f9d6db91433afe1024ac8200f81d260a42:docs/floorp-release-endpoints.json",
+    "endpoint_policy_sha256": "af96437acde3d05eb8f18dc9cc81450aa9d61703579c092b962922de8934c9ca",
+    "oauth_client_id": "1b1a3e44c54fbb58",
+    "oauth_redirect_uri": "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel",
+    "oauth_authority": "existing Floorp iOS FxA release path; Notes requests no new OAuth scopes and receives no token",
+    "account_isolation": "two dedicated production QA accounts with no unrelated Sync data"
   },
   "test_account_policy": {
     "secrets_source": "CI secret environment variables only; never arguments, logs, or artifacts",
-    "cleanup": "revoke both accounts and erase simulator keychains even on failure",
+    "cleanup": "disconnect both QA accounts, reset their Notes Sync state, and erase simulator keychains even on failure; account deletion is recorded when authority permits it",
     "proxy_trace": "host/URL metadata only; no content, token, or key bytes"
   },
   "role_registry": [
     {
       "role": "architecture-owner",
-      "login": "PENDING_ROLE_OWNER",
-      "key_fingerprint": "PENDING_KEY_FINGERPRINT",
-      "authority": "approves the contract, staging environment IDs, and trust anchors"
+      "login": "Ryosuke-Asano",
+      "key_fingerprint": "SHA256:LZmR2WViVB4EV+iar0SYgN2QeZKqkjsCCC7skTazHDY",
+      "authority": "approved the production service contract, mobile enablement scope, and rollback requirement on 2026-08-09"
     },
     {
       "role": "security-reviewer",
@@ -58,9 +76,9 @@
     },
     {
       "role": "rollout-approver",
-      "login": "PENDING_ROLE_OWNER",
-      "key_fingerprint": "PENDING_KEY_FINGERPRINT",
-      "authority": "approves rollout and migration evidence"
+      "login": "Ryosuke-Asano",
+      "key_fingerprint": "SHA256:LZmR2WViVB4EV+iar0SYgN2QeZKqkjsCCC7skTazHDY",
+      "authority": "approved production-capable implementation before public iOS distribution; final G6 signature remains required"
     }
   ],
   "fixture": {
@@ -84,13 +102,14 @@
   "policies": {
     "fxa": "FxA/Application Services sync15 path only; never direct Sync REST or raw tokens in app code",
     "e2ee": "encrypted by the sync15 engine; content never leaves the encrypted record in plaintext",
-    "retention": "staging accounts and traces deleted after each matrix run; artifacts retained 7 days",
+    "retention": "production QA accounts contain no unrelated Sync data; traces omit bodies/credentials and are retained 7 days; account cleanup is mandatory after the matrix",
     "reset": "reset flows go through the engine authority; never destructive local deletion without explicit user action",
-    "rollout": "staging-only; production enablement is a separate post-plan authorization",
+    "rollout": "production service and mobile enablement explicitly authorized on 2026-08-09; QA-account validation, runtime kill switch, G1-G6, and rollback evidence remain mandatory before default-on release",
     "migration": "fixture-driven migration; unknown payload fields preserved byte-for-byte"
   },
   "g6": {
     "signatures": [],
+    "signer_registry_status": "pending_security_privacy_retention_keys",
     "max_age_days": 90,
     "allowed_signers_path": "docs/development/floorp-notes-sync/allowed-signers",
     "revocations_path": "docs/development/floorp-notes-sync/revocations.json"

--- a/floorp-runtime.lock.json
+++ b/floorp-runtime.lock.json
@@ -11,8 +11,8 @@
       "immutable": false
     },
     "materials": {
-      "count": 58,
-      "totalBytes": 250737,
+      "count": 53,
+      "totalBytes": 220264,
       "entries": [
         {
           "path": "browser/base/content/test/caps/browser.toml",
@@ -431,46 +431,6 @@
           "sha256": "9ee35758add99d9dd20c8d20ec26baffa1787401876e205a436015e6d9f00b57"
         },
         {
-          "path": "services/sync/tests/tps/test_floorp_notes.js",
-          "role": "test",
-          "bytes": 2641,
-          "mode": "100644",
-          "gitBlob": "ce928fb13957b688974eef6d14b09543e3d10b5d",
-          "sha256": "7a24eea46d9a418b9089d0f4e6a99ed99d9aaa872682761a403de44932b90ef7"
-        },
-        {
-          "path": "services/sync/tests/tps/tps-floorp-notes.toml",
-          "role": "manifest",
-          "bytes": 736,
-          "mode": "100644",
-          "gitBlob": "895fc3fd7f2b6181438b3eece5c1b517463c1c86",
-          "sha256": "c5b20254de2c5fce8c0dec655a425dbe304bb906dcd293f079d928779a0820a2"
-        },
-        {
-          "path": "services/sync/tests/unit/floorp-notes-merge-v1.json",
-          "role": "support",
-          "bytes": 17256,
-          "mode": "100644",
-          "gitBlob": "fef8f5a0e0e303a3f9106e3ac5ac36a7a67cc6ad",
-          "sha256": "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd"
-        },
-        {
-          "path": "services/sync/tests/unit/test_floorp_notes_prefs.js",
-          "role": "test",
-          "bytes": 9403,
-          "mode": "100644",
-          "gitBlob": "14f2188dad5ae0ca88042800d147839ec552f73c",
-          "sha256": "5a27903dcd166458f0134f61d2ec48cf7322f94d07bc22a3933a96f79d4f5dec"
-        },
-        {
-          "path": "services/sync/tests/unit/xpcshell-floorp-notes.toml",
-          "role": "manifest",
-          "bytes": 437,
-          "mode": "100644",
-          "gitBlob": "881f3e3018af6c05d33e99b92fdebc0b90f51e6b",
-          "sha256": "04439bd4cd0253331e291023ba2bbffead1f15d6104c5ebe6ea5108f4f82d929"
-        },
-        {
           "path": "toolkit/content/tests/browser/common/mockTransfer.js",
           "role": "support",
           "bytes": 2765,
@@ -481,9 +441,9 @@
       ]
     },
     "tests": {
-      "count": 10,
-      "totalTasks": 23,
-      "supportDependencyEdges": 94,
+      "count": 8,
+      "totalTasks": 15,
+      "supportDependencyEdges": 93,
       "entries": [
         {
           "path": "browser/base/content/test/caps/browser_principalSerialization_version1.js",
@@ -538,20 +498,6 @@
           "path": "browser/components/urlbar/tests/browser-UrlbarInput/browser_a11y.js",
           "manifest": "browser/components/urlbar/tests/browser-UrlbarInput/browser.toml",
           "expectedTasks": 1,
-          "headPolicy": "harness-replaced",
-          "supportPolicy": "locked-not-loaded"
-        },
-        {
-          "path": "services/sync/tests/tps/test_floorp_notes.js",
-          "manifest": "services/sync/tests/tps/tps-floorp-notes.toml",
-          "expectedTasks": 3,
-          "headPolicy": "harness-replaced",
-          "supportPolicy": "locked-not-loaded"
-        },
-        {
-          "path": "services/sync/tests/unit/test_floorp_notes_prefs.js",
-          "manifest": "services/sync/tests/unit/xpcshell-floorp-notes.toml",
-          "expectedTasks": 5,
           "headPolicy": "harness-replaced",
           "supportPolicy": "locked-not-loaded"
         }
@@ -702,18 +648,6 @@
           "supportPaths": [
             "browser/components/urlbar/tests/browser-UrlbarInput/head.js",
             "browser/components/urlbar/tests/browser/head-common.js"
-          ]
-        },
-        {
-          "path": "services/sync/tests/tps/tps-floorp-notes.toml",
-          "preferences": [],
-          "supportPaths": []
-        },
-        {
-          "path": "services/sync/tests/unit/xpcshell-floorp-notes.toml",
-          "preferences": [],
-          "supportPaths": [
-            "services/sync/tests/unit/floorp-notes-merge-v1.json"
           ]
         }
       ]

--- a/tools/src/runtime_lock.test.ts
+++ b/tools/src/runtime_lock.test.ts
@@ -46,6 +46,20 @@ Deno.test("Runtime browser lock rejects non-browser harness tests", () => {
     },
     "browser-chrome manifest",
   );
+  expectInvalid(
+    (lock) => {
+      lock.source.tests.entries[0].path =
+        "browser/base/content/test/caps/test_not_browser_chrome.js";
+    },
+    "browser-chrome test path",
+  );
+  expectInvalid(
+    (lock) => {
+      lock.source.tests.manifests[0].path =
+        "browser/base/content/test/caps/xpcshell.toml";
+    },
+    "browser-chrome manifest",
+  );
 });
 
 function artifact(

--- a/tools/src/runtime_lock.test.ts
+++ b/tools/src/runtime_lock.test.ts
@@ -31,6 +31,23 @@ function expectInvalid(
   );
 }
 
+Deno.test("Runtime browser lock rejects non-browser harness tests", () => {
+  expectInvalid(
+    (lock) => {
+      lock.source.tests.entries[0].path =
+        "services/sync/tests/unit/test_floorp_notes_prefs.js";
+    },
+    "browser-chrome test path",
+  );
+  expectInvalid(
+    (lock) => {
+      lock.source.tests.manifests[0].path =
+        "services/sync/tests/unit/xpcshell-floorp-notes.toml";
+    },
+    "browser-chrome manifest",
+  );
+});
+
 function artifact(
   lock: RuntimeLock,
   platform: RuntimeArtifact["platform"],
@@ -75,20 +92,20 @@ Deno.test("canonical Runtime lock pins the complete reviewed source closure", ()
     id: 359773143,
     immutable: false,
   });
-  assertEquals(canonicalLock.source.materials.count, 58);
-  assertEquals(canonicalLock.source.materials.totalBytes, 250737);
-  assertEquals(canonicalLock.source.tests.count, 10);
-  assertEquals(canonicalLock.source.tests.totalTasks, 23);
-  assertEquals(canonicalLock.source.tests.supportDependencyEdges, 94);
+  assertEquals(canonicalLock.source.materials.count, 53);
+  assertEquals(canonicalLock.source.materials.totalBytes, 220264);
+  assertEquals(canonicalLock.source.tests.count, 8);
+  assertEquals(canonicalLock.source.tests.totalTasks, 15);
+  assertEquals(canonicalLock.source.tests.supportDependencyEdges, 93);
 
   const roleCounts = Object.groupBy(
     canonicalLock.source.materials.entries,
     (entry) => entry.role,
   );
-  assertEquals(roleCounts.test?.length, 10);
-  assertEquals(roleCounts.manifest?.length, 8);
+  assertEquals(roleCounts.test?.length, 8);
+  assertEquals(roleCounts.manifest?.length, 6);
   assertEquals(roleCounts["head-support"]?.length, 5);
-  assertEquals(roleCounts.support?.length, 35);
+  assertEquals(roleCounts.support?.length, 34);
 
   assertEquals(
     Object.fromEntries(
@@ -110,8 +127,6 @@ Deno.test("canonical Runtime lock pins the complete reviewed source closure", ()
       "browser/components/tabbrowser/test/browser/tabs/browser_pinned_and_hidden_tabs.js":
         1,
       "browser/components/urlbar/tests/browser-UrlbarInput/browser_a11y.js": 1,
-      "services/sync/tests/tps/test_floorp_notes.js": 3,
-      "services/sync/tests/unit/test_floorp_notes_prefs.js": 5,
     },
   );
 });

--- a/tools/src/runtime_lock.ts
+++ b/tools/src/runtime_lock.ts
@@ -480,9 +480,22 @@ function parseTest(value: unknown, path: string): RuntimeTest {
     ],
     path,
   );
+  const testPath = safePath(source.path, `${path}.path`);
+  const manifestPath = safePath(source.manifest, `${path}.manifest`);
+  if (
+    !testPath.startsWith("browser/") || !/\/browser[^/]*\.js$/.test(testPath)
+  ) {
+    fail(`${path}.path`, `not a browser-chrome test path: ${testPath}`);
+  }
+  if (
+    !manifestPath.startsWith("browser/") ||
+    !/\/browser[^/]*\.toml$/.test(manifestPath)
+  ) {
+    fail(`${path}.manifest`, `not a browser-chrome manifest: ${manifestPath}`);
+  }
   return {
-    path: safePath(source.path, `${path}.path`),
-    manifest: safePath(source.manifest, `${path}.manifest`),
+    path: testPath,
+    manifest: manifestPath,
     expectedTasks: safeInteger(
       source.expectedTasks,
       `${path}.expectedTasks`,
@@ -521,8 +534,15 @@ function parseTestManifest(
   );
   assertStrictlySorted(supportPaths, `${path}.supportPaths`);
   assertCaseInsensitiveUnique(supportPaths, `${path}.supportPaths`);
+  const manifestPath = safePath(source.path, `${path}.path`);
+  if (
+    !manifestPath.startsWith("browser/") ||
+    !/\/browser[^/]*\.toml$/.test(manifestPath)
+  ) {
+    fail(`${path}.path`, `not a browser-chrome manifest: ${manifestPath}`);
+  }
   return {
-    path: safePath(source.path, `${path}.path`),
+    path: manifestPath,
     preferences,
     supportPaths,
   };


### PR DESCRIPTION
## Summary
- replace the staging-GUID prerequisite with the explicitly approved production FxA/Sync release authority
- bind the exact enabled FxA/Sync hosts, endpoint-policy digest, OAuth reuse boundary, and measured prefs record ID
- keep G6 security/privacy/retention signer keys pending instead of synthesizing approvals
- make the browser fixture tests executable without Deno globals and enforce duplicate/blank note IDs fail closed

## Verification
- RED: production authority missing from the shipped prerequisites (8 exact errors)
- GREEN: targeted syncPrerequisites browser test
- WIDER: all 7 pages-notes browser test files pass; deno check; deno fmt --check; git diff --check
- host suite: 209/210; unrelated pre-existing macOS Runtime VERSION assertion expects Windows value 002 but receives host value 000 (targeted reproduction retained)

## Scope
Authorized by the product owner for pre-publication Floorp iOS production-service validation. Transport remains Application Services sync15 only; no direct REST, token, key, payload, or App Store mutation. Runtime rollback and G1-G6 remain mandatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer error reporting for note conflicts, including the affected note and merge source.
  * Added validation to prevent blank or duplicate note identifiers during synchronization.

* **Improvements**
  * Notes Sync now supports approved production services, release validation, rollback evidence, and a runtime kill switch.
  * Disabling synchronization preserves local notes and synchronized state.
  * Improved validation for browser test paths and manifests.

* **Documentation**
  * Updated privacy, retention, approval, signer, and production QA procedures for Notes Sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->