### PR TITLE
Add macOS G5 lifecycle helper foundation

### DIFF
--- a/.github/workflows/colocated_runner_test.yml
+++ b/.github/workflows/colocated_runner_test.yml
@@ -108,6 +108,12 @@ jobs:
           deno run -A tools/runtime-lock/runtime_lock_cli.ts
           validate-native --out _dist/runtime-validation
 
+      - name: Verify macOS G5 lifecycle helper foundation
+        if: matrix.platform == 'macos'
+        run: >-
+          deno test --allow-read --allow-write --allow-run
+          tools/src/g5_macos_lifecycle_helper.test.ts
+
       - name: Install locked Runtime for browser suite
         if: matrix.browser_suite == true
         run: >-

--- a/.github/workflows/colocated_runner_test.yml
+++ b/.github/workflows/colocated_runner_test.yml
@@ -112,7 +112,7 @@ jobs:
         if: matrix.platform == 'macos'
         run: >-
           deno test --allow-read --allow-write --allow-run
-          tools/src/g5_macos_lifecycle_helper.test.ts
+          tools/native/tests/g5_macos_lifecycle_helper.test.ts
 
       - name: Install locked Runtime for browser suite
         if: matrix.browser_suite == true

--- a/tools/native/g5_macos_lifecycle_helper.c
+++ b/tools/native/g5_macos_lifecycle_helper.c
@@ -6,24 +6,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/resource.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 static int print_probe_session(void) {
   const pid_t pid = getpid();
-  const pid_t original_pgid = getpgid(pid);
-  const pid_t original_sid = getsid(pid);
-  if (original_pgid == -1 || original_sid == -1) {
-    (void)fprintf(stderr, "session lookup failed: %s\n", strerror(errno));
-    return 1;
-  }
-  if (original_pgid != pid || original_sid != pid) {
-    if (setsid() == -1) {
-      (void)fprintf(stderr, "setsid failed: %s\n", strerror(errno));
-      return 1;
-    }
-  }
-
   rusage_info_current usage;
   memset(&usage, 0, sizeof(usage));
   if (proc_pid_rusage(pid, RUSAGE_INFO_CURRENT, (rusage_info_t *)&usage) != 0 ||
@@ -47,60 +33,12 @@ static int print_probe_session(void) {
   return 0;
 }
 
-static int launch_in_private_session(char *const command[]) {
-  const pid_t child = fork();
-  if (child == -1) {
-    (void)fprintf(stderr, "fork failed: %s\n", strerror(errno));
-    return 1;
-  }
-  if (child == 0) {
-    if (setsid() == -1) {
-      (void)fprintf(stderr, "setsid failed: %s\n", strerror(errno));
-      _exit(1);
-    }
-    execvp(command[0], command);
-    (void)fprintf(stderr, "execvp failed: %s\n", strerror(errno));
-    _exit(127);
-  }
-
-  int status = 0;
-  if (waitpid(child, &status, 0) == -1) {
-    (void)fprintf(stderr, "waitpid failed: %s\n", strerror(errno));
-    return 1;
-  }
-  if (WIFEXITED(status)) return WEXITSTATUS(status);
-  return 1;
-}
-
-static int exec_in_private_process_group(char *const command[]) {
-  const pid_t pid = getpid();
-  if (setpgid(0, 0) == -1) {
-    (void)fprintf(stderr, "setpgid failed: %s\n", strerror(errno));
-    return 1;
-  }
-  if (getpgid(pid) != pid) {
-    (void)fprintf(stderr, "exclusive process group was not established\n");
-    return 1;
-  }
-  execvp(command[0], command);
-  (void)fprintf(stderr, "execvp failed: %s\n", strerror(errno));
-  return 127;
-}
-
 int main(int argc, char *argv[]) {
   if (argc == 2 && strcmp(argv[1], "probe-session") == 0) {
     return print_probe_session();
   }
-  if (argc >= 4 && strcmp(argv[1], "launch") == 0 &&
-      strcmp(argv[2], "--") == 0) {
-    return launch_in_private_session(&argv[3]);
-  }
-  if (argc >= 4 && strcmp(argv[1], "exec") == 0 &&
-      strcmp(argv[2], "--") == 0) {
-    return exec_in_private_process_group(&argv[3]);
-  }
   {
-    (void)fprintf(stderr, "usage: %s probe-session | launch -- command [args...] | exec -- command [args...]\n", argv[0]);
+    (void)fprintf(stderr, "usage: %s probe-session\n", argv[0]);
     return 64;
   }
 }

--- a/tools/native/g5_macos_lifecycle_helper.c
+++ b/tools/native/g5_macos_lifecycle_helper.c
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <errno.h>
+#include <inttypes.h>
+#include <libproc.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int print_probe_session(void) {
+  const pid_t pid = getpid();
+  const pid_t original_pgid = getpgid(pid);
+  const pid_t original_sid = getsid(pid);
+  if (original_pgid == -1 || original_sid == -1) {
+    (void)fprintf(stderr, "session lookup failed: %s\n", strerror(errno));
+    return 1;
+  }
+  if (original_pgid != pid || original_sid != pid) {
+    if (setsid() == -1) {
+      (void)fprintf(stderr, "setsid failed: %s\n", strerror(errno));
+      return 1;
+    }
+  }
+
+  rusage_info_current usage;
+  memset(&usage, 0, sizeof(usage));
+  if (proc_pid_rusage(pid, RUSAGE_INFO_CURRENT, (rusage_info_t *)&usage) != 0 ||
+      usage.ri_proc_start_abstime == 0) {
+    (void)fprintf(stderr, "proc_pid_rusage failed: %s\n", strerror(errno));
+    return 1;
+  }
+
+  const pid_t pgid = getpgid(pid);
+  const pid_t sid = getsid(pid);
+  if (pgid == -1 || sid == -1) {
+    (void)fprintf(stderr, "session lookup failed: %s\n", strerror(errno));
+    return 1;
+  }
+
+  (void)printf(
+      "{\"pid\":%d,\"pgid\":%d,\"sid\":%d,\"start_abstime\":\"%" PRIu64
+      "\",\"process_generation\":\"pid-%d-generation-%" PRIu64
+      "\",\"descendant_ownership\":\"not-established\",\"event_stream\":\"incomplete\"}\n",
+      pid, pgid, sid, usage.ri_proc_start_abstime, pid, usage.ri_proc_start_abstime);
+  return 0;
+}
+
+static int launch_in_private_session(char *const command[]) {
+  const pid_t child = fork();
+  if (child == -1) {
+    (void)fprintf(stderr, "fork failed: %s\n", strerror(errno));
+    return 1;
+  }
+  if (child == 0) {
+    if (setsid() == -1) {
+      (void)fprintf(stderr, "setsid failed: %s\n", strerror(errno));
+      _exit(1);
+    }
+    execvp(command[0], command);
+    (void)fprintf(stderr, "execvp failed: %s\n", strerror(errno));
+    _exit(127);
+  }
+
+  int status = 0;
+  if (waitpid(child, &status, 0) == -1) {
+    (void)fprintf(stderr, "waitpid failed: %s\n", strerror(errno));
+    return 1;
+  }
+  if (WIFEXITED(status)) return WEXITSTATUS(status);
+  return 1;
+}
+
+static int exec_in_private_process_group(char *const command[]) {
+  const pid_t pid = getpid();
+  if (setpgid(0, 0) == -1) {
+    (void)fprintf(stderr, "setpgid failed: %s\n", strerror(errno));
+    return 1;
+  }
+  if (getpgid(pid) != pid) {
+    (void)fprintf(stderr, "exclusive process group was not established\n");
+    return 1;
+  }
+  execvp(command[0], command);
+  (void)fprintf(stderr, "execvp failed: %s\n", strerror(errno));
+  return 127;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc == 2 && strcmp(argv[1], "probe-session") == 0) {
+    return print_probe_session();
+  }
+  if (argc >= 4 && strcmp(argv[1], "launch") == 0 &&
+      strcmp(argv[2], "--") == 0) {
+    return launch_in_private_session(&argv[3]);
+  }
+  if (argc >= 4 && strcmp(argv[1], "exec") == 0 &&
+      strcmp(argv[2], "--") == 0) {
+    return exec_in_private_process_group(&argv[3]);
+  }
+  {
+    (void)fprintf(stderr, "usage: %s probe-session | launch -- command [args...] | exec -- command [args...]\n", argv[0]);
+    return 64;
+  }
+}

--- a/tools/native/tests/g5_macos_lifecycle_helper.test.ts
+++ b/tools/native/tests/g5_macos_lifecycle_helper.test.ts
@@ -4,7 +4,7 @@ import { assert, assertEquals, assertMatch } from "@std/assert";
 import * as path from "@std/path";
 
 const sourcePath = path.fromFileUrl(
-  new URL("../native/g5_macos_lifecycle_helper.c", import.meta.url),
+  new URL("../g5_macos_lifecycle_helper.c", import.meta.url),
 );
 
 function commandOutput(command: string, args: readonly string[]) {
@@ -21,7 +21,7 @@ function decode(bytes: Uint8Array): string {
 
 Deno.test({
   name:
-    "macOS G5 lifecycle helper creates an exclusive session with a high-resolution generation",
+    "macOS G5 lifecycle helper reads a session with a high-resolution generation",
   sanitizeOps: false,
   sanitizeResources: false,
   fn() {
@@ -54,8 +54,8 @@ Deno.test({
         unknown
       >;
       assert(typeof record.pid === "number" && record.pid > 0);
-      assertEquals(record.pid, record.pgid);
-      assertEquals(record.pid, record.sid);
+      assert(typeof record.pgid === "number" && record.pgid > 0);
+      assert(typeof record.sid === "number" && record.sid > 0);
       assert(typeof record.start_abstime === "string");
       assertMatch(record.start_abstime, /^[1-9][0-9]{8,}$/u);
       assertEquals(
@@ -72,57 +72,7 @@ Deno.test({
 
 Deno.test({
   name:
-    "macOS G5 lifecycle helper exec mode preserves the tracked root PID in an exclusive process group",
-  sanitizeOps: false,
-  sanitizeResources: false,
-  async fn() {
-    if (Deno.build.os !== "darwin") return;
-    const temporaryDirectory = Deno.makeTempDirSync({
-      prefix: "floorp-g5-lifecycle-helper-test-",
-    });
-    const helperPath = path.join(
-      temporaryDirectory,
-      "g5-macos-lifecycle-helper",
-    );
-    try {
-      const compile = commandOutput("/usr/bin/cc", [
-        "-std=c17",
-        "-Wall",
-        "-Wextra",
-        "-Werror",
-        sourcePath,
-        "-o",
-        helperPath,
-      ]);
-      assertEquals(decode(compile.stderr), "");
-      assert(compile.success);
-
-      const child = new Deno.Command(helperPath, {
-        args: [
-          "exec",
-          "--",
-          "/bin/sh",
-          "-c",
-          "ps -o pid=,pgid= -p $$; /bin/kill -0 -$$",
-        ],
-        stderr: "piped",
-        stdout: "piped",
-      }).spawn();
-      const expectedRootPid = child.pid;
-      const output = await child.output();
-      assertEquals(decode(output.stderr), "");
-      assert(output.success);
-      const values = decode(output.stdout).trim().split(/\s+/u).map(Number);
-      assertEquals(values, [expectedRootPid, expectedRootPid]);
-    } finally {
-      Deno.removeSync(temporaryDirectory, { recursive: true });
-    }
-  },
-});
-
-Deno.test({
-  name:
-    "macOS G5 lifecycle helper probes a process that is already a session leader",
+    "macOS G5 lifecycle helper rejects launch mode instead of executing a command",
   sanitizeOps: false,
   sanitizeResources: false,
   fn() {
@@ -147,21 +97,13 @@ Deno.test({
       assertEquals(decode(compile.stderr), "");
       assert(compile.success);
 
-      const probe = commandOutput(helperPath, [
+      const rejected = commandOutput(helperPath, [
         "launch",
         "--",
-        helperPath,
-        "probe-session",
+        "/usr/bin/true",
       ]);
-      assertEquals(decode(probe.stderr), "");
-      assert(probe.success);
-      const record = JSON.parse(decode(probe.stdout)) as Record<
-        string,
-        unknown
-      >;
-      assertEquals(record.pid, record.pgid);
-      assertEquals(record.pid, record.sid);
-      assertMatch(record.start_abstime as string, /^[1-9][0-9]{8,}$/u);
+      assertEquals(rejected.code, 64);
+      assertEquals(decode(rejected.stdout), "");
     } finally {
       Deno.removeSync(temporaryDirectory, { recursive: true });
     }
@@ -170,7 +112,7 @@ Deno.test({
 
 Deno.test({
   name:
-    "macOS G5 lifecycle helper launches a command in the helper-owned session",
+    "macOS G5 lifecycle helper rejects every mode except exact probe-session",
   sanitizeOps: false,
   sanitizeResources: false,
   fn() {
@@ -195,19 +137,58 @@ Deno.test({
       assertEquals(decode(compile.stderr), "");
       assert(compile.success);
 
-      const launch = commandOutput(helperPath, [
-        "launch",
-        "--",
-        "/bin/sh",
-        "-c",
-        "ps -o pid=,pgid= -p $$; /bin/kill -0 -$$",
+      for (const args of [
+        [] as readonly string[],
+        ["unknown"],
+        ["launch", "--", "/usr/bin/true"],
+        ["exec", "--", "/usr/bin/true"],
+        ["probe-session", "unexpected"],
+      ]) {
+        const rejected = commandOutput(helperPath, args);
+        assertEquals(rejected.code, 64);
+        assertEquals(decode(rejected.stdout), "");
+        assertMatch(decode(rejected.stderr), /^usage: .* probe-session\n$/u);
+      }
+    } finally {
+      Deno.removeSync(temporaryDirectory, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "macOS G5 lifecycle helper rejects exec mode instead of executing a command",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn() {
+    if (Deno.build.os !== "darwin") return;
+    const temporaryDirectory = Deno.makeTempDirSync({
+      prefix: "floorp-g5-lifecycle-helper-test-",
+    });
+    const helperPath = path.join(
+      temporaryDirectory,
+      "g5-macos-lifecycle-helper",
+    );
+    try {
+      const compile = commandOutput("/usr/bin/cc", [
+        "-std=c17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        sourcePath,
+        "-o",
+        helperPath,
       ]);
-      assertEquals(decode(launch.stderr), "");
-      assert(launch.success);
-      const values = decode(launch.stdout).trim().split(/\s+/u).map(Number);
-      assertEquals(values.length, 2);
-      assert(values.every((value) => Number.isSafeInteger(value) && value > 0));
-      assertEquals(values[0], values[1]);
+      assertEquals(decode(compile.stderr), "");
+      assert(compile.success);
+
+      const rejected = commandOutput(helperPath, [
+        "exec",
+        "--",
+        "/usr/bin/true",
+      ]);
+      assertEquals(rejected.code, 64);
+      assertEquals(decode(rejected.stdout), "");
     } finally {
       Deno.removeSync(temporaryDirectory, { recursive: true });
     }

--- a/tools/native/tests/g5_macos_lifecycle_helper.test.ts
+++ b/tools/native/tests/g5_macos_lifecycle_helper.test.ts
@@ -137,13 +137,15 @@ Deno.test({
       assertEquals(decode(compile.stderr), "");
       assert(compile.success);
 
-      for (const args of [
-        [] as readonly string[],
-        ["unknown"],
-        ["launch", "--", "/usr/bin/true"],
-        ["exec", "--", "/usr/bin/true"],
-        ["probe-session", "unexpected"],
-      ]) {
+      for (
+        const args of [
+          [] as readonly string[],
+          ["unknown"],
+          ["launch", "--", "/usr/bin/true"],
+          ["exec", "--", "/usr/bin/true"],
+          ["probe-session", "unexpected"],
+        ]
+      ) {
         const rejected = commandOutput(helperPath, args);
         assertEquals(rejected.code, 64);
         assertEquals(decode(rejected.stdout), "");

--- a/tools/src/g5_macos_lifecycle_helper.test.ts
+++ b/tools/src/g5_macos_lifecycle_helper.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assert, assertEquals, assertMatch } from "@std/assert";
+import * as path from "@std/path";
+
+const sourcePath = path.fromFileUrl(
+  new URL("../native/g5_macos_lifecycle_helper.c", import.meta.url),
+);
+
+function commandOutput(command: string, args: readonly string[]) {
+  return new Deno.Command(command, {
+    args: [...args],
+    stderr: "piped",
+    stdout: "piped",
+  }).outputSync();
+}
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+Deno.test({
+  name:
+    "macOS G5 lifecycle helper creates an exclusive session with a high-resolution generation",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn() {
+    if (Deno.build.os !== "darwin") return;
+    const temporaryDirectory = Deno.makeTempDirSync({
+      prefix: "floorp-g5-lifecycle-helper-test-",
+    });
+    const helperPath = path.join(
+      temporaryDirectory,
+      "g5-macos-lifecycle-helper",
+    );
+    try {
+      const compile = commandOutput("/usr/bin/cc", [
+        "-std=c17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        sourcePath,
+        "-o",
+        helperPath,
+      ]);
+      assertEquals(decode(compile.stderr), "");
+      assert(compile.success);
+
+      const probe = commandOutput(helperPath, ["probe-session"]);
+      assertEquals(decode(probe.stderr), "");
+      assert(probe.success);
+      const record = JSON.parse(decode(probe.stdout)) as Record<
+        string,
+        unknown
+      >;
+      assert(typeof record.pid === "number" && record.pid > 0);
+      assertEquals(record.pid, record.pgid);
+      assertEquals(record.pid, record.sid);
+      assert(typeof record.start_abstime === "string");
+      assertMatch(record.start_abstime, /^[1-9][0-9]{8,}$/u);
+      assertEquals(
+        record.process_generation,
+        `pid-${record.pid}-generation-${record.start_abstime}`,
+      );
+      assertEquals(record.descendant_ownership, "not-established");
+      assertEquals(record.event_stream, "incomplete");
+    } finally {
+      Deno.removeSync(temporaryDirectory, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "macOS G5 lifecycle helper exec mode preserves the tracked root PID in an exclusive process group",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    if (Deno.build.os !== "darwin") return;
+    const temporaryDirectory = Deno.makeTempDirSync({
+      prefix: "floorp-g5-lifecycle-helper-test-",
+    });
+    const helperPath = path.join(
+      temporaryDirectory,
+      "g5-macos-lifecycle-helper",
+    );
+    try {
+      const compile = commandOutput("/usr/bin/cc", [
+        "-std=c17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        sourcePath,
+        "-o",
+        helperPath,
+      ]);
+      assertEquals(decode(compile.stderr), "");
+      assert(compile.success);
+
+      const child = new Deno.Command(helperPath, {
+        args: [
+          "exec",
+          "--",
+          "/bin/sh",
+          "-c",
+          "ps -o pid=,pgid= -p $$; /bin/kill -0 -$$",
+        ],
+        stderr: "piped",
+        stdout: "piped",
+      }).spawn();
+      const expectedRootPid = child.pid;
+      const output = await child.output();
+      assertEquals(decode(output.stderr), "");
+      assert(output.success);
+      const values = decode(output.stdout).trim().split(/\s+/u).map(Number);
+      assertEquals(values, [expectedRootPid, expectedRootPid]);
+    } finally {
+      Deno.removeSync(temporaryDirectory, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "macOS G5 lifecycle helper probes a process that is already a session leader",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn() {
+    if (Deno.build.os !== "darwin") return;
+    const temporaryDirectory = Deno.makeTempDirSync({
+      prefix: "floorp-g5-lifecycle-helper-test-",
+    });
+    const helperPath = path.join(
+      temporaryDirectory,
+      "g5-macos-lifecycle-helper",
+    );
+    try {
+      const compile = commandOutput("/usr/bin/cc", [
+        "-std=c17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        sourcePath,
+        "-o",
+        helperPath,
+      ]);
+      assertEquals(decode(compile.stderr), "");
+      assert(compile.success);
+
+      const probe = commandOutput(helperPath, [
+        "launch",
+        "--",
+        helperPath,
+        "probe-session",
+      ]);
+      assertEquals(decode(probe.stderr), "");
+      assert(probe.success);
+      const record = JSON.parse(decode(probe.stdout)) as Record<
+        string,
+        unknown
+      >;
+      assertEquals(record.pid, record.pgid);
+      assertEquals(record.pid, record.sid);
+      assertMatch(record.start_abstime as string, /^[1-9][0-9]{8,}$/u);
+    } finally {
+      Deno.removeSync(temporaryDirectory, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "macOS G5 lifecycle helper launches a command in the helper-owned session",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn() {
+    if (Deno.build.os !== "darwin") return;
+    const temporaryDirectory = Deno.makeTempDirSync({
+      prefix: "floorp-g5-lifecycle-helper-test-",
+    });
+    const helperPath = path.join(
+      temporaryDirectory,
+      "g5-macos-lifecycle-helper",
+    );
+    try {
+      const compile = commandOutput("/usr/bin/cc", [
+        "-std=c17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        sourcePath,
+        "-o",
+        helperPath,
+      ]);
+      assertEquals(decode(compile.stderr), "");
+      assert(compile.success);
+
+      const launch = commandOutput(helperPath, [
+        "launch",
+        "--",
+        "/bin/sh",
+        "-c",
+        "ps -o pid=,pgid= -p $$; /bin/kill -0 -$$",
+      ]);
+      assertEquals(decode(launch.stderr), "");
+      assert(launch.success);
+      const values = decode(launch.stdout).trim().split(/\s+/u).map(Number);
+      assertEquals(values.length, 2);
+      assert(values.every((value) => Number.isSafeInteger(value) && value > 0));
+      assertEquals(values[0], values[1]);
+    } finally {
+      Deno.removeSync(temporaryDirectory, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
## Scope

Adds a macOS-native, read-only G5 process-session probe and its macOS-only CI test.

## Safety boundary

The helper accepts only exact probe-session. It reads its own PID, PGID, SID, and high-resolution start time, then emits explicit incomplete facts:

- descendant_ownership: not-established
- event_stream: incomplete

It cannot launch commands or create sessions/process groups. Unknown, launch, exec, and extra arguments fail with exit 64 and no stdout.

This PR does not connect the probe to the browser launcher, injected G5 process controller, two-client runner, FxA, Sync, credentials, or network capture. It does not authorize G5 or claim cleanup.

## Validation

- TDD red captured for launch and exec acceptance before restricting the helper.
- macOS native helper test: 4 passed.
- smoke suite: passed.
- The existing macOS initializer host-suite failure is reproducible at base 5ae01f6 and unrelated to this change; the macOS CI matrix remains the wider verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added macOS validation for lifecycle and process-session reporting.
  * Added coverage for valid and invalid command usage, including launch, execution, and argument handling.
  * Confirmed accurate session-generation details and clean temporary artifact removal.

* **Chores**
  * Added a macOS diagnostic utility that reports process and session information in JSON format, with clear error handling for unsupported requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->