### PR TITLE
test(sync): add two-client lifecycle proof contract

### DIFF
--- a/tools/src/g5_desktop_two_client_lifecycle_contract.test.ts
+++ b/tools/src/g5_desktop_two_client_lifecycle_contract.test.ts
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  assessG5DesktopTwoClientLifecycleEvidence,
+  FLOORP_G5_TWO_CLIENT_LIFECYCLE_SCHEMA,
+} from "./g5_desktop_two_client_lifecycle_contract.ts";
+
+const RUN_ID = "g5-run-20260814-001";
+const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-001";
+const PAIR_ID = "g5-pair-20260814-001";
+
+type MutableRecord = Record<string, unknown>;
+
+function lifecycle(
+  clientInstanceId: string,
+  rootPid: number,
+  marionettePort: number,
+  rootProcessGeneration: string,
+  captureProofId: string,
+  terminationProofId: string,
+): MutableRecord {
+  return {
+    captureProof: {
+      clientInstanceId,
+      descendantOwnership: "causally-complete",
+      eventStream: "complete",
+      executorInstanceId: EXECUTOR_INSTANCE_ID,
+      marionettePort,
+      operation: "capture",
+      pairId: PAIR_ID,
+      pidGeneration: "high-resolution",
+      proofId: captureProofId,
+      rootPid,
+      rootProcessGeneration,
+      runId: RUN_ID,
+    },
+    terminationProof: {
+      captureProofId,
+      clientInstanceId,
+      descendantOwnership: "causally-complete",
+      eventStream: "complete",
+      executorInstanceId: EXECUTOR_INSTANCE_ID,
+      marionettePort,
+      marionettePortState: "absent",
+      operation: "stop",
+      operationResult: "stopped",
+      ownedTree: "absent",
+      pairId: PAIR_ID,
+      pidGeneration: "high-resolution",
+      proofId: terminationProofId,
+      rootPid,
+      rootProcessGeneration,
+      runId: RUN_ID,
+    },
+  };
+}
+
+function validEvidence(): MutableRecord {
+  return {
+    clients: [
+      lifecycle(
+        "g5-client-a",
+        4_201,
+        28_291,
+        "pid-4201-generation-987654321",
+        "g5-capture-proof-a",
+        "g5-termination-proof-a",
+      ),
+      lifecycle(
+        "g5-client-b",
+        4_202,
+        28_292,
+        "pid-4202-generation-987654322",
+        "g5-capture-proof-b",
+        "g5-termination-proof-b",
+      ),
+    ],
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
+    pairId: PAIR_ID,
+    runId: RUN_ID,
+    schemaVersion: FLOORP_G5_TWO_CLIENT_LIFECYCLE_SCHEMA,
+  };
+}
+
+function clientAt(evidence: MutableRecord, index: number): MutableRecord {
+  return (evidence.clients as MutableRecord[])[index];
+}
+
+function captureAt(evidence: MutableRecord, index: number): MutableRecord {
+  return clientAt(evidence, index).captureProof as MutableRecord;
+}
+
+function terminationAt(evidence: MutableRecord, index: number): MutableRecord {
+  return clientAt(evidence, index).terminationProof as MutableRecord;
+}
+
+function assess(evidence: MutableRecord) {
+  return assessG5DesktopTwoClientLifecycleEvidence(JSON.stringify(evidence));
+}
+
+function assertRejected(evidence: MutableRecord) {
+  const assessment = assess(evidence);
+  assertEquals(assessment.lifecycle_validation, "rejected");
+  assertEquals(assessment.blockers, [
+    "malformed-two-client-lifecycle-evidence",
+  ]);
+  assertEquals(assessment.execution_authorization, "not-granted");
+  assertEquals(assessment.g5_result, "not-assessed");
+}
+
+Deno.test("G5 two-client lifecycle accepts complete distinct pair evidence without authorizing execution", () => {
+  const assessment = assess(validEvidence());
+
+  assertEquals(assessment.lifecycle_validation, "accepted");
+  assertEquals(assessment.blockers, []);
+  assertEquals(assessment.execution_authorization, "not-granted");
+  assertEquals(assessment.g5_result, "not-assessed");
+  assert(Object.isFrozen(assessment));
+  assert(Object.isFrozen(assessment.blockers));
+});
+
+Deno.test("G5 two-client lifecycle rejects duplicate client identities, PIDs, ports, and generations", () => {
+  const duplicateClientId = validEvidence();
+  captureAt(duplicateClientId, 1).clientInstanceId = "g5-client-a";
+  terminationAt(duplicateClientId, 1).clientInstanceId = "g5-client-a";
+
+  const duplicateRootPid = validEvidence();
+  captureAt(duplicateRootPid, 1).rootPid = 4_201;
+  terminationAt(duplicateRootPid, 1).rootPid = 4_201;
+  captureAt(duplicateRootPid, 1).rootProcessGeneration =
+    "pid-4201-generation-987654321";
+  terminationAt(duplicateRootPid, 1).rootProcessGeneration =
+    "pid-4201-generation-987654321";
+
+  const duplicatePort = validEvidence();
+  captureAt(duplicatePort, 1).marionettePort = 28_291;
+  terminationAt(duplicatePort, 1).marionettePort = 28_291;
+
+  for (const evidence of [duplicateClientId, duplicateRootPid, duplicatePort]) {
+    assertRejected(evidence);
+  }
+});
+
+Deno.test("G5 two-client lifecycle rejects cross-pair binding and proof reuse", () => {
+  const foreignPair = validEvidence();
+  terminationAt(foreignPair, 1).pairId = "g5-pair-foreign";
+
+  const foreignCaptureReference = validEvidence();
+  terminationAt(foreignCaptureReference, 1).captureProofId =
+    "g5-capture-proof-a";
+
+  const reusedProof = validEvidence();
+  terminationAt(reusedProof, 1).proofId = "g5-capture-proof-b";
+
+  const reusedTerminationProof = validEvidence();
+  terminationAt(reusedTerminationProof, 1).proofId = "g5-termination-proof-a";
+
+  for (
+    const evidence of [
+      foreignPair,
+      foreignCaptureReference,
+      reusedProof,
+      reusedTerminationProof,
+    ]
+  ) {
+    assertRejected(evidence);
+  }
+});
+
+Deno.test("G5 two-client lifecycle rejects malformed and incomplete termination proof", () => {
+  const residualTree = validEvidence();
+  terminationAt(residualTree, 0).ownedTree = "present";
+
+  const residualPort = validEvidence();
+  terminationAt(residualPort, 0).marionettePortState = "present";
+
+  const missingEventStream = validEvidence();
+  delete terminationAt(missingEventStream, 0).eventStream;
+
+  const extraKey = validEvidence();
+  terminationAt(extraKey, 0).recoveryCommand = "forbidden";
+
+  const mismatchedGeneration = validEvidence();
+  terminationAt(mismatchedGeneration, 0).rootProcessGeneration =
+    "pid-4201-generation-987654399";
+
+  const mismatchedResult = validEvidence();
+  terminationAt(mismatchedResult, 0).operation = "abort";
+
+  for (
+    const evidence of [
+      residualTree,
+      residualPort,
+      missingEventStream,
+      extraKey,
+      mismatchedGeneration,
+      mismatchedResult,
+    ]
+  ) {
+    assertRejected(evidence);
+  }
+});
+
+Deno.test("G5 two-client lifecycle accepts a complete abort proof only with its exact result", () => {
+  const evidence = validEvidence();
+  terminationAt(evidence, 1).operation = "abort";
+  terminationAt(evidence, 1).operationResult = "aborted";
+
+  const assessment = assess(evidence);
+
+  assertEquals(assessment.lifecycle_validation, "accepted");
+  assertEquals(assessment.execution_authorization, "not-granted");
+  assertEquals(assessment.g5_result, "not-assessed");
+});
+
+Deno.test("G5 two-client lifecycle requires canonical JSON and a canonical client ordering", () => {
+  const canonical = JSON.stringify(validEvidence());
+  const duplicateRunId = canonical.replace(
+    `"runId":"${RUN_ID}"`,
+    `"runId":"other","runId":"${RUN_ID}"`,
+  );
+  const alternateEscape = canonical.replace(
+    '"operation":"capture"',
+    '"operation":"cap\\u0074ure"',
+  );
+  const reorderedClients = validEvidence();
+  (reorderedClients.clients as MutableRecord[]).reverse();
+
+  for (
+    const evidenceJson of [
+      canonical.replace('"clients":', '"clients" :'),
+      duplicateRunId,
+      alternateEscape,
+      JSON.stringify(reorderedClients),
+    ]
+  ) {
+    const assessment = assessG5DesktopTwoClientLifecycleEvidence(evidenceJson);
+    assertEquals(assessment.lifecycle_validation, "rejected");
+    assertEquals(assessment.execution_authorization, "not-granted");
+    assertEquals(assessment.g5_result, "not-assessed");
+  }
+});
+
+Deno.test("G5 two-client lifecycle rejects non-string, getter, and Proxy inputs without observing them", () => {
+  let getterTouched = false;
+  const getterInput = Object.create(null) as MutableRecord;
+  Object.defineProperty(getterInput, "evidence", {
+    enumerable: true,
+    get() {
+      getterTouched = true;
+      return JSON.stringify(validEvidence());
+    },
+  });
+  assertEquals(
+    assessG5DesktopTwoClientLifecycleEvidence(getterInput).lifecycle_validation,
+    "rejected",
+  );
+  assertEquals(getterTouched, false);
+
+  let proxyTouched = false;
+  const { proxy, revoke } = Proxy.revocable(validEvidence(), {
+    get() {
+      proxyTouched = true;
+      return undefined;
+    },
+    ownKeys() {
+      proxyTouched = true;
+      return [];
+    },
+  });
+  revoke();
+  assertEquals(
+    assessG5DesktopTwoClientLifecycleEvidence(proxy).lifecycle_validation,
+    "rejected",
+  );
+  assertEquals(proxyTouched, false);
+});
+
+Deno.test("G5 two-client lifecycle contract is pure and has no execution-capable surface", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./g5_desktop_two_client_lifecycle_contract.ts", import.meta.url),
+  );
+  for (
+    const forbidden of [
+      "Deno.Command",
+      ".spawn(",
+      "Deno.env",
+      "Deno.connect",
+      "Deno.listen",
+      "fetch(",
+      "WebSocket",
+      "child_process",
+      "Xcode",
+      "FxA",
+      "Sync",
+      "credential",
+      "test-accounts",
+    ]
+  ) {
+    assertEquals(source.includes(forbidden), false, forbidden);
+  }
+});

--- a/tools/src/g5_desktop_two_client_lifecycle_contract.ts
+++ b/tools/src/g5_desktop_two_client_lifecycle_contract.ts
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * An inert, data-only proof format for a pair of already-completed Desktop
+ * lifecycle observations. This module has no effect beyond validation.
+ */
+export const FLOORP_G5_TWO_CLIENT_LIFECYCLE_SCHEMA =
+  "floorp-g5-desktop-two-client-lifecycle-v1";
+
+export interface G5DesktopTwoClientLifecycleAssessment {
+  readonly blockers:
+    | readonly []
+    | readonly ["malformed-two-client-lifecycle-evidence"];
+  readonly execution_authorization: "not-granted";
+  readonly g5_result: "not-assessed";
+  readonly lifecycle_validation: "accepted" | "rejected";
+}
+
+interface ParsedCaptureProof {
+  readonly clientInstanceId: string;
+  readonly executorInstanceId: string;
+  readonly marionettePort: number;
+  readonly pairId: string;
+  readonly proofId: string;
+  readonly rootPid: number;
+  readonly rootProcessGeneration: string;
+  readonly runId: string;
+}
+
+interface ParsedTerminationProof extends ParsedCaptureProof {
+  readonly captureProofId: string;
+  readonly operation: "abort" | "stop";
+}
+
+interface ParsedClientLifecycle {
+  readonly captureProof: ParsedCaptureProof;
+  readonly terminationProof: ParsedTerminationProof;
+}
+
+interface ParsedEvidence {
+  readonly clients: readonly [ParsedClientLifecycle, ParsedClientLifecycle];
+  readonly executorInstanceId: string;
+  readonly pairId: string;
+  readonly runId: string;
+}
+
+const EVIDENCE_KEYS = [
+  "clients",
+  "executorInstanceId",
+  "pairId",
+  "runId",
+  "schemaVersion",
+] as const;
+const CLIENT_KEYS = ["captureProof", "terminationProof"] as const;
+const CAPTURE_PROOF_KEYS = [
+  "clientInstanceId",
+  "descendantOwnership",
+  "eventStream",
+  "executorInstanceId",
+  "marionettePort",
+  "operation",
+  "pairId",
+  "pidGeneration",
+  "proofId",
+  "rootPid",
+  "rootProcessGeneration",
+  "runId",
+] as const;
+const TERMINATION_PROOF_KEYS = [
+  "captureProofId",
+  "clientInstanceId",
+  "descendantOwnership",
+  "eventStream",
+  "executorInstanceId",
+  "marionettePort",
+  "marionettePortState",
+  "operation",
+  "operationResult",
+  "ownedTree",
+  "pairId",
+  "pidGeneration",
+  "proofId",
+  "rootPid",
+  "rootProcessGeneration",
+  "runId",
+] as const;
+const OPAQUE_IDENTIFIER = /^[a-z0-9][a-z0-9._:-]{0,127}$/u;
+
+function exactDataProperties(
+  value: unknown,
+  expectedKeys: readonly string[],
+): Record<string, unknown> | undefined {
+  if (
+    typeof value !== "object" || value === null || Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    return undefined;
+  }
+  try {
+    const record = value as Record<string, unknown>;
+    const keys = Reflect.ownKeys(record);
+    if (
+      keys.length !== expectedKeys.length ||
+      !keys.every((key) =>
+        typeof key === "string" && expectedKeys.includes(key)
+      )
+    ) {
+      return undefined;
+    }
+    const copied: Record<string, unknown> = {};
+    for (const key of expectedKeys) {
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (descriptor === undefined || !("value" in descriptor)) {
+        return undefined;
+      }
+      copied[key] = descriptor.value;
+    }
+    return copied;
+  } catch {
+    return undefined;
+  }
+}
+
+function isOpaqueIdentifier(value: unknown): value is string {
+  return typeof value === "string" && OPAQUE_IDENTIFIER.test(value);
+}
+
+function isRootPid(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isMarionettePort(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) &&
+    value >= 1_024 && value <= 65_535;
+}
+
+function isHighResolutionGeneration(
+  value: unknown,
+  rootPid: number,
+): value is string {
+  return typeof value === "string" &&
+    new RegExp(`^pid-${rootPid}-generation-[0-9]{9,}$`, "u").test(value);
+}
+
+function parseCaptureProof(
+  value: unknown,
+): ParsedCaptureProof | undefined {
+  const proof = exactDataProperties(value, CAPTURE_PROOF_KEYS);
+  if (
+    proof === undefined || proof.operation !== "capture" ||
+    proof.descendantOwnership !== "causally-complete" ||
+    proof.eventStream !== "complete" ||
+    proof.pidGeneration !== "high-resolution" ||
+    !isOpaqueIdentifier(proof.clientInstanceId) ||
+    !isOpaqueIdentifier(proof.executorInstanceId) ||
+    !isOpaqueIdentifier(proof.pairId) || !isOpaqueIdentifier(proof.proofId) ||
+    !isOpaqueIdentifier(proof.runId) || !isRootPid(proof.rootPid) ||
+    !isMarionettePort(proof.marionettePort) ||
+    !isHighResolutionGeneration(proof.rootProcessGeneration, proof.rootPid)
+  ) {
+    return undefined;
+  }
+  return {
+    clientInstanceId: proof.clientInstanceId,
+    executorInstanceId: proof.executorInstanceId,
+    marionettePort: proof.marionettePort,
+    pairId: proof.pairId,
+    proofId: proof.proofId,
+    rootPid: proof.rootPid,
+    rootProcessGeneration: proof.rootProcessGeneration,
+    runId: proof.runId,
+  };
+}
+
+function parseTerminationProof(
+  value: unknown,
+): ParsedTerminationProof | undefined {
+  const proof = exactDataProperties(value, TERMINATION_PROOF_KEYS);
+  if (
+    proof === undefined ||
+    (proof.operation !== "abort" && proof.operation !== "stop") ||
+    proof.operationResult !==
+      (proof.operation === "abort" ? "aborted" : "stopped") ||
+    proof.ownedTree !== "absent" ||
+    proof.marionettePortState !== "absent" ||
+    proof.descendantOwnership !== "causally-complete" ||
+    proof.eventStream !== "complete" ||
+    proof.pidGeneration !== "high-resolution" ||
+    !isOpaqueIdentifier(proof.captureProofId) ||
+    !isOpaqueIdentifier(proof.clientInstanceId) ||
+    !isOpaqueIdentifier(proof.executorInstanceId) ||
+    !isOpaqueIdentifier(proof.pairId) || !isOpaqueIdentifier(proof.proofId) ||
+    !isOpaqueIdentifier(proof.runId) || !isRootPid(proof.rootPid) ||
+    !isMarionettePort(proof.marionettePort) ||
+    !isHighResolutionGeneration(proof.rootProcessGeneration, proof.rootPid)
+  ) {
+    return undefined;
+  }
+  return {
+    captureProofId: proof.captureProofId,
+    clientInstanceId: proof.clientInstanceId,
+    executorInstanceId: proof.executorInstanceId,
+    marionettePort: proof.marionettePort,
+    pairId: proof.pairId,
+    operation: proof.operation,
+    proofId: proof.proofId,
+    rootPid: proof.rootPid,
+    rootProcessGeneration: proof.rootProcessGeneration,
+    runId: proof.runId,
+  };
+}
+
+function parseClientLifecycle(
+  value: unknown,
+): ParsedClientLifecycle | undefined {
+  const client = exactDataProperties(value, CLIENT_KEYS);
+  if (client === undefined) return undefined;
+  const captureProof = parseCaptureProof(client.captureProof);
+  const terminationProof = parseTerminationProof(client.terminationProof);
+  if (
+    captureProof === undefined || terminationProof === undefined ||
+    terminationProof.captureProofId !== captureProof.proofId ||
+    terminationProof.clientInstanceId !== captureProof.clientInstanceId ||
+    terminationProof.executorInstanceId !== captureProof.executorInstanceId ||
+    terminationProof.marionettePort !== captureProof.marionettePort ||
+    terminationProof.pairId !== captureProof.pairId ||
+    terminationProof.rootPid !== captureProof.rootPid ||
+    terminationProof.rootProcessGeneration !==
+      captureProof.rootProcessGeneration ||
+    terminationProof.runId !== captureProof.runId ||
+    terminationProof.proofId === captureProof.proofId
+  ) {
+    return undefined;
+  }
+  return { captureProof, terminationProof };
+}
+
+function parseEvidence(value: unknown): ParsedEvidence | undefined {
+  const evidence = exactDataProperties(value, EVIDENCE_KEYS);
+  if (
+    evidence === undefined ||
+    evidence.schemaVersion !== FLOORP_G5_TWO_CLIENT_LIFECYCLE_SCHEMA ||
+    !isOpaqueIdentifier(evidence.executorInstanceId) ||
+    !isOpaqueIdentifier(evidence.pairId) ||
+    !isOpaqueIdentifier(evidence.runId) ||
+    !Array.isArray(evidence.clients) || evidence.clients.length !== 2
+  ) {
+    return undefined;
+  }
+  const first = parseClientLifecycle(evidence.clients[0]);
+  const second = parseClientLifecycle(evidence.clients[1]);
+  if (first === undefined || second === undefined) return undefined;
+
+  const firstCapture = first.captureProof;
+  const secondCapture = second.captureProof;
+  if (
+    firstCapture.clientInstanceId >= secondCapture.clientInstanceId ||
+    firstCapture.clientInstanceId === secondCapture.clientInstanceId ||
+    firstCapture.rootPid === secondCapture.rootPid ||
+    firstCapture.marionettePort === secondCapture.marionettePort ||
+    firstCapture.rootProcessGeneration === secondCapture.rootProcessGeneration
+  ) {
+    return undefined;
+  }
+
+  const proofIds = new Set([
+    first.captureProof.proofId,
+    first.terminationProof.proofId,
+    second.captureProof.proofId,
+    second.terminationProof.proofId,
+  ]);
+  if (proofIds.size !== 4) return undefined;
+
+  for (const client of [first, second]) {
+    for (const proof of [client.captureProof, client.terminationProof]) {
+      if (
+        proof.executorInstanceId !== evidence.executorInstanceId ||
+        proof.pairId !== evidence.pairId || proof.runId !== evidence.runId
+      ) {
+        return undefined;
+      }
+    }
+  }
+  return {
+    clients: [first, second],
+    executorInstanceId: evidence.executorInstanceId,
+    pairId: evidence.pairId,
+    runId: evidence.runId,
+  };
+}
+
+function canonicalCaptureProof(
+  proof: ParsedCaptureProof,
+): Record<string, unknown> {
+  return {
+    clientInstanceId: proof.clientInstanceId,
+    descendantOwnership: "causally-complete",
+    eventStream: "complete",
+    executorInstanceId: proof.executorInstanceId,
+    marionettePort: proof.marionettePort,
+    operation: "capture",
+    pairId: proof.pairId,
+    pidGeneration: "high-resolution",
+    proofId: proof.proofId,
+    rootPid: proof.rootPid,
+    rootProcessGeneration: proof.rootProcessGeneration,
+    runId: proof.runId,
+  };
+}
+
+function canonicalTerminationProof(
+  proof: ParsedTerminationProof,
+): Record<string, unknown> {
+  return {
+    captureProofId: proof.captureProofId,
+    clientInstanceId: proof.clientInstanceId,
+    descendantOwnership: "causally-complete",
+    eventStream: "complete",
+    executorInstanceId: proof.executorInstanceId,
+    marionettePort: proof.marionettePort,
+    marionettePortState: "absent",
+    operation: proof.operation,
+    operationResult: proof.operation === "abort" ? "aborted" : "stopped",
+    ownedTree: "absent",
+    pairId: proof.pairId,
+    pidGeneration: "high-resolution",
+    proofId: proof.proofId,
+    rootPid: proof.rootPid,
+    rootProcessGeneration: proof.rootProcessGeneration,
+    runId: proof.runId,
+  };
+}
+
+function canonicalEvidenceJson(evidence: ParsedEvidence): string {
+  return JSON.stringify({
+    clients: evidence.clients.map((client) => ({
+      captureProof: canonicalCaptureProof(client.captureProof),
+      terminationProof: canonicalTerminationProof(client.terminationProof),
+    })),
+    executorInstanceId: evidence.executorInstanceId,
+    pairId: evidence.pairId,
+    runId: evidence.runId,
+    schemaVersion: FLOORP_G5_TWO_CLIENT_LIFECYCLE_SCHEMA,
+  });
+}
+
+function accepted(): G5DesktopTwoClientLifecycleAssessment {
+  return Object.freeze({
+    blockers: Object.freeze([]) as readonly [],
+    execution_authorization: "not-granted" as const,
+    g5_result: "not-assessed" as const,
+    lifecycle_validation: "accepted" as const,
+  });
+}
+
+function rejected(): G5DesktopTwoClientLifecycleAssessment {
+  return Object.freeze({
+    blockers: Object.freeze([
+      "malformed-two-client-lifecycle-evidence",
+    ]) as readonly ["malformed-two-client-lifecycle-evidence"],
+    execution_authorization: "not-granted" as const,
+    g5_result: "not-assessed" as const,
+    lifecycle_validation: "rejected" as const,
+  });
+}
+
+/**
+ * Accepts only canonical, data-only lifecycle evidence for two distinct
+ * clients. Acceptance does not authorize or perform any operation.
+ */
+export function assessG5DesktopTwoClientLifecycleEvidence(
+  evidenceJson: unknown,
+): G5DesktopTwoClientLifecycleAssessment {
+  if (typeof evidenceJson !== "string") return rejected();
+  try {
+    const parsed = parseEvidence(JSON.parse(evidenceJson));
+    return parsed === undefined ||
+        evidenceJson !== canonicalEvidenceJson(parsed)
+      ? rejected()
+      : accepted();
+  } catch {
+    return rejected();
+  }
+}


### PR DESCRIPTION
## Scope

Adds a pure, canonical JSON validator for two already-observed Desktop client lifecycle proofs.

The contract requires distinct client identities, PIDs, ports, process generations, and proof IDs; it rejects swapped, replayed, incomplete, malformed, or noncanonical proof data.

## Safety boundary

This change does not launch a browser or process, create a VM, access the network or environment, read credentials, access FxA or Sync, use Xcode, or access test accounts. A successful assessment remains `execution_authorization: not-granted` and `g5_result: not-assessed`.

## Validation

- Focused contract tests: 8 passed
- Contract plus existing process-controller tests: 22 passed under deny-env, deny-net, deny-run, and deny-write
- deno check, deno fmt --check, and git diff --check passed
- Independent security review: GO; no blocking findings

## Follow-up

This is a non-executing proof-format foundation only. Actual lifecycle supervision, verified cleanup, network evidence, credentials, and protected G5 execution remain separately blocked and unimplemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for canonical two-client desktop lifecycle evidence.
  * Validates client identities, process details, capture and termination relationships, shared execution context, and JSON formatting.
  * Provides clear accepted or rejected assessments without granting execution authorization.

* **Bug Fixes**
  * Rejects duplicate identities, mismatched client bindings, reused proofs, malformed termination data, reordered clients, unsafe inputs, and noncanonical evidence.

* **Tests**
  * Added comprehensive coverage for valid, invalid, and security-sensitive lifecycle evidence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->