### PR TITLE
test(sync): require canonical JSON G5 boundary facts

### DIFF
--- a/tools/src/g5_execution_boundary.test.ts
+++ b/tools/src/g5_execution_boundary.test.ts
@@ -169,6 +169,43 @@ Deno.test("G5 boundary rejects duplicate JSON keys at every accepted object laye
   }
 });
 
+Deno.test("G5 boundary rejects every noncanonical representation independently", () => {
+  const canonical = JSON.stringify(completeFacts());
+  const whitespace = canonical.replace(
+    '"host":"disposable-macos-vm"',
+    '"host" : "disposable-macos-vm"',
+  );
+  const reorderedRoot = JSON.stringify({
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
+    host: "disposable-macos-vm",
+    runId: RUN_ID,
+    supervision: completeFacts().supervision,
+  });
+  const reorderedSupervision = canonical.replace(
+    '"descendants":"causally-complete","eventStream":"complete","kind":"launch-bound-event-supervisor","pidGeneration":"high-resolution"',
+    '"kind":"launch-bound-event-supervisor","eventStream":"complete","descendants":"causally-complete","pidGeneration":"high-resolution"',
+  );
+  const escapedHost = canonical.replace(
+    '"host":"disposable-macos-vm"',
+    '"\\u0068ost":"disposable-macos-vm"',
+  );
+
+  for (
+    const factsJson of [
+      whitespace,
+      reorderedRoot,
+      reorderedSupervision,
+      escapedHost,
+    ]
+  ) {
+    const assessment = assessG5ExecutionBoundary(factsJson);
+    assertEquals(assessment.trustedExecutorVerification, "blocked");
+    assertEquals(assessment.trustedExecutorVerificationBlockers, [
+      "malformed-boundary-facts",
+    ]);
+  }
+});
+
 Deno.test("G5 boundary freezes every returned assessment surface", () => {
   const assessment = assessFacts(completeFacts());
 

--- a/tools/src/g5_execution_boundary.test.ts
+++ b/tools/src/g5_execution_boundary.test.ts
@@ -24,8 +24,12 @@ function completeFacts(): G5BoundaryFacts {
   };
 }
 
+function assessFacts(facts: unknown) {
+  return assessG5ExecutionBoundary(JSON.stringify(facts));
+}
+
 Deno.test("G5 boundary admits a GitHub-hosted macOS candidate only for independent verification", () => {
-  const assessment = assessG5ExecutionBoundary({
+  const assessment = assessFacts({
     ...completeFacts(),
     host: "github-hosted-macos",
   });
@@ -38,7 +42,7 @@ Deno.test("G5 boundary admits a GitHub-hosted macOS candidate only for independe
 
 Deno.test("G5 boundary requires a nonblank executor-instance correlation ID", () => {
   for (const executorInstanceId of ["", "  "]) {
-    const assessment = assessG5ExecutionBoundary({
+    const assessment = assessFacts({
       ...completeFacts(),
       executorInstanceId,
     });
@@ -67,7 +71,7 @@ Deno.test("G5 boundary rejects malformed runtime facts without coercion", () => 
   ];
 
   for (const facts of malformed) {
-    const assessment = assessG5ExecutionBoundary(facts);
+    const assessment = assessFacts(facts);
     assertEquals(assessment.trustedExecutorVerification, "blocked");
     assertEquals(assessment.trustedExecutorVerificationBlockers, [
       "malformed-boundary-facts",
@@ -81,7 +85,7 @@ Deno.test("G5 boundary fails closed rather than throwing for a revoked Proxy", (
   const { proxy, revoke } = Proxy.revocable(completeFacts(), {});
   revoke();
 
-  const assessment = assessG5ExecutionBoundary(proxy);
+  const assessment = assessG5ExecutionBoundary(proxy as unknown as string);
   assertEquals(assessment.trustedExecutorVerification, "blocked");
   assertEquals(assessment.trustedExecutorVerificationBlockers, [
     "malformed-boundary-facts",
@@ -90,8 +94,83 @@ Deno.test("G5 boundary fails closed rather than throwing for a revoked Proxy", (
   assertEquals(assessment.g5Result, "not-assessed");
 });
 
+Deno.test("G5 boundary rejects a live Proxy that forges complete ownership facts", () => {
+  const blockedFacts = {
+    ...completeFacts(),
+    host: "persistent-host",
+    supervision: {
+      descendants: "escaped-or-unprovable",
+      eventStream: "lost-or-unknown",
+      kind: "polling-only",
+      pidGeneration: "coarse-or-unknown",
+    },
+  };
+  let proxyTrapTouched = false;
+  const forgedFacts = new Proxy(blockedFacts, {
+    get(_target, key) {
+      proxyTrapTouched = true;
+      if (key === "host") return "github-hosted-macos";
+      if (key === "supervision") return completeFacts().supervision;
+      return Reflect.get(_target, key);
+    },
+    getOwnPropertyDescriptor(_target, key) {
+      proxyTrapTouched = true;
+      if (key === "host" || key === "supervision") {
+        return {
+          configurable: true,
+          enumerable: true,
+          value: key === "host"
+            ? "github-hosted-macos"
+            : completeFacts().supervision,
+          writable: true,
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(_target, key);
+    },
+  });
+
+  const assessment = assessG5ExecutionBoundary(
+    forgedFacts as unknown as string,
+  );
+  assertEquals(assessment.trustedExecutorVerification, "blocked");
+  assertEquals(assessment.trustedExecutorVerificationBlockers, [
+    "malformed-boundary-facts",
+  ]);
+  assertEquals(proxyTrapTouched, false);
+});
+
+Deno.test("G5 boundary rejects duplicate JSON keys at every accepted object layer", () => {
+  const rootDuplicate = JSON.stringify(completeFacts()).replace(
+    '"host":"disposable-macos-vm"',
+    '"host":"persistent-host","host":"github-hosted-macos"',
+  );
+  const supervisionDuplicate = JSON.stringify(completeFacts()).replace(
+    '"kind":"launch-bound-event-supervisor"',
+    '"kind":"polling-only","kind":"launch-bound-event-supervisor"',
+  );
+
+  const escapedRootDuplicate = JSON.stringify(completeFacts()).replace(
+    '"host":"disposable-macos-vm"',
+    '"host":"persistent-host","\\u0068ost":"github-hosted-macos"',
+  );
+
+  for (
+    const factsJson of [
+      rootDuplicate,
+      supervisionDuplicate,
+      escapedRootDuplicate,
+    ]
+  ) {
+    const assessment = assessG5ExecutionBoundary(factsJson);
+    assertEquals(assessment.trustedExecutorVerification, "blocked");
+    assertEquals(assessment.trustedExecutorVerificationBlockers, [
+      "malformed-boundary-facts",
+    ]);
+  }
+});
+
 Deno.test("G5 boundary freezes every returned assessment surface", () => {
-  const assessment = assessG5ExecutionBoundary(completeFacts());
+  const assessment = assessFacts(completeFacts());
 
   assert(Object.isFrozen(assessment));
   assert(Object.isFrozen(assessment.cleanupBlockers));
@@ -158,7 +237,7 @@ Deno.test("G5 boundary blocks every incomplete local ownership proof", () => {
   ];
 
   for (const { facts, blocker } of cases) {
-    const assessment = assessG5ExecutionBoundary(facts);
+    const assessment = assessFacts(facts);
     assertEquals(assessment.trustedExecutorVerification, "blocked", blocker);
     assertEquals(assessment.trustedExecutorVerificationBlockers, [blocker]);
     assertEquals(assessment.cleanupBoundary, "not-established");
@@ -178,7 +257,7 @@ Deno.test("G5 boundary blocks absent or blank run and executor-instance identiti
       { ...completeFacts(), executorInstanceId: "  " },
     ]
   ) {
-    const assessment = assessG5ExecutionBoundary(facts);
+    const assessment = assessFacts(facts);
     assertEquals(assessment.trustedExecutorVerification, "blocked");
     assertEquals(assessment.trustedExecutorVerificationBlockers, [
       "run-or-executor-instance-identity-absent",
@@ -189,7 +268,7 @@ Deno.test("G5 boundary blocks absent or blank run and executor-instance identiti
 });
 
 Deno.test("G5 boundary requires an independent verifier before execution", () => {
-  const assessment = assessG5ExecutionBoundary(completeFacts());
+  const assessment = assessFacts(completeFacts());
 
   assertEquals(assessment.trustedExecutorVerification, "required");
   assertEquals(assessment.trustedExecutorVerificationBlockers, []);
@@ -201,7 +280,7 @@ Deno.test("G5 boundary requires an independent verifier before execution", () =>
 });
 
 Deno.test("G5 boundary reports every independent ownership failure", () => {
-  const assessment = assessG5ExecutionBoundary({
+  const assessment = assessFacts({
     host: "persistent-host",
     runId: RUN_ID,
     supervision: {
@@ -226,7 +305,7 @@ Deno.test("G5 boundary reports every independent ownership failure", () => {
 });
 
 Deno.test("G5 boundary blocks unrecognized runtime facts", () => {
-  const assessment = assessG5ExecutionBoundary({
+  const assessment = assessFacts({
     host: "unrecognized-host",
     runId: RUN_ID,
     supervision: {
@@ -263,8 +342,15 @@ Deno.test("G5 boundary policy accepts no raw destruction attestation or process 
       "destroyedAt",
       'execution: "eligible"',
       "executionBlockers",
+      "Reflect.ownKeys",
+      "Object.getOwnPropertyDescriptor",
     ]
   ) {
     assertEquals(source.includes(forbidden), false, forbidden);
   }
+  assertEquals(
+    source.includes("factsJson: string"),
+    true,
+    "boundary accepts only serialized JSON facts",
+  );
 });

--- a/tools/src/g5_execution_boundary.ts
+++ b/tools/src/g5_execution_boundary.ts
@@ -89,33 +89,25 @@ function exactDataProperties(
   value: unknown,
   expectedKeys: readonly string[],
 ): Record<string, unknown> | undefined {
-  if (typeof value !== "object" || value === null) {
+  if (
+    typeof value !== "object" || value === null || Array.isArray(value)
+  ) {
     return undefined;
   }
-  try {
-    if (Array.isArray(value)) return undefined;
-    const record = value as Record<string, unknown>;
-    const keys = Reflect.ownKeys(record);
-    if (
-      keys.length !== expectedKeys.length ||
-      !keys.every((key) =>
-        typeof key === "string" && expectedKeys.includes(key)
-      )
-    ) {
-      return undefined;
-    }
-    const copied: Record<string, unknown> = {};
-    for (const key of expectedKeys) {
-      const descriptor = Object.getOwnPropertyDescriptor(record, key);
-      if (descriptor === undefined || !("value" in descriptor)) {
-        return undefined;
-      }
-      copied[key] = descriptor.value;
-    }
-    return copied;
-  } catch {
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    keys.length !== expectedKeys.length ||
+    !keys.every((key) => expectedKeys.includes(key))
+  ) {
     return undefined;
   }
+  const copied: Record<string, unknown> = {};
+  for (const key of expectedKeys) {
+    if (!Object.hasOwn(record, key)) return undefined;
+    copied[key] = record[key];
+  }
+  return copied;
 }
 
 function parseFacts(value: unknown): G5BoundaryFacts | undefined {
@@ -154,6 +146,39 @@ function parseFacts(value: unknown): G5BoundaryFacts | undefined {
     },
     executorInstanceId: facts.executorInstanceId,
   };
+}
+
+function parseFactsJson(value: string): G5BoundaryFacts | undefined {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+  const facts = parseFacts(decoded);
+  if (facts === undefined || value !== canonicalFactsJson(facts)) {
+    return undefined;
+  }
+  return facts;
+}
+
+/**
+ * Accept only the single canonical spelling generated for trusted boundary
+ * facts. This rejects duplicate member names, alternate escapes, whitespace,
+ * and key-order ambiguity before the assessment can become `required`.
+ */
+function canonicalFactsJson(facts: G5BoundaryFacts): string {
+  return JSON.stringify({
+    host: facts.host,
+    runId: facts.runId,
+    supervision: {
+      descendants: facts.supervision.descendants,
+      eventStream: facts.supervision.eventStream,
+      kind: facts.supervision.kind,
+      pidGeneration: facts.supervision.pidGeneration,
+    },
+    executorInstanceId: facts.executorInstanceId,
+  });
 }
 
 function evaluateExecutionBlockers(
@@ -211,11 +236,17 @@ function assessment(
  * `required` is not an execution authorization. It only means the supplied
  * facts have no local policy blockers and must still be independently verified
  * by the trusted executor before it launches anything.
+ *
+ * The input is JSON text rather than an arbitrary JavaScript object. The
+ * policy must not trust caller-controlled getters or Proxy traps at this
+ * boundary; non-string inputs and malformed JSON fail closed.
  */
 export function assessG5ExecutionBoundary(
-  facts: unknown,
+  factsJson: string,
 ): G5BoundaryAssessment {
-  const parsed = parseFacts(facts);
+  const parsed = typeof factsJson === "string"
+    ? parseFactsJson(factsJson)
+    : undefined;
   return assessment(
     parsed === undefined
       ? ["malformed-boundary-facts"]


### PR DESCRIPTION
## What changed

Hardens the non-live G5 execution-boundary input contract. The policy now accepts only one canonical JSON representation of the boundary facts rather than arbitrary JavaScript objects.

## Why

A live Proxy could previously spoof ownership fields through getter/descriptor traps, and normal JSON parsing accepts duplicate keys with last-value-wins semantics. Canonical JSON byte equality rejects non-string input, live/revoked Proxies, duplicate root/nested/escaped keys, alternate key order, whitespace, and alternate escaping before an assessment can become `required`.

## Explicit non-claims

This remains a pure non-live policy. It does not authorize or execute G5, launch a Desktop browser or iOS client, contact FxA/Sync, handle credentials, secrets, accounts, network traffic, lifecycle cleanup, or G5/G6 evidence. `required` still means independent verification is required, not execution authorization.

## Validation

- `deno fmt --check tools/src/g5_execution_boundary.ts tools/src/g5_execution_boundary.test.ts`
- `deno lint tools/src/g5_execution_boundary.ts tools/src/g5_execution_boundary.test.ts`
- `deno check tools/src/g5_execution_boundary.ts`
- `deno test --allow-read --allow-write tools/src/g5_execution_boundary.test.ts tools/src/browser_launcher.test.ts` — 30 passed
- `git diff HEAD^ HEAD --check`

Independent review confirmed the current canonical-JSON version rejects live/revoked Proxy inputs and duplicate root, nested, and escaped keys fail-closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened execution-boundary validation to reject malformed, non-canonical, or tampered input.
  - Duplicate JSON keys—including escaped variants—are now detected and blocked.
  - Non-canonical formatting, reordered properties, and alternate property-name escaping are rejected.
  - Improved protection against forged, revoked, or otherwise invalid proxy objects.
  - Invalid data now fails safely instead of being accepted for assessment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->