### PR TITLE
test(notes): add isolated desktop browser launch foundation

### DIFF
--- a/tools/src/browser_launcher.test.ts
+++ b/tools/src/browser_launcher.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  assertEquals,
+  assertNotEquals,
+  assertThrows,
+} from "@std/assert";
+import * as path from "@std/path";
+import {
+  browserCommand,
+  createIsolatedBrowserLaunch,
+  createIsolatedBrowserPairLaunch,
+} from "./browser_launcher.ts";
+import { PATHS } from "./defines.ts";
+
+function assertPrivateMode(filePath: string): void {
+  if (Deno.build.os === "windows") return;
+  const mode = Deno.lstatSync(filePath).mode;
+  if (mode === null) {
+    throw new Error(`Expected a POSIX mode for ${filePath}`);
+  }
+  assertEquals(mode & 0o077, 0);
+}
+
+Deno.test("isolated browser launch owns a fresh private profile and Marionette port", () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28291,
+  });
+  try {
+    assertEquals(launch.port, 28291);
+    assertNotEquals(launch.profilePath, PATHS.profile_test);
+    assertEquals(launch.command, [
+      "/opt/floorp/Floorp",
+      "--profile",
+      launch.profilePath,
+      "--marionette",
+      "--remote-allow-system-access",
+      "--no-remote",
+    ]);
+    assertPrivateMode(launch.profilePath);
+
+    const userJsPath = path.join(launch.profilePath, "user.js");
+    assertPrivateMode(userJsPath);
+    assertEquals(
+      Deno.readTextFileSync(userJsPath),
+      [
+        'user_pref("remote.active-protocols", 0);',
+        'user_pref("marionette.enabled", true);',
+        'user_pref("marionette.port", 28291);',
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    launch.cleanup();
+  }
+});
+
+Deno.test("isolated launcher rejects invalid Marionette ports", () => {
+  for (const port of [0, 1_023, 65_536]) {
+    assertThrows(
+      () =>
+        createIsolatedBrowserLaunch({
+          binaryPath: "/opt/floorp/Floorp",
+          port,
+        }),
+      Error,
+      "Marionette port",
+    );
+  }
+});
+
+Deno.test("isolated launcher cleanup is idempotent and removes its profile", () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28292,
+  });
+
+  launch.cleanup();
+  launch.cleanup();
+
+  assertThrows(
+    () => Deno.lstatSync(launch.profilePath),
+    Deno.errors.NotFound,
+  );
+});
+
+Deno.test("isolated browser pair rejects shared ports and owns distinct profiles", () => {
+  assertThrows(
+    () =>
+      createIsolatedBrowserPairLaunch({
+        first: {
+          binaryPath: "/opt/floorp/Floorp",
+          port: 28291,
+        },
+        second: {
+          binaryPath: "/opt/floorp/Floorp",
+          port: 28291,
+        },
+      }),
+    Error,
+    "must use distinct ports",
+  );
+
+  const pair = createIsolatedBrowserPairLaunch({
+    first: {
+      binaryPath: "/opt/floorp/Floorp",
+      port: 28291,
+    },
+    second: {
+      binaryPath: "/opt/floorp/Floorp",
+      port: 28292,
+    },
+  });
+  try {
+    assertEquals(pair.first.port, 28291);
+    assertEquals(pair.second.port, 28292);
+    assertNotEquals(pair.first.profilePath, pair.second.profilePath);
+    assertNotEquals(pair.first.profilePath, PATHS.profile_test);
+    assertNotEquals(pair.second.profilePath, PATHS.profile_test);
+    assertPrivateMode(pair.first.profilePath);
+    assertPrivateMode(pair.second.profilePath);
+  } finally {
+    pair.first.cleanup();
+    pair.second.cleanup();
+  }
+});
+
+Deno.test("browser command retains the ordinary single-profile default", () => {
+  const command = browserCommand({ marionette: false });
+  assertEquals(command.includes("--marionette"), false);
+  assertEquals(command.includes("--no-remote"), false);
+});

--- a/tools/src/browser_launcher.ts
+++ b/tools/src/browser_launcher.ts
@@ -27,21 +27,186 @@ function printFirefoxLog(line: string) {
 }
 
 export interface BrowserLaunchOptions {
+  binaryPath?: string;
+  noRemote?: boolean;
   port?: number;
   marionette?: boolean;
+  profilePath?: string;
+}
+
+export interface IsolatedBrowserLaunchOptions {
+  binaryPath: string;
+  port: number;
+}
+
+export interface IsolatedBrowserLaunch {
+  cleanup(): void;
+  command: string[];
+  port: number;
+  profilePath: string;
+}
+
+export interface IsolatedBrowserPairLaunchOptions {
+  first: IsolatedBrowserLaunchOptions;
+  second: IsolatedBrowserLaunchOptions;
+}
+
+export interface IsolatedBrowserPairLaunch {
+  first: IsolatedBrowserLaunch;
+  second: IsolatedBrowserLaunch;
+}
+
+function assertMarionettePort(port: number): void {
+  if (!Number.isInteger(port) || port < 1_024 || port > 65_535) {
+    throw new Error(
+      `Marionette port must be an integer between 1024 and 65535: ${port}`,
+    );
+  }
+}
+
+function assertIsolatedLaunchOptions(
+  options: IsolatedBrowserLaunchOptions,
+): void {
+  if (options.binaryPath.trim().length === 0) {
+    throw new Error("Browser binary path must not be empty");
+  }
+  assertMarionettePort(options.port);
+}
+
+function assertPrivateGeneratedPath(
+  filePath: string,
+  expectedType: "directory" | "file",
+): void {
+  const info = Deno.lstatSync(filePath);
+  const actualType = info.isDirectory
+    ? "directory"
+    : info.isFile
+    ? "file"
+    : "other";
+  if (info.isSymlink || actualType !== expectedType) {
+    throw new Error(
+      `Generated Marionette ${expectedType} has an unsafe type: ${filePath}`,
+    );
+  }
+  if (
+    Deno.build.os !== "windows" &&
+    info.mode !== null &&
+    (info.mode & 0o077) !== 0
+  ) {
+    throw new Error(
+      `Generated Marionette ${expectedType} is not private: ${filePath}`,
+    );
+  }
+}
+
+function cleanupGeneratedProfile(profilePath: string): void {
+  try {
+    Deno.removeSync(profilePath, { recursive: true });
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Creates a new random, private profile-local Marionette configuration. The
+ * profile path is never supplied by a caller, preventing accidental inheritance
+ * of credentials, cookies, or remote-agent state from a shared profile.
+ */
+function prepareMarionetteProfile(port: number): string {
+  assertMarionettePort(port);
+  const profilePath = Deno.makeTempDirSync({
+    prefix: "floorp-notes-sync-marionette-",
+  });
+  try {
+    assertPrivateGeneratedPath(profilePath, "directory");
+    const userJsPath = path.join(profilePath, "user.js");
+    Deno.writeTextFileSync(
+      userJsPath,
+      'user_pref("remote.active-protocols", 0);\n' +
+        'user_pref("marionette.enabled", true);\n' +
+        `user_pref("marionette.port", ${port});\n`,
+      { createNew: true, mode: 0o600 },
+    );
+    assertPrivateGeneratedPath(userJsPath, "file");
+    return profilePath;
+  } catch (error) {
+    try {
+      cleanupGeneratedProfile(profilePath);
+    } catch {
+      // Preserve the original setup failure; no caller-supplied path was used.
+    }
+    throw error;
+  }
 }
 
 export function browserCommand(options: BrowserLaunchOptions = {}): string[] {
-  const { marionette = true } = options;
+  const {
+    binaryPath = BIN_PATH_EXE,
+    marionette = true,
+    noRemote = false,
+    profilePath = PATHS.profile_test,
+  } = options;
   const args = [
-    BIN_PATH_EXE,
+    binaryPath,
     "--profile",
-    PATHS.profile_test,
+    profilePath,
   ];
   if (marionette) {
     args.push("--marionette", "--remote-allow-system-access");
   }
+  if (noRemote) {
+    args.push("--no-remote");
+  }
   return args;
+}
+
+export function createIsolatedBrowserLaunch(
+  options: IsolatedBrowserLaunchOptions,
+): IsolatedBrowserLaunch {
+  assertIsolatedLaunchOptions(options);
+  const profilePath = prepareMarionetteProfile(options.port);
+
+  return {
+    cleanup: () => cleanupGeneratedProfile(profilePath),
+    command: browserCommand({
+      binaryPath: options.binaryPath,
+      marionette: true,
+      noRemote: true,
+      // The profile-local user.js is the single source of the port value.
+      profilePath,
+    }),
+    port: options.port,
+    profilePath,
+  };
+}
+
+/**
+ * Prepares two disposable browser configurations without launching either
+ * browser or writing the legacy global Marionette state file. Callers must use
+ * each returned port explicitly when connecting their corresponding client.
+ */
+export function createIsolatedBrowserPairLaunch(
+  options: IsolatedBrowserPairLaunchOptions,
+): IsolatedBrowserPairLaunch {
+  assertIsolatedLaunchOptions(options.first);
+  assertIsolatedLaunchOptions(options.second);
+  if (options.first.port === options.second.port) {
+    throw new Error("Isolated browser pair must use distinct ports");
+  }
+  const first = createIsolatedBrowserLaunch(options.first);
+  try {
+    const second = createIsolatedBrowserLaunch(options.second);
+    if (first.profilePath === second.profilePath) {
+      second.cleanup();
+      throw new Error("Isolated browser pair generated a shared profile");
+    }
+    return { first, second };
+  } catch (error) {
+    first.cleanup();
+    throw error;
+  }
 }
 
 export async function run(portOrOptions: number | BrowserLaunchOptions = 5180): Promise<void> {
@@ -50,7 +215,7 @@ export async function run(portOrOptions: number | BrowserLaunchOptions = 5180): 
     : portOrOptions;
   const port = options.port ?? 5180;
   const marionette = options.marionette ?? true;
-  const cmd = await browserCommand({ port, marionette });
+  const cmd = browserCommand({ ...options, port, marionette });
 
   console.log("[launcher] Launching browser with command: " + cmd.join(" "));
 


### PR DESCRIPTION
Foundation-only Todo 20 G5 preparation; it does not claim a live production sync result. Adds disposable two-client profile preparation, distinct Marionette ports, and no global state-file use in the new path. Verified with focused Deno lint and five focused launcher tests. Local host suite has one pre-existing macOS/Windows Runtime version-stamp mismatch (actual 000 vs expected 002) outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring browser binaries, profile paths, and remote-access options.
  - Added isolated browser launches with dedicated ports and private profiles.
  - Added paired isolated launches with safeguards against conflicting ports or profiles.
  - Added automatic cleanup for isolated browser profiles.
  - Preserved existing single-profile launch defaults.

- **Bug Fixes**
  - Added validation for invalid, shared, pre-existing, relative, or symlinked profile paths.
  - Added validation for empty binary paths and invalid or duplicate ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->