### PR TITLE
test(sync): add non-live G5 desktop process controller

### DIFF
--- a/tools/src/g5_desktop_process_controller.test.ts
+++ b/tools/src/g5_desktop_process_controller.test.ts
@@ -375,6 +375,44 @@ Deno.test("G5 desktop controller requires non-secret opaque run and executor ide
   }
 });
 
+Deno.test("G5 desktop controller derives its platform type from one explicit Deno subset", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./g5_desktop_process_controller.ts", import.meta.url),
+  );
+
+  assertEquals(
+    source.includes(
+      "as const satisfies readonly (typeof Deno.build.os)[]",
+    ),
+    true,
+  );
+  assertEquals(
+    source.includes(
+      "export type G5DesktopPlatform = (typeof G5_DESKTOP_PLATFORM_VALUES)[number];",
+    ),
+    true,
+  );
+});
+
+Deno.test("G5 desktop controller rejects unsupported Deno targets before requesting capture proof", async () => {
+  let captureCalls = 0;
+  const controller = createController({
+    capture(request) {
+      captureCalls += 1;
+      return Promise.resolve(captureProof(request));
+    },
+  });
+
+  for (const platform of ["android", "illumos"] as const) {
+    await assertRejects(
+      () => controller.capture(child(), launch(), platform),
+      Error,
+      "G5 desktop capture input was rejected",
+    );
+  }
+  assertEquals(captureCalls, 0);
+});
+
 Deno.test("G5 desktop controller is a pure injected lifecycle adapter", async () => {
   const source = await Deno.readTextFile(
     new URL("./g5_desktop_process_controller.ts", import.meta.url),

--- a/tools/src/g5_desktop_process_controller.test.ts
+++ b/tools/src/g5_desktop_process_controller.test.ts
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
+import type {
+  IsolatedBrowserChild,
+  IsolatedBrowserLaunchView,
+  IsolatedBrowserProcessControl,
+  IsolatedBrowserProcessOwnership,
+} from "./browser_launcher.ts";
+import {
+  createG5DesktopProcessController,
+  type G5DesktopCaptureRequest,
+  type G5DesktopTerminationRequest,
+} from "./g5_desktop_process_controller.ts";
+
+const RUN_ID = "g5-run-20260814-001";
+const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-001";
+const PROCESS_GENERATION = "pid-4201-generation-987654321";
+
+function child(pid = 4_201): IsolatedBrowserChild {
+  return {
+    kill() {},
+    pid,
+    status: Promise.resolve({ code: 0, signal: null, success: true }),
+  };
+}
+
+function launch(port = 28_291): IsolatedBrowserLaunchView {
+  return Object.freeze({
+    command: Object.freeze(["/opt/floorp/Floorp"]),
+    port,
+    profilePath: "/private/profile",
+  });
+}
+
+function captureProof(
+  request: G5DesktopCaptureRequest,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    descendantOwnership: "causally-complete",
+    eventStream: "complete",
+    executorInstanceId: request.executorInstanceId,
+    marionettePort: request.marionettePort,
+    operation: "capture",
+    pidGeneration: "high-resolution",
+    rootPid: request.rootPid,
+    rootProcessGeneration: PROCESS_GENERATION,
+    runId: request.runId,
+    ...overrides,
+  };
+}
+
+function terminationProof(
+  request: G5DesktopTerminationRequest,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    descendantOwnership: "causally-complete",
+    eventStream: "complete",
+    capturedRootProcessGeneration: request.capturedRootProcessGeneration,
+    executorInstanceId: request.executorInstanceId,
+    marionettePort: request.marionettePort,
+    marionettePortState: "absent",
+    operation: request.operation,
+    operationResult: request.operation === "stop" ? "stopped" : "aborted",
+    ownedTree: "absent",
+    pidGeneration: "high-resolution",
+    rootPid: request.rootPid,
+    rootProcessGeneration: request.capturedRootProcessGeneration ??
+      PROCESS_GENERATION,
+    runId: request.runId,
+    ...overrides,
+  };
+}
+
+function createController(overrides: {
+  abort?: (request: G5DesktopTerminationRequest) => Promise<unknown>;
+  capture?: (request: G5DesktopCaptureRequest) => Promise<unknown>;
+  stop?: (request: G5DesktopTerminationRequest) => Promise<unknown>;
+} = {}): IsolatedBrowserProcessControl {
+  return createG5DesktopProcessController({
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
+    runId: RUN_ID,
+    supervisor: {
+      abort: overrides.abort ??
+        ((request) => Promise.resolve(terminationProof(request))),
+      capture: overrides.capture ??
+        ((request) => Promise.resolve(captureProof(request))),
+      stop: overrides.stop ??
+        ((request) => Promise.resolve(terminationProof(request))),
+    },
+  });
+}
+
+Deno.test("G5 desktop controller captures only complete high-resolution ownership proof", async () => {
+  const requests: G5DesktopCaptureRequest[] = [];
+  const controller = createController({
+    capture(request) {
+      requests.push(request);
+      return Promise.resolve(captureProof(request));
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+
+  assertEquals(requests, [{
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
+    marionettePort: 28_291,
+    operation: "capture",
+    rootPid: 4_201,
+    runId: RUN_ID,
+  }]);
+  assertEquals(ownership, { platform: "darwin", rootPid: 4_201 });
+  assert(Object.isFrozen(ownership));
+});
+
+Deno.test("G5 desktop controller fails closed for incomplete capture proof", async () => {
+  const incompleteProofs: Array<(request: G5DesktopCaptureRequest) => unknown> =
+    [
+      (request) =>
+        captureProof(request, { pidGeneration: "coarse-or-unknown" }),
+      (request) => captureProof(request, { eventStream: "lost-or-unknown" }),
+      (request) =>
+        captureProof(request, { descendantOwnership: "escaped-or-unprovable" }),
+      (request) => ({ ...captureProof(request), rootProcessGeneration: "" }),
+      (request) => ({ ...captureProof(request), unexpected: "not-accepted" }),
+    ];
+
+  for (const incompleteProof of incompleteProofs) {
+    const controller = createController({
+      capture(request) {
+        return Promise.resolve(incompleteProof(request));
+      },
+    });
+
+    await assertRejects(
+      () => controller.capture(child(), launch(), "darwin"),
+      Error,
+      "G5 desktop capture proof was rejected",
+    );
+  }
+});
+
+Deno.test("G5 desktop controller stops only after its supervisor proves tree and port absence", async () => {
+  const requests: G5DesktopTerminationRequest[] = [];
+  const controller = createController({
+    stop(request) {
+      requests.push(request);
+      return Promise.resolve(terminationProof(request));
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+
+  await controller.stop(browser, browserLaunch, ownership, {});
+
+  assertEquals(requests, [{
+    capturedRootProcessGeneration: PROCESS_GENERATION,
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
+    marionettePort: 28_291,
+    operation: "stop",
+    rootPid: 4_201,
+    runId: RUN_ID,
+  }]);
+});
+
+Deno.test("G5 desktop controller reserves a captured tree before concurrent termination", async () => {
+  const stopStarted = Promise.withResolvers<void>();
+  const stopReleased = Promise.withResolvers<void>();
+  let stopCalls = 0;
+  const controller = createController({
+    stop(request) {
+      stopCalls += 1;
+      stopStarted.resolve();
+      return stopReleased.promise.then(() => terminationProof(request));
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+
+  const firstStop = controller.stop(browser, browserLaunch, ownership, {});
+  await stopStarted.promise;
+  const secondStop = controller.stop(browser, browserLaunch, ownership, {});
+  const concurrentAbort = controller.abort(browser, browserLaunch, {});
+
+  await assertRejects(
+    () => secondStop,
+    Error,
+    "G5 desktop process termination is already pending",
+  );
+  await assertRejects(
+    () => concurrentAbort,
+    Error,
+    "G5 desktop process termination is already pending",
+  );
+  assertEquals(stopCalls, 1);
+  stopReleased.resolve();
+  await firstStop;
+  assertEquals(stopCalls, 1);
+});
+
+Deno.test("G5 desktop controller keeps a supervisor failure reserved and rejects duplicate action", async () => {
+  let stopCalls = 0;
+  const controller = createController({
+    stop() {
+      stopCalls += 1;
+      return Promise.reject(new Error("must not be surfaced"));
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+
+  await assertRejects(
+    () => controller.stop(browser, browserLaunch, ownership, {}),
+    Error,
+    "G5 desktop supervisor operation failed",
+  );
+  await assertRejects(
+    () => controller.stop(browser, browserLaunch, ownership, {}),
+    Error,
+    "G5 desktop process termination is already pending",
+  );
+  assertEquals(stopCalls, 1);
+});
+
+Deno.test("G5 desktop controller keeps a port-residual proof reserved and rejects duplicate action", async () => {
+  let stopCalls = 0;
+  const controller = createController({
+    stop(request) {
+      stopCalls += 1;
+      return Promise.resolve(
+        terminationProof(request, { marionettePortState: "present" }),
+      );
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+
+  await assertRejects(
+    () => controller.stop(browser, browserLaunch, ownership, {}),
+    Error,
+    "G5 desktop termination proof was rejected",
+  );
+  await assertRejects(
+    () => controller.abort(browser, browserLaunch, {}),
+    Error,
+    "G5 desktop process termination is already pending",
+  );
+  assertEquals(stopCalls, 1);
+});
+
+Deno.test("G5 desktop controller rejects malformed termination proof", async () => {
+  const controller = createController({
+    stop(request) {
+      return Promise.resolve({
+        ...terminationProof(request),
+        capturedRootProcessGeneration: undefined,
+      });
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+
+  await assertRejects(
+    () => controller.stop(browser, browserLaunch, ownership, {}),
+    Error,
+    "G5 desktop termination proof was rejected",
+  );
+});
+
+Deno.test("G5 desktop controller keeps an owned-tree-residual proof reserved", async () => {
+  const controller = createController({
+    abort(request) {
+      return Promise.resolve(
+        terminationProof(request, { ownedTree: "present" }),
+      );
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+  await controller.capture(browser, browserLaunch, "darwin");
+
+  await assertRejects(
+    () => controller.abort(browser, browserLaunch, {}),
+    Error,
+    "G5 desktop termination proof was rejected",
+  );
+  await assertRejects(
+    () => controller.abort(browser, browserLaunch, {}),
+    Error,
+    "G5 desktop process termination is already pending",
+  );
+});
+
+Deno.test("G5 desktop controller invalidates captured ownership after a successful abort", async () => {
+  const controller = createController();
+  const browser = child();
+  const browserLaunch = launch();
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+
+  await controller.abort(browser, browserLaunch, {});
+
+  await assertRejects(
+    () => controller.stop(browser, browserLaunch, ownership, {}),
+    Error,
+    "G5 desktop process ownership is not captured",
+  );
+});
+
+Deno.test("G5 desktop controller rejects forged or unknown ownership before stopping", async () => {
+  let stopCalls = 0;
+  const controller = createController({
+    stop(request) {
+      stopCalls += 1;
+      return Promise.resolve(terminationProof(request));
+    },
+  });
+  const browser = child();
+  const browserLaunch = launch();
+  const ownership = await controller.capture(browser, browserLaunch, "darwin");
+  const forged: IsolatedBrowserProcessOwnership = {
+    platform: ownership.platform,
+    rootPid: ownership.rootPid,
+  };
+
+  await assertRejects(
+    () => controller.stop(browser, browserLaunch, forged, {}),
+    Error,
+    "G5 desktop process ownership is not captured",
+  );
+  assertEquals(stopCalls, 0);
+  await controller.stop(browser, browserLaunch, ownership, {});
+  assertEquals(stopCalls, 1);
+});
+
+Deno.test("G5 desktop controller requires non-secret opaque run and executor identities", () => {
+  const supervisor = {
+    abort: (request: G5DesktopTerminationRequest) =>
+      Promise.resolve(terminationProof(request)),
+    capture: (request: G5DesktopCaptureRequest) =>
+      Promise.resolve(captureProof(request)),
+    stop: (request: G5DesktopTerminationRequest) =>
+      Promise.resolve(terminationProof(request)),
+  };
+
+  for (
+    const options of [
+      { executorInstanceId: "", runId: RUN_ID, supervisor },
+      {
+        executorInstanceId: EXECUTOR_INSTANCE_ID,
+        runId: "contains space",
+        supervisor,
+      },
+      { executorInstanceId: "contains@symbol", runId: RUN_ID, supervisor },
+      {
+        executorInstanceId: EXECUTOR_INSTANCE_ID,
+        runId: RUN_ID,
+        supervisor: {},
+      },
+    ]
+  ) {
+    assertThrows(
+      () => createG5DesktopProcessController(options),
+      Error,
+      "G5 desktop process controller configuration is invalid",
+    );
+  }
+});
+
+Deno.test("G5 desktop controller is a pure injected lifecycle adapter", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./g5_desktop_process_controller.ts", import.meta.url),
+  );
+  for (
+    const forbidden of [
+      "Deno.Command",
+      ".spawn(",
+      "Deno.env",
+      "Deno.connect",
+      "Deno.listen",
+      "fetch(",
+      "WebSocket",
+      "console.",
+      "browser_connector",
+      "MarionetteClient",
+      "startIsolatedBrowser",
+      "createIsolatedBrowserLaunch",
+      "executeScript",
+      "screenshot",
+      "credential",
+      "password",
+      "notes",
+      "eval(",
+      "Function(",
+      "g5_execution_boundary",
+      "trustedExecutorVerification",
+      "g5Result",
+    ]
+  ) {
+    assertEquals(source.includes(forbidden), false, forbidden);
+  }
+});

--- a/tools/src/g5_desktop_process_controller.test.ts
+++ b/tools/src/g5_desktop_process_controller.test.ts
@@ -10,12 +10,24 @@ import type {
 import {
   createG5DesktopProcessController,
   type G5DesktopCaptureRequest,
+  type G5DesktopPlatform,
   type G5DesktopTerminationRequest,
 } from "./g5_desktop_process_controller.ts";
 
 const RUN_ID = "g5-run-20260814-001";
 const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-001";
 const PROCESS_GENERATION = "pid-4201-generation-987654321";
+const G5_DESKTOP_PLATFORM_TYPE_FIXTURE = {
+  aix: "aix",
+  darwin: "darwin",
+  freebsd: "freebsd",
+  linux: "linux",
+  netbsd: "netbsd",
+  solaris: "solaris",
+  windows: "windows",
+} satisfies Record<G5DesktopPlatform, G5DesktopPlatform>;
+// @ts-expect-error Android is intentionally not a supported Desktop runner.
+const UNSUPPORTED_G5_DESKTOP_PLATFORM: G5DesktopPlatform = "android";
 
 function child(pid = 4_201): IsolatedBrowserChild {
   return {
@@ -375,23 +387,12 @@ Deno.test("G5 desktop controller requires non-secret opaque run and executor ide
   }
 });
 
-Deno.test("G5 desktop controller derives its platform type from one explicit Deno subset", async () => {
-  const source = await Deno.readTextFile(
-    new URL("./g5_desktop_process_controller.ts", import.meta.url),
-  );
-
+Deno.test("G5 desktop controller has an exact compile-time desktop platform contract", () => {
   assertEquals(
-    source.includes(
-      "as const satisfies readonly (typeof Deno.build.os)[]",
-    ),
-    true,
+    Object.values(G5_DESKTOP_PLATFORM_TYPE_FIXTURE).sort(),
+    ["aix", "darwin", "freebsd", "linux", "netbsd", "solaris", "windows"],
   );
-  assertEquals(
-    source.includes(
-      "export type G5DesktopPlatform = (typeof G5_DESKTOP_PLATFORM_VALUES)[number];",
-    ),
-    true,
-  );
+  assertEquals(UNSUPPORTED_G5_DESKTOP_PLATFORM, "android");
 });
 
 Deno.test("G5 desktop controller rejects unsupported Deno targets before requesting capture proof", async () => {

--- a/tools/src/g5_desktop_process_controller.ts
+++ b/tools/src/g5_desktop_process_controller.ts
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import type {
+  IsolatedBrowserChild,
+  IsolatedBrowserLaunchView,
+  IsolatedBrowserProcessControl,
+  IsolatedBrowserProcessOwnership,
+  IsolatedBrowserSpawnDependencies,
+} from "./browser_launcher.ts";
+
+type G5DesktopPlatform =
+  | "aix"
+  | "darwin"
+  | "freebsd"
+  | "linux"
+  | "netbsd"
+  | "solaris"
+  | "windows";
+
+export interface G5DesktopCaptureRequest {
+  readonly executorInstanceId: string;
+  readonly marionettePort: number;
+  readonly operation: "capture";
+  readonly rootPid: number;
+  readonly runId: string;
+}
+
+export interface G5DesktopCaptureProof extends G5DesktopCaptureRequest {
+  readonly descendantOwnership: "causally-complete";
+  readonly eventStream: "complete";
+  readonly pidGeneration: "high-resolution";
+  readonly rootProcessGeneration: string;
+}
+
+export interface G5DesktopTerminationRequest {
+  readonly capturedRootProcessGeneration: string | null;
+  readonly executorInstanceId: string;
+  readonly marionettePort: number;
+  readonly operation: "abort" | "stop";
+  readonly rootPid: number;
+  readonly runId: string;
+}
+
+export interface G5DesktopTerminationProof extends G5DesktopTerminationRequest {
+  readonly descendantOwnership: "causally-complete";
+  readonly eventStream: "complete";
+  readonly marionettePortState: "absent";
+  readonly operationResult: "aborted" | "stopped";
+  readonly ownedTree: "absent";
+  readonly pidGeneration: "high-resolution";
+  readonly rootProcessGeneration: string;
+}
+
+/**
+ * A caller supplies the supervisor. This adapter neither launches nor inspects
+ * a Desktop process; it accepts only explicit metadata-only proofs.
+ */
+export interface G5DesktopLaunchSupervisor {
+  readonly abort: (
+    request: G5DesktopTerminationRequest,
+  ) => Promise<unknown>;
+  readonly capture: (request: G5DesktopCaptureRequest) => Promise<unknown>;
+  readonly stop: (
+    request: G5DesktopTerminationRequest,
+  ) => Promise<unknown>;
+}
+
+export interface G5DesktopProcessControllerOptions {
+  readonly executorInstanceId: string;
+  readonly runId: string;
+  readonly supervisor: G5DesktopLaunchSupervisor;
+}
+
+interface ParsedSupervisor {
+  readonly abort: G5DesktopLaunchSupervisor["abort"];
+  readonly capture: G5DesktopLaunchSupervisor["capture"];
+  readonly stop: G5DesktopLaunchSupervisor["stop"];
+}
+
+interface ParsedOptions {
+  readonly executorInstanceId: string;
+  readonly runId: string;
+  readonly supervisor: ParsedSupervisor;
+}
+
+interface CaptureAttempt {
+  readonly child: IsolatedBrowserChild;
+  readonly executorInstanceId: string;
+  readonly launch: IsolatedBrowserLaunchView;
+  readonly marionettePort: number;
+  readonly rootPid: number;
+  readonly runId: string;
+  rootProcessGeneration?: string;
+  terminationState: "open" | "pending";
+}
+
+const OPAQUE_IDENTIFIER = /^[a-z0-9][a-z0-9._:-]{0,127}$/iu;
+
+function exactDataProperties(
+  value: unknown,
+  expectedKeys: readonly string[],
+): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    const record = value as Record<string, unknown>;
+    const keys = Reflect.ownKeys(record);
+    if (
+      keys.length !== expectedKeys.length ||
+      !keys.every((key) =>
+        typeof key === "string" && expectedKeys.includes(key)
+      )
+    ) {
+      return undefined;
+    }
+    const copied: Record<string, unknown> = {};
+    for (const key of expectedKeys) {
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (descriptor === undefined || !("value" in descriptor)) {
+        return undefined;
+      }
+      copied[key] = descriptor.value;
+    }
+    return copied;
+  } catch {
+    return undefined;
+  }
+}
+
+function isOpaqueRunId(value: unknown): value is string {
+  return typeof value === "string" && OPAQUE_IDENTIFIER.test(value);
+}
+
+function isOpaqueExecutorInstanceId(value: unknown): value is string {
+  return typeof value === "string" && OPAQUE_IDENTIFIER.test(value);
+}
+
+function isRootPid(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isMarionettePort(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) &&
+    value >= 1_024 && value <= 65_535;
+}
+
+function isPlatform(value: unknown): value is G5DesktopPlatform {
+  return value === "aix" || value === "darwin" || value === "freebsd" ||
+    value === "linux" || value === "netbsd" || value === "solaris" ||
+    value === "windows";
+}
+
+function isHighResolutionGeneration(
+  value: unknown,
+  rootPid: number,
+): value is string {
+  return typeof value === "string" &&
+    new RegExp(`^pid-${rootPid}-generation-[0-9]{9,}$`, "u").test(value);
+}
+
+function parseOptions(value: unknown): ParsedOptions | undefined {
+  const options = exactDataProperties(value, [
+    "executorInstanceId",
+    "runId",
+    "supervisor",
+  ]);
+  if (
+    options === undefined ||
+    !isOpaqueExecutorInstanceId(options.executorInstanceId) ||
+    !isOpaqueRunId(options.runId)
+  ) {
+    return undefined;
+  }
+  const supervisor = exactDataProperties(options.supervisor, [
+    "abort",
+    "capture",
+    "stop",
+  ]);
+  if (
+    supervisor === undefined || typeof supervisor.abort !== "function" ||
+    typeof supervisor.capture !== "function" ||
+    typeof supervisor.stop !== "function"
+  ) {
+    return undefined;
+  }
+  return {
+    executorInstanceId: options.executorInstanceId,
+    runId: options.runId,
+    supervisor: {
+      abort: supervisor.abort as G5DesktopLaunchSupervisor["abort"],
+      capture: supervisor.capture as G5DesktopLaunchSupervisor["capture"],
+      stop: supervisor.stop as G5DesktopLaunchSupervisor["stop"],
+    },
+  };
+}
+
+function captureInput(
+  child: IsolatedBrowserChild,
+  launch: IsolatedBrowserLaunchView,
+): { readonly rootPid: number; readonly marionettePort: number } | undefined {
+  try {
+    if (!isRootPid(child.pid) || !isMarionettePort(launch.port)) {
+      return undefined;
+    }
+    return { marionettePort: launch.port, rootPid: child.pid };
+  } catch {
+    return undefined;
+  }
+}
+
+function parseCaptureProof(
+  value: unknown,
+  request: G5DesktopCaptureRequest,
+): string | undefined {
+  const proof = exactDataProperties(value, [
+    "descendantOwnership",
+    "eventStream",
+    "executorInstanceId",
+    "marionettePort",
+    "operation",
+    "pidGeneration",
+    "rootPid",
+    "rootProcessGeneration",
+    "runId",
+  ]);
+  if (
+    proof === undefined || proof.operation !== "capture" ||
+    proof.runId !== request.runId ||
+    proof.executorInstanceId !== request.executorInstanceId ||
+    proof.rootPid !== request.rootPid ||
+    proof.marionettePort !== request.marionettePort ||
+    proof.pidGeneration !== "high-resolution" ||
+    proof.eventStream !== "complete" ||
+    proof.descendantOwnership !== "causally-complete" ||
+    !isHighResolutionGeneration(proof.rootProcessGeneration, request.rootPid)
+  ) {
+    return undefined;
+  }
+  return proof.rootProcessGeneration;
+}
+
+function parseTerminationProof(
+  value: unknown,
+  request: G5DesktopTerminationRequest,
+): boolean {
+  const proof = exactDataProperties(value, [
+    "capturedRootProcessGeneration",
+    "descendantOwnership",
+    "eventStream",
+    "executorInstanceId",
+    "marionettePort",
+    "marionettePortState",
+    "operation",
+    "operationResult",
+    "ownedTree",
+    "pidGeneration",
+    "rootPid",
+    "rootProcessGeneration",
+    "runId",
+  ]);
+  const expectedResult = request.operation === "stop" ? "stopped" : "aborted";
+  return proof !== undefined && proof.operation === request.operation &&
+    proof.operationResult === expectedResult && proof.runId === request.runId &&
+    proof.executorInstanceId === request.executorInstanceId &&
+    proof.rootPid === request.rootPid &&
+    proof.marionettePort === request.marionettePort &&
+    proof.pidGeneration === "high-resolution" &&
+    proof.eventStream === "complete" &&
+    proof.descendantOwnership === "causally-complete" &&
+    proof.ownedTree === "absent" && proof.marionettePortState === "absent" &&
+    proof.capturedRootProcessGeneration ===
+      request.capturedRootProcessGeneration &&
+    isHighResolutionGeneration(proof.rootProcessGeneration, request.rootPid) &&
+    (request.capturedRootProcessGeneration === null ||
+      proof.rootProcessGeneration === request.capturedRootProcessGeneration);
+}
+
+async function invokeSupervisor(
+  invoke: (request: never) => Promise<unknown>,
+  request: unknown,
+): Promise<unknown> {
+  try {
+    return await invoke(request as never);
+  } catch {
+    throw new Error("G5 desktop supervisor operation failed");
+  }
+}
+
+/**
+ * Creates a pure adapter for an already injected lifecycle supervisor.
+ *
+ * It never authorizes an operation. A successful return means only that the
+ * supervisor supplied a complete, matching ownership or termination proof.
+ */
+export function createG5DesktopProcessController(
+  options: unknown,
+): IsolatedBrowserProcessControl {
+  const parsedOptions = parseOptions(options);
+  if (parsedOptions === undefined) {
+    throw new Error("G5 desktop process controller configuration is invalid");
+  }
+  const parsed: ParsedOptions = parsedOptions;
+
+  const attemptsByChild = new WeakMap<IsolatedBrowserChild, CaptureAttempt>();
+  const attemptsByOwnership = new WeakMap<
+    IsolatedBrowserProcessOwnership,
+    CaptureAttempt
+  >();
+
+  function matchingAttempt(
+    child: IsolatedBrowserChild,
+    launch: IsolatedBrowserLaunchView,
+    ownership?: IsolatedBrowserProcessOwnership,
+  ): CaptureAttempt | undefined {
+    const attempt = ownership === undefined
+      ? attemptsByChild.get(child)
+      : attemptsByOwnership.get(ownership);
+    if (
+      attempt === undefined || attempt.child !== child ||
+      attempt.launch !== launch ||
+      attemptsByChild.get(child) !== attempt ||
+      attempt.rootPid !== child.pid || attempt.marionettePort !== launch.port
+    ) {
+      return undefined;
+    }
+    return attempt;
+  }
+
+  async function terminate(
+    operation: "abort" | "stop",
+    child: IsolatedBrowserChild,
+    launch: IsolatedBrowserLaunchView,
+    ownership?: IsolatedBrowserProcessOwnership,
+  ): Promise<void> {
+    const attempt = matchingAttempt(child, launch, ownership);
+    if (
+      attempt === undefined ||
+      (operation === "stop" && attempt.rootProcessGeneration === undefined)
+    ) {
+      throw new Error("G5 desktop process ownership is not captured");
+    }
+    if (attempt.terminationState !== "open") {
+      throw new Error("G5 desktop process termination is already pending");
+    }
+    attempt.terminationState = "pending";
+    const request: G5DesktopTerminationRequest = {
+      capturedRootProcessGeneration: attempt.rootProcessGeneration ?? null,
+      executorInstanceId: attempt.executorInstanceId,
+      marionettePort: attempt.marionettePort,
+      operation,
+      rootPid: attempt.rootPid,
+      runId: attempt.runId,
+    };
+    if (
+      !isRootPid(request.rootPid) ||
+      !isMarionettePort(request.marionettePort) ||
+      !isOpaqueRunId(request.runId) ||
+      !isOpaqueExecutorInstanceId(request.executorInstanceId) ||
+      (request.capturedRootProcessGeneration !== null &&
+        !isHighResolutionGeneration(
+          request.capturedRootProcessGeneration,
+          request.rootPid,
+        ))
+    ) {
+      // This failure occurs before a supervisor invocation, so no external
+      // action could have been requested and reopening the reservation is safe.
+      attempt.terminationState = "open";
+      throw new Error("G5 desktop process ownership is not captured");
+    }
+    // From this point forward, a rejected or malformed supervisor result may
+    // follow a partial external action. Preserve the reservation to prevent a
+    // duplicate termination request until an out-of-band recovery establishes
+    // the final state.
+    const proof = await invokeSupervisor(
+      (operation === "stop"
+        ? parsed.supervisor.stop
+        : parsed.supervisor.abort) as (
+          request: never,
+        ) => Promise<unknown>,
+      request,
+    );
+    if (!parseTerminationProof(proof, request)) {
+      throw new Error("G5 desktop termination proof was rejected");
+    }
+    attemptsByChild.delete(child);
+    if (ownership !== undefined) attemptsByOwnership.delete(ownership);
+  }
+
+  return Object.freeze({
+    abort(
+      child: IsolatedBrowserChild,
+      launch: IsolatedBrowserLaunchView,
+      _dependencies: IsolatedBrowserSpawnDependencies,
+    ): Promise<void> {
+      return terminate("abort", child, launch);
+    },
+    async capture(
+      child: IsolatedBrowserChild,
+      launch: IsolatedBrowserLaunchView,
+      platform: G5DesktopPlatform,
+    ): Promise<IsolatedBrowserProcessOwnership> {
+      const input = captureInput(child, launch);
+      if (
+        input === undefined || !isPlatform(platform) ||
+        attemptsByChild.has(child)
+      ) {
+        throw new Error("G5 desktop capture input was rejected");
+      }
+      const attempt: CaptureAttempt = {
+        child,
+        executorInstanceId: parsed.executorInstanceId,
+        launch,
+        marionettePort: input.marionettePort,
+        rootPid: input.rootPid,
+        runId: parsed.runId,
+        terminationState: "open",
+      };
+      attemptsByChild.set(child, attempt);
+      const request: G5DesktopCaptureRequest = {
+        executorInstanceId: attempt.executorInstanceId,
+        marionettePort: attempt.marionettePort,
+        operation: "capture",
+        rootPid: attempt.rootPid,
+        runId: attempt.runId,
+      };
+      const proof = await invokeSupervisor(
+        parsed.supervisor.capture as (request: never) => Promise<unknown>,
+        request,
+      );
+      const rootProcessGeneration = parseCaptureProof(proof, request);
+      if (rootProcessGeneration === undefined) {
+        throw new Error("G5 desktop capture proof was rejected");
+      }
+      attempt.rootProcessGeneration = rootProcessGeneration;
+      const ownership = Object.freeze({ platform, rootPid: attempt.rootPid });
+      attemptsByOwnership.set(ownership, attempt);
+      return ownership;
+    },
+    stop(
+      child: IsolatedBrowserChild,
+      launch: IsolatedBrowserLaunchView,
+      ownership: IsolatedBrowserProcessOwnership,
+      _dependencies: IsolatedBrowserSpawnDependencies,
+    ): Promise<void> {
+      return terminate("stop", child, launch, ownership);
+    },
+  });
+}

--- a/tools/src/g5_desktop_process_controller.ts
+++ b/tools/src/g5_desktop_process_controller.ts
@@ -8,14 +8,17 @@ import type {
   IsolatedBrowserSpawnDependencies,
 } from "./browser_launcher.ts";
 
-type G5DesktopPlatform =
-  | "aix"
-  | "darwin"
-  | "freebsd"
-  | "linux"
-  | "netbsd"
-  | "solaris"
-  | "windows";
+const G5_DESKTOP_PLATFORM_VALUES = [
+  "aix",
+  "darwin",
+  "freebsd",
+  "linux",
+  "netbsd",
+  "solaris",
+  "windows",
+] as const satisfies readonly (typeof Deno.build.os)[];
+
+export type G5DesktopPlatform = (typeof G5_DESKTOP_PLATFORM_VALUES)[number];
 
 export interface G5DesktopCaptureRequest {
   readonly executorInstanceId: string;
@@ -145,10 +148,8 @@ function isMarionettePort(value: unknown): value is number {
     value >= 1_024 && value <= 65_535;
 }
 
-function isPlatform(value: unknown): value is G5DesktopPlatform {
-  return value === "aix" || value === "darwin" || value === "freebsd" ||
-    value === "linux" || value === "netbsd" || value === "solaris" ||
-    value === "windows";
+function isPlatform(value: typeof Deno.build.os): value is G5DesktopPlatform {
+  return G5_DESKTOP_PLATFORM_VALUES.includes(value as G5DesktopPlatform);
 }
 
 function isHighResolutionGeneration(
@@ -398,7 +399,7 @@ export function createG5DesktopProcessController(
     async capture(
       child: IsolatedBrowserChild,
       launch: IsolatedBrowserLaunchView,
-      platform: G5DesktopPlatform,
+      platform: typeof Deno.build.os,
     ): Promise<IsolatedBrowserProcessOwnership> {
       const input = captureInput(child, launch);
       if (


### PR DESCRIPTION
Adds a pure, injected Desktop process-controller adapter for a future G5 runner. It accepts only complete metadata proofs, reserves termination before awaiting the supervisor, and rejects concurrent termination, incomplete ownership, residual trees/ports, and malformed supervisor results.

This adapter is non-live and unconnected. It does not launch a browser, authorize G5, contact FxA/Sync, handle credentials or environment data, collect Notes content, create network evidence, or establish cleanup/G5/G6 completion. A future independently verified supervisor is still required.

Validation: focused Deno suite 43 passed; formatting, lint, and git diff checks passed. The clean worktree lacks the npm cache needed to start the full host suite; PR CI is the wider verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop process lifecycle controls for capturing ownership and safely stopping or aborting tracked processes.
  * Added validation for process identity, generations, ports, ownership, configuration, and lifecycle proofs.
  * Added safeguards against malformed or incomplete lifecycle responses and unsupported platforms.

* **Bug Fixes**
  * Prevented unauthorized, forged, or invalid termination requests.
  * Preserved pending termination reservations when operations fail or proofs are rejected.

* **Tests**
  * Added comprehensive coverage for lifecycle validation, concurrency, failures, ownership, and termination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->