### PR TITLE
test(sync): add non-live G5 executor safety boundary

### DIFF
--- a/tools/src/g5_execution_boundary.test.ts
+++ b/tools/src/g5_execution_boundary.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import {
   assessG5ExecutionBoundary,
   type G5BoundaryFacts,
@@ -8,7 +8,7 @@ import {
 } from "./g5_execution_boundary.ts";
 
 const RUN_ID = "g5-run-20260812-001";
-const VM_ID = "macos-vm-20260812-001";
+const EXECUTOR_INSTANCE_ID = "g5-executor-20260812-001";
 
 function completeFacts(): G5BoundaryFacts {
   return {
@@ -20,9 +20,83 @@ function completeFacts(): G5BoundaryFacts {
       kind: "launch-bound-event-supervisor",
       pidGeneration: "high-resolution",
     },
-    vmId: VM_ID,
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
   };
 }
+
+Deno.test("G5 boundary admits a GitHub-hosted macOS candidate only for independent verification", () => {
+  const assessment = assessG5ExecutionBoundary({
+    ...completeFacts(),
+    host: "github-hosted-macos",
+  });
+
+  assertEquals(assessment.trustedExecutorVerification, "required");
+  assertEquals(assessment.trustedExecutorVerificationBlockers, []);
+  assertEquals(assessment.cleanupBoundary, "not-established");
+  assertEquals(assessment.g5Result, "not-assessed");
+});
+
+Deno.test("G5 boundary requires a nonblank executor-instance correlation ID", () => {
+  for (const executorInstanceId of ["", "  "]) {
+    const assessment = assessG5ExecutionBoundary({
+      ...completeFacts(),
+      executorInstanceId,
+    });
+
+    assertEquals(assessment.trustedExecutorVerification, "blocked");
+    assertEquals(assessment.trustedExecutorVerificationBlockers, [
+      "run-or-executor-instance-identity-absent",
+    ]);
+    assertEquals(assessment.cleanupBoundary, "not-established");
+    assertEquals(assessment.g5Result, "not-assessed");
+  }
+});
+
+Deno.test("G5 boundary rejects malformed runtime facts without coercion", () => {
+  const malformed = [
+    null,
+    [],
+    { ...completeFacts(), runId: { trim: () => "forged" } },
+    { ...completeFacts(), executorInstanceId: { trim: () => "forged" } },
+    { ...completeFacts(), supervision: {} },
+    {
+      ...completeFacts(),
+      supervision: { ...completeFacts().supervision, kind: "unrecognized" },
+    },
+    { ...completeFacts(), unexpected: "not-accepted" },
+  ];
+
+  for (const facts of malformed) {
+    const assessment = assessG5ExecutionBoundary(facts);
+    assertEquals(assessment.trustedExecutorVerification, "blocked");
+    assertEquals(assessment.trustedExecutorVerificationBlockers, [
+      "malformed-boundary-facts",
+    ]);
+    assertEquals(assessment.cleanupBoundary, "not-established");
+    assertEquals(assessment.g5Result, "not-assessed");
+  }
+});
+
+Deno.test("G5 boundary fails closed rather than throwing for a revoked Proxy", () => {
+  const { proxy, revoke } = Proxy.revocable(completeFacts(), {});
+  revoke();
+
+  const assessment = assessG5ExecutionBoundary(proxy);
+  assertEquals(assessment.trustedExecutorVerification, "blocked");
+  assertEquals(assessment.trustedExecutorVerificationBlockers, [
+    "malformed-boundary-facts",
+  ]);
+  assertEquals(assessment.cleanupBoundary, "not-established");
+  assertEquals(assessment.g5Result, "not-assessed");
+});
+
+Deno.test("G5 boundary freezes every returned assessment surface", () => {
+  const assessment = assessG5ExecutionBoundary(completeFacts());
+
+  assert(Object.isFrozen(assessment));
+  assert(Object.isFrozen(assessment.cleanupBlockers));
+  assert(Object.isFrozen(assessment.trustedExecutorVerificationBlockers));
+});
 
 Deno.test("G5 boundary blocks every incomplete local ownership proof", () => {
   const cases: Array<{
@@ -89,25 +163,25 @@ Deno.test("G5 boundary blocks every incomplete local ownership proof", () => {
     assertEquals(assessment.trustedExecutorVerificationBlockers, [blocker]);
     assertEquals(assessment.cleanupBoundary, "not-established");
     assertEquals(assessment.cleanupBlockers, [
-      "external-vm-lifecycle-verification-required",
+      "external-executor-lifecycle-verification-required",
     ]);
     assertEquals(assessment.g5Result, "not-assessed");
   }
 });
 
-Deno.test("G5 boundary blocks absent or blank run and VM identities", () => {
+Deno.test("G5 boundary blocks absent or blank run and executor-instance identities", () => {
   for (
     const facts of [
       { ...completeFacts(), runId: "" },
       { ...completeFacts(), runId: "  " },
-      { ...completeFacts(), vmId: "" },
-      { ...completeFacts(), vmId: "  " },
+      { ...completeFacts(), executorInstanceId: "" },
+      { ...completeFacts(), executorInstanceId: "  " },
     ]
   ) {
     const assessment = assessG5ExecutionBoundary(facts);
     assertEquals(assessment.trustedExecutorVerification, "blocked");
     assertEquals(assessment.trustedExecutorVerificationBlockers, [
-      "run-or-vm-identity-absent",
+      "run-or-executor-instance-identity-absent",
     ]);
     assertEquals(assessment.cleanupBoundary, "not-established");
     assertEquals(assessment.g5Result, "not-assessed");
@@ -121,7 +195,7 @@ Deno.test("G5 boundary requires an independent verifier before execution", () =>
   assertEquals(assessment.trustedExecutorVerificationBlockers, []);
   assertEquals(assessment.cleanupBoundary, "not-established");
   assertEquals(assessment.cleanupBlockers, [
-    "external-vm-lifecycle-verification-required",
+    "external-executor-lifecycle-verification-required",
   ]);
   assertEquals(assessment.g5Result, "not-assessed");
 });
@@ -136,7 +210,7 @@ Deno.test("G5 boundary reports every independent ownership failure", () => {
       kind: "polling-only",
       pidGeneration: "coarse-or-unknown",
     },
-    vmId: VM_ID,
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
   });
 
   assertEquals(assessment.trustedExecutorVerification, "blocked");
@@ -161,16 +235,12 @@ Deno.test("G5 boundary blocks unrecognized runtime facts", () => {
       kind: "unrecognized-supervisor",
       pidGeneration: "unrecognized-pid-generation",
     },
-    vmId: VM_ID,
-  } as unknown as G5BoundaryFacts);
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
+  });
 
   assertEquals(assessment.trustedExecutorVerification, "blocked");
   assertEquals(assessment.trustedExecutorVerificationBlockers, [
-    "persistent-or-unknown-host",
-    "polling-or-unknown-supervisor",
-    "coarse-or-unknown-pid-generation",
-    "event-stream-lost-or-unknown",
-    "descendant-ownership-unprovable",
+    "malformed-boundary-facts",
   ]);
 });
 

--- a/tools/src/g5_execution_boundary.test.ts
+++ b/tools/src/g5_execution_boundary.test.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assertEquals } from "@std/assert";
+import {
+  assessG5ExecutionBoundary,
+  type G5BoundaryFacts,
+  type G5ExecutionBlocker,
+} from "./g5_execution_boundary.ts";
+
+const RUN_ID = "g5-run-20260812-001";
+const VM_ID = "macos-vm-20260812-001";
+
+function completeFacts(): G5BoundaryFacts {
+  return {
+    host: "disposable-macos-vm",
+    runId: RUN_ID,
+    supervision: {
+      descendants: "causally-complete",
+      eventStream: "complete",
+      kind: "launch-bound-event-supervisor",
+      pidGeneration: "high-resolution",
+    },
+    vmId: VM_ID,
+  };
+}
+
+Deno.test("G5 boundary blocks every incomplete local ownership proof", () => {
+  const cases: Array<{
+    readonly facts: G5BoundaryFacts;
+    readonly blocker: G5ExecutionBlocker;
+  }> = [
+    {
+      facts: { ...completeFacts(), host: "persistent-host" },
+      blocker: "persistent-or-unknown-host",
+    },
+    {
+      facts: { ...completeFacts(), host: "unknown" },
+      blocker: "persistent-or-unknown-host",
+    },
+    {
+      facts: {
+        ...completeFacts(),
+        supervision: { ...completeFacts().supervision, kind: "polling-only" },
+      },
+      blocker: "polling-or-unknown-supervisor",
+    },
+    {
+      facts: {
+        ...completeFacts(),
+        supervision: { ...completeFacts().supervision, kind: "unknown" },
+      },
+      blocker: "polling-or-unknown-supervisor",
+    },
+    {
+      facts: {
+        ...completeFacts(),
+        supervision: {
+          ...completeFacts().supervision,
+          pidGeneration: "coarse-or-unknown",
+        },
+      },
+      blocker: "coarse-or-unknown-pid-generation",
+    },
+    {
+      facts: {
+        ...completeFacts(),
+        supervision: {
+          ...completeFacts().supervision,
+          eventStream: "lost-or-unknown",
+        },
+      },
+      blocker: "event-stream-lost-or-unknown",
+    },
+    {
+      facts: {
+        ...completeFacts(),
+        supervision: {
+          ...completeFacts().supervision,
+          descendants: "escaped-or-unprovable",
+        },
+      },
+      blocker: "descendant-ownership-unprovable",
+    },
+  ];
+
+  for (const { facts, blocker } of cases) {
+    const assessment = assessG5ExecutionBoundary(facts);
+    assertEquals(assessment.trustedExecutorVerification, "blocked", blocker);
+    assertEquals(assessment.trustedExecutorVerificationBlockers, [blocker]);
+    assertEquals(assessment.cleanupBoundary, "not-established");
+    assertEquals(assessment.cleanupBlockers, [
+      "external-vm-lifecycle-verification-required",
+    ]);
+    assertEquals(assessment.g5Result, "not-assessed");
+  }
+});
+
+Deno.test("G5 boundary blocks absent or blank run and VM identities", () => {
+  for (
+    const facts of [
+      { ...completeFacts(), runId: "" },
+      { ...completeFacts(), runId: "  " },
+      { ...completeFacts(), vmId: "" },
+      { ...completeFacts(), vmId: "  " },
+    ]
+  ) {
+    const assessment = assessG5ExecutionBoundary(facts);
+    assertEquals(assessment.trustedExecutorVerification, "blocked");
+    assertEquals(assessment.trustedExecutorVerificationBlockers, [
+      "run-or-vm-identity-absent",
+    ]);
+    assertEquals(assessment.cleanupBoundary, "not-established");
+    assertEquals(assessment.g5Result, "not-assessed");
+  }
+});
+
+Deno.test("G5 boundary requires an independent verifier before execution", () => {
+  const assessment = assessG5ExecutionBoundary(completeFacts());
+
+  assertEquals(assessment.trustedExecutorVerification, "required");
+  assertEquals(assessment.trustedExecutorVerificationBlockers, []);
+  assertEquals(assessment.cleanupBoundary, "not-established");
+  assertEquals(assessment.cleanupBlockers, [
+    "external-vm-lifecycle-verification-required",
+  ]);
+  assertEquals(assessment.g5Result, "not-assessed");
+});
+
+Deno.test("G5 boundary reports every independent ownership failure", () => {
+  const assessment = assessG5ExecutionBoundary({
+    host: "persistent-host",
+    runId: RUN_ID,
+    supervision: {
+      descendants: "escaped-or-unprovable",
+      eventStream: "lost-or-unknown",
+      kind: "polling-only",
+      pidGeneration: "coarse-or-unknown",
+    },
+    vmId: VM_ID,
+  });
+
+  assertEquals(assessment.trustedExecutorVerification, "blocked");
+  assertEquals(assessment.trustedExecutorVerificationBlockers, [
+    "persistent-or-unknown-host",
+    "polling-or-unknown-supervisor",
+    "coarse-or-unknown-pid-generation",
+    "event-stream-lost-or-unknown",
+    "descendant-ownership-unprovable",
+  ]);
+  assertEquals(assessment.cleanupBoundary, "not-established");
+  assertEquals(assessment.g5Result, "not-assessed");
+});
+
+Deno.test("G5 boundary blocks unrecognized runtime facts", () => {
+  const assessment = assessG5ExecutionBoundary({
+    host: "unrecognized-host",
+    runId: RUN_ID,
+    supervision: {
+      descendants: "unrecognized-descendants",
+      eventStream: "unrecognized-event-stream",
+      kind: "unrecognized-supervisor",
+      pidGeneration: "unrecognized-pid-generation",
+    },
+    vmId: VM_ID,
+  } as unknown as G5BoundaryFacts);
+
+  assertEquals(assessment.trustedExecutorVerification, "blocked");
+  assertEquals(assessment.trustedExecutorVerificationBlockers, [
+    "persistent-or-unknown-host",
+    "polling-or-unknown-supervisor",
+    "coarse-or-unknown-pid-generation",
+    "event-stream-lost-or-unknown",
+    "descendant-ownership-unprovable",
+  ]);
+});
+
+Deno.test("G5 boundary policy accepts no raw destruction attestation or process cleanup input", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./g5_execution_boundary.ts", import.meta.url),
+  );
+  for (
+    const forbidden of [
+      "Deno.Command",
+      "Deno.kill",
+      "Deno.remove",
+      "browser_launcher",
+      "owned_browser_process_controller",
+      "profilePath",
+      ".cleanup(",
+      "externalVmDestruction",
+      "externally-verified",
+      "evidenceSha256",
+      "destroyedAt",
+      'execution: "eligible"',
+      "executionBlockers",
+    ]
+  ) {
+    assertEquals(source.includes(forbidden), false, forbidden);
+  }
+});

--- a/tools/src/g5_execution_boundary.ts
+++ b/tools/src/g5_execution_boundary.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+export type G5ExecutionBlocker =
+  | "persistent-or-unknown-host"
+  | "polling-or-unknown-supervisor"
+  | "coarse-or-unknown-pid-generation"
+  | "event-stream-lost-or-unknown"
+  | "descendant-ownership-unprovable"
+  | "run-or-vm-identity-absent";
+
+export interface G5BoundaryFacts {
+  host: "disposable-macos-vm" | "persistent-host" | "unknown";
+  runId: string;
+  supervision: {
+    descendants: "causally-complete" | "escaped-or-unprovable";
+    eventStream: "complete" | "lost-or-unknown";
+    kind: "launch-bound-event-supervisor" | "polling-only" | "unknown";
+    pidGeneration: "coarse-or-unknown" | "high-resolution";
+  };
+  vmId: string;
+}
+
+export interface G5BoundaryAssessment {
+  cleanupBlockers: readonly ["external-vm-lifecycle-verification-required"];
+  cleanupBoundary: "not-established";
+  g5Result: "not-assessed";
+  trustedExecutorVerification: "blocked" | "required";
+  trustedExecutorVerificationBlockers: readonly G5ExecutionBlocker[];
+}
+
+function nonEmpty(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function evaluateExecutionBlockers(
+  facts: G5BoundaryFacts,
+): readonly G5ExecutionBlocker[] {
+  if (!nonEmpty(facts.runId) || !nonEmpty(facts.vmId)) {
+    return ["run-or-vm-identity-absent"];
+  }
+
+  const blockers: G5ExecutionBlocker[] = [];
+  if (facts.host !== "disposable-macos-vm") {
+    blockers.push("persistent-or-unknown-host");
+  }
+  if (facts.supervision.kind !== "launch-bound-event-supervisor") {
+    blockers.push("polling-or-unknown-supervisor");
+  }
+  if (facts.supervision.pidGeneration !== "high-resolution") {
+    blockers.push("coarse-or-unknown-pid-generation");
+  }
+  if (facts.supervision.eventStream !== "complete") {
+    blockers.push("event-stream-lost-or-unknown");
+  }
+  if (facts.supervision.descendants !== "causally-complete") {
+    blockers.push("descendant-ownership-unprovable");
+  }
+  return blockers;
+}
+
+/**
+ * Pure, pre-execution policy for a protected G5 run.
+ *
+ * It deliberately does not accept or validate external lifecycle evidence.
+ * A separately trusted verifier must bind VM destruction to this run and VM
+ * before any final cleanup or G5 evidence claim can be made.
+ *
+ * `required` is not an execution authorization. It only means the supplied
+ * facts have no local policy blockers and must still be independently verified
+ * by the trusted executor before it launches anything.
+ */
+export function assessG5ExecutionBoundary(
+  facts: G5BoundaryFacts,
+): G5BoundaryAssessment {
+  const trustedExecutorVerificationBlockers = evaluateExecutionBlockers(facts);
+  return {
+    cleanupBlockers: ["external-vm-lifecycle-verification-required"],
+    cleanupBoundary: "not-established",
+    g5Result: "not-assessed",
+    trustedExecutorVerification:
+      trustedExecutorVerificationBlockers.length === 0 ? "required" : "blocked",
+    trustedExecutorVerificationBlockers,
+  };
+}

--- a/tools/src/g5_execution_boundary.ts
+++ b/tools/src/g5_execution_boundary.ts
@@ -6,10 +6,17 @@ export type G5ExecutionBlocker =
   | "coarse-or-unknown-pid-generation"
   | "event-stream-lost-or-unknown"
   | "descendant-ownership-unprovable"
-  | "run-or-vm-identity-absent";
+  | "run-or-executor-instance-identity-absent"
+  | "malformed-boundary-facts";
 
 export interface G5BoundaryFacts {
-  host: "disposable-macos-vm" | "persistent-host" | "unknown";
+  // These are candidate executor classes only. This policy does not establish
+  // their lifecycle or cleanup properties; an independent verifier must do so.
+  host:
+    | "disposable-macos-vm"
+    | "github-hosted-macos"
+    | "persistent-host"
+    | "unknown";
   runId: string;
   supervision: {
     descendants: "causally-complete" | "escaped-or-unprovable";
@@ -17,30 +24,152 @@ export interface G5BoundaryFacts {
     kind: "launch-bound-event-supervisor" | "polling-only" | "unknown";
     pidGeneration: "coarse-or-unknown" | "high-resolution";
   };
-  vmId: string;
+  // This is a non-secret correlation value for a single ephemeral executor
+  // instance. GitHub-hosted runners need not expose a provider VM identifier.
+  executorInstanceId: string;
 }
 
 export interface G5BoundaryAssessment {
-  cleanupBlockers: readonly ["external-vm-lifecycle-verification-required"];
+  cleanupBlockers: readonly [
+    "external-executor-lifecycle-verification-required",
+  ];
   cleanupBoundary: "not-established";
   g5Result: "not-assessed";
   trustedExecutorVerification: "blocked" | "required";
   trustedExecutorVerificationBlockers: readonly G5ExecutionBlocker[];
 }
 
-function nonEmpty(value: string): boolean {
-  return value.trim().length > 0;
+const cleanupBlockers = Object.freeze(
+  [
+    "external-executor-lifecycle-verification-required",
+  ] as const,
+);
+
+function isNonblankString(value: unknown): value is string {
+  return typeof value === "string" && /[^\s]/u.test(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isHost(value: unknown): value is G5BoundaryFacts["host"] {
+  return value === "disposable-macos-vm" ||
+    value === "github-hosted-macos" ||
+    value === "persistent-host" ||
+    value === "unknown";
+}
+
+function isSupervisorKind(
+  value: unknown,
+): value is G5BoundaryFacts["supervision"]["kind"] {
+  return value === "launch-bound-event-supervisor" ||
+    value === "polling-only" || value === "unknown";
+}
+
+function isPIDGeneration(
+  value: unknown,
+): value is G5BoundaryFacts["supervision"]["pidGeneration"] {
+  return value === "coarse-or-unknown" || value === "high-resolution";
+}
+
+function isEventStream(
+  value: unknown,
+): value is G5BoundaryFacts["supervision"]["eventStream"] {
+  return value === "complete" || value === "lost-or-unknown";
+}
+
+function isDescendantOwnership(
+  value: unknown,
+): value is G5BoundaryFacts["supervision"]["descendants"] {
+  return value === "causally-complete" || value === "escaped-or-unprovable";
+}
+
+function exactDataProperties(
+  value: unknown,
+  expectedKeys: readonly string[],
+): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  try {
+    if (Array.isArray(value)) return undefined;
+    const record = value as Record<string, unknown>;
+    const keys = Reflect.ownKeys(record);
+    if (
+      keys.length !== expectedKeys.length ||
+      !keys.every((key) =>
+        typeof key === "string" && expectedKeys.includes(key)
+      )
+    ) {
+      return undefined;
+    }
+    const copied: Record<string, unknown> = {};
+    for (const key of expectedKeys) {
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (descriptor === undefined || !("value" in descriptor)) {
+        return undefined;
+      }
+      copied[key] = descriptor.value;
+    }
+    return copied;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseFacts(value: unknown): G5BoundaryFacts | undefined {
+  const facts = exactDataProperties(value, [
+    "host",
+    "runId",
+    "supervision",
+    "executorInstanceId",
+  ]);
+  if (facts === undefined) return undefined;
+  const supervision = exactDataProperties(facts.supervision, [
+    "descendants",
+    "eventStream",
+    "kind",
+    "pidGeneration",
+  ]);
+  if (
+    supervision === undefined || !isHost(facts.host) ||
+    !isString(facts.runId) ||
+    !isString(facts.executorInstanceId) ||
+    !isDescendantOwnership(supervision.descendants) ||
+    !isEventStream(supervision.eventStream) ||
+    !isSupervisorKind(supervision.kind) ||
+    !isPIDGeneration(supervision.pidGeneration)
+  ) {
+    return undefined;
+  }
+  return {
+    host: facts.host,
+    runId: facts.runId,
+    supervision: {
+      descendants: supervision.descendants,
+      eventStream: supervision.eventStream,
+      kind: supervision.kind,
+      pidGeneration: supervision.pidGeneration,
+    },
+    executorInstanceId: facts.executorInstanceId,
+  };
 }
 
 function evaluateExecutionBlockers(
   facts: G5BoundaryFacts,
 ): readonly G5ExecutionBlocker[] {
-  if (!nonEmpty(facts.runId) || !nonEmpty(facts.vmId)) {
-    return ["run-or-vm-identity-absent"];
+  if (
+    !isNonblankString(facts.runId) ||
+    !isNonblankString(facts.executorInstanceId)
+  ) {
+    return ["run-or-executor-instance-identity-absent"];
   }
-
   const blockers: G5ExecutionBlocker[] = [];
-  if (facts.host !== "disposable-macos-vm") {
+  if (
+    facts.host !== "disposable-macos-vm" &&
+    facts.host !== "github-hosted-macos"
+  ) {
     blockers.push("persistent-or-unknown-host");
   }
   if (facts.supervision.kind !== "launch-bound-event-supervisor") {
@@ -58,27 +187,38 @@ function evaluateExecutionBlockers(
   return blockers;
 }
 
+function assessment(
+  blockers: readonly G5ExecutionBlocker[],
+): G5BoundaryAssessment {
+  return Object.freeze({
+    cleanupBlockers,
+    cleanupBoundary: "not-established" as const,
+    g5Result: "not-assessed" as const,
+    trustedExecutorVerification: blockers.length === 0
+      ? "required" as const
+      : "blocked" as const,
+    trustedExecutorVerificationBlockers: Object.freeze([...blockers]),
+  });
+}
+
 /**
  * Pure, pre-execution policy for a protected G5 run.
  *
  * It deliberately does not accept or validate external lifecycle evidence.
- * A separately trusted verifier must bind VM destruction to this run and VM
- * before any final cleanup or G5 evidence claim can be made.
+ * A separately trusted verifier must bind the executor lifecycle to this run
+ * and instance before any final cleanup or G5 evidence claim can be made.
  *
  * `required` is not an execution authorization. It only means the supplied
  * facts have no local policy blockers and must still be independently verified
  * by the trusted executor before it launches anything.
  */
 export function assessG5ExecutionBoundary(
-  facts: G5BoundaryFacts,
+  facts: unknown,
 ): G5BoundaryAssessment {
-  const trustedExecutorVerificationBlockers = evaluateExecutionBlockers(facts);
-  return {
-    cleanupBlockers: ["external-vm-lifecycle-verification-required"],
-    cleanupBoundary: "not-established",
-    g5Result: "not-assessed",
-    trustedExecutorVerification:
-      trustedExecutorVerificationBlockers.length === 0 ? "required" : "blocked",
-    trustedExecutorVerificationBlockers,
-  };
+  const parsed = parseFacts(facts);
+  return assessment(
+    parsed === undefined
+      ? ["malformed-boundary-facts"]
+      : evaluateExecutionBlockers(parsed),
+  );
 }


### PR DESCRIPTION
## What changed

Adds a pure, non-live pre-execution safety boundary for a future G5 runner. It recognizes GitHub-hosted macOS only as a candidate requiring independent verification, replaces VM-only correlation with a non-secret executor-instance ID, strictly rejects malformed runtime facts, and freezes assessment surfaces.

## Why

The previous boundary was too narrow for an ephemeral GitHub-hosted macOS candidate and accepted runtime-shaped values without a strict parser. This update remains fail-closed for malformed or revoked inputs.

## Explicit non-claims

This is a non-live, pre-execution safety-boundary foundation only. It does not authorize or perform a production FxA/Firefox Sync run, enable Notes Sync, launch iOS or Desktop clients, add credentials or secrets, change GitHub Actions environments, or produce G5/G6 evidence. `trustedExecutorVerification: "required"` means an independent verifier is still required; it is not execution authorization. Cleanup remains unestablished and G5 remains unassessed.

## Validation

- `deno fmt --check tools/src/g5_execution_boundary.ts tools/src/g5_execution_boundary.test.ts`
- `deno lint tools/src/g5_execution_boundary.ts tools/src/g5_execution_boundary.test.ts`
- `deno test --allow-read --allow-write tools/src/g5_execution_boundary.test.ts tools/src/browser_launcher.test.ts` — 28 passed
- `git diff HEAD^ HEAD --check`
- `deno task test:host` was also run: 238 passed, with one known unrelated `initializer.test.ts:633` BuildID expectation mismatch (actual `000`, expected `002`).

Independent reviews: security/fail-closed APPROVE; test-quality GO after red evidence; release-process approval limited to this non-live scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added G5 execution-boundary assessment for hosted macOS environments.
  * Validates host, supervision, process, event-stream, ownership, and identity conditions.
  * Reports specific blockers for invalid, incomplete, revoked, or unrecognized assessment data.
  * Requires independent trusted-executor verification before execution can proceed.

* **Tests**
  * Added comprehensive coverage for valid assessments, malformed inputs, missing evidence, aggregated blockers, and safety restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->