### PR TITLE
Improve reliability and reduce latency of gestures

### DIFF
--- a/.github/workflows/colocated_runner_test.yml
+++ b/.github/workflows/colocated_runner_test.yml
@@ -352,6 +352,10 @@ jobs:
             --allow-net=127.0.0.1 \
             --allow-read=_dist \
             tools/src/mouse_gesture_rocker_w3c_e2e.ts
+          deno run \
+            --allow-net=127.0.0.1 \
+            --allow-read=_dist \
+            tools/src/mouse_gesture_drawn_w3c_e2e.ts
 
       - name: Verify downloaded Firefox execution coverage
         if: matrix.browser_suite == true

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -285,7 +285,7 @@ export class MouseGestureController {
 
     // A fresh right-button mousedown proves that the previous physical button
     // cycle ended, even if its mouseup was lost while focus was changing.
-    if (event.button === 2 && this.isWheelGestureFired) {
+    if (event.button === 2 && (this.isWheelGestureFired || this.isGestureActive)) {
       this.resetGestureState();
     }
 

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -237,7 +237,18 @@ export class MouseGestureController {
     this.pressedButtons.clear();
   }
 
-  private handleInteractionInterrupted = (): void => {
+  private handleInteractionInterrupted = (event: Event): void => {
+    // Gecko fires a top-level "blur" on this window as a side effect of
+    // focus moving between browser elements during a tab close/switch (most
+    // visibly when the closed tab is replaced by a differently-privileged
+    // empty/new-tab page), even though the OS-level window focus never
+    // actually left the browser. Only treat this as a genuine interruption
+    // (alt-tab, switching to another application/window) when the OS focus
+    // really did leave — otherwise this wipes a gesture the user just
+    // started mid-drag.
+    if (event.type === "blur" && Services.focus.activeWindow === this.targetWindow) {
+      return;
+    }
     this.isContextMenuPrevented = false;
     this.clearPreventionTimeout();
     this.resetGestureState();
@@ -468,14 +479,11 @@ export class MouseGestureController {
 
       if (actionInfo) {
         this.display.updateActionName(actionInfo.displayName);
-
-        // Execute the action after a brief display delay
-        this.targetWindow.setTimeout(() => {
-          executeGestureAction(actionInfo.action, this.targetWindow);
-          this.resetGestureState();
-          this.scheduleContextMenuPreventionRelease(preventionTimeout);
-        }, 100);
-
+        executeGestureAction(actionInfo.action, this.targetWindow);
+        this.resetGestureState();
+        this.scheduleContextMenuPreventionRelease(preventionTimeout);
+        event.preventDefault();
+        event.stopPropagation();
         return;
       }
     }
@@ -483,6 +491,8 @@ export class MouseGestureController {
     // No gesture recognized - prevent context menu and reset
     this.resetGestureState();
     this.scheduleContextMenuPreventionRelease(preventionTimeout);
+    event.preventDefault();
+    event.stopPropagation();
   };
 
   private handleMouseWheel = (event: WheelEvent): void => {

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -209,17 +209,34 @@ export class MouseGestureController {
       return;
     }
 
-    this.targetWindow.clearTimeout(this.preventionTimeoutId);
+    const timeoutId = this.preventionTimeoutId;
     this.preventionTimeoutId = null;
+    try {
+      this.targetWindow.clearTimeout(timeoutId);
+    } catch {
+      // A gesture action can synchronously close its browser window. There is
+      // no timeout left to clear once that window's timer APIs are unavailable.
+    }
   }
 
   private scheduleContextMenuPreventionRelease(timeout: number): void {
     this.clearPreventionTimeout();
     this.isContextMenuPrevented = true;
-    this.preventionTimeoutId = this.targetWindow.setTimeout(() => {
+    try {
+      if (!this.eventListenersAttached || this.targetWindow.closed) {
+        this.isContextMenuPrevented = false;
+        return;
+      }
+      this.preventionTimeoutId = this.targetWindow.setTimeout(() => {
+        this.isContextMenuPrevented = false;
+        this.preventionTimeoutId = null;
+      }, timeout);
+    } catch {
+      // A closed window can reject new timers. Do not leave a permanent
+      // suppression latch behind when a bounded release cannot be scheduled.
       this.isContextMenuPrevented = false;
       this.preventionTimeoutId = null;
-    }, timeout);
+    }
   }
 
   private clearWheelGestureState(): void {
@@ -317,14 +334,14 @@ export class MouseGestureController {
       return;
     }
 
-    // A stale drawn gesture can survive same-window focus churn if its physical
-    // right-button mouseup was lost. Reconcile the stored state with Gecko's
-    // physical button bit before rocker detection so the user's next ordinary
-    // left click cannot be misread as a rightLeft rocker.
+    // A stale gesture can survive same-window focus churn if its physical
+    // releases were lost. Reconcile the stored state with Gecko's physical
+    // right-button bit before rocker detection so the user's next ordinary
+    // left click cannot be swallowed or misread as another rocker action.
     if (
-      this.isGestureActive &&
-      !this.isWheelGestureFired &&
-      !this.isRockerGestureFired &&
+      (this.isGestureActive ||
+        this.isWheelGestureFired ||
+        this.isRockerGestureFired) &&
       event.button !== 2 &&
       !this.isSecondaryButtonPhysicallyDown(event)
     ) {
@@ -334,7 +351,10 @@ export class MouseGestureController {
     // A fresh right-button mousedown proves that the previous physical button
     // cycle ended, even if its mouseup was lost while focus was changing.
     if (
-      event.button === 2 && (this.isWheelGestureFired || this.isGestureActive)
+      event.button === 2 &&
+      (this.isWheelGestureFired ||
+        this.isGestureActive ||
+        (this.isRockerGestureFired && (event.buttons & 1) === 0))
     ) {
       this.resetInteractionState();
     }
@@ -400,7 +420,15 @@ export class MouseGestureController {
       return;
     }
 
-    // A rocker action already owns this button cycle. Left unhandled, these
+    // A rocker action already owns this button cycle. A move with no physical
+    // buttons proves that all of its releases were lost; clear it passively.
+    // With one side still held, preserve ownership until the final release.
+    if (this.isRockerGestureFired && event.buttons === 0) {
+      this.resetInteractionState();
+      return;
+    }
+
+    // Left unhandled, these
     // movement events pass straight through to the page and let its native
     // text-selection drag keep extending for as long as both buttons stay
     // down (visibly so if the rocker action scrolls the page underneath the
@@ -525,7 +553,10 @@ export class MouseGestureController {
       // and it should stay suppressed like every other button. Captured
       // before resetGestureState() below clears it.
       const shouldSuppressMouseUp = event.button !== 0 || this.isGestureActive;
-      if (this.pressedButtons.size === 0) {
+      // `buttons` is the authoritative post-release physical state. This also
+      // completes cleanup if an earlier release was lost and therefore remains
+      // stale in pressedButtons.
+      if (event.buttons === 0) {
         this.resetGestureState();
         this.scheduleContextMenuPreventionRelease(
           getConfig().contextMenu.preventionTimeout,
@@ -579,8 +610,17 @@ export class MouseGestureController {
         event.preventDefault();
         event.stopPropagation();
         this.resetGestureState();
-        this.scheduleContextMenuPreventionRelease(preventionTimeout);
-        executeGestureAction(action, this.targetWindow);
+
+        // Keep suppression active throughout the synchronous action. Closing
+        // a tab/window may run nested timers and dispatch contextmenu before
+        // the action returns; starting the release timer beforehand lets that
+        // nested loop expire the latch too early.
+        this.isContextMenuPrevented = true;
+        try {
+          executeGestureAction(action, this.targetWindow);
+        } finally {
+          this.scheduleContextMenuPreventionRelease(preventionTimeout);
+        }
         return;
       }
     }
@@ -607,6 +647,25 @@ export class MouseGestureController {
     if (this.isWheelGestureSuppressionActive) {
       event.preventDefault();
       event.stopPropagation();
+      return;
+    }
+
+    // A wheel/drawn cycle cannot remain active without the physical right
+    // button. Treat a residual wheel after a lost mouseup as evidence that the
+    // cycle ended; it must be passive and must not execute another action.
+    if (
+      (this.isGestureActive || this.isWheelGestureFired) &&
+      !this.isRockerGestureFired &&
+      !this.isSecondaryButtonPhysicallyDown(event)
+    ) {
+      this.resetInteractionState();
+      return;
+    }
+
+    // A leftRight rocker can legitimately continue with only the left button
+    // held. Only a no-buttons wheel proves that the entire rocker cycle ended.
+    if (this.isRockerGestureFired && event.buttons === 0) {
+      this.resetInteractionState();
       return;
     }
 
@@ -654,12 +713,12 @@ export class MouseGestureController {
     }
 
     // Keyboard context-menu input (or any other event with no physical right
-    // button) must not remain blocked by a drawn gesture whose mouseup was lost.
+    // button) must not remain blocked by a gesture whose releases were lost.
     if (
-      this.isGestureActive &&
-      !this.isWheelGestureFired &&
-      !this.isRockerGestureFired &&
-      !this.isSecondaryButtonPhysicallyDown(event)
+      ((this.isGestureActive || this.isWheelGestureFired) &&
+        !this.isRockerGestureFired &&
+        !this.isSecondaryButtonPhysicallyDown(event)) ||
+      (this.isRockerGestureFired && event.buttons === 0)
     ) {
       this.resetInteractionState();
     }

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -242,6 +242,10 @@ export class MouseGestureController {
   }
 
   private resetDisabledState(): void {
+    this.resetInteractionState();
+  }
+
+  private resetInteractionState(): void {
     this.isContextMenuPrevented = false;
     this.clearPreventionTimeout();
     this.resetGestureState();
@@ -270,9 +274,7 @@ export class MouseGestureController {
     ) {
       return;
     }
-    this.isContextMenuPrevented = false;
-    this.clearPreventionTimeout();
-    this.resetGestureState();
+    this.resetInteractionState();
   };
 
   private getViewportPointFromEvent(event: MouseEvent): {
@@ -305,10 +307,28 @@ export class MouseGestureController {
     geckoEvent.preventClickEvent?.();
   }
 
+  private isSecondaryButtonPhysicallyDown(event: MouseEvent): boolean {
+    return (event.buttons & 2) !== 0;
+  }
+
   private handleMouseDown = (event: MouseEvent): void => {
     if (!isEnabled()) {
       this.resetDisabledState();
       return;
+    }
+
+    // A stale drawn gesture can survive same-window focus churn if its physical
+    // right-button mouseup was lost. Reconcile the stored state with Gecko's
+    // physical button bit before rocker detection so the user's next ordinary
+    // left click cannot be misread as a rightLeft rocker.
+    if (
+      this.isGestureActive &&
+      !this.isWheelGestureFired &&
+      !this.isRockerGestureFired &&
+      event.button !== 2 &&
+      !this.isSecondaryButtonPhysicallyDown(event)
+    ) {
+      this.resetInteractionState();
     }
 
     // A fresh right-button mousedown proves that the previous physical button
@@ -316,7 +336,7 @@ export class MouseGestureController {
     if (
       event.button === 2 && (this.isWheelGestureFired || this.isGestureActive)
     ) {
-      this.resetGestureState();
+      this.resetInteractionState();
     }
 
     this.pressedButtons.add(event.button);
@@ -389,6 +409,18 @@ export class MouseGestureController {
     if (this.isRockerGestureFired) {
       event.preventDefault();
       event.stopPropagation();
+      return;
+    }
+
+    // The controller may have missed the physical right-button mouseup while
+    // the active browser window was replacing or closing a tab. A later move
+    // with no secondary-button bit proves the stored trail is stale.
+    if (
+      this.isGestureActive &&
+      !this.isWheelGestureFired &&
+      !this.isSecondaryButtonPhysicallyDown(event)
+    ) {
+      this.resetInteractionState();
       return;
     }
 
@@ -538,21 +570,27 @@ export class MouseGestureController {
       const actionInfo = this.patternActionMap.get(result.patternName);
 
       if (actionInfo) {
+        const action = actionInfo.action;
         this.display.updateActionName(actionInfo.displayName);
-        executeGestureAction(actionInfo.action, this.targetWindow);
-        this.resetGestureState();
-        this.scheduleContextMenuPreventionRelease(preventionTimeout);
+
+        // Prevent Gecko's trusted follow-up auxclick and make the controller
+        // non-reentrant before tab-closing actions can spin a nested event loop.
+        this.preventFollowingClick(event);
         event.preventDefault();
         event.stopPropagation();
+        this.resetGestureState();
+        this.scheduleContextMenuPreventionRelease(preventionTimeout);
+        executeGestureAction(action, this.targetWindow);
         return;
       }
     }
 
     // No gesture recognized - prevent context menu and reset
-    this.resetGestureState();
-    this.scheduleContextMenuPreventionRelease(preventionTimeout);
+    this.preventFollowingClick(event);
     event.preventDefault();
     event.stopPropagation();
+    this.resetGestureState();
+    this.scheduleContextMenuPreventionRelease(preventionTimeout);
   };
 
   private handleMouseWheel = (event: WheelEvent): void => {
@@ -613,6 +651,17 @@ export class MouseGestureController {
     if (!isEnabled()) {
       this.resetDisabledState();
       return;
+    }
+
+    // Keyboard context-menu input (or any other event with no physical right
+    // button) must not remain blocked by a drawn gesture whose mouseup was lost.
+    if (
+      this.isGestureActive &&
+      !this.isWheelGestureFired &&
+      !this.isRockerGestureFired &&
+      !this.isSecondaryButtonPhysicallyDown(event)
+    ) {
+      this.resetInteractionState();
     }
 
     if (

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -105,11 +105,13 @@ function dispatchMouseFrom(
   button: number,
   clientX = 0,
   clientY = 0,
+  buttons = 0,
 ): MouseEvent {
   // Firefox's chrome test context treats these pointer-derived messages as
   // trusted and asserts if they are created with MouseEvent (Bug 1675848).
   const event = new PointerEvent(type, {
     button,
+    buttons,
     clientX,
     clientY,
     bubbles: true,
@@ -125,8 +127,9 @@ function dispatchMouse(
   button: number,
   clientX = 0,
   clientY = 0,
+  buttons = 0,
 ): MouseEvent {
-  return dispatchMouseFrom(win, type, button, clientX, clientY);
+  return dispatchMouseFrom(win, type, button, clientX, clientY, buttons);
 }
 
 // Mirrors buildLineTrail in mouseGestureRecognizer.test.ts: enough steps and
@@ -140,7 +143,7 @@ function dispatchDrag(
 ): void {
   for (let i = 1; i <= steps; i++) {
     const t = i / steps;
-    dispatchMouse(win, "mousemove", 0, endX * t, endY * t);
+    dispatchMouse(win, "mousemove", 0, endX * t, endY * t, 2);
   }
 }
 
@@ -384,6 +387,11 @@ async function testNormalRightClickRemainsAllowed(): Promise<void> {
       "normal mouseup should be allowed",
     );
     assertEquals(
+      mouseUp.clickEventPrevented(),
+      false,
+      "normal right mouseup should not suppress its follow-up auxclick",
+    );
+    assertEquals(
       contextMenu.defaultPrevented,
       false,
       "normal right click should still open the context menu",
@@ -490,7 +498,7 @@ async function testWheelSuppressionExpiresWithoutExtending(): Promise<void> {
         "suppression timeout should not start while the right button is held",
       );
       assertEquals(
-        dispatchMouse(win, "contextmenu", 2).defaultPrevented,
+        dispatchMouse(win, "contextmenu", 2, 0, 0, 2).defaultPrevented,
         true,
         "contextmenu should be suppressed while the wheel gesture is active",
       );
@@ -721,9 +729,9 @@ async function testDestroyClearsWheelSuppressionTimer(): Promise<void> {
 async function testWheelGestureCannotBecomeRockerGesture(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
-      dispatchMouse(win, "mousedown", 2);
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
       dispatchWheel(win, 120);
-      const leftMouseDown = dispatchMouse(win, "mousedown", 0);
+      const leftMouseDown = dispatchMouse(win, "mousedown", 0, 0, 0, 3);
       dispatchMouse(win, "mouseup", 2);
 
       assertEquals(
@@ -744,8 +752,8 @@ async function testWheelGestureCannotBecomeRockerGesture(): Promise<void> {
 async function testRockerGestureCannotBecomeWheelGesture(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
-      dispatchMouse(win, "mousedown", 2);
-      dispatchMouse(win, "mousedown", 0);
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchMouse(win, "mousedown", 0, 0, 0, 3);
       const wheel = dispatchWheel(win, 120);
       dispatchMouse(win, "mouseup", 2);
       dispatchMouse(win, "mouseup", 0);
@@ -789,6 +797,11 @@ async function testRecognizedGestureExecutesSynchronously(): Promise<void> {
         true,
         "recognized gesture's mouseup should be consumed",
       );
+      assertEquals(
+        mouseUp.clickEventPrevented(),
+        true,
+        "recognized gesture should suppress its follow-up auxclick",
+      );
     });
   });
 }
@@ -809,6 +822,11 @@ async function testUnrecognizedMovedGestureConsumesMouseUp(): Promise<void> {
           mouseUp.defaultPrevented,
           true,
           "an unrecognized but moved gesture should still consume its mouseup",
+        );
+        assertEquals(
+          mouseUp.clickEventPrevented(),
+          true,
+          "an unrecognized moved gesture should suppress its follow-up auxclick",
         );
         assertEquals(
           contextMenu.defaultPrevented,
@@ -896,6 +914,181 @@ async function testNewRightMouseDownRecoversFromStaleDrawnGesture(): Promise<
   });
 }
 
+async function testStaleDrawnGestureDoesNotBecomeRockerOnLeftClick(): Promise<
+  void
+> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchDrag(win, 100, 0);
+
+      // The physical right button was released without a delivered mouseup.
+      // Gecko's buttons bit proves this is a fresh ordinary left click, not a
+      // real rightLeft rocker chord.
+      const leftMouseDown = dispatchMouse(win, "mousedown", 0, 0, 0, 1);
+      const leftMouseUp = dispatchMouse(win, "mouseup", 0, 0, 0, 0);
+      const keyboardContextMenu = dispatchMouse(
+        win,
+        "contextmenu",
+        0,
+        0,
+        0,
+        0,
+      );
+
+      assertEquals(
+        counts[ROCKER_RIGHT_LEFT_ACTION],
+        0,
+        "a stale drawn gesture must not turn the next left click into Back",
+      );
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        0,
+        "the abandoned drawn gesture must not execute",
+      );
+      assertEquals(
+        leftMouseDown.defaultPrevented,
+        false,
+        "the next ordinary left mousedown must remain passive",
+      );
+      assertEquals(
+        leftMouseDown.clickEventPrevented(),
+        false,
+        "stale recovery must not suppress the ordinary left click",
+      );
+      assertEquals(
+        leftMouseUp.defaultPrevented,
+        false,
+        "the matching ordinary left mouseup must remain passive",
+      );
+      assertEquals(
+        keyboardContextMenu.defaultPrevented,
+        false,
+        "stale recovery must not leave keyboard contextmenu blocked",
+      );
+    });
+  });
+}
+
+async function testPhysicalButtonMismatchClearsStaleDrawnState(): Promise<
+  void
+> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchDrag(win, 100, 0);
+      const staleMove = dispatchMouse(win, "mousemove", 0, 120, 0, 0);
+      const staleMouseUp = dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchDrag(win, 100, 0);
+      const staleContextMenu = dispatchMouse(
+        win,
+        "contextmenu",
+        0,
+        0,
+        0,
+        0,
+      );
+      const secondStaleMouseUp = dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+      assertEquals(
+        staleMove.defaultPrevented,
+        false,
+        "mousemove with no physical right button should clear stale state passively",
+      );
+      assertEquals(
+        staleMouseUp.defaultPrevented,
+        false,
+        "mouseup after stale move recovery should remain passive",
+      );
+      assertEquals(
+        staleContextMenu.defaultPrevented,
+        false,
+        "keyboard contextmenu should clear stale state and remain passive",
+      );
+      assertEquals(
+        secondStaleMouseUp.defaultPrevented,
+        false,
+        "mouseup after contextmenu recovery should remain passive",
+      );
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        0,
+        "neither abandoned gesture should execute",
+      );
+      assertEquals(
+        counts[ROCKER_RIGHT_LEFT_ACTION],
+        0,
+        "stale recovery should not execute a rocker action",
+      );
+    });
+  });
+}
+
+async function testRecognizedGestureNeutralizesStateBeforeAction(): Promise<
+  void
+> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      const nestedInput: { mouseDown?: MouseEvent; mouseUp?: MouseEvent } = {};
+      gestureActions.registerAction({
+        name: DRAWN_RIGHT_ACTION,
+        fn: () => {
+          counts[DRAWN_RIGHT_ACTION] += 1;
+          nestedInput.mouseDown = dispatchMouse(
+            win,
+            "mousedown",
+            0,
+            0,
+            0,
+            1,
+          );
+          nestedInput.mouseUp = dispatchMouse(win, "mouseup", 0, 0, 0, 0);
+        },
+      });
+
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchDrag(win, 200, 0);
+      const mouseUp = dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        1,
+        "recognized action should execute exactly once",
+      );
+      assertEquals(
+        counts[ROCKER_RIGHT_LEFT_ACTION],
+        0,
+        "nested left input must not reenter the stale rightLeft rocker",
+      );
+      assert(
+        nestedInput.mouseDown,
+        "the action should synchronously dispatch nested input",
+      );
+      assert(
+        nestedInput.mouseUp,
+        "the action should complete its nested input",
+      );
+      assertEquals(
+        nestedInput.mouseDown.defaultPrevented,
+        false,
+        "nested left mousedown should observe neutral gesture state",
+      );
+      assertEquals(
+        nestedInput.mouseUp.defaultPrevented,
+        false,
+        "nested left mouseup should observe neutral gesture state",
+      );
+      assertEquals(
+        mouseUp.clickEventPrevented(),
+        true,
+        "the triggering drawn mouseup should suppress its follow-up auxclick",
+      );
+    });
+  });
+}
+
 async function testRockerGestureConsumesMouseMoveWhileHeld(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
@@ -906,15 +1099,22 @@ async function testRockerGestureConsumesMouseMoveWhileHeld(): Promise<void> {
       // must be consumed - left unhandled, it would let that selection keep
       // extending as the rocker's action (e.g. scrolling) moves content
       // under the still-held cursor.
-      dispatchMouse(win, "mousedown", 0);
-      const rightMouseDown = dispatchMouse(win, "mousedown", 2);
-      const moveWhileHeld = dispatchMouse(win, "mousemove", 0, 50, 0);
+      dispatchMouse(win, "mousedown", 0, 0, 0, 1);
+      const rightMouseDown = dispatchMouse(win, "mousedown", 2, 0, 0, 3);
+      const moveWhileHeld = dispatchMouse(win, "mousemove", 0, 50, 0, 3);
       // Releasing only the right button doesn't end the cycle - the left
       // button is still physically held, so movement must stay consumed.
-      dispatchMouse(win, "mouseup", 2);
-      const moveAfterRightRelease = dispatchMouse(win, "mousemove", 0, 55, 0);
-      dispatchMouse(win, "mouseup", 0);
-      const moveAfterRelease = dispatchMouse(win, "mousemove", 0, 60, 0);
+      dispatchMouse(win, "mouseup", 2, 0, 0, 1);
+      const moveAfterRightRelease = dispatchMouse(
+        win,
+        "mousemove",
+        0,
+        55,
+        0,
+        1,
+      );
+      dispatchMouse(win, "mouseup", 0, 0, 0, 0);
+      const moveAfterRelease = dispatchMouse(win, "mousemove", 0, 60, 0, 0);
 
       assertEquals(
         rightMouseDown.defaultPrevented,
@@ -964,8 +1164,8 @@ async function testMouseDownCaptureSurvivesContentStopPropagation(): Promise<
         event.stopPropagation();
       });
 
-      dispatchMouseFrom(contentEl, "mousedown", 2);
-      dispatchMouseFrom(contentEl, "mousedown", 0);
+      dispatchMouseFrom(contentEl, "mousedown", 2, 0, 0, 2);
+      dispatchMouseFrom(contentEl, "mousedown", 0, 0, 0, 3);
       // Content also stops propagation on its own mousemove. A regression
       // that moved the mousemove listener back to bubble phase would still
       // pass every other assertion here, since rocker detection itself only
@@ -1002,10 +1202,10 @@ async function testLeftRightRockerLetsLeftMouseUpThrough(): Promise<void> {
       // mouseup indiscriminately, the page would never find out the left
       // button was released, leaving native selection mode stuck "on" -
       // even with zero mouse movement during the whole sequence.
-      const leftMouseDown = dispatchMouse(win, "mousedown", 0);
-      const rightMouseDown = dispatchMouse(win, "mousedown", 2);
-      const rightMouseUp = dispatchMouse(win, "mouseup", 2);
-      const leftMouseUp = dispatchMouse(win, "mouseup", 0);
+      const leftMouseDown = dispatchMouse(win, "mousedown", 0, 0, 0, 1);
+      const rightMouseDown = dispatchMouse(win, "mousedown", 2, 0, 0, 3);
+      const rightMouseUp = dispatchMouse(win, "mouseup", 2, 0, 0, 1);
+      const leftMouseUp = dispatchMouse(win, "mouseup", 0, 0, 0, 0);
 
       assertEquals(
         leftMouseDown.clickEventPrevented(),
@@ -1092,10 +1292,10 @@ async function testRightLeftRockerSuppressesLeftMouseUp(): Promise<void> {
       // suppressed like every other button in this cleanup path - letting
       // it through would leave the page with an unmatched mouseup that
       // never had a corresponding unprevented mousedown.
-      const rightMouseDown = dispatchMouse(win, "mousedown", 2);
-      const leftMouseDown = dispatchMouse(win, "mousedown", 0);
-      const rightMouseUp = dispatchMouse(win, "mouseup", 2);
-      const leftMouseUp = dispatchMouse(win, "mouseup", 0);
+      const rightMouseDown = dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      const leftMouseDown = dispatchMouse(win, "mousedown", 0, 0, 0, 3);
+      const rightMouseUp = dispatchMouse(win, "mouseup", 2, 0, 0, 1);
+      const leftMouseUp = dispatchMouse(win, "mouseup", 0, 0, 0, 0);
 
       assertEquals(
         rightMouseDown.clickEventPrevented(),
@@ -1217,6 +1417,18 @@ const tests: TestCase[] = [
   {
     name: "a new right mousedown recovers from a stale drawn gesture",
     fn: testNewRightMouseDownRecoversFromStaleDrawnGesture,
+  },
+  {
+    name: "a stale drawn gesture does not become a rocker on left click",
+    fn: testStaleDrawnGestureDoesNotBecomeRockerOnLeftClick,
+  },
+  {
+    name: "physical button mismatch clears stale drawn state",
+    fn: testPhysicalButtonMismatchClearsStaleDrawnState,
+  },
+  {
+    name: "recognized gesture neutralizes state before action",
+    fn: testRecognizedGestureNeutralizesStateBeforeAction,
   },
   {
     name: "rocker gesture consumes mousemove while held",

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -44,6 +44,7 @@ interface TestConfigOptions {
   enabled?: boolean;
   wheelGesturesEnabled?: boolean;
   preventionTimeout?: number;
+  actions?: MouseGestureConfig["actions"];
 }
 
 function createFakeWindow(): FakeWindowHarness {
@@ -99,6 +100,21 @@ function dispatchMouse(
   return event;
 }
 
+// Mirrors buildLineTrail in mouseGestureRecognizer.test.ts: enough steps and
+// distance per step to clear both the 1.5px move-noise filter and the
+// default 5px activation distance.
+function dispatchDrag(
+  win: Window,
+  endX: number,
+  endY: number,
+  steps = 16,
+): void {
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    dispatchMouse(win, "mousemove", 0, endX * t, endY * t);
+  }
+}
+
 function dispatchWheel(win: Window, deltaY: number): WheelEvent {
   const event = new WheelEvent("wheel", {
     deltaY,
@@ -118,7 +134,7 @@ function createTestConfig(options: TestConfigOptions): MouseGestureConfig {
       ...defaultConfig.contextMenu,
       preventionTimeout: options.preventionTimeout ?? 200,
     },
-    actions: defaultConfig.actions.map((action) => ({
+    actions: (options.actions ?? defaultConfig.actions).map((action) => ({
       pattern: [...action.pattern],
       action: action.action,
     })),
@@ -706,6 +722,133 @@ async function testRockerGestureCannotBecomeWheelGesture(): Promise<void> {
   });
 }
 
+async function testRecognizedGestureExecutesSynchronously(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      dispatchMouse(win, "mousedown", 2);
+      dispatchDrag(win, 200, 0);
+      const mouseUp = dispatchMouse(win, "mouseup", 2);
+
+      // No harness.runAllTimers() call: the action must already have run.
+      // The old code deferred execution behind a 100ms setTimeout, so this
+      // assertion would fail against that version.
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        1,
+        "recognized gesture should execute its action synchronously on mouseup",
+      );
+      assertEquals(
+        mouseUp.defaultPrevented,
+        true,
+        "recognized gesture's mouseup should be consumed",
+      );
+    });
+  });
+}
+
+async function testUnrecognizedMovedGestureConsumesMouseUp(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController(
+      { actions: [{ pattern: ["right"], action: DRAWN_RIGHT_ACTION }] },
+      ({ win }) => {
+        dispatchMouse(win, "mousedown", 2);
+        // Moves past the activation distance but does not match the only
+        // configured pattern ("right"), so no gesture is recognized.
+        dispatchDrag(win, 0, 200);
+        const mouseUp = dispatchMouse(win, "mouseup", 2);
+        const contextMenu = dispatchMouse(win, "contextmenu", 2);
+
+        assertEquals(
+          mouseUp.defaultPrevented,
+          true,
+          "an unrecognized but moved gesture should still consume its mouseup",
+        );
+        assertEquals(
+          contextMenu.defaultPrevented,
+          true,
+          "context menu should stay suppressed after an unrecognized gesture",
+        );
+        assertEquals(
+          counts[DRAWN_RIGHT_ACTION],
+          0,
+          "no action should run for an unrecognized gesture",
+        );
+      },
+    );
+  });
+}
+
+async function testGenuineInterruptionResetsActiveDrawnGesture(): Promise<
+  void
+> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      dispatchMouse(win, "mousedown", 2);
+      dispatchDrag(win, 100, 0);
+
+      // The fake window can never equal Services.focus.activeWindow, so this
+      // exercises the "genuine interruption" branch (as opposed to the
+      // same-window internal-focus-churn case the fix now ignores).
+      win.dispatchEvent(new Event("blur"));
+
+      const mouseUp = dispatchMouse(win, "mouseup", 2);
+      const contextMenu = dispatchMouse(win, "contextmenu", 2);
+
+      assertEquals(
+        mouseUp.defaultPrevented,
+        false,
+        "mouseup after a genuine interruption should be passive",
+      );
+      assertEquals(
+        contextMenu.defaultPrevented,
+        false,
+        "context menu should be allowed after a genuine interruption",
+      );
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        0,
+        "an interrupted drawn gesture must not execute",
+      );
+    });
+  });
+}
+
+async function testNewRightMouseDownRecoversFromStaleDrawnGesture(): Promise<
+  void
+> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      // Start a drawn gesture and lose its mouseup entirely (never
+      // dispatched) - simulates the mouseup being dropped mid-drag, e.g. by
+      // the same tab-close/focus churn that motivated ignoring same-window
+      // blur. Without the fix, isGestureActive stays stuck true forever and
+      // every future right-button mousedown is silently swallowed.
+      dispatchMouse(win, "mousedown", 2);
+      dispatchDrag(win, 100, 0);
+
+      const nextMouseDown = dispatchMouse(win, "mousedown", 2);
+      dispatchDrag(win, 200, 0);
+      const nextMouseUp = dispatchMouse(win, "mouseup", 2);
+
+      assertEquals(
+        nextMouseDown.defaultPrevented,
+        false,
+        "a fresh right-button mousedown is not itself prevented",
+      );
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        1,
+        "the recovered cycle should still recognize and execute its gesture",
+      );
+      assertEquals(
+        nextMouseUp.defaultPrevented,
+        true,
+        "the recovered cycle's recognized mouseup should be consumed",
+      );
+    });
+  });
+}
+
 const tests: TestCase[] = [
   {
     name: "wheel gesture suppresses post-mouseup contextmenu",
@@ -762,6 +905,22 @@ const tests: TestCase[] = [
   {
     name: "rocker gesture cannot become wheel gesture",
     fn: testRockerGestureCannotBecomeWheelGesture,
+  },
+  {
+    name: "recognized gesture executes synchronously on mouseup",
+    fn: testRecognizedGestureExecutesSynchronously,
+  },
+  {
+    name: "unrecognized but moved gesture consumes its mouseup",
+    fn: testUnrecognizedMovedGestureConsumesMouseUp,
+  },
+  {
+    name: "a genuine interruption still resets an active drawn gesture",
+    fn: testGenuineInterruptionResetsActiveDrawnGesture,
+  },
+  {
+    name: "a new right mousedown recovers from a stale drawn gesture",
+    fn: testNewRightMouseDownRecoversFromStaleDrawnGesture,
   },
 ];
 

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -45,6 +45,7 @@ interface TestConfigOptions {
   wheelGesturesEnabled?: boolean;
   preventionTimeout?: number;
   actions?: MouseGestureConfig["actions"];
+  rockerActions?: MouseGestureConfig["rockerActions"];
 }
 
 function attachTimerShim<T extends EventTarget>(
@@ -147,9 +148,14 @@ function dispatchDrag(
   }
 }
 
-function dispatchWheel(win: Window, deltaY: number): WheelEvent {
+function dispatchWheel(
+  win: Window,
+  deltaY: number,
+  buttons: number,
+): WheelEvent {
   const event = new WheelEvent("wheel", {
     deltaY,
+    buttons,
     bubbles: true,
     cancelable: true,
   });
@@ -170,7 +176,9 @@ function createTestConfig(options: TestConfigOptions): MouseGestureConfig {
       pattern: [...action.pattern],
       action: action.action,
     })),
-    rockerActions: { ...defaultConfig.rockerActions },
+    rockerActions: {
+      ...(options.rockerActions ?? defaultConfig.rockerActions),
+    },
   };
 }
 
@@ -297,7 +305,7 @@ async function testWheelGestureSuppressesPostMouseUpContextMenu(): Promise<
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
       dispatchMouse(win, "mousedown", 2);
-      const wheel = dispatchWheel(win, 120);
+      const wheel = dispatchWheel(win, 120, 2);
       const mouseUp = dispatchMouse(win, "mouseup", 2);
       const contextMenu = dispatchMouse(win, "contextmenu", 2);
 
@@ -332,13 +340,13 @@ async function testWheelGestureChainsWhileHeldAndConsumesResidualWheel(): Promis
     await withController({}, (harness) => {
       const { win } = harness;
       dispatchMouse(win, "mousedown", 2);
-      const firstWheel = dispatchWheel(win, 120);
-      dispatchMouse(win, "mousemove", 0, 100, 0);
+      const firstWheel = dispatchWheel(win, 120, 2);
+      dispatchMouse(win, "mousemove", 0, 100, 0, 2);
       // While the right button is held, each wheel notch switches tabs
       // (Floorp issue #2586 regression from the #2559 exact-once latch).
-      const heldResidualWheel = dispatchWheel(win, -120);
+      const heldResidualWheel = dispatchWheel(win, -120, 2);
       dispatchMouse(win, "mouseup", 2);
-      const postMouseUpResidualWheel = dispatchWheel(win, 120);
+      const postMouseUpResidualWheel = dispatchWheel(win, 120, 0);
       harness.runAllTimers();
 
       assertEquals(
@@ -403,7 +411,7 @@ async function testDisabledWheelGesturesRemainPassive(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({ wheelGesturesEnabled: false }, ({ win }) => {
       dispatchMouse(win, "mousedown", 2);
-      const wheel = dispatchWheel(win, 120);
+      const wheel = dispatchWheel(win, 120, 2);
       dispatchMouse(win, "mouseup", 2);
       const contextMenu = dispatchMouse(win, "contextmenu", 2);
 
@@ -430,7 +438,7 @@ async function testDisabledFeatureRemainsPassive(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({ enabled: false }, ({ win }) => {
       dispatchMouse(win, "mousedown", 2);
-      const wheel = dispatchWheel(win, 120);
+      const wheel = dispatchWheel(win, 120, 2);
       const mouseUp = dispatchMouse(win, "mouseup", 2);
       const contextMenu = dispatchMouse(win, "contextmenu", 2);
 
@@ -458,7 +466,7 @@ async function testZeroDeltaWheelRemainsPassive(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
       dispatchMouse(win, "mousedown", 2);
-      const wheel = dispatchWheel(win, 0);
+      const wheel = dispatchWheel(win, 0, 2);
       dispatchMouse(win, "mouseup", 2);
       const contextMenu = dispatchMouse(win, "contextmenu", 2);
 
@@ -491,7 +499,7 @@ async function testWheelSuppressionExpiresWithoutExtending(): Promise<void> {
     await withController({ preventionTimeout: 25 }, (harness) => {
       const { win } = harness;
       dispatchMouse(win, "mousedown", 2);
-      dispatchWheel(win, 120);
+      dispatchWheel(win, 120, 2);
       assertEquals(
         harness.pendingTimerCount(),
         0,
@@ -515,7 +523,7 @@ async function testWheelSuppressionExpiresWithoutExtending(): Promise<void> {
         "contextmenu should be suppressed before timeout",
       );
       assertEquals(
-        dispatchWheel(win, -120).defaultPrevented,
+        dispatchWheel(win, -120, 0).defaultPrevented,
         true,
         "residual wheel should be suppressed before timeout",
       );
@@ -538,7 +546,7 @@ async function testWheelSuppressionExpiresWithoutExtending(): Promise<void> {
         "contextmenu should be allowed after timeout",
       );
       assertEquals(
-        dispatchWheel(win, -120).defaultPrevented,
+        dispatchWheel(win, -120, 0).defaultPrevented,
         false,
         "wheel should be allowed after timeout",
       );
@@ -561,7 +569,7 @@ async function testNewRightClickResetsWheelSuppression(): Promise<void> {
     await withController({}, (harness) => {
       const { win } = harness;
       dispatchMouse(win, "mousedown", 2);
-      dispatchWheel(win, 120);
+      dispatchWheel(win, 120, 2);
       dispatchMouse(win, "mouseup", 2);
       assertEquals(
         harness.pendingTimerCount(),
@@ -590,7 +598,7 @@ async function testNewRightClickRecoversFromLostMouseUp(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
       dispatchMouse(win, "mousedown", 2);
-      dispatchWheel(win, 120);
+      dispatchWheel(win, 120, 2);
 
       // Simulate a mouseup lost outside the chrome window. A later physical
       // right-button press establishes a new cycle and must not stay latched.
@@ -618,15 +626,158 @@ async function testNewRightClickRecoversFromLostMouseUp(): Promise<void> {
   });
 }
 
+async function testLostWheelReleaseRecoveryMatrix(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({ preventionTimeout: 25 }, (harness) => {
+      const { win } = harness;
+
+      // A wheel event with no physical right-button bit proves that the
+      // mouseup was lost. It is residual input, not another tab-switch action.
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchWheel(win, 120, 2);
+      const residualWheel = dispatchWheel(win, -120, 0);
+      const leftAfterResidualDown = dispatchMouse(
+        win,
+        "mousedown",
+        0,
+        0,
+        0,
+        1,
+      );
+      const leftAfterResidualUp = dispatchMouse(
+        win,
+        "mouseup",
+        0,
+        0,
+        0,
+        0,
+      );
+      const contextAfterResidual = dispatchMouse(
+        win,
+        "contextmenu",
+        0,
+        0,
+        0,
+        0,
+      );
+
+      assertEquals(
+        residualWheel.defaultPrevented,
+        false,
+        "a no-buttons residual wheel should pass through while clearing stale state",
+      );
+      assertEquals(
+        counts[PREVIOUS_TAB_ACTION],
+        0,
+        "a no-buttons residual wheel must not switch tabs",
+      );
+      assertEquals(
+        leftAfterResidualDown.defaultPrevented,
+        false,
+        "ordinary left mousedown after residual recovery should be passive",
+      );
+      assertEquals(
+        leftAfterResidualUp.defaultPrevented,
+        false,
+        "ordinary left mouseup after residual recovery should be passive",
+      );
+      assertEquals(
+        contextAfterResidual.defaultPrevented,
+        false,
+        "residual recovery must not suppress keyboard contextmenu",
+      );
+
+      // An ordinary left click can itself be the first reliable evidence that
+      // a wheel cycle's right-button mouseup was lost.
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchWheel(win, 120, 2);
+      const staleWheelLeftDown = dispatchMouse(
+        win,
+        "mousedown",
+        0,
+        0,
+        0,
+        1,
+      );
+      const staleWheelLeftUp = dispatchMouse(
+        win,
+        "mouseup",
+        0,
+        0,
+        0,
+        0,
+      );
+      const staleWheelContextMenu = dispatchMouse(
+        win,
+        "contextmenu",
+        0,
+        0,
+        0,
+        0,
+      );
+
+      assertEquals(
+        staleWheelLeftDown.defaultPrevented,
+        false,
+        "fresh left mousedown should clear a stale wheel cycle passively",
+      );
+      assertEquals(
+        staleWheelLeftDown.clickEventPrevented(),
+        false,
+        "stale wheel recovery must not suppress the fresh left click",
+      );
+      assertEquals(
+        staleWheelLeftUp.defaultPrevented,
+        false,
+        "fresh left mouseup after a stale wheel cycle should be passive",
+      );
+      assertEquals(
+        staleWheelContextMenu.defaultPrevented,
+        false,
+        "left-click stale recovery must allow keyboard contextmenu",
+      );
+
+      // A fresh physical right press starts a new valid cycle rather than
+      // remaining latched in the abandoned wheel gesture.
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchWheel(win, 120, 2);
+      const freshRightDown = dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      const freshWheel = dispatchWheel(win, -120, 2);
+      dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+      assertEquals(
+        freshRightDown.defaultPrevented,
+        false,
+        "a fresh right mousedown should reset and start a valid cycle",
+      );
+      assertEquals(
+        freshWheel.defaultPrevented,
+        true,
+        "wheel input in the recovered right-button cycle should be consumed",
+      );
+      assertEquals(
+        counts[NEXT_TAB_ACTION],
+        3,
+        "each initial held-right wheel should execute exactly once",
+      );
+      assertEquals(
+        counts[PREVIOUS_TAB_ACTION],
+        1,
+        "the new right-button cycle should execute its own wheel action",
+      );
+    });
+  });
+}
+
 async function testBlurClearsWheelGestureWithLostMouseUp(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
       dispatchMouse(win, "mousedown", 2);
-      dispatchWheel(win, 120);
+      dispatchWheel(win, 120, 2);
       win.dispatchEvent(new Event("blur"));
 
       assertEquals(
-        dispatchWheel(win, -120).defaultPrevented,
+        dispatchWheel(win, -120, 0).defaultPrevented,
         false,
         "wheel should become passive after the interrupted cycle is cleared",
       );
@@ -650,7 +801,7 @@ async function testDisableTransitionClearsWheelSuppression(): Promise<void> {
     await withController({}, (harness) => {
       const { win } = harness;
       dispatchMouse(win, "mousedown", 2);
-      dispatchWheel(win, 120);
+      dispatchWheel(win, 120, 2);
       dispatchMouse(win, "mouseup", 2);
       assertEquals(
         harness.pendingTimerCount(),
@@ -659,7 +810,7 @@ async function testDisableTransitionClearsWheelSuppression(): Promise<void> {
       );
 
       setEnabled(false);
-      const residualWheel = dispatchWheel(win, -120);
+      const residualWheel = dispatchWheel(win, -120, 0);
       const contextMenu = dispatchMouse(win, "contextmenu", 2);
 
       assertEquals(
@@ -696,7 +847,7 @@ async function testDestroyClearsWheelSuppressionTimer(): Promise<void> {
     await withController({}, (harness, controller) => {
       const { win } = harness;
       dispatchMouse(win, "mousedown", 2);
-      dispatchWheel(win, 120);
+      dispatchWheel(win, 120, 2);
       dispatchMouse(win, "mouseup", 2);
       assertEquals(
         harness.pendingTimerCount(),
@@ -717,7 +868,7 @@ async function testDestroyClearsWheelSuppressionTimer(): Promise<void> {
         "destroyed controller should no longer intercept contextmenu",
       );
       assertEquals(
-        dispatchWheel(win, 120).defaultPrevented,
+        dispatchWheel(win, 120, 0).defaultPrevented,
         false,
         "destroyed controller should no longer intercept wheel",
       );
@@ -730,7 +881,7 @@ async function testWheelGestureCannotBecomeRockerGesture(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({}, ({ win }) => {
       dispatchMouse(win, "mousedown", 2, 0, 0, 2);
-      dispatchWheel(win, 120);
+      dispatchWheel(win, 120, 2);
       const leftMouseDown = dispatchMouse(win, "mousedown", 0, 0, 0, 3);
       dispatchMouse(win, "mouseup", 2);
 
@@ -754,9 +905,9 @@ async function testRockerGestureCannotBecomeWheelGesture(): Promise<void> {
     await withController({}, ({ win }) => {
       dispatchMouse(win, "mousedown", 2, 0, 0, 2);
       dispatchMouse(win, "mousedown", 0, 0, 0, 3);
-      const wheel = dispatchWheel(win, 120);
-      dispatchMouse(win, "mouseup", 2);
-      dispatchMouse(win, "mouseup", 0);
+      const wheel = dispatchWheel(win, 120, 3);
+      dispatchMouse(win, "mouseup", 2, 0, 0, 1);
+      dispatchMouse(win, "mouseup", 0, 0, 0, 0);
 
       assertEquals(
         wheel.defaultPrevented,
@@ -1030,12 +1181,28 @@ async function testRecognizedGestureNeutralizesStateBeforeAction(): Promise<
   void
 > {
   await withTrackedActions(async (counts) => {
-    await withController({}, ({ win }) => {
-      const nestedInput: { mouseDown?: MouseEvent; mouseUp?: MouseEvent } = {};
+    await withController({ preventionTimeout: 25 }, (harness) => {
+      const { win } = harness;
+      const nestedInput: {
+        mouseDown?: MouseEvent;
+        mouseUp?: MouseEvent;
+        contextMenu?: MouseEvent;
+      } = {};
       gestureActions.registerAction({
         name: DRAWN_RIGHT_ACTION,
         fn: () => {
           counts[DRAWN_RIGHT_ACTION] += 1;
+          // A tab-closing action can spin a nested event loop. Any already
+          // armed timers run before its synchronous work resumes.
+          harness.runAllTimers();
+          nestedInput.contextMenu = dispatchMouse(
+            win,
+            "contextmenu",
+            2,
+            0,
+            0,
+            0,
+          );
           nestedInput.mouseDown = dispatchMouse(
             win,
             "mousedown",
@@ -1070,6 +1237,15 @@ async function testRecognizedGestureNeutralizesStateBeforeAction(): Promise<
         nestedInput.mouseUp,
         "the action should complete its nested input",
       );
+      assert(
+        nestedInput.contextMenu,
+        "the action should synchronously dispatch nested contextmenu",
+      );
+      assertEquals(
+        nestedInput.contextMenu.defaultPrevented,
+        true,
+        "nested contextmenu must stay suppressed while the action is running",
+      );
       assertEquals(
         nestedInput.mouseDown.defaultPrevented,
         false,
@@ -1085,7 +1261,563 @@ async function testRecognizedGestureNeutralizesStateBeforeAction(): Promise<
         true,
         "the triggering drawn mouseup should suppress its follow-up auxclick",
       );
+      assertEquals(
+        harness.pendingTimerCount(),
+        1,
+        "the bounded release timer should start only after the action returns",
+      );
+
+      harness.runAllTimers();
+      assertEquals(
+        dispatchMouse(win, "contextmenu", 2, 0, 0, 0).defaultPrevented,
+        false,
+        "contextmenu suppression should end after the post-action timer",
+      );
     });
+  });
+}
+
+async function testRecognizedGestureSchedulesReleaseAfterThrowingAction(): Promise<
+  void
+> {
+  await withTrackedActions(async (counts) => {
+    await withController({ preventionTimeout: 25 }, (harness) => {
+      const { win } = harness;
+      const originalConsoleError = console.error;
+      gestureActions.registerAction({
+        name: DRAWN_RIGHT_ACTION,
+        fn: () => {
+          counts[DRAWN_RIGHT_ACTION] += 1;
+          throw new Error("intentional gesture-action test failure");
+        },
+      });
+
+      try {
+        // executeGestureAction reports action failures through console.error;
+        // silence this intentionally induced failure within the test only.
+        console.error = () => {};
+        dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+        dispatchDrag(win, 200, 0);
+        const mouseUp = dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+        assertEquals(
+          counts[DRAWN_RIGHT_ACTION],
+          1,
+          "a throwing action should still be invoked exactly once",
+        );
+        assertEquals(
+          mouseUp.defaultPrevented,
+          true,
+          "a throwing action must not escape the gesture mouseup",
+        );
+        assertEquals(
+          harness.pendingTimerCount(),
+          1,
+          "action failure should still arm bounded contextmenu suppression",
+        );
+        assertEquals(
+          dispatchMouse(win, "contextmenu", 2, 0, 0, 0).defaultPrevented,
+          true,
+          "contextmenu should remain suppressed after an action failure",
+        );
+
+        harness.runAllTimers();
+        assertEquals(
+          dispatchMouse(win, "contextmenu", 2, 0, 0, 0).defaultPrevented,
+          false,
+          "suppression after an action failure should remain bounded",
+        );
+      } finally {
+        console.error = originalConsoleError;
+      }
+    });
+  });
+}
+
+async function testRecognizedGestureHandlesTimerFailure(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({ preventionTimeout: 25 }, (harness) => {
+      const { win } = harness;
+      const timerWindow = win as Window & {
+        setTimeout(callback: () => void, delay?: number): number;
+      };
+      const originalSetTimeout = timerWindow.setTimeout;
+      timerWindow.setTimeout = () => {
+        throw new Error("intentional closed-window timer failure");
+      };
+
+      try {
+        dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+        dispatchDrag(win, 200, 0);
+        const mouseUp = dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+        assertEquals(
+          counts[DRAWN_RIGHT_ACTION],
+          1,
+          "timer failure must not prevent the recognized action",
+        );
+        assertEquals(
+          mouseUp.defaultPrevented,
+          true,
+          "timer failure must not escape the gesture mouseup",
+        );
+        assertEquals(
+          harness.pendingTimerCount(),
+          0,
+          "a rejected timer must not leave a phantom pending timeout",
+        );
+        assertEquals(
+          dispatchMouse(win, "contextmenu", 2, 0, 0, 0).defaultPrevented,
+          false,
+          "timer failure must fail open instead of latching contextmenu forever",
+        );
+      } finally {
+        timerWindow.setTimeout = originalSetTimeout;
+      }
+    });
+  });
+}
+
+async function testStaleRockerRecoveryMatrix(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      // rightLeft rocker with both release events lost.
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchMouse(win, "mousedown", 0, 0, 0, 3);
+      const rightLeftFreshLeftDown = dispatchMouse(
+        win,
+        "mousedown",
+        0,
+        0,
+        0,
+        1,
+      );
+      const rightLeftFreshLeftUp = dispatchMouse(
+        win,
+        "mouseup",
+        0,
+        0,
+        0,
+        0,
+      );
+      const rightLeftContextMenu = dispatchMouse(
+        win,
+        "contextmenu",
+        0,
+        0,
+        0,
+        0,
+      );
+
+      assertEquals(
+        counts[ROCKER_RIGHT_LEFT_ACTION],
+        1,
+        "stale rightLeft state must not repeat Back on the next left click",
+      );
+      assertEquals(
+        rightLeftFreshLeftDown.defaultPrevented,
+        false,
+        "fresh left mousedown should clear stale rightLeft state passively",
+      );
+      assertEquals(
+        rightLeftFreshLeftUp.defaultPrevented,
+        false,
+        "fresh left mouseup after stale rightLeft should be passive",
+      );
+      assertEquals(
+        rightLeftContextMenu.defaultPrevented,
+        false,
+        "stale rightLeft recovery should allow keyboard contextmenu",
+      );
+
+      // leftRight rocker with both release events lost.
+      dispatchMouse(win, "mousedown", 0, 0, 0, 1);
+      dispatchMouse(win, "mousedown", 2, 0, 0, 3);
+      const leftRightFreshLeftDown = dispatchMouse(
+        win,
+        "mousedown",
+        0,
+        0,
+        0,
+        1,
+      );
+      const leftRightFreshLeftUp = dispatchMouse(
+        win,
+        "mouseup",
+        0,
+        0,
+        0,
+        0,
+      );
+      const leftRightContextMenu = dispatchMouse(
+        win,
+        "contextmenu",
+        0,
+        0,
+        0,
+        0,
+      );
+
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        1,
+        "stale leftRight state must not repeat Forward on the next left click",
+      );
+      assertEquals(
+        leftRightFreshLeftDown.defaultPrevented,
+        false,
+        "fresh left mousedown should clear stale leftRight state passively",
+      );
+      assertEquals(
+        leftRightFreshLeftUp.defaultPrevented,
+        false,
+        "fresh left mouseup after stale leftRight should be passive",
+      );
+      assertEquals(
+        leftRightContextMenu.defaultPrevented,
+        false,
+        "stale leftRight recovery should allow keyboard contextmenu",
+      );
+    });
+  });
+}
+
+async function testPartialRockerLostReleaseMatrix(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({ preventionTimeout: 25 }, (harness) => {
+      const { win } = harness;
+
+      // leftRight: the right mouseup is lost, but the left button remains
+      // physically held. Ownership must persist until the final left mouseup.
+      dispatchMouse(win, "mousedown", 0, 0, 0, 1);
+      dispatchMouse(win, "mousedown", 2, 0, 0, 3);
+      const leftRightMove = dispatchMouse(
+        win,
+        "mousemove",
+        0,
+        20,
+        0,
+        1,
+      );
+      const leftRightContextWhileHeld = dispatchMouse(
+        win,
+        "contextmenu",
+        2,
+        0,
+        0,
+        1,
+      );
+      const leftRightFinalLeftUp = dispatchMouse(
+        win,
+        "mouseup",
+        0,
+        0,
+        0,
+        0,
+      );
+
+      assertEquals(
+        leftRightMove.defaultPrevented,
+        true,
+        "partial leftRight should keep consuming movement while left is held",
+      );
+      assertEquals(
+        leftRightContextWhileHeld.defaultPrevented,
+        true,
+        "partial leftRight should suppress contextmenu while left is held",
+      );
+      assertEquals(
+        leftRightFinalLeftUp.defaultPrevented,
+        false,
+        "leftRight final left mouseup must reach native selection cleanup",
+      );
+      assertEquals(
+        leftRightFinalLeftUp.clickEventPrevented(),
+        true,
+        "forwarded leftRight final mouseup must not synthesize a click",
+      );
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        1,
+        "partial leftRight cleanup must not repeat its action",
+      );
+      harness.runAllTimers();
+      assertEquals(
+        dispatchMouse(win, "contextmenu", 0, 0, 0, 0).defaultPrevented,
+        false,
+        "leftRight state should be clear after its bounded suppression",
+      );
+
+      // rightLeft: the same lost right mouseup ends on a left mouseup whose
+      // own mousedown was prevented, so that final event remains suppressed.
+      dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+      dispatchMouse(win, "mousedown", 0, 0, 0, 3);
+      const rightLeftFinalLeftUp = dispatchMouse(
+        win,
+        "mouseup",
+        0,
+        0,
+        0,
+        0,
+      );
+
+      assertEquals(
+        rightLeftFinalLeftUp.defaultPrevented,
+        true,
+        "rightLeft final left mouseup should remain suppressed",
+      );
+      assertEquals(
+        rightLeftFinalLeftUp.clickEventPrevented(),
+        true,
+        "rightLeft final left mouseup should suppress its click",
+      );
+      assertEquals(
+        counts[ROCKER_RIGHT_LEFT_ACTION],
+        1,
+        "partial rightLeft cleanup must not repeat Back",
+      );
+      harness.runAllTimers();
+      assertEquals(
+        dispatchMouse(win, "contextmenu", 0, 0, 0, 0).defaultPrevented,
+        false,
+        "rightLeft state should be clear after its bounded suppression",
+      );
+    });
+  });
+}
+
+async function testLeftRightRockerRepeatsWhileLeftAnchorHeld(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController(
+      {
+        preventionTimeout: 25,
+        rockerActions: {
+          leftRight: NEXT_TAB_ACTION,
+          rightLeft: ROCKER_RIGHT_LEFT_ACTION,
+        },
+      },
+      (harness) => {
+        const { win } = harness;
+        const leftDown = dispatchMouse(win, "mousedown", 0, 0, 0, 1);
+        const firstRightDown = dispatchMouse(
+          win,
+          "mousedown",
+          2,
+          0,
+          0,
+          3,
+        );
+        const firstRightUp = dispatchMouse(
+          win,
+          "mouseup",
+          2,
+          0,
+          0,
+          1,
+        );
+        const secondRightDown = dispatchMouse(
+          win,
+          "mousedown",
+          2,
+          0,
+          0,
+          3,
+        );
+        const secondRightUp = dispatchMouse(
+          win,
+          "mouseup",
+          2,
+          0,
+          0,
+          1,
+        );
+        const finalLeftUp = dispatchMouse(
+          win,
+          "mouseup",
+          0,
+          0,
+          0,
+          0,
+        );
+
+        assertEquals(
+          leftDown.defaultPrevented,
+          false,
+          "left anchor mousedown should remain native",
+        );
+        for (const rightDown of [firstRightDown, secondRightDown]) {
+          assertEquals(
+            rightDown.defaultPrevented,
+            true,
+            "each right press should complete and consume leftRight rocker",
+          );
+          assertEquals(
+            rightDown.clickEventPrevented(),
+            true,
+            "each right press should suppress its auxclick",
+          );
+        }
+        for (const rightUp of [firstRightUp, secondRightUp]) {
+          assertEquals(
+            rightUp.defaultPrevented,
+            true,
+            "each right release should remain owned by leftRight rocker",
+          );
+          assertEquals(
+            rightUp.clickEventPrevented(),
+            true,
+            "each right release should suppress its auxclick",
+          );
+        }
+        assertEquals(
+          finalLeftUp.defaultPrevented,
+          false,
+          "final left release should reach native anchor cleanup",
+        );
+        assertEquals(
+          finalLeftUp.clickEventPrevented(),
+          true,
+          "final left release should not synthesize a click",
+        );
+        assertEquals(
+          counts[NEXT_TAB_ACTION],
+          2,
+          "leftRight should fire once for each right press",
+        );
+        assertEquals(
+          counts[DRAWN_RIGHT_ACTION],
+          0,
+          "repeated leftRight must not leak into drawn gesture recognition",
+        );
+
+        harness.runAllTimers();
+        assertEquals(
+          dispatchMouse(win, "mousemove", 0, 10, 0, 0).defaultPrevented,
+          false,
+          "leftRight state should be clear after the anchor releases",
+        );
+        assertEquals(
+          dispatchMouse(win, "contextmenu", 0, 0, 0, 0).defaultPrevented,
+          false,
+          "leftRight cleanup should leave contextmenu passive after timeout",
+        );
+      },
+    );
+  });
+}
+
+async function testRightLeftRockerRepeatsWhileRightAnchorHeld(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController(
+      {
+        preventionTimeout: 25,
+        rockerActions: {
+          leftRight: NEXT_TAB_ACTION,
+          rightLeft: ROCKER_RIGHT_LEFT_ACTION,
+        },
+      },
+      (harness) => {
+        const { win } = harness;
+        dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+        const firstLeftDown = dispatchMouse(
+          win,
+          "mousedown",
+          0,
+          0,
+          0,
+          3,
+        );
+        const firstLeftUp = dispatchMouse(
+          win,
+          "mouseup",
+          0,
+          0,
+          0,
+          2,
+        );
+        const secondLeftDown = dispatchMouse(
+          win,
+          "mousedown",
+          0,
+          0,
+          0,
+          3,
+        );
+        const secondLeftUp = dispatchMouse(
+          win,
+          "mouseup",
+          0,
+          0,
+          0,
+          2,
+        );
+        const finalRightUp = dispatchMouse(
+          win,
+          "mouseup",
+          2,
+          0,
+          0,
+          0,
+        );
+
+        for (const leftDown of [firstLeftDown, secondLeftDown]) {
+          assertEquals(
+            leftDown.defaultPrevented,
+            true,
+            "each left press should complete and consume rightLeft rocker",
+          );
+          assertEquals(
+            leftDown.clickEventPrevented(),
+            true,
+            "each left press should suppress its click",
+          );
+        }
+        for (const leftUp of [firstLeftUp, secondLeftUp]) {
+          assertEquals(
+            leftUp.defaultPrevented,
+            true,
+            "each left release should remain owned by rightLeft rocker",
+          );
+          assertEquals(
+            leftUp.clickEventPrevented(),
+            true,
+            "each left release should suppress its click",
+          );
+        }
+        assertEquals(
+          finalRightUp.defaultPrevented,
+          true,
+          "final right release should complete rocker cleanup",
+        );
+        assertEquals(
+          finalRightUp.clickEventPrevented(),
+          true,
+          "final right release should suppress its auxclick",
+        );
+        assertEquals(
+          counts[ROCKER_RIGHT_LEFT_ACTION],
+          2,
+          "rightLeft should fire once for each left press",
+        );
+        assertEquals(
+          counts[DRAWN_RIGHT_ACTION],
+          0,
+          "repeated rightLeft must not leak into drawn gesture recognition",
+        );
+
+        harness.runAllTimers();
+        assertEquals(
+          dispatchMouse(win, "mousemove", 0, 10, 0, 0).defaultPrevented,
+          false,
+          "rightLeft state should be clear after the anchor releases",
+        );
+        assertEquals(
+          dispatchMouse(win, "contextmenu", 0, 0, 0, 0).defaultPrevented,
+          false,
+          "rightLeft cleanup should leave contextmenu passive after timeout",
+        );
+      },
+    );
   });
 }
 
@@ -1171,9 +1903,16 @@ async function testMouseDownCaptureSurvivesContentStopPropagation(): Promise<
       // pass every other assertion here, since rocker detection itself only
       // depends on mousedown - this is what actually exercises capture-phase
       // mousemove suppression.
-      const moveWhileHeld = dispatchMouseFrom(contentEl, "mousemove", 0, 5, 0);
-      dispatchMouseFrom(contentEl, "mouseup", 2);
-      dispatchMouseFrom(contentEl, "mouseup", 0);
+      const moveWhileHeld = dispatchMouseFrom(
+        contentEl,
+        "mousemove",
+        0,
+        5,
+        0,
+        3,
+      );
+      dispatchMouseFrom(contentEl, "mouseup", 2, 0, 0, 1);
+      dispatchMouseFrom(contentEl, "mouseup", 0, 0, 0, 0);
 
       assertEquals(
         counts[ROCKER_RIGHT_LEFT_ACTION],
@@ -1383,6 +2122,10 @@ const tests: TestCase[] = [
     fn: testNewRightClickRecoversFromLostMouseUp,
   },
   {
+    name: "lost wheel release recovery follows physical buttons",
+    fn: testLostWheelReleaseRecoveryMatrix,
+  },
+  {
     name: "blur clears a wheel gesture whose mouseup was lost",
     fn: testBlurClearsWheelGestureWithLostMouseUp,
   },
@@ -1429,6 +2172,30 @@ const tests: TestCase[] = [
   {
     name: "recognized gesture neutralizes state before action",
     fn: testRecognizedGestureNeutralizesStateBeforeAction,
+  },
+  {
+    name: "recognized gesture schedules release after a throwing action",
+    fn: testRecognizedGestureSchedulesReleaseAfterThrowingAction,
+  },
+  {
+    name: "recognized gesture handles timer failure",
+    fn: testRecognizedGestureHandlesTimerFailure,
+  },
+  {
+    name: "stale rocker recovery follows physical buttons",
+    fn: testStaleRockerRecoveryMatrix,
+  },
+  {
+    name: "partial rocker lost-release cleanup follows physical buttons",
+    fn: testPartialRockerLostReleaseMatrix,
+  },
+  {
+    name: "leftRight rocker repeats while the left anchor is held",
+    fn: testLeftRightRockerRepeatsWhileLeftAnchorHeld,
+  },
+  {
+    name: "rightLeft rocker repeats while the right anchor is held",
+    fn: testRightLeftRockerRepeatsWhileRightAnchorHeld,
   },
   {
     name: "rocker gesture consumes mousemove while held",

--- a/tools/src/mouse_gesture_drawn_w3c_e2e.ts
+++ b/tools/src/mouse_gesture_drawn_w3c_e2e.ts
@@ -1,0 +1,533 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { MarionetteClient } from "./browser_connector.ts";
+
+const ENABLED_PREF = "floorp.mousegesture.enabled";
+const CONFIG_PREF = "floorp.mousegesture.config";
+const STATE_KEY = "__floorpMouseGestureDrawnE2EState";
+const POINTER_ID = "floorp-drawn-e2e-mouse";
+
+type PointerStep =
+  | { type: "pointerDown" | "pointerUp"; button: number }
+  | {
+    type: "pointerMove";
+    duration: number;
+    origin: "viewport";
+    x: number;
+    y: number;
+  };
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface PageState {
+  counts: Record<string, number>;
+  events: Array<{
+    type: string;
+    button: number;
+    buttons: number;
+    defaultPrevented: boolean;
+  }>;
+}
+
+interface BrowserSetup {
+  baselineZoom: number;
+  oneStepZoom: number;
+  twoStepZoom: number;
+  browserRect: Rect;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function extractHandle(response: unknown): string {
+  if (typeof response === "string") {
+    return response;
+  }
+  if (response && typeof response === "object") {
+    const record = response as Record<string, unknown>;
+    if (typeof record.handle === "string") {
+      return record.handle;
+    }
+    if (typeof record.value === "string") {
+      return record.value;
+    }
+  }
+  throw new Error(
+    `Marionette did not return a window handle: ${JSON.stringify(response)}`,
+  );
+}
+
+const client = await MarionetteClient.connect();
+let originalHandle: string | null = null;
+let testHandle: string | null = null;
+
+async function performPointerSequence(
+  x: number,
+  y: number,
+  steps: PointerStep[],
+): Promise<void> {
+  await client.setContext("chrome");
+  try {
+    await client.send("WebDriver:PerformActions", {
+      actions: [
+        {
+          type: "pointer",
+          id: POINTER_ID,
+          parameters: { pointerType: "mouse" },
+          actions: [
+            {
+              type: "pointerMove",
+              duration: 0,
+              origin: "viewport",
+              x,
+              y,
+            },
+            ...steps,
+          ],
+        },
+      ],
+    });
+  } finally {
+    await client.send("WebDriver:ReleaseActions", {});
+  }
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+function dragSteps(
+  startX: number,
+  startY: number,
+  deltaX: number,
+  deltaY: number,
+): PointerStep[] {
+  const steps: PointerStep[] = [{ type: "pointerDown", button: 2 }];
+  for (let index = 1; index <= 12; index++) {
+    steps.push({
+      type: "pointerMove",
+      duration: 8,
+      origin: "viewport",
+      x: startX + Math.round((deltaX * index) / 12),
+      y: startY + Math.round((deltaY * index) / 12),
+    });
+  }
+  steps.push({ type: "pointerUp", button: 2 });
+  return steps;
+}
+
+async function resetPageState(): Promise<void> {
+  await client.setContext("content");
+  await client.executeScript(`
+    window.__floorpDrawnE2E.counts = {
+      mousedown: 0,
+      mousemove: 0,
+      mouseup: 0,
+      click: 0,
+      auxclick: 0,
+      dblclick: 0,
+      contextmenu: 0,
+    };
+    window.__floorpDrawnE2E.events = [];
+  `);
+}
+
+async function readPageState(): Promise<PageState> {
+  await client.setContext("content");
+  const raw = await client.executeScript(`
+    return JSON.stringify(window.__floorpDrawnE2E);
+  `);
+  return JSON.parse(raw) as PageState;
+}
+
+async function readZoom(): Promise<number> {
+  await client.setContext("chrome");
+  return await client.executeScript(`return ZoomManager.zoom;`) as number;
+}
+
+async function resetZoom(): Promise<number> {
+  await client.setContext("chrome");
+  await client.executeScript(`FullZoom.reset();`);
+  return await readZoom();
+}
+
+function assertNoClickLikeEvents(state: PageState, label: string): void {
+  for (const type of ["click", "auxclick", "dblclick", "contextmenu"]) {
+    assert(
+      state.counts[type] === 0,
+      `${label}: expected zero ${type} events, got ${state.counts[type]}: ${
+        JSON.stringify(state.events)
+      }`,
+    );
+  }
+}
+
+async function assertOrdinaryLeftClick(
+  x: number,
+  y: number,
+  label: string,
+): Promise<void> {
+  await resetPageState();
+  await performPointerSequence(x, y, [
+    { type: "pointerDown", button: 0 },
+    { type: "pointerUp", button: 0 },
+  ]);
+  const state = await readPageState();
+  assert(
+    state.counts.mousedown === 1 && state.counts.mouseup === 1,
+    `${label}: ordinary left down/up did not reach content: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assert(
+    state.counts.click === 1 &&
+      state.counts.auxclick === 0 &&
+      state.counts.dblclick === 0 &&
+      state.counts.contextmenu === 0,
+    `${label}: ordinary left click produced unexpected events: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+}
+
+async function assertOrdinaryRightClick(
+  x: number,
+  y: number,
+  label: string,
+): Promise<void> {
+  await resetPageState();
+  await performPointerSequence(x, y, [
+    { type: "pointerDown", button: 2 },
+    { type: "pointerUp", button: 2 },
+  ]);
+  const state = await readPageState();
+  assert(
+    state.counts.mousedown === 1 && state.counts.mouseup === 1,
+    `${label}: ordinary right down/up did not reach content: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assert(
+    state.counts.auxclick === 1,
+    `${label}: expected one ordinary auxclick, got ${state.counts.auxclick}: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assert(
+    state.counts.click === 0 &&
+      state.counts.dblclick === 0 &&
+      state.counts.contextmenu <= 1,
+    `${label}: ordinary right click produced an unexpected primary click: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+}
+
+async function assertRecognizedRightGesture(
+  x: number,
+  y: number,
+  setup: BrowserSetup,
+): Promise<void> {
+  await resetPageState();
+  const zoomBefore = await resetZoom();
+  assert(
+    zoomBefore === setup.baselineZoom,
+    `recognized right: failed to reset zoom to ${setup.baselineZoom}, got ${zoomBefore}`,
+  );
+
+  await performPointerSequence(x, y, dragSteps(x, y, 120, 0));
+
+  const state = await readPageState();
+  const zoomAfter = await readZoom();
+  assert(
+    zoomAfter === setup.oneStepZoom,
+    `recognized right: action must execute exactly once; expected zoom ${setup.oneStepZoom}, got ${zoomAfter} (two steps would be ${setup.twoStepZoom})`,
+  );
+  assert(
+    state.counts.mousedown === 1 && state.counts.mousemove >= 3,
+    `recognized right: pointer drag did not reach content: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assertNoClickLikeEvents(state, "recognized right");
+}
+
+async function assertUnrecognizedDownGesture(
+  x: number,
+  y: number,
+  setup: BrowserSetup,
+): Promise<void> {
+  await resetPageState();
+  const zoomBefore = await resetZoom();
+  assert(
+    zoomBefore === setup.baselineZoom,
+    `unrecognized down: failed to reset zoom to ${setup.baselineZoom}, got ${zoomBefore}`,
+  );
+
+  // Only the simple "right" pattern is configured. A straight downward trail
+  // is therefore deterministically unrecognized and cannot fall back to a
+  // complex $1 template.
+  await performPointerSequence(x, y, dragSteps(x, y, 0, 120));
+
+  const state = await readPageState();
+  const zoomAfter = await readZoom();
+  assert(
+    zoomAfter === setup.baselineZoom,
+    `unrecognized down: no action should run; expected zoom ${setup.baselineZoom}, got ${zoomAfter}`,
+  );
+  assert(
+    state.counts.mousedown === 1 && state.counts.mousemove >= 3,
+    `unrecognized down: pointer drag did not reach content: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assertNoClickLikeEvents(state, "unrecognized down");
+}
+
+let failure: unknown = null;
+
+try {
+  originalHandle = extractHandle(
+    await client.send("WebDriver:GetWindowHandle", {}),
+  );
+  testHandle = extractHandle(
+    await client.send("WebDriver:NewWindow", { type: "tab" }),
+  );
+  await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+
+  await client.setContext("chrome");
+  const setup = JSON.parse(
+    await client.executeScript(`
+      const enabledPref = ${JSON.stringify(ENABLED_PREF)};
+      const configPref = ${JSON.stringify(CONFIG_PREF)};
+      const stateKey = ${JSON.stringify(STATE_KEY)};
+
+      const originalConfig = Services.prefs.getStringPref(configPref, "");
+      if (!originalConfig) {
+        throw new Error("Mouse gesture config pref is empty");
+      }
+      window[stateKey] = {
+        originalZoom: ZoomManager.zoom,
+        hadEnabledUserValue: Services.prefs.prefHasUserValue(enabledPref),
+        originalEnabled: Services.prefs.getBoolPref(enabledPref, false),
+        hadConfigUserValue: Services.prefs.prefHasUserValue(configPref),
+        originalConfig,
+      };
+
+      const config = JSON.parse(originalConfig);
+      config.enabled = true;
+      config.rockerGesturesEnabled = false;
+      config.wheelGesturesEnabled = false;
+      config.sensitivity = 100;
+      config.showTrail = false;
+      config.showLabel = false;
+      config.contextMenu = {
+        ...(config.contextMenu ?? {}),
+        minDistance: 5,
+        preventionTimeout: 200,
+      };
+      config.actions = [
+        { pattern: ["right"], action: "gecko-zoom-in" },
+      ];
+      Services.prefs.setStringPref(configPref, JSON.stringify(config));
+      Services.prefs.setBoolPref(enabledPref, true);
+
+      FullZoom.reset();
+      const baselineZoom = ZoomManager.zoom;
+      FullZoom.enlarge();
+      const oneStepZoom = ZoomManager.zoom;
+      FullZoom.enlarge();
+      const twoStepZoom = ZoomManager.zoom;
+      FullZoom.reset();
+      const rect = gBrowser.selectedBrowser.getBoundingClientRect();
+      return JSON.stringify({
+        baselineZoom,
+        oneStepZoom,
+        twoStepZoom,
+        browserRect: {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+        },
+      });
+    `),
+  ) as BrowserSetup;
+  assert(
+    setup.oneStepZoom !== setup.baselineZoom &&
+      setup.twoStepZoom !== setup.oneStepZoom,
+    `Zoom action precondition failed: ${
+      JSON.stringify({
+        baseline: setup.baselineZoom,
+        oneStep: setup.oneStepZoom,
+        twoSteps: setup.twoStepZoom,
+      })
+    }`,
+  );
+
+  await client.setContext("content");
+  const fixture = `<!doctype html>
+    <meta charset="utf-8">
+    <style>
+      body { margin: 30px; }
+      #target { width: 480px; height: 360px; font-size: 24px; }
+    </style>
+    <button id="target">Drawn gesture target</button>
+    <script>
+      window.__floorpDrawnE2E = { counts: {}, events: [] };
+      for (const type of ["mousedown", "mousemove", "mouseup", "click", "auxclick", "dblclick", "contextmenu"]) {
+        document.addEventListener(type, (event) => {
+          window.__floorpDrawnE2E.counts[type] =
+            (window.__floorpDrawnE2E.counts[type] ?? 0) + 1;
+          window.__floorpDrawnE2E.events.push({
+            type: event.type,
+            button: event.button,
+            buttons: event.buttons,
+            defaultPrevented: event.defaultPrevented,
+          });
+          if (type === "contextmenu") {
+            event.preventDefault();
+          }
+        }, true);
+      }
+    </script>`;
+  await client.navigate(
+    `data:text/html;charset=utf-8,${encodeURIComponent(fixture)}`,
+  );
+  const targetRect = await client.executeScript(`
+    const rect = document.querySelector("#target").getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  `) as Rect;
+  const x = Math.round(
+    setup.browserRect.x + targetRect.x + targetRect.width / 2,
+  );
+  const y = Math.round(
+    setup.browserRect.y + targetRect.y + targetRect.height / 2,
+  );
+  assert(
+    x >= setup.browserRect.x &&
+      x + 120 < setup.browserRect.x + setup.browserRect.width &&
+      y >= setup.browserRect.y &&
+      y + 120 < setup.browserRect.y + setup.browserRect.height,
+    `Gesture coordinates from (${x}, ${y}) are outside the browser viewport ${
+      JSON.stringify(setup.browserRect)
+    }`,
+  );
+
+  console.log(
+    `Mouse gesture drawn W3C target: ${
+      JSON.stringify({
+        browserRect: setup.browserRect,
+        targetRect,
+        x,
+        y,
+      })
+    }`,
+  );
+
+  await assertOrdinaryRightClick(x, y, "ordinary right click before gestures");
+  await assertRecognizedRightGesture(x, y, setup);
+  await assertUnrecognizedDownGesture(x, y, setup);
+  await assertOrdinaryLeftClick(x, y, "ordinary left click after gestures");
+  await assertOrdinaryRightClick(x, y, "ordinary right click after gestures");
+
+  console.log("Mouse gesture drawn W3C E2E passed");
+} catch (error) {
+  failure = error;
+}
+
+const cleanupErrors: unknown[] = [];
+try {
+  await client.send("WebDriver:ReleaseActions", {});
+} catch (error) {
+  cleanupErrors.push(error);
+}
+
+let testHandleSelected = false;
+if (testHandle) {
+  try {
+    await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+    testHandleSelected = true;
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+
+  if (testHandleSelected) {
+    try {
+      await client.setContext("chrome");
+      await client.executeScript(`
+        const enabledPref = ${JSON.stringify(ENABLED_PREF)};
+        const configPref = ${JSON.stringify(CONFIG_PREF)};
+        const stateKey = ${JSON.stringify(STATE_KEY)};
+        const state = window[stateKey];
+        if (state) {
+          if (state.hadConfigUserValue) {
+            Services.prefs.setStringPref(configPref, state.originalConfig);
+          } else if (Services.prefs.prefHasUserValue(configPref)) {
+            Services.prefs.clearUserPref(configPref);
+          }
+          if (state.hadEnabledUserValue) {
+            Services.prefs.setBoolPref(enabledPref, state.originalEnabled);
+          } else if (Services.prefs.prefHasUserValue(enabledPref)) {
+            Services.prefs.clearUserPref(enabledPref);
+          }
+          ZoomManager.zoom = state.originalZoom;
+
+          if (
+            Services.prefs.prefHasUserValue(configPref) !==
+              state.hadConfigUserValue ||
+            Services.prefs.getStringPref(configPref, "") !==
+              state.originalConfig ||
+            Services.prefs.prefHasUserValue(enabledPref) !==
+              state.hadEnabledUserValue ||
+            Services.prefs.getBoolPref(enabledPref, false) !==
+              state.originalEnabled ||
+            ZoomManager.zoom !== state.originalZoom
+          ) {
+            throw new Error("Mouse gesture E2E state restoration mismatch");
+          }
+          delete window[stateKey];
+        }
+      `);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+
+    // Closing the disposable tab is attempted even if state restoration fails.
+    try {
+      await client.send("WebDriver:CloseWindow", {});
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+}
+
+if (originalHandle) {
+  try {
+    await client.send("WebDriver:SwitchToWindow", {
+      handle: originalHandle,
+    });
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+}
+
+await client.close();
+
+if (failure !== null) {
+  if (cleanupErrors.length > 0) {
+    console.error("Mouse gesture drawn E2E cleanup errors:", cleanupErrors);
+  }
+  throw failure;
+}
+if (cleanupErrors.length > 0) {
+  throw new AggregateError(
+    cleanupErrors,
+    "Mouse gesture drawn E2E cleanup failed",
+  );
+}


### PR DESCRIPTION
Closing multiple tabs with gestures, especially if some of the tabs in the chain were internal, was subject to glitches.
Additionally actions were delayed explicitly in the code, this made the browser feel a bit sluggish when using gestures. I'm not sure if this was entirely intentional, or added early on and left over with no real purpose. If that's something you'd like to keep can we make it configurable or only add when displaying the trail and/or label?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mouse gestures now execute immediately when the mouse button is released, improving responsiveness.
  * Prevented unintended gesture interruptions when the browser window remains active.
  * Improved recovery from stale drawn, rocker, and wheel gesture states.
  * Improved handling of mouseup events and context menus after gestures.
  * Prevented unintended clicks and page actions after recognized or unrecognized gestures.
  * Improved reliability when closing windows or when gesture actions encounter errors.
  * Reset stale gesture state when starting a new right-button gesture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->