### PR TITLE
make wheel-gestures bindings configurable

### DIFF
--- a/.github/workflows/colocated_runner_test.yml
+++ b/.github/workflows/colocated_runner_test.yml
@@ -248,9 +248,17 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y -qq xvfb xdotool
-          xdotool version
+          export DISPLAY=:99
           echo "DISPLAY=:99" >> "$GITHUB_ENV"
           Xvfb :99 -screen 0 1280x1024x24 &
+          for i in {1..50}; do
+            if xdotool getdisplaygeometry >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.1
+          done
+          xdotool getdisplaygeometry
+          xdotool version
 
       - name: Run combined browser test suite against locked Runtime
         if: matrix.browser_suite == true

--- a/.github/workflows/colocated_runner_test.yml
+++ b/.github/workflows/colocated_runner_test.yml
@@ -247,7 +247,8 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq xvfb
+          sudo apt-get install -y -qq xvfb xdotool
+          xdotool version
           echo "DISPLAY=:99" >> "$GITHUB_ENV"
           Xvfb :99 -screen 0 1280x1024x24 &
 
@@ -356,6 +357,11 @@ jobs:
             --allow-net=127.0.0.1 \
             --allow-read=_dist \
             tools/src/mouse_gesture_drawn_w3c_e2e.ts
+          deno run \
+            --allow-net=127.0.0.1 \
+            --allow-read=_dist \
+            --allow-run=xdotool \
+            tools/src/mouse_gesture_wheel_x11_e2e.ts
 
       - name: Verify downloaded Firefox execution coverage
         if: matrix.browser_suite == true

--- a/browser-features/chrome/common/mouse-gesture/config.ts
+++ b/browser-features/chrome/common/mouse-gesture/config.ts
@@ -13,6 +13,11 @@ import {
 import { createRootHMR } from "@nora/solid-xul";
 import * as t from "io-ts";
 import { isRight } from "fp-ts/Either";
+import {
+  DEFAULT_WHEEL_ACTIONS,
+  normalizeWheelActions,
+  type WheelActions as PolicyWheelActions,
+} from "./wheel-action-policy.ts";
 
 export const MOUSE_GESTURE_ENABLED_PREF = "floorp.mousegesture.enabled";
 export const MOUSE_GESTURE_CONFIG_PREF = "floorp.mousegesture.config";
@@ -57,7 +62,7 @@ const WheelActionsCodec = t.type({
   scrollUp: t.string,
   scrollDown: t.string,
 });
-export type WheelActions = t.TypeOf<typeof WheelActionsCodec>;
+export type WheelActions = PolicyWheelActions;
 
 const MouseGestureConfigRequired = t.type({
   rockerGesturesEnabled: t.boolean,
@@ -116,13 +121,12 @@ const BASE_DEFAULT_CONFIG: MouseGestureConfig = {
     leftRight: "gecko-forward",
     rightLeft: "gecko-back",
   },
-  wheelActions: {
-    scrollUp: "gecko-show-previous-tab",
-    scrollDown: "gecko-show-next-tab",
-  },
+  wheelActions: { ...DEFAULT_WHEEL_ACTIONS },
 };
 
-const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig => {
+const normalizeConfig = (
+  config: Record<string, unknown>,
+): MouseGestureConfig => {
   const sensitivity = clamp(
     Number.isFinite(config?.sensitivity)
       ? (config.sensitivity as number)
@@ -146,10 +150,7 @@ const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig =>
     ...(config?.rockerActions as Record<string, unknown> | undefined),
   };
 
-  const wheelActions = {
-    ...BASE_DEFAULT_CONFIG.wheelActions,
-    ...(config?.wheelActions as Record<string, unknown> | undefined),
-  };
+  const wheelActions = normalizeWheelActions(config?.wheelActions);
 
   return {
     ...BASE_DEFAULT_CONFIG,
@@ -169,7 +170,10 @@ export const strDefaultConfig = JSON.stringify(defaultConfig);
 
 function createEnabled(): [Accessor<boolean>, Setter<boolean>] {
   const [enabled, setEnabled] = createSignal(
-    Services.prefs.getBoolPref(MOUSE_GESTURE_ENABLED_PREF, defaultConfig.enabled),
+    Services.prefs.getBoolPref(
+      MOUSE_GESTURE_ENABLED_PREF,
+      defaultConfig.enabled,
+    ),
   );
 
   createEffect(() => {
@@ -178,7 +182,10 @@ function createEnabled(): [Accessor<boolean>, Setter<boolean>] {
 
   const enabledObserver = () => {
     setEnabled(
-      Services.prefs.getBoolPref(MOUSE_GESTURE_ENABLED_PREF, defaultConfig.enabled),
+      Services.prefs.getBoolPref(
+        MOUSE_GESTURE_ENABLED_PREF,
+        defaultConfig.enabled,
+      ),
     );
   };
 
@@ -190,7 +197,10 @@ function createEnabled(): [Accessor<boolean>, Setter<boolean>] {
   return [enabled, setEnabled];
 }
 
-function createConfig(): [Accessor<MouseGestureConfig>, Setter<MouseGestureConfig>] {
+function createConfig(): [
+  Accessor<MouseGestureConfig>,
+  Setter<MouseGestureConfig>,
+] {
   const parseConfig = (jsonStr: string): MouseGestureConfig => {
     try {
       const parsed = JSON.parse(jsonStr);
@@ -198,7 +208,9 @@ function createConfig(): [Accessor<MouseGestureConfig>, Setter<MouseGestureConfi
       if (isRight(result)) {
         return normalizeConfig(result.right);
       }
-      console.warn("Mouse gesture config validation failed, recovering partial data");
+      console.warn(
+        "Mouse gesture config validation failed, recovering partial data",
+      );
       return normalizeConfig(parsed);
     } catch (e) {
       console.error("Failed to parse mouse gesture config, using default", e);
@@ -213,14 +225,20 @@ function createConfig(): [Accessor<MouseGestureConfig>, Setter<MouseGestureConfi
   );
 
   createEffect(() => {
-    Services.prefs.setStringPref(MOUSE_GESTURE_CONFIG_PREF, JSON.stringify(config()));
+    Services.prefs.setStringPref(
+      MOUSE_GESTURE_CONFIG_PREF,
+      JSON.stringify(config()),
+    );
   });
 
   const configObserver = () => {
     try {
       setConfig(
         parseConfig(
-          Services.prefs.getStringPref(MOUSE_GESTURE_CONFIG_PREF, strDefaultConfig),
+          Services.prefs.getStringPref(
+            MOUSE_GESTURE_CONFIG_PREF,
+            strDefaultConfig,
+          ),
         ),
       );
     } catch (e) {
@@ -238,13 +256,20 @@ function createConfig(): [Accessor<MouseGestureConfig>, Setter<MouseGestureConfi
   return [config, setConfig];
 }
 
-export const [_enabled, _setEnabled] = createRootHMR(createEnabled, import.meta.hot);
-export const [_config, _setConfig] = createRootHMR(createConfig, import.meta.hot);
+export const [_enabled, _setEnabled] = createRootHMR(
+  createEnabled,
+  import.meta.hot,
+);
+export const [_config, _setConfig] = createRootHMR(
+  createConfig,
+  import.meta.hot,
+);
 
 export const isEnabled = () => _enabled();
 export const setEnabled = (value: boolean) => _setEnabled(value);
 export const getConfig = () => _config();
-export const setConfig = (value: MouseGestureConfig) => _setConfig(normalizeConfig(value));
+export const setConfig = (value: MouseGestureConfig) =>
+  _setConfig(normalizeConfig(value));
 
 export function patternToString(pattern: GesturePattern): string {
   return pattern.join("-");

--- a/browser-features/chrome/common/mouse-gesture/config.ts
+++ b/browser-features/chrome/common/mouse-gesture/config.ts
@@ -53,6 +53,12 @@ const RockerActionsCodec = t.type({
 });
 export type RockerActions = t.TypeOf<typeof RockerActionsCodec>;
 
+const WheelActionsCodec = t.type({
+  scrollUp: t.string,
+  scrollDown: t.string,
+});
+export type WheelActions = t.TypeOf<typeof WheelActionsCodec>;
+
 const MouseGestureConfigRequired = t.type({
   rockerGesturesEnabled: t.boolean,
   wheelGesturesEnabled: t.boolean,
@@ -64,6 +70,7 @@ const MouseGestureConfigRequired = t.type({
   contextMenu: ContextMenuCodec,
   actions: t.array(GestureActionCodec),
   rockerActions: RockerActionsCodec,
+  wheelActions: WheelActionsCodec,
 });
 
 const MouseGestureConfigOptional = t.partial({
@@ -109,6 +116,10 @@ const BASE_DEFAULT_CONFIG: MouseGestureConfig = {
     leftRight: "gecko-forward",
     rightLeft: "gecko-back",
   },
+  wheelActions: {
+    scrollUp: "gecko-show-previous-tab",
+    scrollDown: "gecko-show-next-tab",
+  },
 };
 
 const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig => {
@@ -135,6 +146,11 @@ const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig =>
     ...(config?.rockerActions as Record<string, unknown> | undefined),
   };
 
+  const wheelActions = {
+    ...BASE_DEFAULT_CONFIG.wheelActions,
+    ...(config?.wheelActions as Record<string, unknown> | undefined),
+  };
+
   return {
     ...BASE_DEFAULT_CONFIG,
     ...config,
@@ -144,6 +160,7 @@ const normalizeConfig = (config: Record<string, unknown>): MouseGestureConfig =>
       ? (config.actions as GestureAction[])
       : BASE_DEFAULT_CONFIG.actions,
     rockerActions,
+    wheelActions,
   } as MouseGestureConfig;
 };
 

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -5,6 +5,7 @@
 
 import { getConfig, isEnabled, patternToString } from "./config.ts";
 import { GestureDisplay } from "./components/GestureDisplay.tsx";
+import { normalizeWheelActions } from "./wheel-action-policy.ts";
 import {
   executeGestureAction,
   getActionDisplayName,
@@ -523,6 +524,8 @@ export class MouseGestureController {
     // alive long enough to cover Firefox's post-mouseup contextmenu event and
     // any residual wheel events, but does not permit another action.
     if (this.isWheelGestureFired) {
+      this.preventFollowingClick(event);
+
       if (event.button === 2) {
         const preventionTimeout = getConfig().contextMenu.preventionTimeout;
         this.isContextMenuPrevented = false;
@@ -685,11 +688,15 @@ export class MouseGestureController {
       return;
     }
 
+    // Defend the execution boundary as well as preference parsing. Tests,
+    // extensions, or future callers can update the in-memory config directly;
+    // none may turn repeatable wheel input into a destructive action.
+    const wheelActions = normalizeWheelActions(config.wheelActions);
     let action: string | null = null;
     if (event.deltaY < 0) {
-      action = config.wheelActions.scrollUp;
+      action = wheelActions.scrollUp;
     } else if (event.deltaY > 0) {
-      action = config.wheelActions.scrollDown;
+      action = wheelActions.scrollDown;
     }
 
     if (action) {

--- a/browser-features/chrome/common/mouse-gesture/controller.ts
+++ b/browser-features/chrome/common/mouse-gesture/controller.ts
@@ -520,9 +520,9 @@ export class MouseGestureController {
 
     let action: string | null = null;
     if (event.deltaY < 0) {
-      action = "gecko-show-previous-tab";
+      action = config.wheelActions.scrollUp;
     } else if (event.deltaY > 0) {
-      action = "gecko-show-next-tab";
+      action = config.wheelActions.scrollDown;
     }
 
     if (action) {

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureConfig.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureConfig.test.ts
@@ -2,23 +2,35 @@
 // @colocated-env browser
 
 import {
-  assertEquals,
   assert,
+  assertEquals,
   runTests,
   type TestCase,
 } from "../../../test/utils/test_harness.ts";
 import {
-  patternToString,
-  stringToPattern,
   defaultConfig,
-  strDefaultConfig,
-  MOUSE_GESTURE_ENABLED_PREF,
-  MOUSE_GESTURE_CONFIG_PREF,
-  MouseGestureConfigCodec,
-  GestureDirectionCodec,
   GestureActionCodec,
+  GestureDirectionCodec,
+  getConfig,
+  MOUSE_GESTURE_CONFIG_PREF,
+  MOUSE_GESTURE_ENABLED_PREF,
+  MouseGestureConfigCodec,
+  patternToString,
+  setConfig,
+  strDefaultConfig,
+  stringToPattern,
 } from "../config.ts";
-import type { GestureDirection, GesturePattern } from "../config.ts";
+import type {
+  GestureDirection,
+  GesturePattern,
+  MouseGestureConfig,
+} from "../config.ts";
+import {
+  DEFAULT_WHEEL_ACTIONS,
+  isRepeatSafeWheelAction,
+  normalizeWheelActions,
+  REPEAT_SAFE_WHEEL_ACTIONS,
+} from "../wheel-action-policy.ts";
 
 // ---------------------------------------------------------------------------
 // patternToString / stringToPattern tests
@@ -376,7 +388,7 @@ function testDefaultConfigNineActions(): void {
 
 function testDefaultConfigActionPatternsUnique(): void {
   const patternStrings = defaultConfig.actions.map((a) =>
-    patternToString(a.pattern),
+    patternToString(a.pattern)
   );
   const uniquePatterns = new Set(patternStrings);
   assertEquals(
@@ -735,6 +747,206 @@ function testConfigCodecInvalidRockerActionsWrongType(): void {
   );
 }
 
+function testRepeatSafeWheelActionPolicy(): void {
+  const expected = [
+    "gecko-show-previous-tab",
+    "gecko-show-next-tab",
+    "gecko-scroll-line-up",
+    "gecko-scroll-line-down",
+    "gecko-scroll-up",
+    "gecko-scroll-down",
+    "gecko-scroll-left",
+    "gecko-scroll-right",
+    "gecko-scroll-to-top",
+    "gecko-scroll-to-bottom",
+    "gecko-zoom-in",
+    "gecko-zoom-out",
+    "gecko-reset-zoom",
+    "gecko-workspace-next",
+    "gecko-workspace-previous",
+    "gecko-show-next-search-result",
+    "gecko-show-previous-search-result",
+  ] as const;
+
+  assertEquals(
+    REPEAT_SAFE_WHEEL_ACTIONS.length,
+    expected.length,
+    "wheel allowlist should contain exactly the approved actions",
+  );
+  for (let index = 0; index < expected.length; index++) {
+    assertEquals(
+      REPEAT_SAFE_WHEEL_ACTIONS[index],
+      expected[index],
+      `wheel allowlist entry ${index}`,
+    );
+    assert(
+      isRepeatSafeWheelAction(expected[index]),
+      `approved wheel action should be repeat-safe: ${expected[index]}`,
+    );
+  }
+
+  for (
+    const forbidden of [
+      "gecko-close-tab",
+      "gecko-close-window",
+      "gecko-quit-from-application",
+      "unknown-action",
+      "",
+      42,
+      null,
+      undefined,
+    ]
+  ) {
+    assert(
+      !isRepeatSafeWheelAction(forbidden),
+      `non-allowlisted value should be rejected: ${String(forbidden)}`,
+    );
+  }
+  assertEquals(
+    DEFAULT_WHEEL_ACTIONS.scrollUp,
+    "gecko-show-previous-tab",
+    "scroll-up default",
+  );
+  assertEquals(
+    DEFAULT_WHEEL_ACTIONS.scrollDown,
+    "gecko-show-next-tab",
+    "scroll-down default",
+  );
+}
+
+function testNormalizeWheelActions(): void {
+  const missing = normalizeWheelActions(undefined);
+  assertEquals(
+    missing.scrollUp,
+    DEFAULT_WHEEL_ACTIONS.scrollUp,
+    "missing scroll-up should use its default",
+  );
+  assertEquals(
+    missing.scrollDown,
+    DEFAULT_WHEEL_ACTIONS.scrollDown,
+    "missing scroll-down should use its default",
+  );
+
+  const partial = normalizeWheelActions({ scrollUp: "gecko-zoom-in" });
+  assertEquals(
+    partial.scrollUp,
+    "gecko-zoom-in",
+    "safe partial scroll-up should be preserved",
+  );
+  assertEquals(
+    partial.scrollDown,
+    DEFAULT_WHEEL_ACTIONS.scrollDown,
+    "missing partial scroll-down should use its own default",
+  );
+
+  const unsafe = normalizeWheelActions({
+    scrollUp: "unknown-action",
+    scrollDown: "gecko-close-tab",
+    extra: "gecko-zoom-out",
+  });
+  assertEquals(
+    unsafe.scrollUp,
+    DEFAULT_WHEEL_ACTIONS.scrollUp,
+    "unknown scroll-up should use its own default",
+  );
+  assertEquals(
+    unsafe.scrollDown,
+    DEFAULT_WHEEL_ACTIONS.scrollDown,
+    "forbidden scroll-down should use its own default",
+  );
+  assertEquals(
+    Object.keys(unsafe).length,
+    2,
+    "normalization should discard unrecognized fields",
+  );
+
+  const safe = normalizeWheelActions({
+    scrollUp: "gecko-workspace-previous",
+    scrollDown: "gecko-show-next-search-result",
+  });
+  assertEquals(
+    safe.scrollUp,
+    "gecko-workspace-previous",
+    "safe scroll-up should survive normalization",
+  );
+  assertEquals(
+    safe.scrollDown,
+    "gecko-show-next-search-result",
+    "safe scroll-down should survive normalization",
+  );
+}
+
+function testCoreConfigNormalizesWheelActions(): void {
+  const previousConfig = getConfig();
+  const hadConfigPref = Services.prefs.prefHasUserValue(
+    MOUSE_GESTURE_CONFIG_PREF,
+  );
+  const previousConfigPref = hadConfigPref
+    ? Services.prefs.getStringPref(MOUSE_GESTURE_CONFIG_PREF)
+    : null;
+
+  const applyRawWheelActions = (wheelActions: unknown): void => {
+    const rawConfig = { ...previousConfig } as Record<string, unknown>;
+    if (wheelActions === undefined) {
+      delete rawConfig.wheelActions;
+    } else {
+      rawConfig.wheelActions = wheelActions;
+    }
+    setConfig(rawConfig as unknown as MouseGestureConfig);
+  };
+
+  try {
+    applyRawWheelActions(undefined);
+    assertEquals(
+      getConfig().wheelActions.scrollUp,
+      DEFAULT_WHEEL_ACTIONS.scrollUp,
+      "core config should recover a missing scroll-up default",
+    );
+    assertEquals(
+      getConfig().wheelActions.scrollDown,
+      DEFAULT_WHEEL_ACTIONS.scrollDown,
+      "core config should recover a missing scroll-down default",
+    );
+
+    applyRawWheelActions({ scrollUp: "gecko-zoom-in" });
+    assertEquals(
+      getConfig().wheelActions.scrollUp,
+      "gecko-zoom-in",
+      "core config should preserve a safe partial binding",
+    );
+    assertEquals(
+      getConfig().wheelActions.scrollDown,
+      DEFAULT_WHEEL_ACTIONS.scrollDown,
+      "core config should fill a partial binding independently",
+    );
+
+    applyRawWheelActions({
+      scrollUp: "unknown-action",
+      scrollDown: "gecko-close-tab",
+    });
+    assertEquals(
+      getConfig().wheelActions.scrollUp,
+      DEFAULT_WHEEL_ACTIONS.scrollUp,
+      "core config should replace an unknown binding",
+    );
+    assertEquals(
+      getConfig().wheelActions.scrollDown,
+      DEFAULT_WHEEL_ACTIONS.scrollDown,
+      "core config should replace a forbidden binding",
+    );
+  } finally {
+    setConfig(previousConfig);
+    if (previousConfigPref !== null) {
+      Services.prefs.setStringPref(
+        MOUSE_GESTURE_CONFIG_PREF,
+        previousConfigPref,
+      );
+    } else {
+      Services.prefs.clearUserPref(MOUSE_GESTURE_CONFIG_PREF);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Pref constants tests
 // ---------------------------------------------------------------------------
@@ -997,6 +1209,18 @@ const tests: TestCase[] = [
   {
     name: "ConfigCodec invalid rockerActions wrong type",
     fn: testConfigCodecInvalidRockerActionsWrongType,
+  },
+  {
+    name: "repeat-safe wheel action policy",
+    fn: testRepeatSafeWheelActionPolicy,
+  },
+  {
+    name: "normalize wheel actions",
+    fn: testNormalizeWheelActions,
+  },
+  {
+    name: "core config normalizes wheel actions",
+    fn: testCoreConfigNormalizesWheelActions,
   },
   // pref constants
   { name: "pref constants", fn: testPrefConstants },

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureConfig.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureConfig.test.ts
@@ -645,6 +645,96 @@ function testConfigCodecInvalidActionMissingAction(): void {
   );
 }
 
+function testConfigCodecInvalidMissingWheelActions(): void {
+  const invalidConfig = {
+    rockerGesturesEnabled: true,
+    wheelGesturesEnabled: true,
+    sensitivity: 40,
+    showTrail: true,
+    showLabel: true,
+    trailColor: "#fff",
+    trailWidth: 3,
+    contextMenu: { minDistance: 5, preventionTimeout: 200 },
+    actions: [],
+    rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    // wheelActions omitted entirely
+  };
+  const result = MouseGestureConfigCodec.decode(invalidConfig);
+  assert(
+    result._tag === "Left",
+    "missing wheelActions should fail validation",
+  );
+}
+
+function testConfigCodecInvalidWheelActionsWrongType(): void {
+  const invalidConfig = {
+    rockerGesturesEnabled: true,
+    wheelGesturesEnabled: true,
+    sensitivity: 40,
+    showTrail: true,
+    showLabel: true,
+    trailColor: "#fff",
+    trailWidth: 3,
+    contextMenu: { minDistance: 5, preventionTimeout: 200 },
+    actions: [],
+    rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: { scrollUp: 42, scrollDown: "gecko-show-next-tab" }, // scrollUp should be a string
+  };
+  const result = MouseGestureConfigCodec.decode(invalidConfig);
+  assert(
+    result._tag === "Left",
+    "non-string wheelActions.scrollUp should fail validation",
+  );
+}
+
+function testConfigCodecInvalidMissingRockerActions(): void {
+  const invalidConfig = {
+    rockerGesturesEnabled: true,
+    wheelGesturesEnabled: true,
+    sensitivity: 40,
+    showTrail: true,
+    showLabel: true,
+    trailColor: "#fff",
+    trailWidth: 3,
+    contextMenu: { minDistance: 5, preventionTimeout: 200 },
+    actions: [],
+    // rockerActions omitted entirely
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
+  };
+  const result = MouseGestureConfigCodec.decode(invalidConfig);
+  assert(
+    result._tag === "Left",
+    "missing rockerActions should fail validation",
+  );
+}
+
+function testConfigCodecInvalidRockerActionsWrongType(): void {
+  const invalidConfig = {
+    rockerGesturesEnabled: true,
+    wheelGesturesEnabled: true,
+    sensitivity: 40,
+    showTrail: true,
+    showLabel: true,
+    trailColor: "#fff",
+    trailWidth: 3,
+    contextMenu: { minDistance: 5, preventionTimeout: 200 },
+    actions: [],
+    rockerActions: { leftRight: "gecko-forward" }, // missing rightLeft
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
+  };
+  const result = MouseGestureConfigCodec.decode(invalidConfig);
+  assert(
+    result._tag === "Left",
+    "rockerActions missing 'rightLeft' should fail validation",
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Pref constants tests
 // ---------------------------------------------------------------------------
@@ -891,6 +981,22 @@ const tests: TestCase[] = [
   {
     name: "ConfigCodec invalid action missing action field",
     fn: testConfigCodecInvalidActionMissingAction,
+  },
+  {
+    name: "ConfigCodec invalid missing wheelActions",
+    fn: testConfigCodecInvalidMissingWheelActions,
+  },
+  {
+    name: "ConfigCodec invalid wheelActions wrong type",
+    fn: testConfigCodecInvalidWheelActionsWrongType,
+  },
+  {
+    name: "ConfigCodec invalid missing rockerActions",
+    fn: testConfigCodecInvalidMissingRockerActions,
+  },
+  {
+    name: "ConfigCodec invalid rockerActions wrong type",
+    fn: testConfigCodecInvalidRockerActionsWrongType,
   },
   // pref constants
   { name: "pref constants", fn: testPrefConstants },

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureConfig.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureConfig.test.ts
@@ -418,6 +418,7 @@ function testDefaultConfigHasAllBaseFields(): void {
   assert(config.contextMenu !== undefined, "contextMenu should exist");
   assert(config.actions !== undefined, "actions should exist");
   assert(config.rockerActions !== undefined, "rockerActions should exist");
+  assert(config.wheelActions !== undefined, "wheelActions should exist");
 }
 
 // ---------------------------------------------------------------------------
@@ -436,6 +437,10 @@ function testConfigCodecValidMinimal(): void {
     contextMenu: { minDistance: 5, preventionTimeout: 200 },
     actions: [{ pattern: ["left"], action: "back" }],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(validConfig);
   assert(result._tag === "Right", "valid config should pass validation");
@@ -454,6 +459,10 @@ function testConfigCodecValidWithOptionalEnabled(): void {
     contextMenu: { minDistance: 10, preventionTimeout: 500 },
     actions: [],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(validConfig);
   assert(
@@ -474,6 +483,10 @@ function testConfigCodecValidEmptyActions(): void {
     contextMenu: { minDistance: 5, preventionTimeout: 200 },
     actions: [],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(validConfig);
   assert(result._tag === "Right", "empty actions array should be valid");
@@ -503,6 +516,10 @@ function testConfigCodecInvalidSensitivityType(): void {
     contextMenu: { minDistance: 5, preventionTimeout: 200 },
     actions: [],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(invalidConfig);
   assert(
@@ -523,6 +540,10 @@ function testConfigCodecInvalidActionPattern(): void {
     contextMenu: { minDistance: 5, preventionTimeout: 200 },
     actions: [{ pattern: ["invalid-direction"], action: "test" }],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(invalidConfig);
   assert(
@@ -543,6 +564,10 @@ function testConfigCodecInvalidTrailWidthType(): void {
     contextMenu: { minDistance: 5, preventionTimeout: 200 },
     actions: [],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(invalidConfig);
   assert(
@@ -563,6 +588,10 @@ function testConfigCodecInvalidShowTrailType(): void {
     contextMenu: { minDistance: 5, preventionTimeout: 200 },
     actions: [],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(invalidConfig);
   assert(result._tag === "Left", "wrong showTrail type should fail validation");
@@ -580,6 +609,10 @@ function testConfigCodecInvalidContextMenuStructure(): void {
     contextMenu: { minDistance: "five" }, // Should be number, missing preventionTimeout
     actions: [],
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(invalidConfig);
   assert(
@@ -600,6 +633,10 @@ function testConfigCodecInvalidActionMissingAction(): void {
     contextMenu: { minDistance: 5, preventionTimeout: 200 },
     actions: [{ pattern: ["left"] }], // Missing "action" field
     rockerActions: { leftRight: "gecko-forward", rightLeft: "gecko-back" },
+    wheelActions: {
+      scrollUp: "gecko-show-previous-tab",
+      scrollDown: "gecko-show-next-tab",
+    },
   };
   const result = MouseGestureConfigCodec.decode(invalidConfig);
   assert(

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -44,6 +44,7 @@ interface TestConfigOptions {
   enabled?: boolean;
   wheelGesturesEnabled?: boolean;
   preventionTimeout?: number;
+  wheelActions?: MouseGestureConfig["wheelActions"];
 }
 
 function createFakeWindow(): FakeWindowHarness {
@@ -123,6 +124,7 @@ function createTestConfig(options: TestConfigOptions): MouseGestureConfig {
       action: action.action,
     })),
     rockerActions: { ...defaultConfig.rockerActions },
+    wheelActions: options.wheelActions ?? { ...defaultConfig.wheelActions },
   };
 }
 
@@ -706,6 +708,49 @@ async function testRockerGestureCannotBecomeWheelGesture(): Promise<void> {
   });
 }
 
+async function testWheelGestureUsesConfiguredActions(): Promise<void> {
+  await withTrackedActions(async (counts) => {
+    await withController(
+      {
+        wheelActions: {
+          scrollUp: ROCKER_RIGHT_LEFT_ACTION,
+          scrollDown: DRAWN_RIGHT_ACTION,
+        },
+      },
+      ({ win }) => {
+        dispatchMouse(win, "mousedown", 2);
+        dispatchWheel(win, -120);
+        dispatchWheel(win, 120);
+        dispatchMouse(win, "mouseup", 2);
+
+        assertEquals(
+          counts[ROCKER_RIGHT_LEFT_ACTION],
+          1,
+          "scroll-up should run the configured action instead of the " +
+            "hardcoded previous-tab action",
+        );
+        assertEquals(
+          counts[DRAWN_RIGHT_ACTION],
+          1,
+          "scroll-down should run the configured action instead of the " +
+            "hardcoded next-tab action",
+        );
+        assertEquals(
+          counts[PREVIOUS_TAB_ACTION],
+          0,
+          "the hardcoded previous-tab action must not run once configured " +
+            "away",
+        );
+        assertEquals(
+          counts[NEXT_TAB_ACTION],
+          0,
+          "the hardcoded next-tab action must not run once configured away",
+        );
+      },
+    );
+  });
+}
+
 const tests: TestCase[] = [
   {
     name: "wheel gesture suppresses post-mouseup contextmenu",
@@ -762,6 +807,10 @@ const tests: TestCase[] = [
   {
     name: "rocker gesture cannot become wheel gesture",
     fn: testRockerGestureCannotBecomeWheelGesture,
+  },
+  {
+    name: "wheel gesture uses configured actions",
+    fn: testWheelGestureUsesConfiguredActions,
   },
 ];
 

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -324,6 +324,11 @@ async function testWheelGestureSuppressesPostMouseUpContextMenu(): Promise<
         "right mouseup should be consumed",
       );
       assertEquals(
+        mouseUp.clickEventPrevented(),
+        true,
+        "wheel-owned right mouseup should suppress its follow-up auxclick",
+      );
+      assertEquals(
         contextMenu.defaultPrevented,
         true,
         "post-mouseup contextmenu should remain suppressed",
@@ -736,6 +741,11 @@ async function testLostWheelReleaseRecoveryMatrix(): Promise<void> {
         "fresh left mouseup after a stale wheel cycle should be passive",
       );
       assertEquals(
+        staleWheelLeftUp.clickEventPrevented(),
+        false,
+        "stale wheel recovery must not suppress the fresh left mouseup click",
+      );
+      assertEquals(
         staleWheelContextMenu.defaultPrevented,
         false,
         "left-click stale recovery must allow keyboard contextmenu",
@@ -937,37 +947,73 @@ async function testWheelGestureUsesConfiguredActions(): Promise<void> {
     await withController(
       {
         wheelActions: {
-          scrollUp: ROCKER_RIGHT_LEFT_ACTION,
-          scrollDown: DRAWN_RIGHT_ACTION,
+          scrollUp: NEXT_TAB_ACTION,
+          scrollDown: PREVIOUS_TAB_ACTION,
         },
       },
       ({ win }) => {
+        // A safe custom mapping reverses the two defaults. Exercise each
+        // direction independently so hardcoded defaults cannot satisfy the
+        // assertions by coincidence.
+        dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+        dispatchWheel(win, -120, 2);
+        dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+        assertEquals(
+          counts[NEXT_TAB_ACTION],
+          1,
+          "scroll-up should run its safe custom next-tab action",
+        );
+        assertEquals(
+          counts[PREVIOUS_TAB_ACTION],
+          0,
+          "scroll-up must not run the previous-tab default once configured away",
+        );
+
+        dispatchMouse(win, "mousedown", 2, 0, 0, 2);
+        dispatchWheel(win, 120, 2);
+        dispatchMouse(win, "mouseup", 2, 0, 0, 0);
+
+        assertEquals(
+          counts[PREVIOUS_TAB_ACTION],
+          1,
+          "scroll-down should run its safe custom previous-tab action",
+        );
+
+        // Bypass setConfig's normalizer by mutating the live test object. The
+        // controller's execution boundary must still reject destructive or
+        // otherwise non-repeat-safe values and use direction-specific defaults.
+        const liveWheelActions = getConfig().wheelActions as unknown as {
+          scrollUp: string;
+          scrollDown: string;
+        };
+        liveWheelActions.scrollUp = ROCKER_RIGHT_LEFT_ACTION;
+        liveWheelActions.scrollDown = DRAWN_RIGHT_ACTION;
+
         dispatchMouse(win, "mousedown", 2, 0, 0, 2);
         dispatchWheel(win, -120, 2);
         dispatchWheel(win, 120, 2);
         dispatchMouse(win, "mouseup", 2, 0, 0, 0);
 
         assertEquals(
-          counts[ROCKER_RIGHT_LEFT_ACTION],
-          1,
-          "scroll-up should run the configured action instead of the " +
-            "hardcoded previous-tab action",
-        );
-        assertEquals(
-          counts[DRAWN_RIGHT_ACTION],
-          1,
-          "scroll-down should run the configured action instead of the " +
-            "hardcoded next-tab action",
-        );
-        assertEquals(
           counts[PREVIOUS_TAB_ACTION],
-          0,
-          "the hardcoded previous-tab action must not run once configured away",
+          2,
+          "forbidden scroll-up should fall back to previous-tab",
         );
         assertEquals(
           counts[NEXT_TAB_ACTION],
+          2,
+          "forbidden scroll-down should fall back to next-tab",
+        );
+        assertEquals(
+          counts[ROCKER_RIGHT_LEFT_ACTION],
           0,
-          "the hardcoded next-tab action must not run once configured away",
+          "forbidden scroll-up action must never execute",
+        );
+        assertEquals(
+          counts[DRAWN_RIGHT_ACTION],
+          0,
+          "forbidden scroll-down action must never execute",
         );
       },
     );

--- a/browser-features/chrome/common/mouse-gesture/wheel-action-policy.ts
+++ b/browser-features/chrome/common/mouse-gesture/wheel-action-policy.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Wheel gestures may fire repeatedly while the secondary button is held.
+// Keep this list deliberately narrow: every entry must be safe to repeat
+// without destroying tabs, windows, user data, or the application session.
+export const REPEAT_SAFE_WHEEL_ACTIONS = [
+  "gecko-show-previous-tab",
+  "gecko-show-next-tab",
+  "gecko-scroll-line-up",
+  "gecko-scroll-line-down",
+  "gecko-scroll-up",
+  "gecko-scroll-down",
+  "gecko-scroll-left",
+  "gecko-scroll-right",
+  "gecko-scroll-to-top",
+  "gecko-scroll-to-bottom",
+  "gecko-zoom-in",
+  "gecko-zoom-out",
+  "gecko-reset-zoom",
+  "gecko-workspace-next",
+  "gecko-workspace-previous",
+  "gecko-show-next-search-result",
+  "gecko-show-previous-search-result",
+] as const;
+
+export type RepeatSafeWheelAction = (typeof REPEAT_SAFE_WHEEL_ACTIONS)[number];
+
+export interface WheelActions {
+  scrollUp: RepeatSafeWheelAction;
+  scrollDown: RepeatSafeWheelAction;
+}
+
+export const DEFAULT_WHEEL_ACTIONS = {
+  scrollUp: "gecko-show-previous-tab",
+  scrollDown: "gecko-show-next-tab",
+} as const satisfies WheelActions;
+
+const repeatSafeWheelActionSet = new Set<string>(REPEAT_SAFE_WHEEL_ACTIONS);
+
+export function isRepeatSafeWheelAction(
+  action: unknown,
+): action is RepeatSafeWheelAction {
+  return typeof action === "string" && repeatSafeWheelActionSet.has(action);
+}
+
+export function normalizeWheelActions(value: unknown): WheelActions {
+  const configured = value !== null && typeof value === "object"
+    ? value as Record<string, unknown>
+    : {};
+
+  return {
+    scrollUp: isRepeatSafeWheelAction(configured.scrollUp)
+      ? configured.scrollUp
+      : DEFAULT_WHEEL_ACTIONS.scrollUp,
+    scrollDown: isRepeatSafeWheelAction(configured.scrollDown)
+      ? configured.scrollDown
+      : DEFAULT_WHEEL_ACTIONS.scrollDown,
+  };
+}

--- a/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
+++ b/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
@@ -163,6 +163,7 @@ export function GeneralSettings({
                   </div>
                   <select
                     className="select select-bordered w-64 max-w-xs text-sm"
+                    aria-label={t("mouseGesture.rockerLeftRight")}
                     value={config.rockerActions.leftRight}
                     onChange={(e) =>
                       updateRockerAction("leftRight", e.target.value)}
@@ -187,6 +188,7 @@ export function GeneralSettings({
                   </div>
                   <select
                     className="select select-bordered w-64 max-w-xs text-sm"
+                    aria-label={t("mouseGesture.rockerRightLeft")}
                     value={config.rockerActions.rightLeft}
                     onChange={(e) =>
                       updateRockerAction("rightLeft", e.target.value)}
@@ -230,6 +232,7 @@ export function GeneralSettings({
                   </div>
                   <select
                     className="select select-bordered w-64 max-w-xs text-sm"
+                    aria-label={t("mouseGesture.wheelScrollUp")}
                     value={config.wheelActions.scrollUp}
                     onChange={(e) =>
                       updateWheelAction("scrollUp", e.target.value)}
@@ -254,6 +257,7 @@ export function GeneralSettings({
                   </div>
                   <select
                     className="select select-bordered w-64 max-w-xs text-sm"
+                    aria-label={t("mouseGesture.wheelScrollDown")}
                     value={config.wheelActions.scrollDown}
                     onChange={(e) =>
                       updateWheelAction("scrollDown", e.target.value)}

--- a/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
+++ b/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
@@ -10,6 +10,8 @@ import { Switch } from "@/components/common/switch.tsx";
 import { Seekbar } from "@/components/common/seekbar.tsx";
 import type { MouseGestureConfig } from "@/types/pref.ts";
 import { useAvailableActions } from "../useAvailableActions.ts";
+import type { MouseGestureConfigUpdate } from "../configPersistence.ts";
+import { REPEAT_SAFE_WHEEL_ACTIONS } from "#features-chrome/common/mouse-gesture/wheel-action-policy.ts";
 import {
   Card,
   CardContent,
@@ -21,7 +23,7 @@ import {
 interface GeneralSettingsProps {
   config: MouseGestureConfig;
   toggleEnabled: () => Promise<boolean>;
-  updateConfig: (config: Partial<MouseGestureConfig>) => Promise<boolean>;
+  updateConfig: (update: MouseGestureConfigUpdate) => Promise<boolean>;
   updateRockerAction: (
     rockerType: "leftRight" | "rightLeft",
     action: string,
@@ -41,14 +43,16 @@ export function GeneralSettings({
 }: GeneralSettingsProps) {
   const { t } = useTranslation();
   const availableActions = useAvailableActions();
+  const wheelActions = useAvailableActions(REPEAT_SAFE_WHEEL_ACTIONS);
 
   const toggleShowTrail = async () => {
-    await updateConfig({ showTrail: !config.showTrail });
+    await updateConfig((current) => ({ showTrail: !current.showTrail }));
   };
 
   const toggleShowLabel = async () => {
-    const current = config.showLabel ?? true;
-    await updateConfig({ showLabel: !current });
+    await updateConfig((current) => ({
+      showLabel: !(current.showLabel ?? true),
+    }));
   };
 
   const handleSensitivityChange = async (
@@ -78,12 +82,12 @@ export function GeneralSettings({
   ) => {
     const target = e.target;
     const value = Number.parseInt(target.value);
-    await updateConfig({
+    await updateConfig((current) => ({
       contextMenu: {
-        ...config.contextMenu,
+        ...current.contextMenu,
         minDistance: value,
       },
-    });
+    }));
   };
 
   const handlePreventionTimeoutChange = async (
@@ -91,12 +95,12 @@ export function GeneralSettings({
   ) => {
     const target = e.target;
     const value = Number.parseInt(target.value);
-    await updateConfig({
+    await updateConfig((current) => ({
       contextMenu: {
-        ...config.contextMenu,
+        ...current.contextMenu,
         preventionTimeout: value,
       },
-    });
+    }));
   };
 
   return (
@@ -141,10 +145,10 @@ export function GeneralSettings({
               <Switch
                 checked={config.rockerGesturesEnabled ?? true}
                 onChange={() =>
-                  updateConfig({
+                  updateConfig((current) => ({
                     rockerGesturesEnabled:
-                      !(config.rockerGesturesEnabled ?? true),
-                  })}
+                      !(current.rockerGesturesEnabled ?? true),
+                  }))}
                 disabled={!config.enabled}
               />
             </div>
@@ -211,9 +215,10 @@ export function GeneralSettings({
               <Switch
                 checked={config.wheelGesturesEnabled ?? true}
                 onChange={() =>
-                  updateConfig({
-                    wheelGesturesEnabled: !(config.wheelGesturesEnabled ?? true),
-                  })}
+                  updateConfig((current) => ({
+                    wheelGesturesEnabled:
+                      !(current.wheelGesturesEnabled ?? true),
+                  }))}
                 disabled={!config.enabled}
               />
             </div>
@@ -238,7 +243,7 @@ export function GeneralSettings({
                       updateWheelAction("scrollUp", e.target.value)}
                     disabled={!config.enabled}
                   >
-                    {availableActions.map((action) => (
+                    {wheelActions.map((action) => (
                       <option key={action.id} value={action.id}>
                         {action.name}
                       </option>
@@ -263,7 +268,7 @@ export function GeneralSettings({
                       updateWheelAction("scrollDown", e.target.value)}
                     disabled={!config.enabled}
                   >
-                    {availableActions.map((action) => (
+                    {wheelActions.map((action) => (
                       <option key={action.id} value={action.id}>
                         {action.name}
                       </option>

--- a/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
+++ b/browser-features/pages-settings/src/app/gesture/components/Preferences.tsx
@@ -26,6 +26,10 @@ interface GeneralSettingsProps {
     rockerType: "leftRight" | "rightLeft",
     action: string,
   ) => Promise<boolean>;
+  updateWheelAction: (
+    wheelType: "scrollUp" | "scrollDown",
+    action: string,
+  ) => Promise<boolean>;
 }
 
 export function GeneralSettings({
@@ -33,6 +37,7 @@ export function GeneralSettings({
   toggleEnabled,
   updateConfig,
   updateRockerAction,
+  updateWheelAction,
 }: GeneralSettingsProps) {
   const { t } = useTranslation();
   const availableActions = useAvailableActions();
@@ -210,6 +215,59 @@ export function GeneralSettings({
                 disabled={!config.enabled}
               />
             </div>
+
+            {/* Wheel Actions - only show when enabled */}
+            {config.wheelGesturesEnabled && (
+              <>
+                <div className="flex items-center justify-between py-2 pl-4">
+                  <div className="flex-1">
+                    <span className="text-base-content/90 font-medium">
+                      {t("mouseGesture.wheelScrollUp")}
+                    </span>
+                    <p className="text-sm text-base-content/60">
+                      {t("mouseGesture.wheelScrollUpDescription")}
+                    </p>
+                  </div>
+                  <select
+                    className="select select-bordered w-64 max-w-xs text-sm"
+                    value={config.wheelActions.scrollUp}
+                    onChange={(e) =>
+                      updateWheelAction("scrollUp", e.target.value)}
+                    disabled={!config.enabled}
+                  >
+                    {availableActions.map((action) => (
+                      <option key={action.id} value={action.id}>
+                        {action.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="flex items-center justify-between py-2 pl-4">
+                  <div className="flex-1">
+                    <span className="text-base-content/90 font-medium">
+                      {t("mouseGesture.wheelScrollDown")}
+                    </span>
+                    <p className="text-sm text-base-content/60">
+                      {t("mouseGesture.wheelScrollDownDescription")}
+                    </p>
+                  </div>
+                  <select
+                    className="select select-bordered w-64 max-w-xs text-sm"
+                    value={config.wheelActions.scrollDown}
+                    onChange={(e) =>
+                      updateWheelAction("scrollDown", e.target.value)}
+                    disabled={!config.enabled}
+                  >
+                    {availableActions.map((action) => (
+                      <option key={action.id} value={action.id}>
+                        {action.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </>
+            )}
           </div>
 
           <div className="divider" />

--- a/browser-features/pages-settings/src/app/gesture/configPersistence.ts
+++ b/browser-features/pages-settings/src/app/gesture/configPersistence.ts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import type { MouseGestureConfig } from "../../types/pref.ts";
+import {
+  DEFAULT_WHEEL_ACTIONS,
+  normalizeWheelActions,
+} from "#features-chrome/common/mouse-gesture/wheel-action-policy.ts";
+
+export const MOUSE_GESTURE_ENABLED_PREF = "floorp.mousegesture.enabled";
+export const MOUSE_GESTURE_CONFIG_PREF = "floorp.mousegesture.config";
+
+const MIN_CONTEXT_MENU_DISTANCE = 5;
+const GESTURE_DIRECTIONS = new Set([
+  "up",
+  "down",
+  "left",
+  "right",
+  "upRight",
+  "upLeft",
+  "downRight",
+  "downLeft",
+]);
+
+type PersistedMouseGestureConfig = Omit<MouseGestureConfig, "enabled">;
+
+export type MouseGestureConfigUpdate =
+  | Partial<PersistedMouseGestureConfig>
+  | ((
+    current: Readonly<MouseGestureConfig>,
+  ) => Partial<PersistedMouseGestureConfig>);
+
+export interface GestureConfigWriters {
+  writeEnabled(enabled: boolean): Promise<void>;
+  writeConfig(serializedConfig: string): Promise<void>;
+}
+
+export interface GestureConfigPersistenceSnapshot {
+  config: MouseGestureConfig;
+  pending: boolean;
+  error: string | null;
+}
+
+export interface GestureConfigPersistence {
+  getSnapshot(): GestureConfigPersistenceSnapshot;
+  subscribe(
+    listener: (snapshot: GestureConfigPersistenceSnapshot) => void,
+  ): () => void;
+  updateEnabled(
+    update: boolean | ((currentEnabled: boolean) => boolean),
+  ): Promise<boolean>;
+  updateConfig(update: MouseGestureConfigUpdate): Promise<boolean>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function booleanOr(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function finiteNumberOr(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function normalizeActions(
+  value: unknown,
+  fallback: MouseGestureConfig["actions"],
+): MouseGestureConfig["actions"] {
+  if (!Array.isArray(value)) return fallback.map((action) => ({ ...action }));
+
+  return value.flatMap((candidate) => {
+    if (!isRecord(candidate) || typeof candidate.action !== "string") return [];
+    if (
+      !Array.isArray(candidate.pattern) ||
+      !candidate.pattern.every((direction) =>
+        typeof direction === "string" && GESTURE_DIRECTIONS.has(direction)
+      )
+    ) return [];
+
+    return [{
+      pattern: [
+        ...candidate.pattern,
+      ] as MouseGestureConfig["actions"][number]["pattern"],
+      action: candidate.action,
+    }];
+  });
+}
+
+export function createDefaultMouseGestureConfig(
+  enabled: boolean,
+): MouseGestureConfig {
+  return {
+    enabled,
+    rockerGesturesEnabled: true,
+    wheelGesturesEnabled: true,
+    sensitivity: 40,
+    showTrail: true,
+    showLabel: true,
+    trailColor: "#37ff00",
+    trailWidth: 6,
+    contextMenu: {
+      minDistance: 12,
+      preventionTimeout: 200,
+    },
+    actions: [],
+    rockerActions: {
+      leftRight: "gecko-forward",
+      rightLeft: "gecko-back",
+    },
+    wheelActions: { ...DEFAULT_WHEEL_ACTIONS },
+  };
+}
+
+export function normalizeMouseGestureConfig(
+  value: unknown,
+  enabled: boolean,
+): MouseGestureConfig {
+  const defaults = createDefaultMouseGestureConfig(enabled);
+  const source = isRecord(value) ? value : {};
+  const contextMenu = isRecord(source.contextMenu) ? source.contextMenu : {};
+  const rockerActions = isRecord(source.rockerActions)
+    ? source.rockerActions
+    : {};
+
+  return {
+    enabled,
+    rockerGesturesEnabled: booleanOr(
+      source.rockerGesturesEnabled,
+      defaults.rockerGesturesEnabled,
+    ),
+    wheelGesturesEnabled: booleanOr(
+      source.wheelGesturesEnabled,
+      defaults.wheelGesturesEnabled,
+    ),
+    sensitivity: Math.min(
+      100,
+      Math.max(1, finiteNumberOr(source.sensitivity, defaults.sensitivity)),
+    ),
+    showTrail: booleanOr(source.showTrail, defaults.showTrail),
+    showLabel: booleanOr(source.showLabel, defaults.showLabel),
+    trailColor: stringOr(source.trailColor, defaults.trailColor),
+    trailWidth: finiteNumberOr(source.trailWidth, defaults.trailWidth),
+    contextMenu: {
+      minDistance: Math.max(
+        MIN_CONTEXT_MENU_DISTANCE,
+        finiteNumberOr(
+          contextMenu.minDistance,
+          defaults.contextMenu.minDistance,
+        ),
+      ),
+      preventionTimeout: Math.max(
+        0,
+        finiteNumberOr(
+          contextMenu.preventionTimeout,
+          defaults.contextMenu.preventionTimeout,
+        ),
+      ),
+    },
+    actions: normalizeActions(source.actions, defaults.actions),
+    rockerActions: {
+      leftRight: stringOr(
+        rockerActions.leftRight,
+        defaults.rockerActions.leftRight,
+      ),
+      rightLeft: stringOr(
+        rockerActions.rightLeft,
+        defaults.rockerActions.rightLeft,
+      ),
+    },
+    wheelActions: normalizeWheelActions(source.wheelActions),
+  };
+}
+
+export function parseMouseGestureConfig(
+  serializedConfig: string | null,
+  enabled: boolean,
+): MouseGestureConfig {
+  if (!serializedConfig) return createDefaultMouseGestureConfig(enabled);
+
+  try {
+    return normalizeMouseGestureConfig(JSON.parse(serializedConfig), enabled);
+  } catch (error) {
+    console.error("Failed to parse mouse gesture configuration", error);
+    return createDefaultMouseGestureConfig(enabled);
+  }
+}
+
+export function serializeMouseGestureConfig(
+  config: MouseGestureConfig,
+): string {
+  const { enabled: _, ...configWithoutEnabled } = config;
+  return JSON.stringify(configWithoutEnabled);
+}
+
+function errorToMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createGestureConfigPersistence(
+  initialConfig: MouseGestureConfig,
+  writers: GestureConfigWriters,
+): GestureConfigPersistence {
+  let snapshot: GestureConfigPersistenceSnapshot = {
+    config: normalizeMouseGestureConfig(initialConfig, initialConfig.enabled),
+    pending: false,
+    error: null,
+  };
+  let pendingCount = 0;
+  let queueTail: Promise<void> = Promise.resolve();
+  const listeners = new Set<
+    (currentSnapshot: GestureConfigPersistenceSnapshot) => void
+  >();
+
+  const notify = () => {
+    const currentSnapshot = { ...snapshot };
+    for (const listener of listeners) listener(currentSnapshot);
+  };
+
+  const setPendingCount = (nextPendingCount: number) => {
+    pendingCount = nextPendingCount;
+    snapshot = { ...snapshot, pending: pendingCount > 0 };
+    notify();
+  };
+
+  const enqueue = (
+    operation: () => Promise<MouseGestureConfig>,
+  ): Promise<boolean> => {
+    setPendingCount(pendingCount + 1);
+
+    const result = queueTail.then(async () => {
+      try {
+        const committedConfig = await operation();
+        snapshot = {
+          config: committedConfig,
+          pending: snapshot.pending,
+          error: null,
+        };
+        return true;
+      } catch (error) {
+        snapshot = {
+          ...snapshot,
+          error: errorToMessage(error),
+        };
+        return false;
+      } finally {
+        setPendingCount(pendingCount - 1);
+      }
+    });
+
+    queueTail = result.then(() => undefined, () => undefined);
+    return result;
+  };
+
+  return {
+    getSnapshot: () => ({ ...snapshot }),
+    subscribe: (listener) => {
+      listeners.add(listener);
+      listener({ ...snapshot });
+      return () => listeners.delete(listener);
+    },
+    updateEnabled: (update) =>
+      enqueue(async () => {
+        const current = snapshot.config;
+        const enabled = typeof update === "function"
+          ? update(current.enabled)
+          : update;
+        await writers.writeEnabled(enabled);
+        return { ...current, enabled };
+      }),
+    updateConfig: (update) =>
+      enqueue(async () => {
+        const current = snapshot.config;
+        const partial = typeof update === "function" ? update(current) : update;
+        const nextConfig = normalizeMouseGestureConfig(
+          { ...current, ...partial },
+          current.enabled,
+        );
+        await writers.writeConfig(serializeMouseGestureConfig(nextConfig));
+        return nextConfig;
+      }),
+  };
+}

--- a/browser-features/pages-settings/src/app/gesture/dataManager.ts
+++ b/browser-features/pages-settings/src/app/gesture/dataManager.ts
@@ -52,6 +52,10 @@ export const useMouseGestureConfig = () => {
             leftRight: "gecko-forward",
             rightLeft: "gecko-back",
           },
+          wheelActions: {
+            scrollUp: "gecko-show-previous-tab",
+            scrollDown: "gecko-show-next-tab",
+          },
         };
 
         try {
@@ -137,6 +141,15 @@ export const useMouseGestureConfig = () => {
     });
   };
 
+  const updateWheelAction = (wheelType: "scrollUp" | "scrollDown", action: string) => {
+    return updateConfig({
+      wheelActions: {
+        ...config.wheelActions,
+        [wheelType]: action,
+      },
+    });
+  };
+
   return {
     config,
     loading,
@@ -147,6 +160,7 @@ export const useMouseGestureConfig = () => {
     updateAction,
     deleteAction,
     updateRockerAction,
+    updateWheelAction,
   };
 };
 

--- a/browser-features/pages-settings/src/app/gesture/dataManager.ts
+++ b/browser-features/pages-settings/src/app/gesture/dataManager.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { rpc } from "../../lib/rpc/rpc.ts";
 import type {
   GestureAction,
@@ -18,6 +18,18 @@ export const useMouseGestureConfig = () => {
   const [config, setConfig] = useState<MouseGestureConfig>(
     {} as MouseGestureConfig,
   );
+  // Every updater below reads its "current" config from this ref, not from
+  // `config` directly. Two rapid updates (e.g. changing both wheel-action
+  // selectors before the first async save resolves) would otherwise both
+  // build on the same stale `config` closure, and whichever save resolves
+  // last would silently discard the other's change. The ref is updated
+  // synchronously in `applyConfig`, before any await, so each subsequent
+  // call always builds on the latest requested config.
+  const configRef = useRef<MouseGestureConfig>(config);
+  const applyConfig = (newConfig: MouseGestureConfig) => {
+    configRef.current = newConfig;
+    setConfig(newConfig);
+  };
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -63,7 +75,7 @@ export const useMouseGestureConfig = () => {
           if (configStr) {
             const parsedConfig = JSON.parse(configStr);
             // Merge defaults with parsed config
-            setConfig({
+            applyConfig({
               ...defaultConfig,
               ...parsedConfig,
               contextMenu: {
@@ -73,11 +85,11 @@ export const useMouseGestureConfig = () => {
               enabled,
             });
           } else {
-            setConfig(defaultConfig);
+            applyConfig(defaultConfig);
           }
         } catch (parseError) {
           console.error("Failed to parse configuration", parseError);
-          setConfig(defaultConfig);
+          applyConfig(defaultConfig);
         }
       } catch (error) {
         console.error("Failed to load configuration", error);
@@ -102,7 +114,12 @@ export const useMouseGestureConfig = () => {
         JSON.stringify(configWithoutEnabled),
       );
 
-      setConfig(newConfig);
+      // If a newer update has already advanced configRef past this call's
+      // snapshot (e.g. this save resolved after a later one, out of order),
+      // committing newConfig to state now would revert that newer change.
+      if (configRef.current === newConfig) {
+        setConfig(newConfig);
+      }
       return true;
     } catch (error) {
       console.error("Failed to save configuration", error);
@@ -111,23 +128,25 @@ export const useMouseGestureConfig = () => {
   };
 
   const updateConfig = (partialConfig: Partial<MouseGestureConfig>) => {
-    const newConfig = { ...config, ...partialConfig };
+    const newConfig = { ...configRef.current, ...partialConfig };
+    configRef.current = newConfig;
     return saveConfig(newConfig);
   };
 
-  const toggleEnabled = () => updateConfig({ enabled: !config.enabled });
+  const toggleEnabled = () =>
+    updateConfig({ enabled: !configRef.current.enabled });
 
   const addAction = (action: GestureAction) =>
-    updateConfig({ actions: [...config.actions, action] });
+    updateConfig({ actions: [...configRef.current.actions, action] });
 
   const updateAction = (index: number, action: GestureAction) => {
-    const newActions = [...config.actions];
+    const newActions = [...configRef.current.actions];
     newActions[index] = action;
     return updateConfig({ actions: newActions });
   };
 
   const deleteAction = (index: number) => {
-    const newActions = [...config.actions];
+    const newActions = [...configRef.current.actions];
     newActions.splice(index, 1);
     return updateConfig({ actions: newActions });
   };
@@ -135,7 +154,7 @@ export const useMouseGestureConfig = () => {
   const updateRockerAction = (rockerType: "leftRight" | "rightLeft", action: string) => {
     return updateConfig({
       rockerActions: {
-        ...config.rockerActions,
+        ...configRef.current.rockerActions,
         [rockerType]: action,
       },
     });
@@ -144,7 +163,7 @@ export const useMouseGestureConfig = () => {
   const updateWheelAction = (wheelType: "scrollUp" | "scrollDown", action: string) => {
     return updateConfig({
       wheelActions: {
-        ...config.wheelActions,
+        ...configRef.current.wheelActions,
         [wheelType]: action,
       },
     });

--- a/browser-features/pages-settings/src/app/gesture/dataManager.ts
+++ b/browser-features/pages-settings/src/app/gesture/dataManager.ts
@@ -10,36 +10,29 @@ import type {
   GestureDirection,
   MouseGestureConfig,
 } from "../../types/pref.ts";
-
-const MOUSE_GESTURE_ENABLED_PREF = "floorp.mousegesture.enabled";
-const MOUSE_GESTURE_CONFIG_PREF = "floorp.mousegesture.config";
+import {
+  createDefaultMouseGestureConfig,
+  createGestureConfigPersistence,
+  type GestureConfigPersistence,
+  MOUSE_GESTURE_CONFIG_PREF,
+  MOUSE_GESTURE_ENABLED_PREF,
+  type MouseGestureConfigUpdate,
+  parseMouseGestureConfig,
+} from "./configPersistence.ts";
 
 export const useMouseGestureConfig = () => {
   const [config, setConfig] = useState<MouseGestureConfig>(
-    {} as MouseGestureConfig,
+    () => createDefaultMouseGestureConfig(false),
   );
-  // Every updater below reads its "current" config from this ref, not from
-  // `config` directly. Two rapid updates (e.g. changing both wheel-action
-  // selectors before the first async save resolves) would otherwise both
-  // build on the same stale `config` closure, and whichever save resolves
-  // last would silently discard the other's change. The ref is updated
-  // synchronously in `applyConfig`, before any await, so each subsequent
-  // call always builds on the latest requested config.
-  const configRef = useRef<MouseGestureConfig>(config);
-  const applyConfig = (newConfig: MouseGestureConfig) => {
-    configRef.current = newConfig;
-    setConfig(newConfig);
-  };
-  // Persistence writes (rpc.setBoolPref/setStringPref) are queued through
-  // this ref-backed promise chain so they always land in invocation order.
-  // Without it, two saves in flight could complete out of order, and an
-  // older save resolving last would overwrite a newer wheel/rocker-action
-  // choice in the actual persisted pref - silently reverting it on the next
-  // page load, even though in-memory state briefly showed the newer value.
-  const saveQueueRef = useRef<Promise<boolean>>(Promise.resolve(true));
   const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const persistenceRef = useRef<GestureConfigPersistence | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+    let unsubscribe: (() => void) | null = null;
+
     const loadConfig = async () => {
       try {
         setLoading(true);
@@ -53,138 +46,99 @@ export const useMouseGestureConfig = () => {
           enabled = false;
         }
 
-        const defaultConfig: MouseGestureConfig = {
-          enabled,
-          rockerGesturesEnabled: true,
-          wheelGesturesEnabled: true,
-          sensitivity: 40,
-          showTrail: true,
-          showLabel: true,
-          trailColor: "#37ff00",
-          trailWidth: 6,
-          contextMenu: {
-            minDistance: 12,
-            preventionTimeout: 200,
-          },
-          actions: [],
-          rockerActions: {
-            leftRight: "gecko-forward",
-            rightLeft: "gecko-back",
-          },
-          wheelActions: {
-            scrollUp: "gecko-show-previous-tab",
-            scrollDown: "gecko-show-next-tab",
-          },
-        };
-
+        let loadedConfig = createDefaultMouseGestureConfig(enabled);
         try {
           const configStr = await rpc.getStringPref(MOUSE_GESTURE_CONFIG_PREF);
-          if (configStr) {
-            const parsedConfig = JSON.parse(configStr);
-            // Merge defaults with parsed config
-            applyConfig({
-              ...defaultConfig,
-              ...parsedConfig,
-              contextMenu: {
-                ...defaultConfig.contextMenu,
-                ...parsedConfig.contextMenu,
-              },
-              enabled,
-            });
-          } else {
-            applyConfig(defaultConfig);
-          }
+          loadedConfig = parseMouseGestureConfig(configStr, enabled);
         } catch (parseError) {
-          console.error("Failed to parse configuration", parseError);
-          applyConfig(defaultConfig);
+          console.error("Failed to load configuration", parseError);
         }
+
+        if (cancelled) return;
+        const persistence = createGestureConfigPersistence(loadedConfig, {
+          writeEnabled: (nextEnabled) =>
+            rpc.setBoolPref(MOUSE_GESTURE_ENABLED_PREF, nextEnabled),
+          writeConfig: (serializedConfig) =>
+            rpc.setStringPref(
+              MOUSE_GESTURE_CONFIG_PREF,
+              serializedConfig,
+            ),
+        });
+        persistenceRef.current = persistence;
+        unsubscribe = persistence.subscribe((snapshot) => {
+          if (cancelled) return;
+          setConfig(snapshot.config);
+          setPending(snapshot.pending);
+          setError(snapshot.error);
+        });
       } catch (error) {
         console.error("Failed to load configuration", error);
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
     loadConfig();
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+      persistenceRef.current = null;
+    };
   }, []);
 
-  const saveConfig = async (newConfig: MouseGestureConfig) => {
-    console.log("saveConfig", newConfig);
-    try {
-      await rpc.setBoolPref(MOUSE_GESTURE_ENABLED_PREF, newConfig.enabled);
-      const configToSave = { ...newConfig };
-      // deno-lint-ignore no-unused-vars
-      const { enabled, ...configWithoutEnabled } = configToSave;
-      console.log("Saving configWithoutEnabled", configWithoutEnabled);
-      await rpc.setStringPref(
-        MOUSE_GESTURE_CONFIG_PREF,
-        JSON.stringify(configWithoutEnabled),
-      );
-
-      // If a newer update has already advanced configRef past this call's
-      // snapshot (e.g. this save resolved after a later one, out of order),
-      // committing newConfig to state now would revert that newer change.
-      if (configRef.current === newConfig) {
-        setConfig(newConfig);
-      }
-      return true;
-    } catch (error) {
-      console.error("Failed to save configuration", error);
-      return false;
-    }
-  };
-
-  const updateConfig = (partialConfig: Partial<MouseGestureConfig>) => {
-    const newConfig = { ...configRef.current, ...partialConfig };
-    // Apply optimistically so the UI reflects the choice immediately,
-    // rather than lagging until the save round-trip completes.
-    applyConfig(newConfig);
-
-    const queuedSave = saveQueueRef.current.then(() => saveConfig(newConfig));
-    saveQueueRef.current = queuedSave;
-    return queuedSave;
-  };
+  const updateConfig = (update: MouseGestureConfigUpdate) =>
+    persistenceRef.current?.updateConfig(update) ?? Promise.resolve(false);
 
   const toggleEnabled = () =>
-    updateConfig({ enabled: !configRef.current.enabled });
+    persistenceRef.current?.updateEnabled((enabled) => !enabled) ??
+      Promise.resolve(false);
 
   const addAction = (action: GestureAction) =>
-    updateConfig({ actions: [...configRef.current.actions, action] });
+    updateConfig((current) => ({
+      actions: [...current.actions, action],
+    }));
 
-  const updateAction = (index: number, action: GestureAction) => {
-    const newActions = [...configRef.current.actions];
-    newActions[index] = action;
-    return updateConfig({ actions: newActions });
-  };
+  const updateAction = (index: number, action: GestureAction) =>
+    updateConfig((current) => {
+      const actions = [...current.actions];
+      actions[index] = action;
+      return { actions };
+    });
 
-  const deleteAction = (index: number) => {
-    const newActions = [...configRef.current.actions];
-    newActions.splice(index, 1);
-    return updateConfig({ actions: newActions });
-  };
+  const deleteAction = (index: number) =>
+    updateConfig((current) => ({
+      actions: current.actions.filter((_, actionIndex) =>
+        actionIndex !== index
+      ),
+    }));
 
-  const updateRockerAction = (rockerType: "leftRight" | "rightLeft", action: string) => {
-    return updateConfig({
+  const updateRockerAction = (
+    rockerType: "leftRight" | "rightLeft",
+    action: string,
+  ) =>
+    updateConfig((current) => ({
       rockerActions: {
-        ...configRef.current.rockerActions,
+        ...current.rockerActions,
         [rockerType]: action,
       },
-    });
-  };
+    }));
 
-  const updateWheelAction = (wheelType: "scrollUp" | "scrollDown", action: string) => {
-    return updateConfig({
+  const updateWheelAction = (
+    wheelType: "scrollUp" | "scrollDown",
+    action: string,
+  ) =>
+    updateConfig((current) => ({
       wheelActions: {
-        ...configRef.current.wheelActions,
+        ...current.wheelActions,
         [wheelType]: action,
       },
-    });
-  };
+    }));
 
   return {
     config,
     loading,
-    saveConfig,
+    pending,
+    error,
     updateConfig,
     toggleEnabled,
     addAction,

--- a/browser-features/pages-settings/src/app/gesture/dataManager.ts
+++ b/browser-features/pages-settings/src/app/gesture/dataManager.ts
@@ -30,6 +30,13 @@ export const useMouseGestureConfig = () => {
     configRef.current = newConfig;
     setConfig(newConfig);
   };
+  // Persistence writes (rpc.setBoolPref/setStringPref) are queued through
+  // this ref-backed promise chain so they always land in invocation order.
+  // Without it, two saves in flight could complete out of order, and an
+  // older save resolving last would overwrite a newer wheel/rocker-action
+  // choice in the actual persisted pref - silently reverting it on the next
+  // page load, even though in-memory state briefly showed the newer value.
+  const saveQueueRef = useRef<Promise<boolean>>(Promise.resolve(true));
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -129,8 +136,13 @@ export const useMouseGestureConfig = () => {
 
   const updateConfig = (partialConfig: Partial<MouseGestureConfig>) => {
     const newConfig = { ...configRef.current, ...partialConfig };
-    configRef.current = newConfig;
-    return saveConfig(newConfig);
+    // Apply optimistically so the UI reflects the choice immediately,
+    // rather than lagging until the save round-trip completes.
+    applyConfig(newConfig);
+
+    const queuedSave = saveQueueRef.current.then(() => saveConfig(newConfig));
+    saveQueueRef.current = queuedSave;
+    return queuedSave;
   };
 
   const toggleEnabled = () =>

--- a/browser-features/pages-settings/src/app/gesture/page.tsx
+++ b/browser-features/pages-settings/src/app/gesture/page.tsx
@@ -19,6 +19,7 @@ export default function Page() {
         updateAction,
         deleteAction,
         updateRockerAction,
+        updateWheelAction,
     } = useMouseGestureConfig();
 
     if (loading) {
@@ -42,6 +43,7 @@ export default function Page() {
                     toggleEnabled={toggleEnabled}
                     updateConfig={updateConfig}
                     updateRockerAction={updateRockerAction}
+                    updateWheelAction={updateWheelAction}
                 />
 
                 <ActionsSettings

--- a/browser-features/pages-settings/src/app/gesture/page.tsx
+++ b/browser-features/pages-settings/src/app/gesture/page.tsx
@@ -9,50 +9,69 @@ import { GeneralSettings } from "./components/Preferences.tsx";
 import { ActionsSettings } from "./components/ActionsSettings.tsx";
 
 export default function Page() {
-    const { t } = useTranslation();
-    const {
-        config,
-        loading,
-        updateConfig,
-        toggleEnabled,
-        addAction,
-        updateAction,
-        deleteAction,
-        updateRockerAction,
-        updateWheelAction,
-    } = useMouseGestureConfig();
+  const { t } = useTranslation();
+  const {
+    config,
+    loading,
+    pending,
+    error,
+    updateConfig,
+    toggleEnabled,
+    addAction,
+    updateAction,
+    deleteAction,
+    updateRockerAction,
+    updateWheelAction,
+  } = useMouseGestureConfig();
 
-    if (loading) {
-        return <div className="py-6 text-center">{t("loading")}...</div>;
-    }
+  if (loading) {
+    return <div className="py-6 text-center">{t("loading")}...</div>;
+  }
 
-    return (
-        <div className="p-6 space-y-3">
-            <div className="flex flex-col items-start pl-6">
-                <h1 className="text-3xl font-bold mb-2">
-                    {t("pages.mouseGesture")}
-                </h1>
-                <p className="text-sm mb-8">
-                    {t("mouseGesture.description")}
-                </p>
-            </div>
+  return (
+    <div className="p-6 space-y-3">
+      <div className="flex flex-col items-start pl-6">
+        <h1 className="text-3xl font-bold mb-2">
+          {t("pages.mouseGesture")}
+        </h1>
+        <p className="text-sm mb-8">
+          {t("mouseGesture.description")}
+        </p>
+      </div>
 
-            <div className="space-y-3 pl-6">
-                <GeneralSettings
-                    config={config}
-                    toggleEnabled={toggleEnabled}
-                    updateConfig={updateConfig}
-                    updateRockerAction={updateRockerAction}
-                    updateWheelAction={updateWheelAction}
-                />
-
-                <ActionsSettings
-                    config={config}
-                    addAction={addAction}
-                    updateAction={updateAction}
-                    deleteAction={deleteAction}
-                />
-            </div>
+      <div className="space-y-3 pl-6">
+        <div
+          className="min-h-6 text-sm"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {pending && (
+            <p role="status" className="text-base-content/70">
+              {t("mouseGesture.saving")}
+            </p>
+          )}
+          {error && (
+            <p role="alert" className="text-error">
+              {t("mouseGesture.saveError")}
+            </p>
+          )}
         </div>
-    );
+
+        <GeneralSettings
+          config={config}
+          toggleEnabled={toggleEnabled}
+          updateConfig={updateConfig}
+          updateRockerAction={updateRockerAction}
+          updateWheelAction={updateWheelAction}
+        />
+
+        <ActionsSettings
+          config={config}
+          addAction={addAction}
+          updateAction={updateAction}
+          deleteAction={deleteAction}
+        />
+      </div>
+    </div>
+  );
 }

--- a/browser-features/pages-settings/src/app/gesture/useAvailableActions.ts
+++ b/browser-features/pages-settings/src/app/gesture/useAvailableActions.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 interface ActionOption {
@@ -108,18 +108,16 @@ export const GESTURE_ACTIONS = [
   "floorp-split-view-remove-pane",
 ] as const;
 
-export const useAvailableActions = () => {
+export const useAvailableActions = (
+  actionIds: readonly string[] = GESTURE_ACTIONS,
+) => {
   const { t } = useTranslation();
-  const [actions, setActions] = useState<ActionOption[]>([]);
-
-  useEffect(() => {
-    const translatedActions = GESTURE_ACTIONS.map((id) => ({
-      id,
-      name: t(`mouseGesture.actions.${id}`, id),
-    }));
-
-    setActions(translatedActions);
-  }, [t]);
-
-  return actions;
+  return useMemo<ActionOption[]>(
+    () =>
+      actionIds.map((id) => ({
+        id,
+        name: t(`mouseGesture.actions.${id}`, id),
+      })),
+    [actionIds, t],
+  );
 };

--- a/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
@@ -511,6 +511,8 @@
     },
     "mouseGesture": {
         "description": "Control your browser with mouse movements.",
+        "saving": "Saving mouse gesture settings…",
+        "saveError": "Mouse gesture settings could not be saved. Your previous settings are still active.",
         "generalSettings": "General Settings",
         "generalSettingsDescription": "Basic mouse gesture settings",
         "enabled": "Enable mouse gestures",

--- a/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
@@ -547,6 +547,10 @@
         "rockerRightLeft": "Right → Left",
         "rockerRightLeftDescription": "Hold right button, then click left button",
         "wheelGesturesEnabled": "Enable wheel gestures",
+        "wheelScrollUp": "Scroll Up",
+        "wheelScrollUpDescription": "Action when scrolling the wheel up while holding the right button",
+        "wheelScrollDown": "Scroll Down",
+        "wheelScrollDownDescription": "Action when scrolling the wheel down while holding the right button",
         "actions": {
             "gecko-back": "Go Back",
             "gecko-forward": "Go Forward",

--- a/browser-features/pages-settings/src/types/pref.ts
+++ b/browser-features/pages-settings/src/types/pref.ts
@@ -183,6 +183,11 @@ export const zRockerActions = t.type({
   rightLeft: t.string,
 });
 
+export const zWheelActions = t.type({
+  scrollUp: t.string,
+  scrollDown: t.string,
+});
+
 export const zMouseGestureConfig = t.type({
   enabled: t.boolean,
   rockerGesturesEnabled: t.boolean,
@@ -195,6 +200,7 @@ export const zMouseGestureConfig = t.type({
   contextMenu: zMouseGestureContextMenu,
   actions: t.array(zGestureAction),
   rockerActions: zRockerActions,
+  wheelActions: zWheelActions,
 });
 
 export type GestureAction = t.TypeOf<typeof zGestureAction>;

--- a/browser-features/pages-settings/test/app/gesture/configPersistence.test.ts
+++ b/browser-features/pages-settings/test/app/gesture/configPersistence.test.ts
@@ -273,9 +273,9 @@ async function testQueueRecoversAfterFailure(): Promise<void> {
   const persistence = createGestureConfigPersistence(
     createDefaultMouseGestureConfig(false),
     {
-      writeEnabled: async () => {
+      writeEnabled: () => {
         operations.push("enabled");
-        throw new Error("bool failed");
+        return Promise.reject(new Error("bool failed"));
       },
       writeConfig: (serialized) => {
         operations.push("config");
@@ -324,9 +324,9 @@ async function testBoolUpdateRecoversAfterConfigFailure(): Promise<void> {
         boolWrites.push(enabled);
         return Promise.resolve();
       },
-      writeConfig: async () => {
+      writeConfig: () => {
         operations.push("config");
-        throw new Error("json failed");
+        return Promise.reject(new Error("json failed"));
       },
     },
   );

--- a/browser-features/pages-settings/test/app/gesture/configPersistence.test.ts
+++ b/browser-features/pages-settings/test/app/gesture/configPersistence.test.ts
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+import {
+  createDefaultMouseGestureConfig,
+  createGestureConfigPersistence,
+  normalizeMouseGestureConfig,
+} from "../../../src/app/gesture/configPersistence.ts";
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function testEnabledUpdateWritesOnlyBool(): Promise<void> {
+  const boolWrites: boolean[] = [];
+  const configWrites: string[] = [];
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(false),
+    {
+      writeEnabled: (enabled) => {
+        boolWrites.push(enabled);
+        return Promise.resolve();
+      },
+      writeConfig: (serialized) => {
+        configWrites.push(serialized);
+        return Promise.resolve();
+      },
+    },
+  );
+
+  return persistence.updateEnabled(true).then((saved) => {
+    assertEquals(saved, true, "enabled update succeeds");
+    assertEquals(boolWrites.length, 1, "enabled update writes one bool pref");
+    assertEquals(boolWrites[0], true, "enabled update writes requested value");
+    assertEquals(configWrites.length, 0, "enabled update does not write JSON");
+    assertEquals(
+      persistence.getSnapshot().config.enabled,
+      true,
+      "enabled state commits after the bool write",
+    );
+  });
+}
+
+function testConfigUpdateWritesOnlyJsonWithoutEnabled(): Promise<void> {
+  const boolWrites: boolean[] = [];
+  const configWrites: string[] = [];
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(true),
+    {
+      writeEnabled: (enabled) => {
+        boolWrites.push(enabled);
+        return Promise.resolve();
+      },
+      writeConfig: (serialized) => {
+        configWrites.push(serialized);
+        return Promise.resolve();
+      },
+    },
+  );
+
+  return persistence.updateConfig({ showTrail: false }).then((saved) => {
+    assertEquals(saved, true, "config update succeeds");
+    assertEquals(
+      boolWrites.length,
+      0,
+      "config update does not write bool pref",
+    );
+    assertEquals(configWrites.length, 1, "config update writes one JSON pref");
+    const persisted = JSON.parse(configWrites[0]);
+    assertEquals(
+      Object.hasOwn(persisted, "enabled"),
+      false,
+      "JSON pref omits enabled",
+    );
+    assertEquals(persisted.showTrail, false, "JSON contains the config update");
+  });
+}
+
+async function testRapidNestedUpdatesUseLastCommittedConfig(): Promise<void> {
+  const persisted: Array<Record<string, unknown>> = [];
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(true),
+    {
+      writeEnabled: () => Promise.resolve(),
+      writeConfig: async (serialized) => {
+        await Promise.resolve();
+        persisted.push(JSON.parse(serialized));
+      },
+    },
+  );
+
+  const minDistanceUpdate = persistence.updateConfig((current) => ({
+    contextMenu: { ...current.contextMenu, minDistance: 24 },
+  }));
+  const timeoutUpdate = persistence.updateConfig((current) => ({
+    contextMenu: { ...current.contextMenu, preventionTimeout: 850 },
+  }));
+
+  const results = await Promise.all([minDistanceUpdate, timeoutUpdate]);
+  assert(
+    results.every((result) => result),
+    "both queued nested updates should succeed",
+  );
+  assertEquals(persisted.length, 2, "queued updates write in order");
+  assertEquals(
+    persistence.getSnapshot().config.contextMenu.minDistance,
+    24,
+    "second update retains first nested value",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.contextMenu.preventionTimeout,
+    850,
+    "second nested value commits",
+  );
+}
+
+async function testRapidWheelUpdatesRetainBothActions(): Promise<void> {
+  const persisted: Array<Record<string, unknown>> = [];
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(true),
+    {
+      writeEnabled: () => Promise.resolve(),
+      writeConfig: (serialized) => {
+        persisted.push(JSON.parse(serialized));
+        return Promise.resolve();
+      },
+    },
+  );
+
+  const scrollUpUpdate = persistence.updateConfig((current) => ({
+    wheelActions: {
+      ...current.wheelActions,
+      scrollUp: "gecko-zoom-in",
+    },
+  }));
+  const scrollDownUpdate = persistence.updateConfig((current) => ({
+    wheelActions: {
+      ...current.wheelActions,
+      scrollDown: "gecko-zoom-out",
+    },
+  }));
+
+  const results = await Promise.all([scrollUpUpdate, scrollDownUpdate]);
+  assert(
+    results.every((result) => result),
+    "both rapid wheel updates should succeed",
+  );
+  assertEquals(persisted.length, 2, "both wheel updates persist");
+  const secondWheelActions = persisted[1].wheelActions as Record<
+    string,
+    unknown
+  >;
+  assertEquals(
+    secondWheelActions.scrollUp,
+    "gecko-zoom-in",
+    "second persisted config retains scrollUp update",
+  );
+  assertEquals(
+    secondWheelActions.scrollDown,
+    "gecko-zoom-out",
+    "second persisted config contains scrollDown update",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.wheelActions.scrollUp,
+    "gecko-zoom-in",
+    "committed config retains scrollUp update",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.wheelActions.scrollDown,
+    "gecko-zoom-out",
+    "committed config contains scrollDown update",
+  );
+}
+
+async function testPendingAndCommitAfterSuccess(): Promise<void> {
+  const firstDeferred = createDeferred();
+  const secondDeferred = createDeferred();
+  let writeIndex = 0;
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(true),
+    {
+      writeEnabled: () => Promise.resolve(),
+      writeConfig: () =>
+        writeIndex++ === 0 ? firstDeferred.promise : secondDeferred.promise,
+    },
+  );
+
+  const firstSave = persistence.updateConfig({ trailColor: "#123456" });
+  const secondSave = persistence.updateConfig({ showTrail: false });
+  assertEquals(
+    persistence.getSnapshot().pending,
+    true,
+    "two queued writes are pending",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.trailColor,
+    "#37ff00",
+    "UI config does not update before persistence succeeds",
+  );
+
+  firstDeferred.resolve();
+  assertEquals(await firstSave, true, "first deferred write succeeds");
+  await Promise.resolve();
+  assertEquals(
+    persistence.getSnapshot().pending,
+    true,
+    "pending remains true while the second write is queued",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.trailColor,
+    "#123456",
+    "first successful write commits while the second remains pending",
+  );
+
+  secondDeferred.resolve();
+  assertEquals(await secondSave, true, "second deferred write succeeds");
+  assertEquals(persistence.getSnapshot().pending, false, "pending clears");
+  assertEquals(
+    persistence.getSnapshot().config.trailColor,
+    "#123456",
+    "UI config commits after persistence succeeds",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.showTrail,
+    false,
+    "second queued write commits after it succeeds",
+  );
+}
+
+async function testFailurePreservesCommittedConfig(): Promise<void> {
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(true),
+    {
+      writeEnabled: () => Promise.resolve(),
+      writeConfig: () => Promise.reject(new Error("write failed")),
+    },
+  );
+
+  const saved = await persistence.updateConfig({ showTrail: false });
+  assertEquals(saved, false, "failed write reports false");
+  assertEquals(
+    persistence.getSnapshot().config.showTrail,
+    true,
+    "failed write does not commit UI config",
+  );
+  assertEquals(
+    persistence.getSnapshot().pending,
+    false,
+    "failed write settles",
+  );
+  assert(
+    persistence.getSnapshot().error?.includes("write failed"),
+    "failed write exposes an error",
+  );
+}
+
+async function testQueueRecoversAfterFailure(): Promise<void> {
+  const operations: string[] = [];
+  let configAttempts = 0;
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(false),
+    {
+      writeEnabled: async () => {
+        operations.push("enabled");
+        throw new Error("bool failed");
+      },
+      writeConfig: (serialized) => {
+        operations.push("config");
+        configAttempts++;
+        JSON.parse(serialized);
+        return Promise.resolve();
+      },
+    },
+  );
+
+  const failedToggle = persistence.updateEnabled(true);
+  const recoveredConfig = persistence.updateConfig({ showLabel: false });
+  assertEquals(await failedToggle, false, "first queued write fails");
+  assertEquals(await recoveredConfig, true, "later queued write still runs");
+  assertEquals(
+    operations.join(","),
+    "enabled,config",
+    "one queue preserves order",
+  );
+  assertEquals(configAttempts, 1, "post-failure config writer runs once");
+  assertEquals(
+    persistence.getSnapshot().config.enabled,
+    false,
+    "recovery builds from last successful enabled state",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.showLabel,
+    false,
+    "post-failure update commits",
+  );
+  assertEquals(
+    persistence.getSnapshot().error,
+    null,
+    "success clears old error",
+  );
+}
+
+async function testBoolUpdateRecoversAfterConfigFailure(): Promise<void> {
+  const operations: string[] = [];
+  const boolWrites: boolean[] = [];
+  const persistence = createGestureConfigPersistence(
+    createDefaultMouseGestureConfig(false),
+    {
+      writeEnabled: (enabled) => {
+        operations.push("enabled");
+        boolWrites.push(enabled);
+        return Promise.resolve();
+      },
+      writeConfig: async () => {
+        operations.push("config");
+        throw new Error("json failed");
+      },
+    },
+  );
+
+  const failedConfig = persistence.updateConfig({ showTrail: false });
+  const recoveredToggle = persistence.updateEnabled(true);
+  assertEquals(await failedConfig, false, "JSON write fails");
+  assertEquals(await recoveredToggle, true, "later bool write still succeeds");
+  assertEquals(
+    operations.join(","),
+    "config,enabled",
+    "shared queue preserves JSON then bool order",
+  );
+  assertEquals(boolWrites.length, 1, "recovery writes only one bool pref");
+  assertEquals(boolWrites[0], true, "recovery writes requested bool value");
+  assertEquals(
+    persistence.getSnapshot().config.showTrail,
+    true,
+    "failed JSON update remains uncommitted",
+  );
+  assertEquals(
+    persistence.getSnapshot().config.enabled,
+    true,
+    "bool recovery commits from last successful config",
+  );
+  assertEquals(
+    persistence.getSnapshot().error,
+    null,
+    "bool success clears error",
+  );
+}
+
+function testDeepNormalization(): void {
+  const normalized = normalizeMouseGestureConfig(
+    {
+      contextMenu: { minDistance: 21 },
+      rockerActions: { leftRight: "gecko-reload" },
+      wheelActions: {
+        scrollUp: "gecko-close-tab",
+        scrollDown: "gecko-zoom-in",
+      },
+    },
+    true,
+  );
+
+  assertEquals(normalized.enabled, true, "separate enabled pref wins");
+  assertEquals(normalized.contextMenu.minDistance, 21, "nested value survives");
+  assertEquals(
+    normalized.contextMenu.preventionTimeout,
+    200,
+    "missing nested context value receives default",
+  );
+  assertEquals(
+    normalized.rockerActions.rightLeft,
+    "gecko-back",
+    "missing rocker action receives default",
+  );
+  assertEquals(
+    normalized.wheelActions.scrollUp,
+    "gecko-show-previous-tab",
+    "unsafe wheel action is replaced with safe default",
+  );
+  assertEquals(
+    normalized.wheelActions.scrollDown,
+    "gecko-zoom-in",
+    "repeat-safe wheel action is preserved",
+  );
+}
+
+const tests: TestCase[] = [
+  {
+    name: "enabled update writes bool only",
+    fn: testEnabledUpdateWritesOnlyBool,
+  },
+  {
+    name: "config update writes JSON only without enabled",
+    fn: testConfigUpdateWritesOnlyJsonWithoutEnabled,
+  },
+  {
+    name: "rapid nested updates use last committed config",
+    fn: testRapidNestedUpdatesUseLastCommittedConfig,
+  },
+  {
+    name: "rapid wheel updates retain both actions",
+    fn: testRapidWheelUpdatesRetainBothActions,
+  },
+  {
+    name: "pending state commits only after success",
+    fn: testPendingAndCommitAfterSuccess,
+  },
+  {
+    name: "failure preserves committed config",
+    fn: testFailurePreservesCommittedConfig,
+  },
+  {
+    name: "queue recovers after failure",
+    fn: testQueueRecoversAfterFailure,
+  },
+  {
+    name: "bool update recovers after JSON failure",
+    fn: testBoolUpdateRecoversAfterConfigFailure,
+  },
+  {
+    name: "load normalization is deep and wheel-safe",
+    fn: testDeepNormalization,
+  },
+];
+
+export async function runAllTests(): Promise<void> {
+  await runTests("configPersistence.test.ts", tests);
+}

--- a/browser-features/pages-settings/tsconfig.json
+++ b/browser-features/pages-settings/tsconfig.json
@@ -18,6 +18,9 @@
       ],
       "#libs/*": [
         "../../libs/*"
+      ],
+      "#features-chrome/*": [
+        "../chrome/*"
       ]
     },
     "types": [

--- a/tools/src/mouse_gesture_wheel_x11_e2e.ts
+++ b/tools/src/mouse_gesture_wheel_x11_e2e.ts
@@ -1,0 +1,818 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { MarionetteClient } from "./browser_connector.ts";
+
+const ENABLED_PREF = "floorp.mousegesture.enabled";
+const CONFIG_PREF = "floorp.mousegesture.config";
+const PREVENTION_TIMEOUT_MS = 500;
+const SAFE_SCROLL_UP_ACTION = "gecko-zoom-in";
+const SAFE_SCROLL_DOWN_ACTION = "gecko-zoom-out";
+const FORBIDDEN_ACTION = "gecko-close-tab";
+const NORMALIZED_SCROLL_UP_ACTION = "gecko-show-previous-tab";
+const WINDOW_TITLE_MARKER = "Floorp wheel native X11 E2E";
+
+if (Deno.build.os !== "linux") {
+  throw new Error("Mouse gesture native X11 E2E requires Linux");
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface WindowGeometry {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface WheelActions {
+  scrollUp: string;
+  scrollDown: string;
+}
+
+interface OriginalState {
+  originalZoom: number;
+  hadEnabledUserValue: boolean;
+  originalEnabled: boolean;
+  hadConfigUserValue: boolean;
+  originalConfig: string;
+}
+
+interface BrowserSetup {
+  processId: number;
+  baselineZoom: number;
+  zoomInOne: number;
+  zoomInTwo: number;
+}
+
+interface TargetPoint {
+  x: number;
+  y: number;
+  devicePixelRatio: number;
+  targetRect: Rect;
+  contentScreenOrigin: { x: number; y: number };
+}
+
+interface PageState {
+  counts: Record<string, number>;
+  events: Array<{
+    type: string;
+    button: number;
+    buttons: number;
+    deltaY: number | null;
+    defaultPrevented: boolean;
+  }>;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function extractHandle(response: unknown): string {
+  if (typeof response === "string") {
+    return response;
+  }
+  if (response && typeof response === "object") {
+    const record = response as Record<string, unknown>;
+    if (typeof record.handle === "string") {
+      return record.handle;
+    }
+    if (typeof record.value === "string") {
+      return record.value;
+    }
+  }
+  throw new Error(
+    `Marionette did not return a window handle: ${JSON.stringify(response)}`,
+  );
+}
+
+function extractHandles(response: unknown): string[] {
+  const value = Array.isArray(response)
+    ? response
+    : response && typeof response === "object"
+    ? (response as Record<string, unknown>).value
+    : null;
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value as string[];
+  }
+  throw new Error(
+    `Marionette did not return window handles: ${JSON.stringify(response)}`,
+  );
+}
+
+const textDecoder = new TextDecoder();
+
+async function runXdotool(args: string[]): Promise<string> {
+  // Each invocation is a direct process with a fixed argument array. XTEST
+  // input is global and targets the sole visible Floorp top-level.
+  const output = await new Deno.Command("xdotool", {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const stdout = textDecoder.decode(output.stdout).trim();
+  const stderr = textDecoder.decode(output.stderr).trim();
+  if (!output.success) {
+    throw new Error(
+      `xdotool ${JSON.stringify(args)} failed with exit ${output.code}: ${
+        stderr || stdout
+      }`,
+    );
+  }
+  return stdout;
+}
+
+function parseWindowIds(output: string): string[] {
+  const ids = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  assert(
+    ids.every((id) => /^\d+$/.test(id)),
+    `xdotool returned invalid window IDs: ${JSON.stringify(ids)}`,
+  );
+  return [...new Set(ids)];
+}
+
+function parseWindowGeometry(id: string, output: string): WindowGeometry {
+  const position = output.match(/Position:\s*(-?\d+),(-?\d+)/);
+  const size = output.match(/Geometry:\s*(\d+)x(\d+)/);
+  assert(
+    position && size,
+    `Could not parse xdotool geometry for ${id}: ${output}`,
+  );
+  return {
+    id,
+    x: Number(position[1]),
+    y: Number(position[2]),
+    width: Number(size[1]),
+    height: Number(size[2]),
+  };
+}
+
+async function findSoleVisibleFloorpWindow(
+  processId: number,
+): Promise<WindowGeometry> {
+  const ids = parseWindowIds(
+    await runXdotool([
+      "search",
+      "--all",
+      "--onlyvisible",
+      "--maxdepth",
+      "1",
+      "--pid",
+      String(processId),
+      "--name",
+      ".*",
+    ]),
+  );
+  assert(
+    ids.length === 1,
+    `Expected exactly one visible top-level Floorp window for PID ${processId}, got ${
+      JSON.stringify(ids)
+    }`,
+  );
+
+  const id = ids[0];
+  const [reportedPid, title, geometry] = await Promise.all([
+    runXdotool(["getwindowpid", id]),
+    runXdotool(["getwindowname", id]),
+    runXdotool(["getwindowgeometry", id]),
+  ]);
+  assert(
+    reportedPid === String(processId),
+    `X11 window ${id} belongs to PID ${reportedPid}, expected Floorp PID ${processId}`,
+  );
+  assert(
+    title.includes(WINDOW_TITLE_MARKER),
+    `X11 window ${id} does not have the Floorp test title: ${title}`,
+  );
+  return parseWindowGeometry(id, geometry);
+}
+
+const client = await MarionetteClient.connect();
+let originalHandle: string | null = null;
+let testHandle: string | null = null;
+let originalState: OriginalState | null = null;
+let secondaryButtonHeld = false;
+
+async function moveNativePointer(x: number, y: number): Promise<void> {
+  await runXdotool(["mousemove", "--sync", String(x), String(y)]);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+async function pressNativeSecondary(): Promise<void> {
+  // Mark the intended physical state before launching the helper so the outer
+  // cleanup still attempts a release if the helper reports a partial failure.
+  secondaryButtonHeld = true;
+  await runXdotool(["mousedown", "3"]);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+async function releaseNativeSecondary(): Promise<void> {
+  await runXdotool(["mouseup", "3"]);
+  secondaryButtonHeld = false;
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+async function sendNativeWheel(button: 4 | 5): Promise<void> {
+  await runXdotool(["click", String(button)]);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+async function runNativeSecondaryWheelCycle(
+  x: number,
+  y: number,
+  body: () => Promise<void>,
+): Promise<void> {
+  let failure: unknown = null;
+  await moveNativePointer(x, y);
+  await pressNativeSecondary();
+  try {
+    await body();
+  } catch (error) {
+    failure = error;
+  }
+
+  let releaseError: unknown = null;
+  try {
+    await releaseNativeSecondary();
+  } catch (error) {
+    releaseError = error;
+  }
+
+  if (failure !== null) {
+    if (releaseError !== null) {
+      console.error("Native RMB release error:", releaseError);
+    }
+    throw failure;
+  }
+  if (releaseError !== null) {
+    throw releaseError;
+  }
+}
+
+async function resetPageState(): Promise<void> {
+  await client.setContext("content");
+  await client.executeScript(`
+    window.__floorpWheelX11E2E.counts = {
+      mousedown: 0,
+      mouseup: 0,
+      click: 0,
+      auxclick: 0,
+      dblclick: 0,
+      contextmenu: 0,
+      wheel: 0,
+    };
+    window.__floorpWheelX11E2E.events = [];
+  `);
+}
+
+async function readPageState(): Promise<PageState> {
+  await client.setContext("content");
+  const raw = await client.executeScript(`
+    return JSON.stringify(window.__floorpWheelX11E2E);
+  `);
+  return JSON.parse(raw) as PageState;
+}
+
+async function readZoom(): Promise<number> {
+  await client.setContext("chrome");
+  return await client.executeScript(`return ZoomManager.zoom;`) as number;
+}
+
+async function resetZoom(): Promise<number> {
+  await client.setContext("chrome");
+  await client.executeScript(`FullZoom.reset();`);
+  return await readZoom();
+}
+
+async function readWheelActionsFromPref(): Promise<WheelActions> {
+  await client.setContext("chrome");
+  const raw = await client.executeScript(`
+    const config = JSON.parse(
+      Services.prefs.getStringPref(${JSON.stringify(CONFIG_PREF)}, "{}"),
+    );
+    return JSON.stringify(config.wheelActions ?? null);
+  `);
+  return JSON.parse(raw) as WheelActions;
+}
+
+async function waitForWheelActions(
+  expected: WheelActions,
+  label: string,
+): Promise<void> {
+  let observed: WheelActions | null = null;
+  for (let attempt = 0; attempt < 40; attempt++) {
+    observed = await readWheelActionsFromPref();
+    if (
+      observed?.scrollUp === expected.scrollUp &&
+      observed?.scrollDown === expected.scrollDown
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `${label}: expected wheel actions ${JSON.stringify(expected)}, got ${
+      JSON.stringify(observed)
+    }`,
+  );
+}
+
+function assertNoWheelGestureActivation(
+  state: PageState,
+  label: string,
+): void {
+  for (const type of ["click", "auxclick", "dblclick", "contextmenu"]) {
+    assert(
+      state.counts[type] === 0,
+      `${label}: expected zero ${type} events, got ${state.counts[type]}: ${
+        JSON.stringify(state.events)
+      }`,
+    );
+  }
+}
+
+async function assertSafeWheelSequence(
+  x: number,
+  y: number,
+  setup: BrowserSetup,
+): Promise<void> {
+  await resetPageState();
+  const zoomBefore = await resetZoom();
+  assert(
+    zoomBefore === setup.baselineZoom,
+    `safe wheel: failed to reset zoom to ${setup.baselineZoom}, got ${zoomBefore}`,
+  );
+
+  await runNativeSecondaryWheelCycle(x, y, async () => {
+    await sendNativeWheel(4);
+    assert(
+      await readZoom() === setup.zoomInOne,
+      `native wheel up tick 1 must zoom exactly once to ${setup.zoomInOne}`,
+    );
+
+    await sendNativeWheel(4);
+    assert(
+      await readZoom() === setup.zoomInTwo,
+      `native wheel up tick 2 must execute independently and zoom to ${setup.zoomInTwo}`,
+    );
+
+    await sendNativeWheel(5);
+    assert(
+      await readZoom() === setup.zoomInOne,
+      `native wheel down tick 1 must zoom out exactly once to ${setup.zoomInOne}`,
+    );
+
+    await sendNativeWheel(5);
+    assert(
+      await readZoom() === setup.baselineZoom,
+      `native wheel down tick 2 must return zoom to ${setup.baselineZoom}`,
+    );
+  });
+
+  const gestureState = await readPageState();
+  assert(
+    gestureState.counts.mousedown === 1,
+    `safe wheel: native right mousedown did not reach content: ${
+      JSON.stringify(gestureState.events)
+    }`,
+  );
+  assert(
+    gestureState.counts.wheel === 0,
+    `safe wheel: consumed native wheel events leaked into content: ${
+      JSON.stringify(gestureState.events)
+    }`,
+  );
+  assertNoWheelGestureActivation(gestureState, "safe wheel");
+
+  // A residual native wheel inside the bounded post-mouseup window must be
+  // consumed without re-running either configured action.
+  await sendNativeWheel(4);
+  assert(
+    await readZoom() === setup.baselineZoom,
+    "residual native wheel after release must not execute zoom-in",
+  );
+  const residualState = await readPageState();
+  assert(
+    residualState.counts.wheel === 0,
+    `residual wheel should remain suppressed before timeout: ${
+      JSON.stringify(residualState.events)
+    }`,
+  );
+  assertNoWheelGestureActivation(residualState, "residual wheel");
+
+  // After the bounded suppression expires, an ordinary wheel with no right
+  // button must pass to content but still must not execute a gesture action.
+  await new Promise((resolve) =>
+    setTimeout(resolve, PREVENTION_TIMEOUT_MS + 150)
+  );
+  await resetPageState();
+  await sendNativeWheel(4);
+  const ordinaryState = await readPageState();
+  assert(
+    ordinaryState.counts.wheel >= 1,
+    `ordinary native wheel after timeout did not reach content: ${
+      JSON.stringify(ordinaryState.events)
+    }`,
+  );
+  assert(
+    await readZoom() === setup.baselineZoom,
+    "ordinary native wheel without RMB must not execute zoom-in",
+  );
+
+  console.log(
+    `Native wheel action counts: ${
+      JSON.stringify({ scrollUp: 2, scrollDown: 2, residualActions: 0 })
+    }`,
+  );
+}
+
+async function assertOrdinaryRightClick(x: number, y: number): Promise<void> {
+  await resetPageState();
+  await moveNativePointer(x, y);
+  await runXdotool(["click", "3"]);
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  const state = await readPageState();
+  assert(
+    state.counts.mousedown === 1 && state.counts.mouseup === 1,
+    `ordinary native right down/up did not reach content: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assert(
+    state.counts.auxclick === 1 && state.counts.contextmenu === 1,
+    `ordinary native right click must retain auxclick/contextmenu behavior: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+  assert(
+    state.counts.click === 0 && state.counts.dblclick === 0,
+    `ordinary native right click produced a primary activation: ${
+      JSON.stringify(state.events)
+    }`,
+  );
+}
+
+async function installForbiddenManualMapping(): Promise<void> {
+  await client.setContext("chrome");
+  await client.executeScript(`
+    const pref = ${JSON.stringify(CONFIG_PREF)};
+    const config = JSON.parse(Services.prefs.getStringPref(pref, "{}"));
+    config.wheelActions = {
+      ...config.wheelActions,
+      scrollUp: ${JSON.stringify(FORBIDDEN_ACTION)},
+      scrollDown: ${JSON.stringify(SAFE_SCROLL_DOWN_ACTION)},
+    };
+    Services.prefs.setStringPref(pref, JSON.stringify(config));
+  `);
+}
+
+async function assertForbiddenMappingFailsSafe(
+  x: number,
+  y: number,
+  setup: BrowserSetup,
+): Promise<void> {
+  await resetZoom();
+  await installForbiddenManualMapping();
+  await waitForWheelActions(
+    {
+      scrollUp: NORMALIZED_SCROLL_UP_ACTION,
+      scrollDown: SAFE_SCROLL_DOWN_ACTION,
+    },
+    "forbidden manual mapping normalization",
+  );
+
+  const handlesBefore = extractHandles(
+    await client.send("WebDriver:GetWindowHandles", {}),
+  );
+  assert(
+    testHandle !== null && handlesBefore.includes(testHandle),
+    "forbidden mapping precondition: disposable test tab is missing",
+  );
+
+  // If close-tab escapes normalization or the controller's execution-boundary
+  // policy, the trusted native wheel closes testHandle and this fails.
+  await runNativeSecondaryWheelCycle(x, y, async () => {
+    await sendNativeWheel(4);
+  });
+
+  const handlesAfter = extractHandles(
+    await client.send("WebDriver:GetWindowHandles", {}),
+  );
+  assert(
+    handlesAfter.length === handlesBefore.length &&
+      testHandle !== null &&
+      handlesAfter.includes(testHandle),
+    `forbidden ${FORBIDDEN_ACTION} mapping executed destructively: before=${
+      JSON.stringify(handlesBefore)
+    }, after=${JSON.stringify(handlesAfter)}`,
+  );
+
+  // The normalized previous-tab action may select the original tab.
+  await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+  assert(
+    await readZoom() === setup.baselineZoom,
+    "forbidden mapping must not execute the requested close-tab or zoom",
+  );
+}
+
+async function restoreOriginalState(
+  state: OriginalState,
+  restoreTestTabZoom: boolean,
+): Promise<void> {
+  await client.setContext("chrome");
+  await client.executeScript(`
+    const enabledPref = ${JSON.stringify(ENABLED_PREF)};
+    const configPref = ${JSON.stringify(CONFIG_PREF)};
+    const state = ${JSON.stringify(state)};
+    const restoreTestTabZoom = ${JSON.stringify(restoreTestTabZoom)};
+
+    if (state.hadConfigUserValue) {
+      Services.prefs.setStringPref(configPref, state.originalConfig);
+    } else if (Services.prefs.prefHasUserValue(configPref)) {
+      Services.prefs.clearUserPref(configPref);
+    }
+    if (state.hadEnabledUserValue) {
+      Services.prefs.setBoolPref(enabledPref, state.originalEnabled);
+    } else if (Services.prefs.prefHasUserValue(enabledPref)) {
+      Services.prefs.clearUserPref(enabledPref);
+    }
+    if (restoreTestTabZoom) {
+      ZoomManager.zoom = state.originalZoom;
+    }
+
+    if (
+      Services.prefs.prefHasUserValue(configPref) !==
+        state.hadConfigUserValue ||
+      Services.prefs.getStringPref(configPref, "") !== state.originalConfig ||
+      Services.prefs.prefHasUserValue(enabledPref) !==
+        state.hadEnabledUserValue ||
+      Services.prefs.getBoolPref(enabledPref, false) !==
+        state.originalEnabled ||
+      (restoreTestTabZoom && ZoomManager.zoom !== state.originalZoom)
+    ) {
+      throw new Error("Mouse gesture wheel X11 E2E state restoration mismatch");
+    }
+  `);
+}
+
+let failure: unknown = null;
+
+try {
+  originalHandle = extractHandle(
+    await client.send("WebDriver:GetWindowHandle", {}),
+  );
+  testHandle = extractHandle(
+    await client.send("WebDriver:NewWindow", { type: "tab" }),
+  );
+  await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+
+  await client.setContext("chrome");
+  originalState = JSON.parse(
+    await client.executeScript(`
+      const enabledPref = ${JSON.stringify(ENABLED_PREF)};
+      const configPref = ${JSON.stringify(CONFIG_PREF)};
+      const originalConfig = Services.prefs.getStringPref(configPref, "");
+      if (!originalConfig) {
+        throw new Error("Mouse gesture config pref is empty");
+      }
+      return JSON.stringify({
+        originalZoom: ZoomManager.zoom,
+        hadEnabledUserValue: Services.prefs.prefHasUserValue(enabledPref),
+        originalEnabled: Services.prefs.getBoolPref(enabledPref, false),
+        hadConfigUserValue: Services.prefs.prefHasUserValue(configPref),
+        originalConfig,
+      });
+    `),
+  ) as OriginalState;
+
+  const setup = JSON.parse(
+    await client.executeScript(`
+      const enabledPref = ${JSON.stringify(ENABLED_PREF)};
+      const configPref = ${JSON.stringify(CONFIG_PREF)};
+      const config = JSON.parse(
+        Services.prefs.getStringPref(configPref, "{}"),
+      );
+      config.enabled = true;
+      config.rockerGesturesEnabled = false;
+      config.wheelGesturesEnabled = true;
+      config.showTrail = false;
+      config.showLabel = false;
+      config.contextMenu = {
+        ...(config.contextMenu ?? {}),
+        preventionTimeout: ${PREVENTION_TIMEOUT_MS},
+      };
+      config.wheelActions = {
+        scrollUp: ${JSON.stringify(SAFE_SCROLL_UP_ACTION)},
+        scrollDown: ${JSON.stringify(SAFE_SCROLL_DOWN_ACTION)},
+      };
+      Services.prefs.setStringPref(configPref, JSON.stringify(config));
+      Services.prefs.setBoolPref(enabledPref, true);
+
+      FullZoom.reset();
+      const baselineZoom = ZoomManager.zoom;
+      FullZoom.enlarge();
+      const zoomInOne = ZoomManager.zoom;
+      FullZoom.enlarge();
+      const zoomInTwo = ZoomManager.zoom;
+      FullZoom.reduce();
+      const zoomAfterOneReduction = ZoomManager.zoom;
+      FullZoom.reduce();
+      const zoomAfterTwoReductions = ZoomManager.zoom;
+      FullZoom.reset();
+      return JSON.stringify({
+        processId: Services.appinfo.processID,
+        baselineZoom,
+        zoomInOne,
+        zoomInTwo,
+        zoomAfterOneReduction,
+        zoomAfterTwoReductions,
+      });
+    `),
+  ) as BrowserSetup & {
+    zoomAfterOneReduction: number;
+    zoomAfterTwoReductions: number;
+  };
+  assert(
+    Number.isInteger(setup.processId) && setup.processId > 0,
+    `Invalid Floorp process ID: ${setup.processId}`,
+  );
+  assert(
+    setup.zoomInOne !== setup.baselineZoom &&
+      setup.zoomInTwo !== setup.zoomInOne &&
+      setup.zoomAfterOneReduction === setup.zoomInOne &&
+      setup.zoomAfterTwoReductions === setup.baselineZoom,
+    `Zoom action precondition failed: ${JSON.stringify(setup)}`,
+  );
+  await waitForWheelActions(
+    {
+      scrollUp: SAFE_SCROLL_UP_ACTION,
+      scrollDown: SAFE_SCROLL_DOWN_ACTION,
+    },
+    "safe wheel mapping",
+  );
+
+  await client.setContext("content");
+  const fixture = `<!doctype html>
+    <meta charset="utf-8">
+    <title>${WINDOW_TITLE_MARKER}</title>
+    <style>
+      body { margin: 30px; }
+      #target { width: 480px; height: 360px; font-size: 24px; }
+    </style>
+    <button id="target">Wheel gesture target</button>
+    <script>
+      window.__floorpWheelX11E2E = { counts: {}, events: [] };
+      for (const type of ["mousedown", "mouseup", "click", "auxclick", "dblclick", "contextmenu", "wheel"]) {
+        document.addEventListener(type, (event) => {
+          window.__floorpWheelX11E2E.counts[type] =
+            (window.__floorpWheelX11E2E.counts[type] ?? 0) + 1;
+          window.__floorpWheelX11E2E.events.push({
+            type: event.type,
+            button: event.button ?? 0,
+            buttons: event.buttons ?? 0,
+            deltaY: typeof event.deltaY === "number" ? event.deltaY : null,
+            defaultPrevented: event.defaultPrevented,
+          });
+          if (type === "contextmenu") {
+            event.preventDefault();
+          }
+        }, true);
+      }
+    </script>`;
+  await client.navigate(
+    `data:text/html;charset=utf-8,${encodeURIComponent(fixture)}`,
+  );
+  const point = await client.executeScript(`
+    const rect = document.querySelector("#target").getBoundingClientRect();
+    const dpr = window.devicePixelRatio;
+    return {
+      x: Math.round((window.mozInnerScreenX + rect.x + rect.width / 2) * dpr),
+      y: Math.round((window.mozInnerScreenY + rect.y + rect.height / 2) * dpr),
+      devicePixelRatio: dpr,
+      targetRect: {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      },
+      contentScreenOrigin: {
+        x: window.mozInnerScreenX,
+        y: window.mozInnerScreenY,
+      },
+    };
+  `) as TargetPoint;
+  assert(
+    Number.isFinite(point.x) &&
+      Number.isFinite(point.y) &&
+      point.devicePixelRatio > 0,
+    `Invalid Marionette content screen point: ${JSON.stringify(point)}`,
+  );
+
+  const floorpWindow = await findSoleVisibleFloorpWindow(setup.processId);
+  assert(
+    point.x >= floorpWindow.x &&
+      point.x < floorpWindow.x + floorpWindow.width &&
+      point.y >= floorpWindow.y &&
+      point.y < floorpWindow.y + floorpWindow.height,
+    `Marionette content point (${point.x}, ${point.y}) is outside xdotool Floorp geometry ${
+      JSON.stringify(floorpWindow)
+    }`,
+  );
+
+  console.log(
+    `Mouse gesture wheel X11 target: ${
+      JSON.stringify({ floorpWindow, point })
+    }`,
+  );
+
+  await assertSafeWheelSequence(point.x, point.y, setup);
+  await assertOrdinaryRightClick(point.x, point.y);
+  await assertForbiddenMappingFailsSafe(point.x, point.y, setup);
+
+  console.log("Mouse gesture wheel X11 E2E passed");
+} catch (error) {
+  failure = error;
+}
+
+const cleanupErrors: unknown[] = [];
+if (secondaryButtonHeld) {
+  try {
+    await releaseNativeSecondary();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+}
+
+let handles: string[] = [];
+try {
+  handles = extractHandles(
+    await client.send("WebDriver:GetWindowHandles", {}),
+  );
+} catch (error) {
+  cleanupErrors.push(error);
+}
+
+const testHandleExists = testHandle !== null && handles.includes(testHandle);
+const restorationHandle = testHandleExists
+  ? testHandle
+  : originalHandle && handles.includes(originalHandle)
+  ? originalHandle
+  : null;
+
+if (restorationHandle) {
+  try {
+    await client.send("WebDriver:SwitchToWindow", {
+      handle: restorationHandle,
+    });
+    if (originalState) {
+      await restoreOriginalState(originalState, testHandleExists);
+    }
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+} else if (originalState) {
+  cleanupErrors.push(
+    new Error("No surviving browser tab is available to restore preferences"),
+  );
+}
+
+if (testHandleExists && testHandle) {
+  try {
+    await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+    await client.send("WebDriver:CloseWindow", {});
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+}
+
+if (originalHandle && handles.includes(originalHandle)) {
+  try {
+    await client.send("WebDriver:SwitchToWindow", {
+      handle: originalHandle,
+    });
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+}
+
+await client.close();
+
+if (failure !== null) {
+  if (cleanupErrors.length > 0) {
+    console.error("Mouse gesture wheel X11 E2E cleanup errors:", cleanupErrors);
+  }
+  throw failure;
+}
+if (cleanupErrors.length > 0) {
+  throw new AggregateError(
+    cleanupErrors,
+    "Mouse gesture wheel X11 E2E cleanup failed",
+  );
+}

--- a/tools/src/mouse_gesture_wheel_x11_e2e.ts
+++ b/tools/src/mouse_gesture_wheel_x11_e2e.ts
@@ -256,6 +256,47 @@ let testHandle: string | null = null;
 let originalState: OriginalState | null = null;
 let secondaryButtonHeld = false;
 
+async function withContentContext<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  await client.setContext("content");
+  return await operation();
+}
+
+async function getContentWindowHandle(): Promise<string> {
+  return extractHandle(
+    await withContentContext(() =>
+      client.send("WebDriver:GetWindowHandle", {})
+    ),
+  );
+}
+
+async function getContentWindowHandles(): Promise<string[]> {
+  return extractHandles(
+    await withContentContext(() =>
+      client.send("WebDriver:GetWindowHandles", {})
+    ),
+  );
+}
+
+async function newContentTab(): Promise<string> {
+  return extractHandle(
+    await withContentContext(() =>
+      client.send("WebDriver:NewWindow", { type: "tab" })
+    ),
+  );
+}
+
+async function switchToContentWindow(handle: string): Promise<void> {
+  await withContentContext(() =>
+    client.send("WebDriver:SwitchToWindow", { handle })
+  );
+}
+
+async function closeContentWindow(): Promise<void> {
+  await withContentContext(() => client.send("WebDriver:CloseWindow", {}));
+}
+
 async function moveNativePointer(x: number, y: number): Promise<void> {
   await runXdotool(["mousemove", "--sync", String(x), String(y)]);
   await new Promise((resolve) => setTimeout(resolve, 50));
@@ -727,12 +768,12 @@ async function assertForbiddenMappingFailsSafe(
     "forbidden manual mapping normalization",
   );
 
-  const handlesBefore = extractHandles(
-    await client.send("WebDriver:GetWindowHandles", {}),
-  );
+  const handlesBefore = await getContentWindowHandles();
   assert(
     testHandle !== null && handlesBefore.includes(testHandle),
-    "forbidden mapping precondition: disposable test tab is missing",
+    `forbidden mapping precondition: disposable test tab is missing: ${
+      JSON.stringify({ originalHandle, testHandle, handlesBefore })
+    }`,
   );
 
   // If close-tab escapes normalization or the controller's execution-boundary
@@ -741,9 +782,7 @@ async function assertForbiddenMappingFailsSafe(
     await sendNativeWheel(4);
   });
 
-  const handlesAfter = extractHandles(
-    await client.send("WebDriver:GetWindowHandles", {}),
-  );
+  const handlesAfter = await getContentWindowHandles();
   assert(
     handlesAfter.length === handlesBefore.length &&
       testHandle !== null &&
@@ -754,7 +793,7 @@ async function assertForbiddenMappingFailsSafe(
   );
 
   // The normalized previous-tab action may select the original tab.
-  await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+  await switchToContentWindow(testHandle);
   assert(
     await readZoom() === setup.baselineZoom,
     "forbidden mapping must not execute the requested close-tab or zoom",
@@ -804,13 +843,9 @@ async function restoreOriginalState(
 let failure: unknown = null;
 
 try {
-  originalHandle = extractHandle(
-    await client.send("WebDriver:GetWindowHandle", {}),
-  );
-  testHandle = extractHandle(
-    await client.send("WebDriver:NewWindow", { type: "tab" }),
-  );
-  await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
+  originalHandle = await getContentWindowHandle();
+  testHandle = await newContentTab();
+  await switchToContentWindow(testHandle);
 
   await client.setContext("chrome");
   originalState = JSON.parse(
@@ -982,9 +1017,7 @@ if (secondaryButtonHeld) {
 
 let handles: string[] = [];
 try {
-  handles = extractHandles(
-    await client.send("WebDriver:GetWindowHandles", {}),
-  );
+  handles = await getContentWindowHandles();
 } catch (error) {
   cleanupErrors.push(error);
 }
@@ -998,9 +1031,7 @@ const restorationHandle = testHandleExists
 
 if (restorationHandle) {
   try {
-    await client.send("WebDriver:SwitchToWindow", {
-      handle: restorationHandle,
-    });
+    await switchToContentWindow(restorationHandle);
     if (originalState) {
       await restoreOriginalState(originalState, testHandleExists);
     }
@@ -1015,8 +1046,8 @@ if (restorationHandle) {
 
 if (testHandleExists && testHandle) {
   try {
-    await client.send("WebDriver:SwitchToWindow", { handle: testHandle });
-    await client.send("WebDriver:CloseWindow", {});
+    await switchToContentWindow(testHandle);
+    await closeContentWindow();
   } catch (error) {
     cleanupErrors.push(error);
   }
@@ -1024,9 +1055,7 @@ if (testHandleExists && testHandle) {
 
 if (originalHandle && handles.includes(originalHandle)) {
   try {
-    await client.send("WebDriver:SwitchToWindow", {
-      handle: originalHandle,
-    });
+    await switchToContentWindow(originalHandle);
   } catch (error) {
     cleanupErrors.push(error);
   }

--- a/tools/src/mouse_gesture_wheel_x11_e2e.ts
+++ b/tools/src/mouse_gesture_wheel_x11_e2e.ts
@@ -10,7 +10,11 @@ const SAFE_SCROLL_DOWN_ACTION = "gecko-zoom-out";
 const FORBIDDEN_ACTION = "gecko-close-tab";
 const NORMALIZED_SCROLL_UP_ACTION = "gecko-show-previous-tab";
 const WINDOW_TITLE_MARKER = "Floorp wheel native X11 E2E";
-const SETTINGS_URL = "chrome://noraneko-settings/content#/features/gesture";
+const SETTINGS_ORIGIN = "http://localhost:5183";
+const SETTINGS_ROUTE = "#/features/gesture";
+const SETTINGS_URL = `${SETTINGS_ORIGIN}/${SETTINGS_ROUTE}`;
+const WINDOW_DISCOVERY_TIMEOUT_MS = 10_000;
+const WINDOW_DISCOVERY_INTERVAL_MS = 100;
 const REPEAT_SAFE_WHEEL_ACTIONS = [
   "gecko-show-previous-tab",
   "gecko-show-next-tab",
@@ -182,7 +186,7 @@ function parseWindowGeometry(id: string, output: string): WindowGeometry {
   };
 }
 
-async function findSoleVisibleFloorpWindow(
+async function inspectSoleVisibleFloorpWindow(
   processId: number,
 ): Promise<WindowGeometry> {
   const ids = parseWindowIds(
@@ -220,6 +224,30 @@ async function findSoleVisibleFloorpWindow(
     `X11 window ${id} does not have the Floorp test title: ${title}`,
   );
   return parseWindowGeometry(id, geometry);
+}
+
+async function findSoleVisibleFloorpWindow(
+  processId: number,
+): Promise<WindowGeometry> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - startedAt < WINDOW_DISCOVERY_TIMEOUT_MS) {
+    try {
+      return await inspectSoleVisibleFloorpWindow(processId);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) =>
+        setTimeout(resolve, WINDOW_DISCOVERY_INTERVAL_MS)
+      );
+    }
+  }
+
+  throw new Error(
+    `Timed out after ${WINDOW_DISCOVERY_TIMEOUT_MS}ms waiting for exactly one visible Floorp window for PID ${processId}: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
 }
 
 const client = await MarionetteClient.connect();
@@ -319,7 +347,7 @@ async function resetZoom(): Promise<number> {
   return await readZoom();
 }
 
-async function readWheelActionsFromPref(): Promise<WheelActions> {
+async function readWheelActionsFromPref(): Promise<WheelActions | null> {
   await client.setContext("chrome");
   const raw = await client.executeScript(`
     const config = JSON.parse(
@@ -327,7 +355,19 @@ async function readWheelActionsFromPref(): Promise<WheelActions> {
     );
     return JSON.stringify(config.wheelActions ?? null);
   `);
-  return JSON.parse(raw) as WheelActions;
+  const parsed: unknown = JSON.parse(raw);
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed)
+  ) {
+    return null;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  return typeof candidate.scrollUp === "string" &&
+      typeof candidate.scrollDown === "string"
+    ? candidate as unknown as WheelActions
+    : null;
 }
 
 async function waitForWheelActions(
@@ -449,9 +489,49 @@ async function setWheelActionsThroughSettings(): Promise<void> {
   `);
 }
 
+async function assertTestSettingsEnvironment(): Promise<void> {
+  await client.setContext("chrome");
+  const raw = await client.executeScript(`
+    return JSON.stringify({
+      startupMode: Services.prefs.getStringPref("nora.startup.mode", ""),
+      allowHttpLoader: Services.prefs.getBoolPref(
+        "nora.dev.allow_http_loader",
+        false,
+      ),
+    });
+  `);
+  const environment = JSON.parse(raw) as {
+    startupMode: string;
+    allowHttpLoader: boolean;
+  };
+  assert(
+    environment.startupMode === "test" && environment.allowHttpLoader,
+    `Refusing settings HTTP E2E outside the expected test loader: ${
+      JSON.stringify(environment)
+    }`,
+  );
+}
+
+async function assertSettingsRoute(): Promise<void> {
+  await client.setContext("content");
+  const raw = await client.executeScript(`
+    return JSON.stringify({
+      origin: location.origin,
+      hash: location.hash,
+    });
+  `);
+  const location = JSON.parse(raw) as { origin: string; hash: string };
+  assert(
+    location.origin === SETTINGS_ORIGIN && location.hash === SETTINGS_ROUTE,
+    `Unexpected settings route: ${JSON.stringify(location)}`,
+  );
+}
+
 async function assertSettingsPersistence(): Promise<void> {
+  await assertTestSettingsEnvironment();
   await client.setContext("content");
   await client.navigate(SETTINGS_URL);
+  await assertSettingsRoute();
   const initial = await waitForWheelSettings();
   assertWheelSettingsContract(initial);
 
@@ -468,6 +548,7 @@ async function assertSettingsPersistence(): Promise<void> {
   // recreated from stored preferences rather than retaining local state.
   await client.setContext("content");
   await client.navigate(SETTINGS_URL);
+  await assertSettingsRoute();
   const reloaded = await waitForWheelSettings([
     SAFE_SCROLL_UP_ACTION,
     SAFE_SCROLL_DOWN_ACTION,

--- a/tools/src/mouse_gesture_wheel_x11_e2e.ts
+++ b/tools/src/mouse_gesture_wheel_x11_e2e.ts
@@ -10,6 +10,26 @@ const SAFE_SCROLL_DOWN_ACTION = "gecko-zoom-out";
 const FORBIDDEN_ACTION = "gecko-close-tab";
 const NORMALIZED_SCROLL_UP_ACTION = "gecko-show-previous-tab";
 const WINDOW_TITLE_MARKER = "Floorp wheel native X11 E2E";
+const SETTINGS_URL = "chrome://noraneko-settings/content#/features/gesture";
+const REPEAT_SAFE_WHEEL_ACTIONS = [
+  "gecko-show-previous-tab",
+  "gecko-show-next-tab",
+  "gecko-scroll-line-up",
+  "gecko-scroll-line-down",
+  "gecko-scroll-up",
+  "gecko-scroll-down",
+  "gecko-scroll-left",
+  "gecko-scroll-right",
+  "gecko-scroll-to-top",
+  "gecko-scroll-to-bottom",
+  "gecko-zoom-in",
+  "gecko-zoom-out",
+  "gecko-reset-zoom",
+  "gecko-workspace-next",
+  "gecko-workspace-previous",
+  "gecko-show-next-search-result",
+  "gecko-show-previous-search-result",
+] as const;
 
 if (Deno.build.os !== "linux") {
   throw new Error("Mouse gesture native X11 E2E requires Linux");
@@ -67,6 +87,14 @@ interface PageState {
     deltaY: number | null;
     defaultPrevented: boolean;
   }>;
+}
+
+interface WheelSettingsSnapshot {
+  allSelectCount: number;
+  wheelSelectCount: number;
+  selectedValues: string[];
+  disabled: boolean[];
+  optionValues: string[][];
 }
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -320,6 +348,136 @@ async function waitForWheelActions(
   throw new Error(
     `${label}: expected wheel actions ${JSON.stringify(expected)}, got ${
       JSON.stringify(observed)
+    }`,
+  );
+}
+
+async function readWheelSettingsSnapshot(): Promise<WheelSettingsSnapshot> {
+  await client.setContext("content");
+  const raw = await client.executeScript(`
+    const allowed = ${JSON.stringify(REPEAT_SAFE_WHEEL_ACTIONS)};
+    const sortedAllowed = [...allowed].sort();
+    const selects = [...document.querySelectorAll("select")];
+    const wheelSelects = selects.filter((select) => {
+      const values = [...select.options].map((option) => option.value).sort();
+      return values.length === sortedAllowed.length &&
+        values.every((value, index) => value === sortedAllowed[index]);
+    });
+    return JSON.stringify({
+      allSelectCount: selects.length,
+      wheelSelectCount: wheelSelects.length,
+      selectedValues: wheelSelects.map((select) => select.value),
+      disabled: wheelSelects.map((select) => select.disabled),
+      optionValues: wheelSelects.map((select) =>
+        [...select.options].map((option) => option.value)
+      ),
+    });
+  `);
+  return JSON.parse(raw) as WheelSettingsSnapshot;
+}
+
+async function waitForWheelSettings(
+  expectedValues?: [string, string],
+): Promise<WheelSettingsSnapshot> {
+  let observed: WheelSettingsSnapshot | null = null;
+  for (let attempt = 0; attempt < 120; attempt++) {
+    observed = await readWheelSettingsSnapshot();
+    const valuesMatch = !expectedValues ||
+      observed.selectedValues[0] === expectedValues[0] &&
+        observed.selectedValues[1] === expectedValues[1];
+    if (
+      observed.wheelSelectCount === 2 &&
+      observed.disabled.every((disabled) => !disabled) &&
+      valuesMatch
+    ) {
+      return observed;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    `Mouse gesture settings did not become ready: ${JSON.stringify(observed)}`,
+  );
+}
+
+function assertWheelSettingsContract(snapshot: WheelSettingsSnapshot): void {
+  assert(
+    snapshot.wheelSelectCount === 2,
+    `Expected exactly two wheel action selects, got ${snapshot.wheelSelectCount} among ${snapshot.allSelectCount} selects`,
+  );
+  for (const [index, values] of snapshot.optionValues.entries()) {
+    assert(
+      values.length === REPEAT_SAFE_WHEEL_ACTIONS.length,
+      `Wheel select ${index} has ${values.length} options, expected ${REPEAT_SAFE_WHEEL_ACTIONS.length}`,
+    );
+    assert(
+      !values.includes(FORBIDDEN_ACTION),
+      `Wheel select ${index} exposes forbidden ${FORBIDDEN_ACTION}`,
+    );
+  }
+}
+
+async function setWheelActionsThroughSettings(): Promise<void> {
+  await client.setContext("content");
+  await client.executeScript(`
+    const allowed = ${JSON.stringify(REPEAT_SAFE_WHEEL_ACTIONS)};
+    const sortedAllowed = [...allowed].sort();
+    const wheelSelects = [...document.querySelectorAll("select")].filter(
+      (select) => {
+        const values = [...select.options].map((option) => option.value).sort();
+        return values.length === sortedAllowed.length &&
+          values.every((value, index) => value === sortedAllowed[index]);
+      },
+    );
+    if (wheelSelects.length !== 2) {
+      throw new Error(
+        "Expected exactly two wheel action selects, got " +
+          wheelSelects.length,
+      );
+    }
+    const nativeValueSetter = Object.getOwnPropertyDescriptor(
+      HTMLSelectElement.prototype,
+      "value",
+    ).set;
+    const nextValues = [
+      ${JSON.stringify(SAFE_SCROLL_UP_ACTION)},
+      ${JSON.stringify(SAFE_SCROLL_DOWN_ACTION)},
+    ];
+    wheelSelects.forEach((select, index) => {
+      nativeValueSetter.call(select, nextValues[index]);
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+  `);
+}
+
+async function assertSettingsPersistence(): Promise<void> {
+  await client.setContext("content");
+  await client.navigate(SETTINGS_URL);
+  const initial = await waitForWheelSettings();
+  assertWheelSettingsContract(initial);
+
+  await setWheelActionsThroughSettings();
+  await waitForWheelActions(
+    {
+      scrollUp: SAFE_SCROLL_UP_ACTION,
+      scrollDown: SAFE_SCROLL_DOWN_ACTION,
+    },
+    "settings wheel action update",
+  );
+
+  // Re-navigate to the exact route so the React tree and persistence hook are
+  // recreated from stored preferences rather than retaining local state.
+  await client.setContext("content");
+  await client.navigate(SETTINGS_URL);
+  const reloaded = await waitForWheelSettings([
+    SAFE_SCROLL_UP_ACTION,
+    SAFE_SCROLL_DOWN_ACTION,
+  ]);
+  assertWheelSettingsContract(reloaded);
+  assert(
+    reloaded.selectedValues[0] === SAFE_SCROLL_UP_ACTION &&
+      reloaded.selectedValues[1] === SAFE_SCROLL_DOWN_ACTION,
+    `Wheel action settings did not persist after reload: ${
+      JSON.stringify(reloaded.selectedValues)
     }`,
   );
 }
@@ -608,10 +766,6 @@ try {
         ...(config.contextMenu ?? {}),
         preventionTimeout: ${PREVENTION_TIMEOUT_MS},
       };
-      config.wheelActions = {
-        scrollUp: ${JSON.stringify(SAFE_SCROLL_UP_ACTION)},
-        scrollDown: ${JSON.stringify(SAFE_SCROLL_DOWN_ACTION)},
-      };
       Services.prefs.setStringPref(configPref, JSON.stringify(config));
       Services.prefs.setBoolPref(enabledPref, true);
 
@@ -650,13 +804,8 @@ try {
       setup.zoomAfterTwoReductions === setup.baselineZoom,
     `Zoom action precondition failed: ${JSON.stringify(setup)}`,
   );
-  await waitForWheelActions(
-    {
-      scrollUp: SAFE_SCROLL_UP_ACTION,
-      scrollDown: SAFE_SCROLL_DOWN_ACTION,
-    },
-    "safe wheel mapping",
-  );
+
+  await assertSettingsPersistence();
 
   await client.setContext("content");
   const fixture = `<!doctype html>


### PR DESCRIPTION
Similarly to previously added rocker gestures bindings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customizable actions for mouse wheel gestures, with separate controls for scrolling up and down.
  - Added localized labels and descriptions for wheel gesture options.
  - Added saving status and error messages in gesture settings.
  - Added reliable configuration persistence with queued updates and safe defaults.

- **Bug Fixes**
  - Wheel gestures now execute configured, validated actions safely.
  - Improved reliability during interrupted gestures, rapid wheel input, and normal right-click interactions.
  - Invalid or unsupported mappings now fall back to safe defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->