### PR TITLE
fix(docs): switch star history chart to star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,4 +243,4 @@ Notice: If you are a maintainer of any listed component and your name or license
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Floorp-Projects/Floorp&type=date&legend=top-left)](https://www.star-history.com/#Floorp-Projects/Floorp&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Floorp-Projects/Floorp&type=date&legend=top-left)](https://star-history.dera.page/#Floorp-Projects/Floorp&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken because its upstream data source is constrained by GitHub stargazer API restrictions. This change points the chart at an alternative source that needs no API token and serves both the API and the frontend from the same domain, so the chart continues to render reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart image and link to use the new Star History website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->