### PR TITLE
chore(runtime): pin production TPS validation head

### DIFF
--- a/floorp-runtime.lock.json
+++ b/floorp-runtime.lock.json
@@ -4,8 +4,8 @@
     "repository": "Floorp-Projects/Floorp-Runtime",
     "trackingRef": "nora-0.2.0",
     "ref": "daily-998",
-    "commit": "ca3d0003976321fd67061d463ab56958b0f38cd9",
-    "tree": "a524742367f62767f607764cb5944ec3d613a77c",
+    "commit": "3bf9399564e59be32f92dcc1b044094881b4fb6a",
+    "tree": "533f9fdca9bdccb7f3d2a13842be7e2375160ae5",
     "release": {
       "id": 359773143,
       "immutable": false

--- a/tools/src/runtime_lock.test.ts
+++ b/tools/src/runtime_lock.test.ts
@@ -96,11 +96,11 @@ Deno.test("canonical Runtime lock pins the complete reviewed source closure", ()
   assertEquals(canonicalLock.source.ref, "daily-998");
   assertEquals(
     canonicalLock.source.commit,
-    "ca3d0003976321fd67061d463ab56958b0f38cd9",
+    "3bf9399564e59be32f92dcc1b044094881b4fb6a",
   );
   assertEquals(
     canonicalLock.source.tree,
-    "a524742367f62767f607764cb5944ec3d613a77c",
+    "533f9fdca9bdccb7f3d2a13842be7e2375160ae5",
   );
   assertEquals(canonicalLock.source.release, {
     id: 359773143,


### PR DESCRIPTION
## Summary
- Advance the canonical Floorp-Runtime lock from `ca3d0003976321fd67061d463ab56958b0f38cd9` to merged Runtime PR #61 commit `3bf9399564e59be32f92dcc1b044094881b4fb6a` and tree `533f9fdca9bdccb7f3d2a13842be7e2375160ae5`.
- Preserve the artifact release ref `daily-998` and the reviewed browser-chrome closure.
- Update only the canonical lock and its exact commit/tree assertions.

## Provenance
- Runtime PR: Floorp-Projects/Floorp-Runtime#61
- Exact-head Runtime CI: https://github.com/Floorp-Projects/Floorp-Runtime/actions/runs/31330766054
- Candidate comparison: 53 materials, 220264 bytes, 8 tests, 15 tasks, and 93 support edges unchanged; changed Runtime paths intersect zero locked paths.
- Production TPS: phase 1-3 and both cleanup profiles passed with no credentials, raw logs, or Notes payload retained.

## Verification
- Runtime lock targeted tests: 13/13
- Runtime lock CLI tests: 5/5
- Firefox collector tests: 16/16
- `deno task test:smoke`: 6/6 steps, including type-check and lint of 912 files
- Locked collect/triage/prepare: 53 files, 8 already-allowed candidates, 8 wrappers
- `deno fmt --check` and `git diff --check`

## Known baseline
Local macOS `deno task test:host` retains the existing host/target legacy-version mismatch in `initializer.test.ts` (210 pass, 1 fail; host writes `000`, Windows-target assertion expects `002`). The relevant initializer/defines blobs are identical to base and Todo 16, where the same failure is recorded. This PR does not change those files. The exact-head Ubuntu `smoke` CI job, where `VERSION=002`, is required to pass before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime lock to reference the latest source revision.
  * Refreshed validation fixtures to match the updated runtime source identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->