### PR TITLE
test(notes): require owned isolated browser lifecycle

### DIFF
--- a/tools/src/browser_launcher.test.ts
+++ b/tools/src/browser_launcher.test.ts
@@ -3,6 +3,7 @@
 import {
   assertEquals,
   assertNotEquals,
+  assertRejects,
   assertThrows,
 } from "@std/assert";
 import * as path from "@std/path";
@@ -10,6 +11,10 @@ import {
   browserCommand,
   createIsolatedBrowserLaunch,
   createIsolatedBrowserPairLaunch,
+  type IsolatedBrowserChild,
+  type IsolatedBrowserProcessControl,
+  startIsolatedBrowser,
+  startIsolatedBrowserPair,
 } from "./browser_launcher.ts";
 import { PATHS } from "./defines.ts";
 
@@ -20,6 +25,32 @@ function assertPrivateMode(filePath: string): void {
     throw new Error(`Expected a POSIX mode for ${filePath}`);
   }
   assertEquals(mode & 0o077, 0);
+}
+
+function mockProcessControl(
+  stop: (child: IsolatedBrowserChild) => Promise<void> = (child) => {
+    child.kill("SIGTERM");
+    return Promise.resolve();
+  },
+): IsolatedBrowserProcessControl {
+  return {
+    capture(child, _launch, platform) {
+      return Promise.resolve({ platform, rootPid: child.pid });
+    },
+    stop(child) {
+      return stop(child);
+    },
+  };
+}
+
+function removeProfileForTest(profilePath: string): void {
+  try {
+    Deno.removeSync(profilePath, { recursive: true });
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
 }
 
 Deno.test("isolated browser launch owns a fresh private profile and Marionette port", () => {
@@ -38,6 +69,8 @@ Deno.test("isolated browser launch owns a fresh private profile and Marionette p
       "--remote-allow-system-access",
       "--no-remote",
     ]);
+    assertEquals(Object.isFrozen(launch), true);
+    assertEquals(Object.isFrozen(launch.command), true);
     assertPrivateMode(launch.profilePath);
 
     const userJsPath = path.join(launch.profilePath, "user.js");
@@ -52,7 +85,7 @@ Deno.test("isolated browser launch owns a fresh private profile and Marionette p
       ].join("\n"),
     );
   } finally {
-    launch.cleanup();
+    removeProfileForTest(launch.profilePath);
   }
 });
 
@@ -123,6 +156,388 @@ Deno.test("isolated browser pair rejects shared ports and owns distinct profiles
   } finally {
     pair.first.cleanup();
     pair.second.cleanup();
+  }
+});
+
+Deno.test("isolated browser process clears inherited secrets and cleans its profile", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28291,
+  });
+  const killed: string[] = [];
+  let captured:
+    | {
+      command: readonly string[];
+      options: {
+        clearEnv: boolean;
+        env: Record<string, string>;
+        stderr: string;
+        stdin: string;
+        stdout: string;
+      };
+    }
+    | undefined;
+
+  const running = await startIsolatedBrowser(launch, {
+    environment: {
+      FLOORP_FXA_TEST_SECRET: "must-not-reach-browser",
+      HOME: "/private/tmp/floorp-home",
+      PATH: "/usr/bin:/bin",
+    },
+    processControl: mockProcessControl(),
+    spawn: (command, options) => {
+      captured = { command, options };
+      return {
+        pid: 42,
+        kill: (signal) => killed.push(signal ?? "SIGTERM"),
+        status: Promise.resolve({ code: 0, signal: null, success: true }),
+      };
+    },
+  });
+  try {
+    if (captured === undefined) {
+      throw new Error("isolated browser was not spawned");
+    }
+    assertEquals(captured.command, launch.command);
+    assertEquals(captured.options.clearEnv, true);
+    assertEquals(captured.options.stdin, "null");
+    assertEquals(captured.options.stdout, "null");
+    assertEquals(captured.options.stderr, "null");
+    assertEquals(captured.options.env.FLOORP_FXA_TEST_SECRET, undefined);
+    assertEquals(captured.options.env.HOME, "/private/tmp/floorp-home");
+    assertEquals(captured.options.env.PATH, "/usr/bin:/bin");
+
+    await running.stop();
+    assertEquals(killed, ["SIGTERM"]);
+    assertThrows(
+      () => Deno.lstatSync(launch.profilePath),
+      Deno.errors.NotFound,
+    );
+  } finally {
+    await running.stop();
+  }
+});
+
+Deno.test("isolated Windows browser normalizes safe environment names and delegates owned-tree termination", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28293,
+  });
+  const terminatedPIDs: number[] = [];
+  const killed: string[] = [];
+  let capturedEnvironment: Record<string, string> | undefined;
+  let resolveStatus: ((status: Deno.CommandStatus) => void) | undefined;
+
+  const running = await startIsolatedBrowser(launch, {
+    environment: {
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+      FLOORP_FXA_TEST_SECRET: "must-not-reach-browser",
+      HTTP_PROXY: "http://must-not-reach-browser.invalid",
+      Path: "C:\\Windows\\System32",
+      SystemRoot: "C:\\Windows",
+      UNRELATED: "must-not-reach-browser",
+    },
+    platform: "windows",
+    processControl: mockProcessControl((child) => {
+      terminatedPIDs.push(child.pid);
+      if (resolveStatus === undefined) {
+        throw new Error("isolated browser status resolver was not installed");
+      }
+      resolveStatus({ code: 0, signal: null, success: true });
+      return Promise.resolve();
+    }),
+    spawn: (_command, options) => {
+      capturedEnvironment = options.env;
+      return {
+        pid: 43,
+        kill: (signal) => killed.push(signal ?? "SIGTERM"),
+        status: new Promise((resolve) => {
+          resolveStatus = resolve;
+        }),
+      };
+    },
+  });
+  try {
+    assertEquals(capturedEnvironment, {
+      COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      PATH: "C:\\Windows\\System32",
+      SYSTEMROOT: "C:\\Windows",
+    });
+    await running.stop();
+    assertEquals(terminatedPIDs, [43]);
+    assertEquals(killed, []);
+  } finally {
+    removeProfileForTest(launch.profilePath);
+  }
+});
+
+Deno.test("isolated browser retains its profile when the owned process cannot be confirmed stopped", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28294,
+  });
+  const killed: string[] = [];
+  const running = await startIsolatedBrowser(launch, {
+    environment: {},
+    processControl: mockProcessControl(() =>
+      Promise.reject(new Error("owned process did not exit"))
+    ),
+    spawn: () => ({
+      pid: 44,
+      kill: (signal) => killed.push(signal ?? "SIGTERM"),
+      status: new Promise<Deno.CommandStatus>(() => undefined),
+    }),
+  });
+  try {
+    await assertRejects(
+      () => running.stop(),
+      Error,
+      "did not exit",
+    );
+    assertEquals(killed, []);
+    assertEquals(Deno.lstatSync(launch.profilePath).isDirectory, true);
+  } finally {
+    removeProfileForTest(launch.profilePath);
+  }
+});
+
+Deno.test("isolated browser retains its profile when ownership capture fails after spawn", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28298,
+  });
+  const killed: string[] = [];
+  const processControl: IsolatedBrowserProcessControl = {
+    capture: () => Promise.reject(new Error("could not capture owned process")),
+    stop: () => Promise.resolve(),
+  };
+  try {
+    await assertRejects(
+      () =>
+        startIsolatedBrowser(launch, {
+          environment: {},
+          processControl,
+          spawn: () => ({
+            pid: 45,
+            kill: (signal) => killed.push(signal ?? "SIGTERM"),
+            status: new Promise<Deno.CommandStatus>(() => undefined),
+          }),
+        }),
+      Error,
+      "could not capture",
+    );
+    assertEquals(killed, ["SIGTERM"]);
+    assertEquals(Deno.lstatSync(launch.profilePath).isDirectory, true);
+  } finally {
+    removeProfileForTest(launch.profilePath);
+  }
+});
+
+Deno.test("isolated browser prevents external profile cleanup after spawn", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28301,
+  });
+  let resolveCapture:
+    | ((ownership: { platform: typeof Deno.build.os; rootPid: number }) => void)
+    | undefined;
+  const processControl: IsolatedBrowserProcessControl = {
+    capture: () =>
+      new Promise((resolve) => {
+        resolveCapture = resolve;
+      }),
+    stop: () => Promise.resolve(),
+  };
+  const starting = startIsolatedBrowser(launch, {
+    environment: {},
+    processControl,
+    spawn: () => ({
+      pid: 46,
+      kill: () => undefined,
+      status: new Promise<Deno.CommandStatus>(() => undefined),
+    }),
+  });
+  try {
+    assertThrows(() => launch.cleanup(), Error, "running");
+    if (resolveCapture === undefined) {
+      throw new Error("ownership capture was not started");
+    }
+    resolveCapture({ platform: Deno.build.os, rootPid: 46 });
+    const running = await starting;
+    assertEquals("cleanup" in running.launch, false);
+    await running.stop();
+  } finally {
+    removeProfileForTest(launch.profilePath);
+  }
+});
+
+Deno.test("isolated browser pair removes the first profile if the second spawn fails", async () => {
+  const commands: string[][] = [];
+  await assertRejects(
+    () =>
+      startIsolatedBrowserPair(
+        {
+          first: {
+            binaryPath: "/opt/floorp/Floorp",
+            port: 28291,
+          },
+          second: {
+            binaryPath: "/opt/floorp/Floorp",
+            port: 28292,
+          },
+        },
+        {
+          environment: {},
+          processControl: mockProcessControl(),
+          spawn: (command) => {
+            commands.push([...command]);
+            if (commands.length === 2) {
+              throw new Error("second browser spawn failed");
+            }
+            return {
+              pid: 41,
+              kill: () => undefined,
+              status: Promise.resolve({ code: 0, signal: null, success: true }),
+            };
+          },
+        },
+      ),
+    Error,
+    "second browser spawn failed",
+  );
+  assertEquals(commands.length, 2);
+  const firstProfilePath = commands[0][2];
+  assertThrows(
+    () => Deno.lstatSync(firstProfilePath),
+    Deno.errors.NotFound,
+  );
+});
+
+Deno.test("isolated browser pair attempts both stops and retains only an unverified profile", async () => {
+  const commands: string[][] = [];
+  const pair = await startIsolatedBrowserPair(
+    {
+      first: {
+        binaryPath: "/opt/floorp/Floorp",
+        port: 28295,
+      },
+      second: {
+        binaryPath: "/opt/floorp/Floorp",
+        port: 28296,
+      },
+    },
+    {
+      environment: {},
+      processControl: mockProcessControl((child) =>
+        child.pid === 1
+          ? Promise.reject(new Error("owned process did not exit"))
+          : Promise.resolve()
+      ),
+      spawn: (command) => {
+        commands.push([...command]);
+        return {
+          pid: commands.length,
+          kill: () => undefined,
+          status: commands.length === 1
+            ? new Promise<Deno.CommandStatus>(() => undefined)
+            : Promise.resolve({ code: 0, signal: null, success: true }),
+        };
+      },
+    },
+  );
+  const firstProfilePath = commands[0][2];
+  const secondProfilePath = commands[1][2];
+  try {
+    await assertRejects(() => pair.stop(), AggregateError, "Failed to stop");
+    assertEquals(Deno.lstatSync(firstProfilePath).isDirectory, true);
+    assertThrows(
+      () => Deno.lstatSync(secondProfilePath),
+      Deno.errors.NotFound,
+    );
+  } finally {
+    removeProfileForTest(pair.first.launch.profilePath);
+    removeProfileForTest(pair.second.launch.profilePath);
+  }
+});
+
+Deno.test("isolated browser pair retains a profile whose ownership capture fails", async () => {
+  const commands: string[][] = [];
+  const processControl: IsolatedBrowserProcessControl = {
+    capture(child, _launch, platform) {
+      return child.pid === 2
+        ? Promise.reject(new Error("could not capture second owned process"))
+        : Promise.resolve({ platform, rootPid: child.pid });
+    },
+    stop: () => Promise.resolve(),
+  };
+  await assertRejects(
+    () =>
+      startIsolatedBrowserPair(
+        {
+          first: {
+            binaryPath: "/opt/floorp/Floorp",
+            port: 28299,
+          },
+          second: {
+            binaryPath: "/opt/floorp/Floorp",
+            port: 28300,
+          },
+        },
+        {
+          environment: {},
+          processControl,
+          spawn: (command) => {
+            commands.push([...command]);
+            return {
+              pid: commands.length,
+              kill: () => undefined,
+              status: new Promise<Deno.CommandStatus>(() => undefined),
+            };
+          },
+        },
+      ),
+    Error,
+    "could not capture second",
+  );
+  const firstProfilePath = commands[0][2];
+  const secondProfilePath = commands[1][2];
+  try {
+    assertThrows(
+      () => Deno.lstatSync(firstProfilePath),
+      Deno.errors.NotFound,
+    );
+    assertEquals(Deno.lstatSync(secondProfilePath).isDirectory, true);
+  } finally {
+    removeProfileForTest(secondProfilePath);
+  }
+});
+
+Deno.test("isolated browser refuses to spawn without an ownership controller", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28297,
+  });
+  let spawnCalled = false;
+  try {
+    await assertRejects(
+      () =>
+        startIsolatedBrowser(launch, {
+          environment: {},
+          spawn: () => {
+            spawnCalled = true;
+            throw new Error("must not spawn without ownership control");
+          },
+        }),
+      Error,
+      "ownership controller",
+    );
+    assertEquals(spawnCalled, false);
+    assertThrows(
+      () => Deno.lstatSync(launch.profilePath),
+      Deno.errors.NotFound,
+    );
+  } finally {
+    launch.cleanup();
   }
 });
 

--- a/tools/src/browser_launcher.test.ts
+++ b/tools/src/browser_launcher.test.ts
@@ -37,6 +37,10 @@ function mockProcessControl(
     capture(child, _launch, platform) {
       return Promise.resolve({ platform, rootPid: child.pid });
     },
+    abort(child) {
+      child.kill("SIGTERM");
+      return Promise.resolve();
+    },
     stop(child) {
       return stop(child);
     },
@@ -231,11 +235,15 @@ Deno.test("isolated Windows browser normalizes safe environment names and delega
   const running = await startIsolatedBrowser(launch, {
     environment: {
       ComSpec: "C:\\Windows\\System32\\cmd.exe",
+      DISPLAY: ":99",
       FLOORP_FXA_TEST_SECRET: "must-not-reach-browser",
       HTTP_PROXY: "http://must-not-reach-browser.invalid",
       Path: "C:\\Windows\\System32",
       SystemRoot: "C:\\Windows",
       UNRELATED: "must-not-reach-browser",
+      WAYLAND_DISPLAY: "wayland-0",
+      XAUTHORITY: "/tmp/floorp-xauthority",
+      XDG_RUNTIME_DIR: "/tmp/floorp-runtime",
     },
     platform: "windows",
     processControl: mockProcessControl((child) => {
@@ -260,8 +268,12 @@ Deno.test("isolated Windows browser normalizes safe environment names and delega
   try {
     assertEquals(capturedEnvironment, {
       COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      DISPLAY: ":99",
       PATH: "C:\\Windows\\System32",
       SYSTEMROOT: "C:\\Windows",
+      WAYLAND_DISPLAY: "wayland-0",
+      XAUTHORITY: "/tmp/floorp-xauthority",
+      XDG_RUNTIME_DIR: "/tmp/floorp-runtime",
     });
     await running.stop();
     assertEquals(terminatedPIDs, [43]);
@@ -301,6 +313,44 @@ Deno.test("isolated browser retains its profile when the owned process cannot be
   }
 });
 
+Deno.test("isolated browser retries a failed verified stop", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28302,
+  });
+  let stopAttempts = 0;
+  const running = await startIsolatedBrowser(launch, {
+    environment: {},
+    processControl: mockProcessControl(() => {
+      stopAttempts += 1;
+      return stopAttempts === 1
+        ? Promise.reject(new Error("first verified stop failed"))
+        : Promise.resolve();
+    }),
+    spawn: () => ({
+      pid: 47,
+      kill: () => undefined,
+      status: new Promise<Deno.CommandStatus>(() => undefined),
+    }),
+  });
+  try {
+    await assertRejects(
+      () => running.stop(),
+      Error,
+      "first verified stop failed",
+    );
+    assertEquals(Deno.lstatSync(launch.profilePath).isDirectory, true);
+    await running.stop();
+    assertEquals(stopAttempts, 2);
+    assertThrows(
+      () => Deno.lstatSync(launch.profilePath),
+      Deno.errors.NotFound,
+    );
+  } finally {
+    removeProfileForTest(launch.profilePath);
+  }
+});
+
 Deno.test("isolated browser retains its profile when ownership capture fails after spawn", async () => {
   const launch = createIsolatedBrowserLaunch({
     binaryPath: "/opt/floorp/Floorp",
@@ -309,6 +359,10 @@ Deno.test("isolated browser retains its profile when ownership capture fails aft
   const killed: string[] = [];
   const processControl: IsolatedBrowserProcessControl = {
     capture: () => Promise.reject(new Error("could not capture owned process")),
+    abort: (child) => {
+      child.kill("SIGTERM");
+      return Promise.reject(new Error("could not abort owned process"));
+    },
     stop: () => Promise.resolve(),
   };
   try {
@@ -333,6 +387,45 @@ Deno.test("isolated browser retains its profile when ownership capture fails aft
   }
 });
 
+Deno.test("isolated browser cleans its profile when capture abort is verified", async () => {
+  const launch = createIsolatedBrowserLaunch({
+    binaryPath: "/opt/floorp/Floorp",
+    port: 28305,
+  });
+  const abortedPIDs: number[] = [];
+  const processControl: IsolatedBrowserProcessControl = {
+    capture: () => Promise.reject(new Error("could not capture owned process")),
+    abort: (child) => {
+      abortedPIDs.push(child.pid);
+      return Promise.resolve();
+    },
+    stop: () => Promise.resolve(),
+  };
+  try {
+    await assertRejects(
+      () =>
+        startIsolatedBrowser(launch, {
+          environment: {},
+          processControl,
+          spawn: () => ({
+            pid: 48,
+            kill: () => undefined,
+            status: new Promise<Deno.CommandStatus>(() => undefined),
+          }),
+        }),
+      Error,
+      "could not capture",
+    );
+    assertEquals(abortedPIDs, [48]);
+    assertThrows(
+      () => Deno.lstatSync(launch.profilePath),
+      Deno.errors.NotFound,
+    );
+  } finally {
+    removeProfileForTest(launch.profilePath);
+  }
+});
+
 Deno.test("isolated browser prevents external profile cleanup after spawn", async () => {
   const launch = createIsolatedBrowserLaunch({
     binaryPath: "/opt/floorp/Floorp",
@@ -346,6 +439,7 @@ Deno.test("isolated browser prevents external profile cleanup after spawn", asyn
       new Promise((resolve) => {
         resolveCapture = resolve;
       }),
+    abort: () => Promise.resolve(),
     stop: () => Promise.resolve(),
   };
   const starting = startIsolatedBrowser(launch, {
@@ -460,6 +554,59 @@ Deno.test("isolated browser pair attempts both stops and retains only an unverif
   }
 });
 
+Deno.test("isolated browser pair retries after one verified stop fails", async () => {
+  const commands: string[][] = [];
+  let firstStopAttempts = 0;
+  const pair = await startIsolatedBrowserPair(
+    {
+      first: {
+        binaryPath: "/opt/floorp/Floorp",
+        port: 28303,
+      },
+      second: {
+        binaryPath: "/opt/floorp/Floorp",
+        port: 28304,
+      },
+    },
+    {
+      environment: {},
+      processControl: mockProcessControl((child) => {
+        if (child.pid === 1) {
+          firstStopAttempts += 1;
+          return firstStopAttempts === 1
+            ? Promise.reject(new Error("first pair stop failed"))
+            : Promise.resolve();
+        }
+        return Promise.resolve();
+      }),
+      spawn: (command) => {
+        commands.push([...command]);
+        return {
+          pid: commands.length,
+          kill: () => undefined,
+          status: new Promise<Deno.CommandStatus>(() => undefined),
+        };
+      },
+    },
+  );
+  try {
+    await assertRejects(() => pair.stop(), AggregateError, "Failed to stop");
+    await pair.stop();
+    assertEquals(firstStopAttempts, 2);
+    assertThrows(
+      () => Deno.lstatSync(commands[0][2]),
+      Deno.errors.NotFound,
+    );
+    assertThrows(
+      () => Deno.lstatSync(commands[1][2]),
+      Deno.errors.NotFound,
+    );
+  } finally {
+    removeProfileForTest(pair.first.launch.profilePath);
+    removeProfileForTest(pair.second.launch.profilePath);
+  }
+});
+
 Deno.test("isolated browser pair retains a profile whose ownership capture fails", async () => {
   const commands: string[][] = [];
   const processControl: IsolatedBrowserProcessControl = {
@@ -468,6 +615,8 @@ Deno.test("isolated browser pair retains a profile whose ownership capture fails
         ? Promise.reject(new Error("could not capture second owned process"))
         : Promise.resolve({ platform, rootPid: child.pid });
     },
+    abort: () =>
+      Promise.reject(new Error("could not abort second owned process")),
     stop: () => Promise.resolve(),
   };
   await assertRejects(

--- a/tools/src/browser_launcher.ts
+++ b/tools/src/browser_launcher.ts
@@ -98,10 +98,16 @@ export interface IsolatedBrowserProcessOwnership {
 }
 
 /**
- * The controller owns process identity capture and must resolve `stop` only
- * after it has verified the owned root/tree and Marionette port are gone.
+ * The controller owns process identity capture and must resolve `stop` or
+ * `abort` only after it has verified the owned root/tree and Marionette port
+ * are gone.
  */
 export interface IsolatedBrowserProcessControl {
+  abort(
+    child: IsolatedBrowserChild,
+    launch: IsolatedBrowserLaunchView,
+    dependencies: IsolatedBrowserSpawnDependencies,
+  ): Promise<void>;
   capture(
     child: IsolatedBrowserChild,
     launch: IsolatedBrowserLaunchView,
@@ -130,6 +136,7 @@ export interface RunningIsolatedBrowserPair {
 const ISOLATED_BROWSER_ENV_ALLOWLIST = new Set([
   "APPDATA",
   "COMSPEC",
+  "DISPLAY",
   "HOME",
   "LANG",
   "LC_ALL",
@@ -141,7 +148,10 @@ const ISOLATED_BROWSER_ENV_ALLOWLIST = new Set([
   "TMP",
   "TMPDIR",
   "USERPROFILE",
+  "WAYLAND_DISPLAY",
   "WINDIR",
+  "XAUTHORITY",
+  "XDG_RUNTIME_DIR",
   "__CF_USER_TEXT_ENCODING",
 ]);
 
@@ -430,13 +440,20 @@ export async function startIsolatedBrowser(
   let ownership: IsolatedBrowserProcessOwnership;
   try {
     ownership = await processControl.capture(child, launchView, platform);
-  } catch (error) {
+  } catch (captureError) {
     try {
-      child.kill("SIGTERM");
-    } catch {
-      // The process may have exited before ownership capture failed.
+      await processControl.abort(child, launchView, dependencies);
+      cleanupIsolatedBrowserLaunch(launch, true);
+    } catch (abortError) {
+      const captureMessage = captureError instanceof Error
+        ? `: ${captureError.message}`
+        : "";
+      throw new AggregateError(
+        [captureError, abortError],
+        `Failed to capture isolated browser ownership and abort its process${captureMessage}`,
+      );
     }
-    throw error;
+    throw captureError;
   }
 
   let stopPromise: Promise<void> | undefined;
@@ -445,10 +462,16 @@ export async function startIsolatedBrowser(
     pid: child.pid,
     stop: () => {
       if (stopPromise === undefined) {
-        stopPromise = (async () => {
+        const attempt = (async () => {
           await processControl.stop(child, launchView, ownership, dependencies);
           cleanupIsolatedBrowserLaunch(launch, true);
         })();
+        stopPromise = attempt;
+        void attempt.catch(() => {
+          if (stopPromise === attempt) {
+            stopPromise = undefined;
+          }
+        });
       }
       return stopPromise;
     },
@@ -473,7 +496,7 @@ export async function startIsolatedBrowserPair(
       second,
       stop: () => {
         if (stopPromise === undefined) {
-          stopPromise = (async () => {
+          const attempt = (async () => {
             const results = await Promise.allSettled([
               runningFirst.stop(),
               second.stop(),
@@ -488,6 +511,12 @@ export async function startIsolatedBrowserPair(
               );
             }
           })();
+          stopPromise = attempt;
+          void attempt.catch(() => {
+            if (stopPromise === attempt) {
+              stopPromise = undefined;
+            }
+          });
         }
         return stopPromise;
       },

--- a/tools/src/browser_launcher.ts
+++ b/tools/src/browser_launcher.ts
@@ -4,7 +4,11 @@ import * as path from "@std/path";
 import { BIN_PATH_EXE, PATHS, PROJECT_ROOT } from "./defines.ts";
 import { ProcessUtils } from "./utils.ts";
 
-export const MARIONETTE_STATE_FILE = path.join(PROJECT_ROOT, "_dist", "marionette-port.txt");
+export const MARIONETTE_STATE_FILE = path.join(
+  PROJECT_ROOT,
+  "_dist",
+  "marionette-port.txt",
+);
 
 /**
  * Minimal port of tools/lib/browser_launcher.rb
@@ -12,9 +16,10 @@ export const MARIONETTE_STATE_FILE = path.join(PROJECT_ROOT, "_dist", "marionett
 
 function printFirefoxLog(line: string) {
   if (
-    /MOZ_CRASH|JavaScript error:|console\.error|\] Errors|\[fluent\] Couldn't find a message:|\[fluent\] Missing|EGL Error:/.test(
-      line,
-    )
+    /MOZ_CRASH|JavaScript error:|console\.error|\] Errors|\[fluent\] Couldn't find a message:|\[fluent\] Missing|EGL Error:/
+      .test(
+        line,
+      )
   ) {
     console.log(`\x1b[31m${line}\x1b[0m`);
   } else if (/console\.warn|WARNING:|\[WARN|JavaScript warning:/.test(line)) {
@@ -41,9 +46,15 @@ export interface IsolatedBrowserLaunchOptions {
 
 export interface IsolatedBrowserLaunch {
   cleanup(): void;
-  command: string[];
-  port: number;
-  profilePath: string;
+  readonly command: readonly string[];
+  readonly port: number;
+  readonly profilePath: string;
+}
+
+export interface IsolatedBrowserLaunchView {
+  readonly command: readonly string[];
+  readonly port: number;
+  readonly profilePath: string;
 }
 
 export interface IsolatedBrowserPairLaunchOptions {
@@ -54,6 +65,141 @@ export interface IsolatedBrowserPairLaunchOptions {
 export interface IsolatedBrowserPairLaunch {
   first: IsolatedBrowserLaunch;
   second: IsolatedBrowserLaunch;
+}
+
+export interface IsolatedBrowserChild {
+  kill(signal?: Deno.Signal): void;
+  pid: number;
+  status: Promise<Deno.CommandStatus>;
+}
+
+export interface IsolatedBrowserSpawnOptions {
+  clearEnv: boolean;
+  env: Record<string, string>;
+  stderr: "null";
+  stdin: "null";
+  stdout: "null";
+}
+
+export interface IsolatedBrowserSpawnDependencies {
+  environment?: Record<string, string>;
+  platform?: typeof Deno.build.os;
+  processControl?: IsolatedBrowserProcessControl;
+  shutdownTimeoutMilliseconds?: number;
+  spawn?(
+    command: readonly string[],
+    options: IsolatedBrowserSpawnOptions,
+  ): IsolatedBrowserChild;
+}
+
+export interface IsolatedBrowserProcessOwnership {
+  platform: typeof Deno.build.os;
+  rootPid: number;
+}
+
+/**
+ * The controller owns process identity capture and must resolve `stop` only
+ * after it has verified the owned root/tree and Marionette port are gone.
+ */
+export interface IsolatedBrowserProcessControl {
+  capture(
+    child: IsolatedBrowserChild,
+    launch: IsolatedBrowserLaunchView,
+    platform: typeof Deno.build.os,
+  ): Promise<IsolatedBrowserProcessOwnership>;
+  stop(
+    child: IsolatedBrowserChild,
+    launch: IsolatedBrowserLaunchView,
+    ownership: IsolatedBrowserProcessOwnership,
+    dependencies: IsolatedBrowserSpawnDependencies,
+  ): Promise<void>;
+}
+
+export interface RunningIsolatedBrowser {
+  launch: IsolatedBrowserLaunchView;
+  pid: number;
+  stop(): Promise<void>;
+}
+
+export interface RunningIsolatedBrowserPair {
+  first: RunningIsolatedBrowser;
+  second: RunningIsolatedBrowser;
+  stop(): Promise<void>;
+}
+
+const ISOLATED_BROWSER_ENV_ALLOWLIST = new Set([
+  "APPDATA",
+  "COMSPEC",
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOCALAPPDATA",
+  "PATH",
+  "SYSTEMROOT",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "USERPROFILE",
+  "WINDIR",
+  "__CF_USER_TEXT_ENCODING",
+]);
+
+type IsolatedBrowserLaunchPhase = "prepared" | "running" | "cleaned";
+
+interface IsolatedBrowserLaunchState {
+  phase: IsolatedBrowserLaunchPhase;
+  profilePath: string;
+}
+
+const isolatedBrowserLaunchStates = new WeakMap<
+  IsolatedBrowserLaunch,
+  IsolatedBrowserLaunchState
+>();
+
+function isolatedBrowserLaunchState(
+  launch: IsolatedBrowserLaunch,
+): IsolatedBrowserLaunchState {
+  const state = isolatedBrowserLaunchStates.get(launch);
+  if (state === undefined) {
+    throw new Error("Isolated browser launch was not created by this launcher");
+  }
+  return state;
+}
+
+function beginIsolatedBrowserLaunch(launch: IsolatedBrowserLaunch): void {
+  const state = isolatedBrowserLaunchState(launch);
+  if (state.phase !== "prepared") {
+    throw new Error(`Isolated browser launch is not prepared: ${state.phase}`);
+  }
+  state.phase = "running";
+}
+
+function cleanupIsolatedBrowserLaunch(
+  launch: IsolatedBrowserLaunch,
+  verifiedStopped = false,
+): void {
+  const state = isolatedBrowserLaunchState(launch);
+  if (state.phase === "cleaned") {
+    return;
+  }
+  if (state.phase === "running" && !verifiedStopped) {
+    throw new Error(
+      "Cannot clean an isolated browser profile while its process may be running",
+    );
+  }
+  cleanupGeneratedProfile(state.profilePath);
+  state.phase = "cleaned";
+}
+
+function isolatedBrowserLaunchView(
+  launch: IsolatedBrowserLaunch,
+): IsolatedBrowserLaunchView {
+  return Object.freeze({
+    command: Object.freeze([...launch.command]),
+    port: launch.port,
+    profilePath: launch.profilePath,
+  });
 }
 
 function assertMarionettePort(port: number): void {
@@ -107,6 +253,38 @@ function cleanupGeneratedProfile(profilePath: string): void {
       throw error;
     }
   }
+}
+
+function isolatedBrowserEnvironment(
+  environment: Record<string, string>,
+  platform: typeof Deno.build.os,
+): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [name, value] of Object.entries(environment)) {
+    const allowedName = platform === "windows" ? name.toUpperCase() : name;
+    if (ISOLATED_BROWSER_ENV_ALLOWLIST.has(allowedName)) {
+      filtered[allowedName] = value;
+    }
+  }
+  return filtered;
+}
+
+function defaultIsolatedBrowserSpawner(
+  command: readonly string[],
+  options: IsolatedBrowserSpawnOptions,
+): IsolatedBrowserChild {
+  const [executable, ...args] = command;
+  if (executable === undefined) {
+    throw new Error("Isolated browser command is empty");
+  }
+  return new Deno.Command(executable, {
+    args,
+    clearEnv: options.clearEnv,
+    env: options.env,
+    stderr: options.stderr,
+    stdin: options.stdin,
+    stdout: options.stdout,
+  }).spawn();
 }
 
 /**
@@ -167,19 +345,26 @@ export function createIsolatedBrowserLaunch(
 ): IsolatedBrowserLaunch {
   assertIsolatedLaunchOptions(options);
   const profilePath = prepareMarionetteProfile(options.port);
-
-  return {
-    cleanup: () => cleanupGeneratedProfile(profilePath),
-    command: browserCommand({
-      binaryPath: options.binaryPath,
-      marionette: true,
-      noRemote: true,
-      // The profile-local user.js is the single source of the port value.
-      profilePath,
-    }),
+  const state: IsolatedBrowserLaunchState = {
+    phase: "prepared",
+    profilePath,
+  };
+  const launch: IsolatedBrowserLaunch = {
+    cleanup: () => cleanupIsolatedBrowserLaunch(launch),
+    command: Object.freeze(
+      browserCommand({
+        binaryPath: options.binaryPath,
+        marionette: true,
+        noRemote: true,
+        // The profile-local user.js is the single source of the port value.
+        profilePath,
+      }),
+    ),
     port: options.port,
     profilePath,
   };
+  isolatedBrowserLaunchStates.set(launch, state);
+  return Object.freeze(launch);
 }
 
 /**
@@ -209,7 +394,132 @@ export function createIsolatedBrowserPairLaunch(
   }
 }
 
-export async function run(portOrOptions: number | BrowserLaunchOptions = 5180): Promise<void> {
+export async function startIsolatedBrowser(
+  launch: IsolatedBrowserLaunch,
+  dependencies: IsolatedBrowserSpawnDependencies = {},
+): Promise<RunningIsolatedBrowser> {
+  const processControl = dependencies.processControl;
+  if (processControl === undefined) {
+    launch.cleanup();
+    throw new Error(
+      "Isolated browser launch requires an ownership controller before spawning",
+    );
+  }
+  const launchView = isolatedBrowserLaunchView(launch);
+  const environment = isolatedBrowserEnvironment(
+    dependencies.environment ?? Deno.env.toObject(),
+    dependencies.platform ?? Deno.build.os,
+  );
+  const spawnOptions: IsolatedBrowserSpawnOptions = {
+    clearEnv: true,
+    env: environment,
+    stderr: "null",
+    stdin: "null",
+    stdout: "null",
+  };
+  const spawn = dependencies.spawn ?? defaultIsolatedBrowserSpawner;
+  let child: IsolatedBrowserChild;
+  beginIsolatedBrowserLaunch(launch);
+  try {
+    child = spawn(launch.command, spawnOptions);
+  } catch (error) {
+    cleanupIsolatedBrowserLaunch(launch, true);
+    throw error;
+  }
+  const platform = dependencies.platform ?? Deno.build.os;
+  let ownership: IsolatedBrowserProcessOwnership;
+  try {
+    ownership = await processControl.capture(child, launchView, platform);
+  } catch (error) {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // The process may have exited before ownership capture failed.
+    }
+    throw error;
+  }
+
+  let stopPromise: Promise<void> | undefined;
+  return {
+    launch: launchView,
+    pid: child.pid,
+    stop: () => {
+      if (stopPromise === undefined) {
+        stopPromise = (async () => {
+          await processControl.stop(child, launchView, ownership, dependencies);
+          cleanupIsolatedBrowserLaunch(launch, true);
+        })();
+      }
+      return stopPromise;
+    },
+  };
+}
+
+export async function startIsolatedBrowserPair(
+  options: IsolatedBrowserPairLaunchOptions,
+  dependencies: IsolatedBrowserSpawnDependencies = {},
+): Promise<RunningIsolatedBrowserPair> {
+  const launches = createIsolatedBrowserPairLaunch(options);
+  let first: RunningIsolatedBrowser | undefined;
+  let secondAttempted = false;
+  try {
+    first = await startIsolatedBrowser(launches.first, dependencies);
+    secondAttempted = true;
+    const second = await startIsolatedBrowser(launches.second, dependencies);
+    const runningFirst = first;
+    let stopPromise: Promise<void> | undefined;
+    return {
+      first: runningFirst,
+      second,
+      stop: () => {
+        if (stopPromise === undefined) {
+          stopPromise = (async () => {
+            const results = await Promise.allSettled([
+              runningFirst.stop(),
+              second.stop(),
+            ]);
+            const failures = results.flatMap((result) =>
+              result.status === "rejected" ? [result.reason] : []
+            );
+            if (failures.length > 0) {
+              throw new AggregateError(
+                failures,
+                "Failed to stop isolated browser pair",
+              );
+            }
+          })();
+        }
+        return stopPromise;
+      },
+    };
+  } catch (error) {
+    const cleanupFailures: unknown[] = [];
+    if (first !== undefined) {
+      const result = await Promise.allSettled([first.stop()]);
+      if (result[0].status === "rejected") {
+        cleanupFailures.push(result[0].reason);
+      }
+    }
+    if (!secondAttempted) {
+      try {
+        launches.second.cleanup();
+      } catch (cleanupError) {
+        cleanupFailures.push(cleanupError);
+      }
+    }
+    if (cleanupFailures.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupFailures],
+        "Failed to start isolated browser pair cleanly",
+      );
+    }
+    throw error;
+  }
+}
+
+export async function run(
+  portOrOptions: number | BrowserLaunchOptions = 5180,
+): Promise<void> {
   const options: BrowserLaunchOptions = typeof portOrOptions === "number"
     ? { port: portOrOptions, marionette: true }
     : portOrOptions;
@@ -226,7 +536,9 @@ export async function run(portOrOptions: number | BrowserLaunchOptions = 5180): 
       if (m) {
         console.log("nora-{bbd11c51-3be9-4676-b912-ca4c0bdcab94}-webdriver");
         Deno.writeTextFileSync(MARIONETTE_STATE_FILE, m[1]);
-        console.log(`[launcher] Marionette port saved to ${MARIONETTE_STATE_FILE}`);
+        console.log(
+          `[launcher] Marionette port saved to ${MARIONETTE_STATE_FILE}`,
+        );
       }
       printFirefoxLog(line.trim());
     },


### PR DESCRIPTION
## Summary

- Add a disposable two-client browser lifecycle API that refuses to spawn without an explicit owned-process controller.
- Keep private profiles immutable and prevent all public cleanup paths after spawn; cleanup follows only controller-confirmed stop.
- Clear inherited environment state with a Windows-safe allowlist and preserve both profiles correctly through pair failures.

## Verification

- `deno lint tools/src/browser_launcher.ts tools/src/browser_launcher.test.ts`
- `deno test --allow-read --allow-write tools/src/browser_launcher.test.ts` (14 passed)
- `git diff --check`
- `deno task test:host` (224 passed; one pre-existing macOS/Windows Runtime version-stamp mismatch is documented separately)

## Scope

This is Desktop-only, fail-closed preparation. It launches no real browser during this change and performs no FxA/Sync/account, credential, signing, release, or App Store operation. It is not G5/G6 evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolated browser startup and shutdown reliability.
  * Prevented launches when process ownership cannot be verified.
  * Added cleanup for browser profiles after failed or partial launches.
  * Made stopping browsers safe to repeat and ensured cleanup occurs only after confirmed termination.
  * Improved handling of failures when starting or stopping browser pairs.
* **Improvements**
  * Launch details are now protected from accidental modification.
  * Browser processes use safer environment handling and lifecycle tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->