### PR TITLE
Fixes for rockers - selection and context menu glitches

### DIFF
--- a/.github/workflows/colocated_runner_test.yml
+++ b/.github/workflows/colocated_runner_test.yml
@@ -348,6 +348,10 @@ jobs:
           fi
 
           wait "$TEST_PID"
+          deno run \
+            --allow-net=127.0.0.1 \
+            --allow-read=_dist \
+            tools/src/mouse_gesture_rocker_w3c_e2e.ts
 
       - name: Verify downloaded Firefox execution coverage
         if: matrix.browser_suite == true

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -285,6 +285,13 @@ export class MouseGestureController {
     return { x: event.clientX, y: event.clientY };
   }
 
+  private preventFollowingClick(event: MouseEvent): void {
+    const geckoEvent = event as MouseEvent & {
+      preventClickEvent?: () => void;
+    };
+    geckoEvent.preventClickEvent?.();
+  }
+
   private handleMouseDown = (event: MouseEvent): void => {
     if (!isEnabled()) {
       this.resetDisabledState();
@@ -326,6 +333,7 @@ export class MouseGestureController {
       }
 
       if (action) {
+        this.preventFollowingClick(event);
         executeGestureAction(action, this.targetWindow);
         event.preventDefault();
         event.stopPropagation();
@@ -455,6 +463,8 @@ export class MouseGestureController {
 
     // Handle rocker gesture cleanup
     if (this.isRockerGestureFired) {
+      this.preventFollowingClick(event);
+
       // For a leftRight rocker (left pressed first), the left mousedown is
       // never prevented - a lone left click must still behave normally - so
       // the browser already started real native selection-drag tracking on

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -56,11 +56,22 @@ export class MouseGestureController {
       return;
     }
 
-    this.targetWindow.addEventListener("mousedown", this.handleMouseDown);
-    this.targetWindow.addEventListener("mousemove", this.handleMouseMove);
-    // Capture-phase mouseup: content scripts (e.g. video players) may call
-    // stopPropagation() on mouseup, which would prevent the wheel-gesture
-    // cleanup / context-menu suppression from starting (Floorp issue #2586).
+    // Capture-phase mousedown/mousemove/mouseup: content scripts (e.g. video
+    // players, or any page that stops propagation on its own mouse handlers)
+    // may call stopPropagation(), which would otherwise prevent rocker- and
+    // drawn-gesture detection from ever running, and would prevent the
+    // wheel-gesture cleanup / context-menu suppression from starting
+    // (Floorp issue #2586).
+    this.targetWindow.addEventListener(
+      "mousedown",
+      this.handleMouseDown,
+      true,
+    );
+    this.targetWindow.addEventListener(
+      "mousemove",
+      this.handleMouseMove,
+      true,
+    );
     this.targetWindow.addEventListener("mouseup", this.handleMouseUp, true);
     this.targetWindow.addEventListener(
       "contextmenu",
@@ -83,8 +94,16 @@ export class MouseGestureController {
 
   public destroy(): void {
     if (this.eventListenersAttached) {
-      this.targetWindow.removeEventListener("mousedown", this.handleMouseDown);
-      this.targetWindow.removeEventListener("mousemove", this.handleMouseMove);
+      this.targetWindow.removeEventListener(
+        "mousedown",
+        this.handleMouseDown,
+        true,
+      );
+      this.targetWindow.removeEventListener(
+        "mousemove",
+        this.handleMouseMove,
+        true,
+      );
       this.targetWindow.removeEventListener(
         "mouseup",
         this.handleMouseUp,
@@ -338,6 +357,18 @@ export class MouseGestureController {
       return;
     }
 
+    // A rocker action already owns this button cycle. Left unhandled, these
+    // movement events pass straight through to the page and let its native
+    // text-selection drag keep extending for as long as both buttons stay
+    // down (visibly so if the rocker action scrolls the page underneath the
+    // still-held cursor) - selecting the page instead of just running the
+    // gesture.
+    if (this.isRockerGestureFired) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
     // Wheel gestures are discrete and must not fall through to drawn gesture
     // recognition if the pointer moves before the right button is released.
     if (!this.isGestureActive || this.isWheelGestureFired) return;
@@ -430,8 +461,17 @@ export class MouseGestureController {
           getConfig().contextMenu.preventionTimeout,
         );
       }
-      event.preventDefault();
-      event.stopPropagation();
+      // The left button's own mousedown is never prevented (a lone left
+      // click must still behave normally), so for a leftRight rocker the
+      // browser already started real native selection-drag tracking on
+      // press. That tracking only ends once the page actually receives the
+      // matching left mouseup - swallowing it here like every other button
+      // leaves the page thinking the button is still held, with selection
+      // mode stuck "on" until an unrelated future left click resets it.
+      if (event.button !== 0) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       return;
     }
 

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -455,20 +455,26 @@ export class MouseGestureController {
 
     // Handle rocker gesture cleanup
     if (this.isRockerGestureFired) {
+      // For a leftRight rocker (left pressed first), the left mousedown is
+      // never prevented - a lone left click must still behave normally - so
+      // the browser already started real native selection-drag tracking on
+      // press. That tracking only ends once the page actually receives the
+      // matching left mouseup, so it must be let through. `isGestureActive`
+      // is exactly the signal for which case this is: it's still true here
+      // only for a rightLeft rocker (right pressed first, which does start
+      // the normal drawn-gesture path), where the left mousedown *was*
+      // already prevented when it completed the combo - so unlike leftRight,
+      // there's no unblocked native default for that mouseup to terminate,
+      // and it should stay suppressed like every other button. Captured
+      // before resetGestureState() below clears it.
+      const shouldSuppressMouseUp = event.button !== 0 || this.isGestureActive;
       if (this.pressedButtons.size === 0) {
         this.resetGestureState();
         this.scheduleContextMenuPreventionRelease(
           getConfig().contextMenu.preventionTimeout,
         );
       }
-      // The left button's own mousedown is never prevented (a lone left
-      // click must still behave normally), so for a leftRight rocker the
-      // browser already started real native selection-drag tracking on
-      // press. That tracking only ends once the page actually receives the
-      // matching left mouseup - swallowing it here like every other button
-      // leaves the page thinking the button is still held, with selection
-      // mode stuck "on" until an unrelated future left click resets it.
-      if (event.button !== 0) {
+      if (shouldSuppressMouseUp) {
         event.preventDefault();
         event.stopPropagation();
       }

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -769,6 +769,7 @@ async function testRockerGestureConsumesMouseMoveWhileHeld(): Promise<void> {
       // Releasing only the right button doesn't end the cycle - the left
       // button is still physically held, so movement must stay consumed.
       dispatchMouse(win, "mouseup", 2);
+      const moveAfterRightRelease = dispatchMouse(win, "mousemove", 0, 55, 0);
       dispatchMouse(win, "mouseup", 0);
       const moveAfterRelease = dispatchMouse(win, "mousemove", 0, 60, 0);
 
@@ -782,6 +783,12 @@ async function testRockerGestureConsumesMouseMoveWhileHeld(): Promise<void> {
         true,
         "mousemove while a rocker action is active must not leak through " +
           "to the page (it would extend a native selection drag)",
+      );
+      assertEquals(
+        moveAfterRightRelease.defaultPrevented,
+        true,
+        "mousemove must stay consumed after only the right button releases " +
+          "- the left button is still held, so the cycle isn't over yet",
       );
       assertEquals(
         moveAfterRelease.defaultPrevented,
@@ -810,9 +817,18 @@ async function testMouseDownCaptureSurvivesContentStopPropagation(): Promise<
       contentEl.addEventListener("mousedown", (event) => {
         event.stopPropagation();
       });
+      contentEl.addEventListener("mousemove", (event) => {
+        event.stopPropagation();
+      });
 
       dispatchMouseFrom(contentEl, "mousedown", 2);
       dispatchMouseFrom(contentEl, "mousedown", 0);
+      // Content also stops propagation on its own mousemove. A regression
+      // that moved the mousemove listener back to bubble phase would still
+      // pass every other assertion here, since rocker detection itself only
+      // depends on mousedown - this is what actually exercises capture-phase
+      // mousemove suppression.
+      const moveWhileHeld = dispatchMouseFrom(contentEl, "mousemove", 0, 5, 0);
       dispatchMouseFrom(contentEl, "mouseup", 2);
       dispatchMouseFrom(contentEl, "mouseup", 0);
 
@@ -821,6 +837,12 @@ async function testMouseDownCaptureSurvivesContentStopPropagation(): Promise<
         1,
         "rocker gesture should still be detected even when content stops " +
           "propagation on its own mousedown",
+      );
+      assertEquals(
+        moveWhileHeld.defaultPrevented,
+        true,
+        "mousemove while a rocker action is active should stay consumed " +
+          "even when content stops propagation on its own mousemove",
       );
     });
   });
@@ -863,6 +885,49 @@ async function testLeftRightRockerLetsLeftMouseUpThrough(): Promise<void> {
         counts[DRAWN_RIGHT_ACTION],
         1,
         "leftRight rocker action should fire once",
+      );
+    });
+  });
+}
+
+async function testRightLeftRockerSuppressesLeftMouseUp(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      // Mirror of the leftRight case above, but for the opposite order:
+      // right pressed first starts the normal drawn-gesture path (also
+      // unprevented, but right-click doesn't anchor a native selection
+      // drag), and the left mousedown that completes the combo *is*
+      // prevented. Unlike leftRight, there's no unblocked native default
+      // here for the left mouseup to terminate, so it should stay
+      // suppressed like every other button in this cleanup path - letting
+      // it through would leave the page with an unmatched mouseup that
+      // never had a corresponding unprevented mousedown.
+      dispatchMouse(win, "mousedown", 2);
+      const leftMouseDown = dispatchMouse(win, "mousedown", 0);
+      const rightMouseUp = dispatchMouse(win, "mouseup", 2);
+      const leftMouseUp = dispatchMouse(win, "mouseup", 0);
+
+      assertEquals(
+        leftMouseDown.defaultPrevented,
+        true,
+        "the rocker-completing mousedown should be consumed",
+      );
+      assertEquals(
+        rightMouseUp.defaultPrevented,
+        true,
+        "the right button's mouseup should stay consumed",
+      );
+      assertEquals(
+        leftMouseUp.defaultPrevented,
+        true,
+        "the left button's mouseup should stay consumed too - its own " +
+          "mousedown was already prevented, so there's no native default " +
+          "left to terminate",
+      );
+      assertEquals(
+        counts[ROCKER_RIGHT_LEFT_ACTION],
+        1,
+        "rightLeft rocker action should fire once",
       );
     });
   });
@@ -936,6 +1001,10 @@ const tests: TestCase[] = [
   {
     name: "leftRight rocker lets the left mouseup through",
     fn: testLeftRightRockerLetsLeftMouseUpThrough,
+  },
+  {
+    name: "rightLeft rocker suppresses the left mouseup",
+    fn: testRightLeftRockerSuppressesLeftMouseUp,
   },
 ];
 

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -859,10 +859,17 @@ async function testLeftRightRockerLetsLeftMouseUpThrough(): Promise<void> {
       // mouseup indiscriminately, the page would never find out the left
       // button was released, leaving native selection mode stuck "on" -
       // even with zero mouse movement during the whole sequence.
-      dispatchMouse(win, "mousedown", 0);
+      const leftMouseDown = dispatchMouse(win, "mousedown", 0);
       const rightMouseDown = dispatchMouse(win, "mousedown", 2);
       const rightMouseUp = dispatchMouse(win, "mouseup", 2);
       const leftMouseUp = dispatchMouse(win, "mouseup", 0);
+
+      assertEquals(
+        leftMouseDown.clickEventPrevented(),
+        false,
+        "the ordinary left mousedown must not suppress its click before a " +
+          "rocker is confirmed",
+      );
 
       assertEquals(
         rightMouseDown.defaultPrevented,
@@ -876,15 +883,55 @@ async function testLeftRightRockerLetsLeftMouseUpThrough(): Promise<void> {
           "context menu)",
       );
       assertEquals(
+        rightMouseDown.clickEventPrevented(),
+        true,
+        "the rocker-completing mousedown should suppress its auxclick",
+      );
+      assertEquals(
+        rightMouseUp.clickEventPrevented(),
+        true,
+        "the rocker-owned right mouseup should suppress its auxclick",
+      );
+      assertEquals(
         leftMouseUp.defaultPrevented,
         false,
         "the left button's own mouseup must reach the page so native " +
           "selection-drag tracking can terminate",
       );
       assertEquals(
+        leftMouseUp.clickEventPrevented(),
+        true,
+        "the forwarded left mouseup must not synthesize a page click",
+      );
+      assertEquals(
         counts[DRAWN_RIGHT_ACTION],
         1,
         "leftRight rocker action should fire once",
+      );
+
+      const nextLeftMouseDown = dispatchMouse(win, "mousedown", 0);
+      const nextLeftMouseUp = dispatchMouse(win, "mouseup", 0);
+      const nextRightMouseDown = dispatchMouse(win, "mousedown", 2);
+      const nextRightMouseUp = dispatchMouse(win, "mouseup", 2);
+      assertEquals(
+        nextLeftMouseDown.clickEventPrevented(),
+        false,
+        "click suppression must not leak into the next left mousedown",
+      );
+      assertEquals(
+        nextLeftMouseUp.clickEventPrevented(),
+        false,
+        "click suppression must not leak into the next left mouseup",
+      );
+      assertEquals(
+        nextRightMouseDown.clickEventPrevented(),
+        false,
+        "click suppression must not leak into the next right mousedown",
+      );
+      assertEquals(
+        nextRightMouseUp.clickEventPrevented(),
+        false,
+        "click suppression must not leak into the next right mouseup",
       );
     });
   });
@@ -902,10 +949,17 @@ async function testRightLeftRockerSuppressesLeftMouseUp(): Promise<void> {
       // suppressed like every other button in this cleanup path - letting
       // it through would leave the page with an unmatched mouseup that
       // never had a corresponding unprevented mousedown.
-      dispatchMouse(win, "mousedown", 2);
+      const rightMouseDown = dispatchMouse(win, "mousedown", 2);
       const leftMouseDown = dispatchMouse(win, "mousedown", 0);
       const rightMouseUp = dispatchMouse(win, "mouseup", 2);
       const leftMouseUp = dispatchMouse(win, "mouseup", 0);
+
+      assertEquals(
+        rightMouseDown.clickEventPrevented(),
+        false,
+        "the ordinary right mousedown must not suppress its click before a " +
+          "rocker is confirmed",
+      );
 
       assertEquals(
         leftMouseDown.defaultPrevented,
@@ -913,9 +967,19 @@ async function testRightLeftRockerSuppressesLeftMouseUp(): Promise<void> {
         "the rocker-completing mousedown should be consumed",
       );
       assertEquals(
+        leftMouseDown.clickEventPrevented(),
+        true,
+        "the rocker-completing left mousedown should suppress its click",
+      );
+      assertEquals(
         rightMouseUp.defaultPrevented,
         true,
         "the right button's mouseup should stay consumed",
+      );
+      assertEquals(
+        rightMouseUp.clickEventPrevented(),
+        true,
+        "the rocker-owned right mouseup should suppress its auxclick",
       );
       assertEquals(
         leftMouseUp.defaultPrevented,
@@ -923,6 +987,11 @@ async function testRightLeftRockerSuppressesLeftMouseUp(): Promise<void> {
         "the left button's mouseup should stay consumed too - its own " +
           "mousedown was already prevented, so there's no native default " +
           "left to terminate",
+      );
+      assertEquals(
+        leftMouseUp.clickEventPrevented(),
+        true,
+        "the rocker-owned left mouseup should suppress its click",
       );
       assertEquals(
         counts[ROCKER_RIGHT_LEFT_ACTION],

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -46,11 +46,12 @@ interface TestConfigOptions {
   preventionTimeout?: number;
 }
 
-function createFakeWindow(): FakeWindowHarness {
-  const eventTarget = new EventTarget();
+function attachTimerShim<T extends EventTarget>(
+  target: T,
+): FakeWindowHarness {
   const timers = new Map<number, () => void>();
   let nextTimerId = 1;
-  const fakeWindow = eventTarget as EventTarget & {
+  const fakeWindow = target as T & {
     setTimeout(callback: () => void, delay?: number): number;
     clearTimeout(timerId?: number): void;
   };
@@ -79,8 +80,26 @@ function createFakeWindow(): FakeWindowHarness {
   };
 }
 
-function dispatchMouse(
-  win: Window,
+function createFakeWindow(): FakeWindowHarness {
+  return attachTimerShim(new EventTarget());
+}
+
+// A bare EventTarget has no ancestor/descendant relationship, so it cannot
+// exercise capture-vs-bubble ordering. This harness uses a real (detached)
+// DOM parent/child pair instead, so a "content" node can stopPropagation()
+// its own mousedown the way a page's own JS might, letting tests verify the
+// window-level listener still runs because it's registered on capture.
+function createFakeWindowWithContent(): FakeWindowHarness & {
+  contentEl: HTMLElement;
+} {
+  const container = document.createElement("div");
+  const contentEl = document.createElement("div");
+  container.appendChild(contentEl);
+  return { ...attachTimerShim(container), contentEl };
+}
+
+function dispatchMouseFrom(
+  target: EventTarget,
   type: "mousedown" | "mouseup" | "mousemove" | "contextmenu",
   button: number,
   clientX = 0,
@@ -95,8 +114,18 @@ function dispatchMouse(
     bubbles: true,
     cancelable: true,
   });
-  win.dispatchEvent(event);
+  target.dispatchEvent(event);
   return event;
+}
+
+function dispatchMouse(
+  win: Window,
+  type: "mousedown" | "mouseup" | "mousemove" | "contextmenu",
+  button: number,
+  clientX = 0,
+  clientY = 0,
+): MouseEvent {
+  return dispatchMouseFrom(win, type, button, clientX, clientY);
 }
 
 function dispatchWheel(win: Window, deltaY: number): WheelEvent {
@@ -205,6 +234,24 @@ async function withTrackedActions(
       }
     }
   }
+}
+
+async function withControllerAndContent(
+  options: TestConfigOptions,
+  fn: (
+    harness: FakeWindowHarness & { contentEl: HTMLElement },
+    controller: MouseGestureController,
+  ) => void | Promise<void>,
+): Promise<void> {
+  await withTestConfig(options, async () => {
+    const harness = createFakeWindowWithContent();
+    const controller = new MouseGestureController(harness.win);
+    try {
+      await fn(harness, controller);
+    } finally {
+      controller.destroy();
+    }
+  });
 }
 
 async function withController(
@@ -706,6 +753,121 @@ async function testRockerGestureCannotBecomeWheelGesture(): Promise<void> {
   });
 }
 
+async function testRockerGestureConsumesMouseMoveWhileHeld(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      // Left-then-right ("leftRight") rocker: the left mousedown anchors a
+      // native text-selection drag before the combo can be detected (a lone
+      // left click must still behave normally). Once the right mousedown
+      // completes the combo, every mousemove while both buttons stay down
+      // must be consumed - left unhandled, it would let that selection keep
+      // extending as the rocker's action (e.g. scrolling) moves content
+      // under the still-held cursor.
+      dispatchMouse(win, "mousedown", 0);
+      const rightMouseDown = dispatchMouse(win, "mousedown", 2);
+      const moveWhileHeld = dispatchMouse(win, "mousemove", 0, 50, 0);
+      // Releasing only the right button doesn't end the cycle - the left
+      // button is still physically held, so movement must stay consumed.
+      dispatchMouse(win, "mouseup", 2);
+      dispatchMouse(win, "mouseup", 0);
+      const moveAfterRelease = dispatchMouse(win, "mousemove", 0, 60, 0);
+
+      assertEquals(
+        rightMouseDown.defaultPrevented,
+        true,
+        "the rocker-completing mousedown should be consumed",
+      );
+      assertEquals(
+        moveWhileHeld.defaultPrevented,
+        true,
+        "mousemove while a rocker action is active must not leak through " +
+          "to the page (it would extend a native selection drag)",
+      );
+      assertEquals(
+        moveAfterRelease.defaultPrevented,
+        false,
+        "mousemove after the rocker cycle ends should be passive again",
+      );
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        1,
+        "leftRight rocker action should fire once",
+      );
+    });
+  });
+}
+
+async function testMouseDownCaptureSurvivesContentStopPropagation(): Promise<
+  void
+> {
+  await withTrackedActions(async (counts) => {
+    await withControllerAndContent({}, ({ contentEl }) => {
+      // Simulate a page (e.g. an image gallery, map, or editor) that stops
+      // propagation on its own mousedown. Before mousedown was capture-phase,
+      // this would prevent the gesture controller - registered on the window
+      // ancestor - from ever seeing the event, silently breaking rocker
+      // detection on that page.
+      contentEl.addEventListener("mousedown", (event) => {
+        event.stopPropagation();
+      });
+
+      dispatchMouseFrom(contentEl, "mousedown", 2);
+      dispatchMouseFrom(contentEl, "mousedown", 0);
+      dispatchMouseFrom(contentEl, "mouseup", 2);
+      dispatchMouseFrom(contentEl, "mouseup", 0);
+
+      assertEquals(
+        counts[ROCKER_RIGHT_LEFT_ACTION],
+        1,
+        "rocker gesture should still be detected even when content stops " +
+          "propagation on its own mousedown",
+      );
+    });
+  });
+}
+
+async function testLeftRightRockerLetsLeftMouseUpThrough(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController({}, ({ win }) => {
+      // The left button's own mousedown is never prevented (a lone left
+      // click must still behave normally), so the browser already started
+      // real native selection-drag tracking for it once pressed. That
+      // tracking only ends once the page actually receives the matching
+      // left mouseup. If the rocker cleanup swallowed every button's
+      // mouseup indiscriminately, the page would never find out the left
+      // button was released, leaving native selection mode stuck "on" -
+      // even with zero mouse movement during the whole sequence.
+      dispatchMouse(win, "mousedown", 0);
+      const rightMouseDown = dispatchMouse(win, "mousedown", 2);
+      const rightMouseUp = dispatchMouse(win, "mouseup", 2);
+      const leftMouseUp = dispatchMouse(win, "mouseup", 0);
+
+      assertEquals(
+        rightMouseDown.defaultPrevented,
+        true,
+        "the rocker-completing mousedown should be consumed",
+      );
+      assertEquals(
+        rightMouseUp.defaultPrevented,
+        true,
+        "the right button's mouseup should stay consumed (suppresses its " +
+          "context menu)",
+      );
+      assertEquals(
+        leftMouseUp.defaultPrevented,
+        false,
+        "the left button's own mouseup must reach the page so native " +
+          "selection-drag tracking can terminate",
+      );
+      assertEquals(
+        counts[DRAWN_RIGHT_ACTION],
+        1,
+        "leftRight rocker action should fire once",
+      );
+    });
+  });
+}
+
 const tests: TestCase[] = [
   {
     name: "wheel gesture suppresses post-mouseup contextmenu",
@@ -762,6 +924,18 @@ const tests: TestCase[] = [
   {
     name: "rocker gesture cannot become wheel gesture",
     fn: testRockerGestureCannotBecomeWheelGesture,
+  },
+  {
+    name: "rocker gesture consumes mousemove while held",
+    fn: testRockerGestureConsumesMouseMoveWhileHeld,
+  },
+  {
+    name: "mousedown capture survives content stopPropagation",
+    fn: testMouseDownCaptureSurvivesContentStopPropagation,
+  },
+  {
+    name: "leftRight rocker lets the left mouseup through",
+    fn: testLeftRightRockerLetsLeftMouseUpThrough,
   },
 ];
 

--- a/tools/src/mouse_gesture_rocker_w3c_e2e.ts
+++ b/tools/src/mouse_gesture_rocker_w3c_e2e.ts
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { MarionetteClient } from "./browser_connector.ts";
+
+const ENABLED_PREF = "floorp.mousegesture.enabled";
+const CONFIG_PREF = "floorp.mousegesture.config";
+const STATE_KEY = "__floorpMouseGestureRockerE2EState";
+const POINTER_ID = "floorp-rocker-e2e-mouse";
+
+type PointerStep =
+  | { type: "pointerDown" | "pointerUp"; button: number }
+  | {
+    type: "pointerMove";
+    duration: number;
+    origin: "viewport";
+    x: number;
+    y: number;
+  };
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface PageState {
+  counts: Record<string, number>;
+  events: Array<{
+    type: string;
+    button: number;
+    buttons: number;
+    defaultPrevented: boolean;
+  }>;
+}
+
+interface BrowserSetup {
+  baselineZoom: number;
+  oneStepZoom: number;
+  browserRect: Rect;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function extractHandle(response: unknown): string {
+  if (typeof response === "string") {
+    return response;
+  }
+  if (response && typeof response === "object") {
+    const record = response as Record<string, unknown>;
+    if (typeof record.handle === "string") {
+      return record.handle;
+    }
+    if (typeof record.value === "string") {
+      return record.value;
+    }
+  }
+  throw new Error(
+    `Marionette did not return a window handle: ${JSON.stringify(response)}`,
+  );
+}
+
+const client = await MarionetteClient.connect();
+let originalHandle: string | null = null;
+let testHandle: string | null = null;
+
+async function performPointerSequence(
+  x: number,
+  y: number,
+  steps: PointerStep[],
+): Promise<void> {
+  await client.setContext("chrome");
+  try {
+    await client.send("WebDriver:PerformActions", {
+      actions: [
+        {
+          type: "pointer",
+          id: POINTER_ID,
+          parameters: { pointerType: "mouse" },
+          actions: [
+            {
+              type: "pointerMove",
+              duration: 0,
+              origin: "viewport",
+              x,
+              y,
+            },
+            ...steps,
+          ],
+        },
+      ],
+    });
+  } finally {
+    await client.send("WebDriver:ReleaseActions", {});
+  }
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+async function resetPageState(): Promise<void> {
+  await client.setContext("content");
+  await client.executeScript(`
+    window.__floorpRockerE2E.counts = {
+      mousedown: 0,
+      mouseup: 0,
+      click: 0,
+      auxclick: 0,
+      dblclick: 0,
+      contextmenu: 0,
+    };
+    window.__floorpRockerE2E.events = [];
+  `);
+}
+
+async function readPageState(): Promise<PageState> {
+  await client.setContext("content");
+  const raw = await client.executeScript(`
+    return JSON.stringify(window.__floorpRockerE2E);
+  `);
+  return JSON.parse(raw) as PageState;
+}
+
+async function readZoom(): Promise<number> {
+  await client.setContext("chrome");
+  return await client.executeScript(`return ZoomManager.zoom;`) as number;
+}
+
+async function resetZoom(): Promise<number> {
+  await client.setContext("chrome");
+  await client.executeScript(`FullZoom.reset();`);
+  return await readZoom();
+}
+
+function assertNoRockerActivation(state: PageState, label: string): void {
+  for (const type of ["click", "auxclick", "dblclick", "contextmenu"]) {
+    assert(
+      state.counts[type] === 0,
+      `${label}: expected zero ${type} events, got ${state.counts[type]}: ${
+        JSON.stringify(state.events)
+      }`,
+    );
+  }
+}
+
+async function assertOrdinaryClick(
+  x: number,
+  y: number,
+  label: string,
+): Promise<void> {
+  await resetPageState();
+  await performPointerSequence(x, y, [
+    { type: "pointerDown", button: 0 },
+    { type: "pointerUp", button: 0 },
+  ]);
+  const state = await readPageState();
+  assert(
+    state.counts.mousedown === 1 && state.counts.mouseup === 1,
+    `${label}: ordinary left down/up did not reach content: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assert(
+    state.counts.click === 1,
+    `${label}: expected one ordinary click, got ${state.counts.click}: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assert(
+    state.counts.auxclick === 0 &&
+      state.counts.dblclick === 0 &&
+      state.counts.contextmenu === 0,
+    `${label}: ordinary click produced an unexpected click-like event: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+}
+
+async function assertRocker(
+  x: number,
+  y: number,
+  setup: BrowserSetup,
+  label: string,
+  steps: PointerStep[],
+  expectForwardedLeftRelease: boolean,
+): Promise<void> {
+  await resetPageState();
+  const zoomBefore = await resetZoom();
+  assert(
+    zoomBefore === setup.baselineZoom,
+    `${label}: failed to reset zoom to ${setup.baselineZoom}, got ${zoomBefore}`,
+  );
+
+  await performPointerSequence(x, y, steps);
+
+  // Marionette context is session-wide, so content and chrome reads must not
+  // race each other on the same connection.
+  const state = await readPageState();
+  const zoomAfter = await readZoom();
+  assert(
+    zoomAfter === setup.oneStepZoom,
+    `${label}: rocker action must execute exactly once; expected zoom ${setup.oneStepZoom}, got ${zoomAfter}`,
+  );
+  assertNoRockerActivation(state, label);
+
+  if (expectForwardedLeftRelease) {
+    const leftDown = state.events.filter((event) =>
+      event.type === "mousedown" && event.button === 0
+    ).length;
+    const leftUp = state.events.filter((event) =>
+      event.type === "mouseup" && event.button === 0
+    ).length;
+    assert(
+      leftDown === 1 && leftUp === 1,
+      `${label}: leftRight must forward the matching left down/up without activating the target: ${
+        JSON.stringify(state.events)
+      }`,
+    );
+  }
+
+  await assertOrdinaryClick(x, y, `${label} follow-up`);
+}
+
+try {
+  originalHandle = extractHandle(
+    await client.send("WebDriver:GetWindowHandle", {}),
+  );
+  testHandle = extractHandle(
+    await client.send("WebDriver:NewWindow", { type: "tab" }),
+  );
+  await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+
+  await client.setContext("chrome");
+  const setup = JSON.parse(
+    await client.executeScript(`
+      const enabledPref = ${JSON.stringify(ENABLED_PREF)};
+      const configPref = ${JSON.stringify(CONFIG_PREF)};
+      const stateKey = ${JSON.stringify(STATE_KEY)};
+
+      const originalConfig = Services.prefs.getStringPref(configPref, "");
+      if (!originalConfig) {
+        throw new Error("Mouse gesture config pref is empty");
+      }
+      window[stateKey] = {
+        originalZoom: ZoomManager.zoom,
+        hadEnabledUserValue: Services.prefs.prefHasUserValue(enabledPref),
+        originalEnabled: Services.prefs.getBoolPref(enabledPref, false),
+        hadConfigUserValue: Services.prefs.prefHasUserValue(configPref),
+        originalConfig,
+      };
+
+      const config = JSON.parse(originalConfig);
+      config.enabled = true;
+      config.rockerGesturesEnabled = true;
+      config.rockerActions = {
+        leftRight: "gecko-zoom-in",
+        rightLeft: "gecko-zoom-in",
+      };
+      Services.prefs.setStringPref(configPref, JSON.stringify(config));
+      Services.prefs.setBoolPref(enabledPref, true);
+
+      FullZoom.reset();
+      const baselineZoom = ZoomManager.zoom;
+      FullZoom.enlarge();
+      const oneStepZoom = ZoomManager.zoom;
+      FullZoom.reset();
+      const rect = gBrowser.selectedBrowser.getBoundingClientRect();
+      return JSON.stringify({
+        baselineZoom,
+        oneStepZoom,
+        browserRect: {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+        },
+      });
+    `),
+  ) as BrowserSetup;
+
+  await client.setContext("content");
+  const fixture = `<!doctype html>
+    <meta charset="utf-8">
+    <style>
+      body { margin: 40px; }
+      #target { width: 260px; height: 120px; font-size: 24px; }
+    </style>
+    <button id="target">Rocker target</button>
+    <script>
+      window.__floorpRockerE2E = { counts: {}, events: [] };
+      const target = document.getElementById("target");
+      for (const type of ["mousedown", "mouseup", "click", "auxclick", "dblclick", "contextmenu"]) {
+        target.addEventListener(type, (event) => {
+          window.__floorpRockerE2E.counts[type] =
+            (window.__floorpRockerE2E.counts[type] ?? 0) + 1;
+          window.__floorpRockerE2E.events.push({
+            type: event.type,
+            button: event.button,
+            buttons: event.buttons,
+            defaultPrevented: event.defaultPrevented,
+          });
+          if (type === "contextmenu") {
+            event.preventDefault();
+          }
+        });
+      }
+    </script>`;
+  await client.navigate(
+    `data:text/html;charset=utf-8,${encodeURIComponent(fixture)}`,
+  );
+  const targetRect = await client.executeScript(`
+    const rect = document.querySelector("#target").getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  `) as Rect;
+  const x = Math.round(
+    setup.browserRect.x + targetRect.x + targetRect.width / 2,
+  );
+  const y = Math.round(
+    setup.browserRect.y + targetRect.y + targetRect.height / 2,
+  );
+  assert(
+    x >= setup.browserRect.x &&
+      x < setup.browserRect.x + setup.browserRect.width &&
+      y >= setup.browserRect.y &&
+      y < setup.browserRect.y + setup.browserRect.height,
+    `Target coordinate (${x}, ${y}) is outside the browser viewport ${
+      JSON.stringify(setup.browserRect)
+    }`,
+  );
+
+  console.log(
+    `Mouse gesture rocker W3C target: ${
+      JSON.stringify({
+        browserRect: setup.browserRect,
+        targetRect,
+        x,
+        y,
+      })
+    }`,
+  );
+
+  await assertOrdinaryClick(x, y, "ordinary click before rockers");
+  await assertRocker(
+    x,
+    y,
+    setup,
+    "leftRight",
+    [
+      { type: "pointerDown", button: 0 },
+      { type: "pointerDown", button: 2 },
+      { type: "pointerUp", button: 2 },
+      { type: "pointerUp", button: 0 },
+    ],
+    true,
+  );
+  await assertRocker(
+    x,
+    y,
+    setup,
+    "rightLeft",
+    [
+      { type: "pointerDown", button: 2 },
+      { type: "pointerDown", button: 0 },
+      { type: "pointerUp", button: 2 },
+      { type: "pointerUp", button: 0 },
+    ],
+    false,
+  );
+
+  console.log("Mouse gesture rocker W3C E2E passed");
+} finally {
+  try {
+    await client.send("WebDriver:ReleaseActions", {});
+  } catch {
+    // The session may not own any active actions after a successful test.
+  }
+  try {
+    if (testHandle) {
+      await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+      await client.setContext("chrome");
+      await client.executeScript(`
+        const enabledPref = ${JSON.stringify(ENABLED_PREF)};
+        const configPref = ${JSON.stringify(CONFIG_PREF)};
+        const stateKey = ${JSON.stringify(STATE_KEY)};
+        const state = window[stateKey];
+        if (state) {
+          if (state.hadConfigUserValue) {
+            Services.prefs.setStringPref(configPref, state.originalConfig);
+          } else if (Services.prefs.prefHasUserValue(configPref)) {
+            Services.prefs.clearUserPref(configPref);
+          }
+          if (state.hadEnabledUserValue) {
+            Services.prefs.setBoolPref(enabledPref, state.originalEnabled);
+          } else if (Services.prefs.prefHasUserValue(enabledPref)) {
+            Services.prefs.clearUserPref(enabledPref);
+          }
+          ZoomManager.zoom = state.originalZoom;
+          delete window[stateKey];
+        }
+      `);
+      await client.send("WebDriver:CloseWindow", {});
+    }
+    if (originalHandle) {
+      await client.send("WebDriver:SwitchToWindow", {
+        handle: originalHandle,
+      });
+    }
+  } finally {
+    await client.close();
+  }
+}

--- a/tools/src/mouse_gesture_rocker_w3c_e2e.ts
+++ b/tools/src/mouse_gesture_rocker_w3c_e2e.ts
@@ -279,6 +279,10 @@ try {
       });
     `),
   ) as BrowserSetup;
+  assert(
+    setup.oneStepZoom !== setup.baselineZoom,
+    `Zoom action precondition failed: enlarge kept zoom at ${setup.baselineZoom}`,
+  );
 
   await client.setContext("content");
   const fixture = `<!doctype html>


### PR DESCRIPTION
When using lmb>rmb rocker to scroll it may cause the website text to be selected, and sometimes the context menu pops up when using rockers overall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse gesture detection on pages that block event propagation.
  * Prevented rocker gestures from triggering unintended text selection or synthetic clicks.
  * Allowed the final left-click release to work normally after a rocker gesture.
  * Correctly suppressed unrelated mouse-button releases after rocker gestures.
  * Improved reliability of left-right and right-left rocker gestures, including expected zoom changes and event forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->