### PR TITLE
refactor(tools): make G5 fixture data-only

### DIFF
--- a/tools/src/g5_desktop_two_client_executor.test.ts
+++ b/tools/src/g5_desktop_two_client_executor.test.ts
@@ -86,6 +86,26 @@ function fixtureJson(value: MutableFixture = fixture()): string {
   return JSON.stringify(value);
 }
 
+function legacyClientKeyOrderJson(value: MutableFixture = fixture()): string {
+  return JSON.stringify({
+    clients: value.clients.map((client) => ({
+      captureProofId: client.captureProofId,
+      clientInstanceId: client.clientInstanceId,
+      fictional: client.fictional,
+      profileToken: client.profileToken,
+      port: client.port,
+      rootPid: client.rootPid,
+      rootProcessGeneration: client.rootProcessGeneration,
+      terminationProofId: client.terminationProofId,
+    })),
+    executorInstanceId: value.executorInstanceId,
+    mode: value.mode,
+    pairId: value.pairId,
+    runId: value.runId,
+    schemaVersion: value.schemaVersion,
+  });
+}
+
 Deno.test("offline fixture accepts exactly two fictional data clients and only returns a withheld G5 result", () => {
   const executor = createOfflineFakeG5DesktopTwoClientExecutor(fixtureJson());
 
@@ -267,6 +287,12 @@ Deno.test("offline fixture rejects noncanonical or non-fictional input before co
   });
   const nonFictional = fixture();
   nonFictional.clients[1].fictional = false;
+  const shortGeneration = fixture();
+  shortGeneration.clients[0].rootProcessGeneration =
+    "pid-4201-generation-12345678";
+  const mismatchedGeneration = fixture();
+  mismatchedGeneration.clients[0].rootProcessGeneration =
+    "pid-4202-generation-987654321";
   const belowPortRange = fixture();
   belowPortRange.clients[0].port = 1_023;
   const abovePortRange = fixture();
@@ -293,7 +319,10 @@ Deno.test("offline fixture rejects noncanonical or non-fictional input before co
     const input of [
       oneClientJson,
       threeClientJson,
+      legacyClientKeyOrderJson(),
       fixtureJson(nonFictional),
+      fixtureJson(shortGeneration),
+      fixtureJson(mismatchedGeneration),
       fixtureJson(belowPortRange),
       fixtureJson(abovePortRange),
       fixtureJson(zeroRootPid),
@@ -329,10 +358,17 @@ Deno.test("offline fixture has no executable imports, capabilities, or live surf
     new URL("./g5_desktop_two_client_executor.ts", import.meta.url),
   );
 
+  const runtimeModuleSources = [
+    ...source.matchAll(
+      /^\s*(?:import|export)\s+(?!type\b)[\s\S]*?\sfrom\s+["']([^"']+)["'];/gmu,
+    ),
+  ].map((match) => match[1]);
   assertEquals(
-    source.includes('from "./g5_desktop_two_client_lifecycle_contract.ts"'),
-    true,
+    runtimeModuleSources,
+    ["./g5_desktop_two_client_lifecycle_contract.ts"],
   );
+  assertEquals(/^\s*import\s+["'][^"']+["'];/mu.test(source), false);
+  assertEquals(/\bimport\s*\(/u.test(source), false);
   for (
     const forbidden of [
       "./browser_launcher.ts",
@@ -340,12 +376,12 @@ Deno.test("offline fixture has no executable imports, capabilities, or live surf
       "createG5DesktopProcessController",
       "G5DesktopLaunchSupervisor",
       "Deno.",
-      "import(",
       "eval(",
       "Function(",
       "fetch(",
       "WebSocket",
       "child_process",
+      "require(",
       "startIsolatedBrowser",
       "createIsolatedBrowserLaunch",
       "new RegExp(",

--- a/tools/src/g5_desktop_two_client_executor.test.ts
+++ b/tools/src/g5_desktop_two_client_executor.test.ts
@@ -13,10 +13,26 @@ const RUN_ID = "g5-run-20260814-003";
 const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-003";
 const PAIR_ID = "g5-pair-20260814-003";
 const FIXTURE_SCHEMA = "floorp-g5-desktop-two-client-offline-fixture-v2";
-const MODULE_DECLARATION =
-  /^\s*(?:import|export)\s+((?:(?!;)[\s\S])*?)\s+from\s+["']([^"']+)["']\s*;/gmu;
+const DYNAMIC_IMPORT_TOKEN =
+  /\bimport\b(?:(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*)*)\(/u;
 const TYPE_ONLY_NAMED_SPECIFIER =
   /^type\s+[A-Za-z_$][\w$]*(?:\s+as\s+[A-Za-z_$][\w$]*)?$/u;
+
+interface ModuleImportScan {
+  readonly dynamicImport: boolean;
+  readonly runtimeSources: readonly string[];
+}
+
+interface ParsedFromModule {
+  readonly clause: string;
+  readonly next: number;
+  readonly source: string | undefined;
+}
+
+interface ParsedStringLiteral {
+  readonly next: number;
+  readonly value: string;
+}
 
 interface MutableClientFixture {
   captureProofId: string;
@@ -111,7 +127,8 @@ function legacyClientKeyOrderJson(value: MutableFixture = fixture()): string {
 }
 
 function isTypeOnlyModuleClause(clause: string): boolean {
-  const normalized = clause.replace(/\s+/gu, " ").trim();
+  const normalized = clause.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/gu, " ")
+    .replace(/\s+/gu, " ").trim();
   if (normalized.startsWith("type ")) return true;
   if (!normalized.startsWith("{") || !normalized.endsWith("}")) {
     return false;
@@ -125,10 +142,220 @@ function isTypeOnlyModuleClause(clause: string): boolean {
     );
 }
 
-function runtimeModuleSources(source: string): string[] {
-  return [...source.matchAll(MODULE_DECLARATION)].filter((match) =>
-    !isTypeOnlyModuleClause(match[1])
-  ).map((match) => match[2]);
+function isIdentifierPart(value: string | undefined): boolean {
+  return value !== undefined && /[A-Za-z0-9_$]/u.test(value);
+}
+
+function hasKeywordAt(source: string, index: number, keyword: string): boolean {
+  return source.startsWith(keyword, index) &&
+    !isIdentifierPart(source[index - 1]) &&
+    !isIdentifierPart(source[index + keyword.length]);
+}
+
+function skipTrivia(source: string, index: number): number {
+  let cursor = index;
+  while (cursor < source.length) {
+    if (/\s/u.test(source[cursor])) {
+      cursor += 1;
+      continue;
+    }
+    if (source.startsWith("//", cursor)) {
+      const newline = source.indexOf("\n", cursor + 2);
+      cursor = newline === -1 ? source.length : newline + 1;
+      continue;
+    }
+    if (source.startsWith("/*", cursor)) {
+      const end = source.indexOf("*/", cursor + 2);
+      cursor = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    return cursor;
+  }
+  return cursor;
+}
+
+function parseStringLiteral(
+  source: string,
+  index: number,
+): ParsedStringLiteral | undefined {
+  const quote = source[index];
+  if (quote !== '"' && quote !== "'") return undefined;
+  let cursor = index + 1;
+  while (cursor < source.length) {
+    if (source[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (source[cursor] === quote) {
+      return {
+        next: cursor + 1,
+        value: source.slice(index + 1, cursor),
+      };
+    }
+    cursor += 1;
+  }
+  return undefined;
+}
+
+function skipTemplateLiteral(source: string, index: number): number {
+  let cursor = index + 1;
+  while (cursor < source.length) {
+    if (source[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (source[cursor] === "`") return cursor + 1;
+    cursor += 1;
+  }
+  return source.length;
+}
+
+function parseFromModule(source: string, index: number): ParsedFromModule {
+  let braceDepth = 0;
+  let cursor = index;
+  while (cursor < source.length) {
+    const next = skipTrivia(source, cursor);
+    if (next !== cursor) {
+      cursor = next;
+      continue;
+    }
+    if (source[cursor] === "{") {
+      braceDepth += 1;
+      cursor += 1;
+      continue;
+    }
+    if (source[cursor] === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+      cursor += 1;
+      continue;
+    }
+    if (source[cursor] === ";") {
+      return {
+        clause: source.slice(index, cursor),
+        next: cursor + 1,
+        source: undefined,
+      };
+    }
+    if (braceDepth === 0 && hasKeywordAt(source, cursor, "from")) {
+      const moduleStart = skipTrivia(source, cursor + "from".length);
+      const module = parseStringLiteral(source, moduleStart);
+      return {
+        clause: source.slice(index, cursor),
+        next: module?.next ?? moduleStart + 1,
+        source: module?.value,
+      };
+    }
+    if (source[cursor] === '"' || source[cursor] === "'") {
+      const literal = parseStringLiteral(source, cursor);
+      return {
+        clause: source.slice(index, cursor),
+        next: literal?.next ?? cursor + 1,
+        source: undefined,
+      };
+    }
+    if (source[cursor] === "`") {
+      return {
+        clause: source.slice(index, cursor),
+        next: skipTemplateLiteral(source, cursor),
+        source: undefined,
+      };
+    }
+    cursor += 1;
+  }
+  return {
+    clause: source.slice(index),
+    next: source.length,
+    source: undefined,
+  };
+}
+
+function scanModuleImports(source: string): ModuleImportScan {
+  let dynamicImport = false;
+  const runtimeSources: string[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const next = skipTrivia(source, cursor);
+    if (next !== cursor) {
+      cursor = next;
+      continue;
+    }
+    if (source[cursor] === '"' || source[cursor] === "'") {
+      cursor = parseStringLiteral(source, cursor)?.next ?? cursor + 1;
+      continue;
+    }
+    if (source[cursor] === "`") {
+      cursor = skipTemplateLiteral(source, cursor);
+      continue;
+    }
+    if (source[cursor - 1] === ".") {
+      cursor += 1;
+      continue;
+    }
+    if (hasKeywordAt(source, cursor, "import")) {
+      const declarationStart = skipTrivia(source, cursor + "import".length);
+      if (source[declarationStart] === "(") {
+        dynamicImport = true;
+        cursor = declarationStart + 1;
+        continue;
+      }
+      const sideEffect = parseStringLiteral(source, declarationStart);
+      if (sideEffect !== undefined) {
+        runtimeSources.push(sideEffect.value);
+        cursor = sideEffect.next;
+        continue;
+      }
+      if (source[declarationStart] === ".") {
+        cursor = declarationStart + 1;
+        continue;
+      }
+      const parsed = parseFromModule(source, declarationStart);
+      if (parsed.source === undefined) {
+        runtimeSources.push("<unparseable-runtime-import>");
+      } else if (
+        !hasKeywordAt(source, declarationStart, "type") &&
+        !isTypeOnlyModuleClause(parsed.clause)
+      ) {
+        runtimeSources.push(parsed.source);
+      }
+      cursor = parsed.next;
+      continue;
+    }
+    if (hasKeywordAt(source, cursor, "export")) {
+      const exportStart = skipTrivia(source, cursor + "export".length);
+      const typeOnly = hasKeywordAt(source, exportStart, "type");
+      const declarationStart = typeOnly
+        ? skipTrivia(source, exportStart + "type".length)
+        : exportStart;
+      if (
+        source[declarationStart] !== "{" && source[declarationStart] !== "*"
+      ) {
+        cursor = declarationStart + 1;
+        continue;
+      }
+      const parsed = parseFromModule(source, exportStart);
+      if (
+        parsed.source !== undefined && !typeOnly &&
+        !isTypeOnlyModuleClause(parsed.clause)
+      ) {
+        runtimeSources.push(parsed.source);
+      }
+      cursor = parsed.next;
+      continue;
+    }
+    cursor += 1;
+  }
+
+  return { dynamicImport, runtimeSources };
+}
+
+function runtimeModuleSources(source: string): readonly string[] {
+  return scanModuleImports(source).runtimeSources;
+}
+
+function hasDynamicModuleImport(source: string): boolean {
+  return scanModuleImports(source).dynamicImport ||
+    DYNAMIC_IMPORT_TOKEN.test(source);
 }
 
 Deno.test("offline fixture accepts exactly two fictional data clients and only returns a withheld G5 result", () => {
@@ -402,6 +629,43 @@ Deno.test("offline fixture source scanner ignores type-only modules but retains 
   );
 });
 
+Deno.test("offline fixture source scanner rejects runtime imports despite trivia or semicolon evasions", () => {
+  const moduleSource = [
+    'import { RuntimeWithoutSemicolon } from "./named-without-semicolon.ts"',
+    'import /* side-effect */ "./side-effect-without-semicolon.ts"',
+    'import { RuntimeWithFromComment } from /* source */ "./from-comment.ts";',
+    'import RuntimeWithAttributes from "./attributes.json" with { type: "json" };',
+    'import /* dynamic */ ("./dynamic-comment.ts");',
+    'import type * as TypeNamespace from "./type-namespace.ts";',
+    'export type * as ExportedTypeNamespace from "./export-type-namespace.ts";',
+    'import { /* comment */ type InlineType as InlineAlias } from "./commented-inline-type.ts";',
+    'export { /* comment */ type InlineExportedType as InlineExportedAlias } from "./commented-inline-export-type.ts";',
+    'import { type InlineType, RuntimeValue } from "./mixed.ts";',
+    'export { type InlineExportedType, RuntimeValue } from "./mixed-export.ts";',
+    'export * from "./star.ts";',
+  ].join("\n");
+
+  assertEquals(
+    runtimeModuleSources(moduleSource),
+    [
+      "./named-without-semicolon.ts",
+      "./side-effect-without-semicolon.ts",
+      "./from-comment.ts",
+      "./attributes.json",
+      "./mixed.ts",
+      "./mixed-export.ts",
+      "./star.ts",
+    ],
+  );
+  assertEquals(hasDynamicModuleImport(moduleSource), true);
+  assertEquals(
+    hasDynamicModuleImport(
+      'const templateDynamic = `${import /* dynamic */("./template-dynamic.ts")}`;',
+    ),
+    true,
+  );
+});
+
 Deno.test("offline fixture has no executable imports, capabilities, or live surface", async () => {
   const source = await Deno.readTextFile(
     new URL("./g5_desktop_two_client_executor.ts", import.meta.url),
@@ -412,7 +676,7 @@ Deno.test("offline fixture has no executable imports, capabilities, or live surf
     ["./g5_desktop_two_client_lifecycle_contract.ts"],
   );
   assertEquals(/^\s*import\s+["'][^"']+["'];/mu.test(source), false);
-  assertEquals(/\bimport\s*\(/u.test(source), false);
+  assertEquals(hasDynamicModuleImport(source), false);
   for (
     const forbidden of [
       "./browser_launcher.ts",

--- a/tools/src/g5_desktop_two_client_executor.test.ts
+++ b/tools/src/g5_desktop_two_client_executor.test.ts
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
+import type {
+  IsolatedBrowserChild,
+  IsolatedBrowserLaunchView,
+} from "./browser_launcher.ts";
+import type {
+  G5DesktopCaptureRequest,
+  G5DesktopLaunchSupervisor,
+  G5DesktopTerminationRequest,
+} from "./g5_desktop_process_controller.ts";
+import {
+  createOfflineFakeG5DesktopTwoClientExecutor,
+  G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
+} from "./g5_desktop_two_client_executor.ts";
+
+const RUN_ID = "g5-run-20260814-002";
+const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-002";
+const PAIR_ID = "g5-pair-20260814-002";
+
+interface FakeClientPlan {
+  readonly captureProofId: string;
+  readonly clientInstanceId: string;
+  readonly rootProcessGeneration: string;
+  readonly terminationProofId: string;
+}
+
+interface FakeClientSession {
+  readonly child: IsolatedBrowserChild;
+  readonly launch: IsolatedBrowserLaunchView;
+}
+
+interface FakeExecutorFixture {
+  readonly abortRequests: G5DesktopTerminationRequest[];
+  readonly captureRequests: G5DesktopCaptureRequest[];
+  readonly executor: ReturnType<
+    typeof createOfflineFakeG5DesktopTwoClientExecutor
+  >;
+  readonly startSlots: string[];
+  readonly stopRequests: G5DesktopTerminationRequest[];
+}
+
+function generationFor(pid: number): string {
+  return `pid-${pid}-generation-987654321`;
+}
+
+function child(pid: number): IsolatedBrowserChild {
+  return Object.freeze({
+    kill() {},
+    pid,
+    status: Promise.resolve({ code: 0, signal: null, success: true }),
+  });
+}
+
+function launch(port: number): IsolatedBrowserLaunchView {
+  return Object.freeze({
+    command: Object.freeze(["/opt/floorp/Floorp"]),
+    port,
+    profilePath: `/private/fake-profile-${port}`,
+  });
+}
+
+function clientPlan(
+  clientInstanceId: string,
+  pid: number,
+  captureProofId: string,
+  terminationProofId: string,
+): FakeClientPlan {
+  return {
+    captureProofId,
+    clientInstanceId,
+    rootProcessGeneration: generationFor(pid),
+    terminationProofId,
+  };
+}
+
+function captureProof(
+  request: G5DesktopCaptureRequest,
+): Record<string, unknown> {
+  return {
+    descendantOwnership: "causally-complete",
+    eventStream: "complete",
+    executorInstanceId: request.executorInstanceId,
+    marionettePort: request.marionettePort,
+    operation: "capture",
+    pidGeneration: "high-resolution",
+    rootPid: request.rootPid,
+    rootProcessGeneration: generationFor(request.rootPid),
+    runId: request.runId,
+  };
+}
+
+function terminationProof(
+  request: G5DesktopTerminationRequest,
+): Record<string, unknown> {
+  return {
+    capturedRootProcessGeneration: request.capturedRootProcessGeneration,
+    descendantOwnership: "causally-complete",
+    eventStream: "complete",
+    executorInstanceId: request.executorInstanceId,
+    marionettePort: request.marionettePort,
+    marionettePortState: "absent",
+    operation: request.operation,
+    operationResult: request.operation === "abort" ? "aborted" : "stopped",
+    ownedTree: "absent",
+    pidGeneration: "high-resolution",
+    rootPid: request.rootPid,
+    rootProcessGeneration: request.capturedRootProcessGeneration ??
+      generationFor(request.rootPid),
+    runId: request.runId,
+  };
+}
+
+function createFixture(overrides: {
+  readonly clients?: readonly [FakeClientPlan, FakeClientPlan];
+  readonly pairId?: string;
+  readonly startClient?: (
+    slot: "first" | "second",
+  ) => Promise<FakeClientSession>;
+  readonly supervisor?: Partial<G5DesktopLaunchSupervisor>;
+} = {}): FakeExecutorFixture {
+  const captureRequests: G5DesktopCaptureRequest[] = [];
+  const abortRequests: G5DesktopTerminationRequest[] = [];
+  const stopRequests: G5DesktopTerminationRequest[] = [];
+  const startSlots: string[] = [];
+  const sessions = {
+    first: { child: child(4_201), launch: launch(28_291) },
+    second: { child: child(4_202), launch: launch(28_292) },
+  } as const;
+  const supervisor: G5DesktopLaunchSupervisor = Object.freeze({
+    abort(request: G5DesktopTerminationRequest) {
+      abortRequests.push(request);
+      return overrides.supervisor?.abort?.(request) ??
+        Promise.resolve(terminationProof(request));
+    },
+    capture(request: G5DesktopCaptureRequest) {
+      captureRequests.push(request);
+      return overrides.supervisor?.capture?.(request) ??
+        Promise.resolve(captureProof(request));
+    },
+    stop(request: G5DesktopTerminationRequest) {
+      stopRequests.push(request);
+      return overrides.supervisor?.stop?.(request) ??
+        Promise.resolve(terminationProof(request));
+    },
+  });
+  const startClient = async (
+    { slot }: { readonly slot: "first" | "second" },
+  ) => {
+    startSlots.push(slot);
+    return await overrides.startClient?.(slot) ?? sessions[slot];
+  };
+  return {
+    abortRequests,
+    captureRequests,
+    executor: createOfflineFakeG5DesktopTwoClientExecutor({
+      clients: overrides.clients ?? [
+        clientPlan(
+          "g5-client-a",
+          4_201,
+          "g5-capture-proof-a",
+          "g5-termination-proof-a",
+        ),
+        clientPlan(
+          "g5-client-b",
+          4_202,
+          "g5-capture-proof-b",
+          "g5-termination-proof-b",
+        ),
+      ],
+      dependencies: { startClient, supervisor },
+      executorInstanceId: EXECUTOR_INSTANCE_ID,
+      mode: G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
+      pairId: overrides.pairId ?? PAIR_ID,
+      runId: RUN_ID,
+    }),
+    startSlots,
+    stopRequests,
+  };
+}
+
+Deno.test("offline fake executor binds a distinct pair and permanently withholds a G5 result", async () => {
+  const fixture = createFixture();
+
+  const result = await fixture.executor.runFakeLifecycle();
+
+  assertEquals(fixture.startSlots, ["first", "second"]);
+  assertEquals(
+    fixture.captureRequests.map((request) => [
+      request.rootPid,
+      request.marionettePort,
+    ]),
+    [[4_201, 28_291], [4_202, 28_292]],
+  );
+  assertEquals(fixture.stopRequests.length, 2);
+  assertEquals(fixture.abortRequests, []);
+  assertEquals(result.mode, G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY);
+  assertEquals(result.execution_authorization, "not-granted");
+  assertEquals(result.g5_result, "not-assessed");
+  assertEquals(result.boundary.g5Result, "not-assessed");
+  assertEquals(result.boundary.trustedExecutorVerification, "blocked");
+  assertEquals(result.lifecycle.execution_authorization, "not-granted");
+  assertEquals(result.lifecycle.g5_result, "not-assessed");
+  assertEquals(result.lifecycle.lifecycle_validation, "accepted");
+});
+
+Deno.test("offline fake executor rejects overlapping pair, client, and proof identities before starting", () => {
+  const invalidOverrides: ReadonlyArray<{
+    readonly clients?: readonly [FakeClientPlan, FakeClientPlan];
+    readonly pairId?: string;
+  }> = [
+    { pairId: RUN_ID },
+    {
+      clients: [
+        clientPlan(
+          "g5-client-a",
+          4_201,
+          "g5-capture-proof-a",
+          "g5-termination-proof-a",
+        ),
+        clientPlan(
+          "g5-client-a",
+          4_202,
+          "g5-capture-proof-b",
+          "g5-termination-proof-b",
+        ),
+      ],
+    },
+    {
+      clients: [
+        clientPlan(
+          "g5-client-a",
+          4_201,
+          "g5-capture-proof-a",
+          "g5-termination-proof-a",
+        ),
+        clientPlan(
+          "g5-client-b",
+          4_202,
+          "g5-capture-proof-a",
+          "g5-termination-proof-b",
+        ),
+      ],
+    },
+  ];
+
+  for (const overrides of invalidOverrides) {
+    let startCalls = 0;
+    assertThrows(
+      () =>
+        createFixture({
+          ...overrides,
+          startClient(slot) {
+            startCalls += 1;
+            return Promise.resolve(
+              slot === "first"
+                ? { child: child(4_201), launch: launch(28_291) }
+                : { child: child(4_202), launch: launch(28_292) },
+            );
+          },
+        }),
+      Error,
+      "G5 offline fake two-client identity invariants were rejected",
+    );
+    assertEquals(startCalls, 0);
+  }
+});
+
+Deno.test("offline fake executor aborts its first fake client when second startup fails", async () => {
+  const fixture = createFixture({
+    startClient(slot) {
+      if (slot === "second") {
+        return Promise.reject(new Error("second fake startup failed"));
+      }
+      return Promise.resolve({ child: child(4_201), launch: launch(28_291) });
+    },
+  });
+
+  await assertRejects(
+    () => fixture.executor.runFakeLifecycle(),
+    Error,
+    "second fake startup failed",
+  );
+  assertEquals(fixture.startSlots, ["first", "second"]);
+  assertEquals(fixture.abortRequests.length, 1);
+  assertEquals(fixture.abortRequests[0].rootPid, 4_201);
+  assertEquals(fixture.stopRequests, []);
+});
+
+Deno.test("offline fake executor propagates cleanup failure after second startup failure", async () => {
+  const fixture = createFixture({
+    startClient(slot) {
+      if (slot === "second") {
+        return Promise.reject(new Error("second fake startup failed"));
+      }
+      return Promise.resolve({ child: child(4_201), launch: launch(28_291) });
+    },
+    supervisor: {
+      abort() {
+        return Promise.reject(new Error("first fake cleanup failed"));
+      },
+    },
+  });
+
+  let failure: unknown;
+  try {
+    await fixture.executor.runFakeLifecycle();
+  } catch (error) {
+    failure = error;
+  }
+
+  assert(failure instanceof AggregateError);
+  assertEquals(
+    failure.errors.map((error) =>
+      error instanceof Error ? error.message : error
+    ),
+    ["second fake startup failed", "G5 desktop supervisor operation failed"],
+  );
+  assertEquals(fixture.abortRequests.length, 1);
+});
+
+Deno.test("offline fake executor does not contain a live execution path", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./g5_desktop_two_client_executor.ts", import.meta.url),
+  );
+
+  for (
+    const forbidden of [
+      "Deno.Command",
+      ".spawn(",
+      "Deno.env",
+      "Deno.connect",
+      "Deno.listen",
+      "fetch(",
+      "WebSocket",
+      "startIsolatedBrowser",
+      "createIsolatedBrowserLaunch",
+      "Marionette",
+      "FxA",
+      "Sync",
+      "credential",
+      "password",
+      "process.env",
+    ]
+  ) {
+    assertEquals(source.includes(forbidden), false, forbidden);
+  }
+});

--- a/tools/src/g5_desktop_two_client_executor.test.ts
+++ b/tools/src/g5_desktop_two_client_executor.test.ts
@@ -1,346 +1,324 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
-import type {
-  IsolatedBrowserChild,
-  IsolatedBrowserLaunchView,
-} from "./browser_launcher.ts";
-import type {
-  G5DesktopCaptureRequest,
-  G5DesktopLaunchSupervisor,
-  G5DesktopTerminationRequest,
-} from "./g5_desktop_process_controller.ts";
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  assessG5DesktopTwoClientLifecycleEvidence,
+} from "./g5_desktop_two_client_lifecycle_contract.ts";
 import {
   createOfflineFakeG5DesktopTwoClientExecutor,
   G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
 } from "./g5_desktop_two_client_executor.ts";
 
-const RUN_ID = "g5-run-20260814-002";
-const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-002";
-const PAIR_ID = "g5-pair-20260814-002";
+const RUN_ID = "g5-run-20260814-003";
+const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-003";
+const PAIR_ID = "g5-pair-20260814-003";
+const FIXTURE_SCHEMA = "floorp-g5-desktop-two-client-offline-fixture-v2";
 
-interface FakeClientPlan {
-  readonly captureProofId: string;
-  readonly clientInstanceId: string;
-  readonly rootProcessGeneration: string;
-  readonly terminationProofId: string;
+interface MutableClientFixture {
+  captureProofId: string;
+  clientInstanceId: string;
+  fictional: boolean;
+  profileToken: string;
+  port: number;
+  rootPid: number;
+  rootProcessGeneration: string;
+  terminationProofId: string;
 }
 
-interface FakeClientSession {
-  readonly child: IsolatedBrowserChild;
-  readonly launch: IsolatedBrowserLaunchView;
+interface MutableFixture {
+  clients: [MutableClientFixture, MutableClientFixture];
+  executorInstanceId: string;
+  mode: string;
+  pairId: string;
+  runId: string;
+  schemaVersion: string;
 }
 
-interface FakeExecutorFixture {
-  readonly abortRequests: G5DesktopTerminationRequest[];
-  readonly captureRequests: G5DesktopCaptureRequest[];
-  readonly executor: ReturnType<
-    typeof createOfflineFakeG5DesktopTwoClientExecutor
-  >;
-  readonly startSlots: string[];
-  readonly stopRequests: G5DesktopTerminationRequest[];
-}
-
-function generationFor(pid: number): string {
-  return `pid-${pid}-generation-987654321`;
-}
-
-function child(pid: number): IsolatedBrowserChild {
-  return Object.freeze({
-    kill() {},
-    pid,
-    status: Promise.resolve({ code: 0, signal: null, success: true }),
-  });
-}
-
-function launch(port: number): IsolatedBrowserLaunchView {
-  return Object.freeze({
-    command: Object.freeze(["/opt/floorp/Floorp"]),
-    port,
-    profilePath: `/private/fake-profile-${port}`,
-  });
-}
-
-function clientPlan(
+function client(
   clientInstanceId: string,
-  pid: number,
+  rootPid: number,
+  port: number,
+  profileToken: string,
   captureProofId: string,
   terminationProofId: string,
-): FakeClientPlan {
+): MutableClientFixture {
   return {
     captureProofId,
     clientInstanceId,
-    rootProcessGeneration: generationFor(pid),
+    fictional: true,
+    profileToken,
+    port,
+    rootPid,
+    rootProcessGeneration: `pid-${rootPid}-generation-987654321`,
     terminationProofId,
   };
 }
 
-function captureProof(
-  request: G5DesktopCaptureRequest,
-): Record<string, unknown> {
+function fixture(): MutableFixture {
   return {
-    descendantOwnership: "causally-complete",
-    eventStream: "complete",
-    executorInstanceId: request.executorInstanceId,
-    marionettePort: request.marionettePort,
-    operation: "capture",
-    pidGeneration: "high-resolution",
-    rootPid: request.rootPid,
-    rootProcessGeneration: generationFor(request.rootPid),
-    runId: request.runId,
+    clients: [
+      client(
+        "g5-client-a",
+        4_201,
+        28_291,
+        "g5-profile-token-a",
+        "g5-capture-proof-a",
+        "g5-termination-proof-a",
+      ),
+      client(
+        "g5-client-b",
+        4_202,
+        28_292,
+        "g5-profile-token-b",
+        "g5-capture-proof-b",
+        "g5-termination-proof-b",
+      ),
+    ],
+    executorInstanceId: EXECUTOR_INSTANCE_ID,
+    mode: G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
+    pairId: PAIR_ID,
+    runId: RUN_ID,
+    schemaVersion: FIXTURE_SCHEMA,
   };
 }
 
-function terminationProof(
-  request: G5DesktopTerminationRequest,
-): Record<string, unknown> {
-  return {
-    capturedRootProcessGeneration: request.capturedRootProcessGeneration,
-    descendantOwnership: "causally-complete",
-    eventStream: "complete",
-    executorInstanceId: request.executorInstanceId,
-    marionettePort: request.marionettePort,
-    marionettePortState: "absent",
-    operation: request.operation,
-    operationResult: request.operation === "abort" ? "aborted" : "stopped",
-    ownedTree: "absent",
-    pidGeneration: "high-resolution",
-    rootPid: request.rootPid,
-    rootProcessGeneration: request.capturedRootProcessGeneration ??
-      generationFor(request.rootPid),
-    runId: request.runId,
-  };
+function fixtureJson(value: MutableFixture = fixture()): string {
+  return JSON.stringify(value);
 }
 
-function createFixture(overrides: {
-  readonly clients?: readonly [FakeClientPlan, FakeClientPlan];
-  readonly pairId?: string;
-  readonly startClient?: (
-    slot: "first" | "second",
-  ) => Promise<FakeClientSession>;
-  readonly supervisor?: Partial<G5DesktopLaunchSupervisor>;
-} = {}): FakeExecutorFixture {
-  const captureRequests: G5DesktopCaptureRequest[] = [];
-  const abortRequests: G5DesktopTerminationRequest[] = [];
-  const stopRequests: G5DesktopTerminationRequest[] = [];
-  const startSlots: string[] = [];
-  const sessions = {
-    first: { child: child(4_201), launch: launch(28_291) },
-    second: { child: child(4_202), launch: launch(28_292) },
-  } as const;
-  const supervisor: G5DesktopLaunchSupervisor = Object.freeze({
-    abort(request: G5DesktopTerminationRequest) {
-      abortRequests.push(request);
-      return overrides.supervisor?.abort?.(request) ??
-        Promise.resolve(terminationProof(request));
-    },
-    capture(request: G5DesktopCaptureRequest) {
-      captureRequests.push(request);
-      return overrides.supervisor?.capture?.(request) ??
-        Promise.resolve(captureProof(request));
-    },
-    stop(request: G5DesktopTerminationRequest) {
-      stopRequests.push(request);
-      return overrides.supervisor?.stop?.(request) ??
-        Promise.resolve(terminationProof(request));
-    },
-  });
-  const startClient = async (
-    { slot }: { readonly slot: "first" | "second" },
-  ) => {
-    startSlots.push(slot);
-    return await overrides.startClient?.(slot) ?? sessions[slot];
-  };
-  return {
-    abortRequests,
-    captureRequests,
-    executor: createOfflineFakeG5DesktopTwoClientExecutor({
-      clients: overrides.clients ?? [
-        clientPlan(
-          "g5-client-a",
-          4_201,
-          "g5-capture-proof-a",
-          "g5-termination-proof-a",
-        ),
-        clientPlan(
-          "g5-client-b",
-          4_202,
-          "g5-capture-proof-b",
-          "g5-termination-proof-b",
-        ),
-      ],
-      dependencies: { startClient, supervisor },
-      executorInstanceId: EXECUTOR_INSTANCE_ID,
-      mode: G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
-      pairId: overrides.pairId ?? PAIR_ID,
-      runId: RUN_ID,
-    }),
-    startSlots,
-    stopRequests,
-  };
-}
+Deno.test("offline fixture accepts exactly two fictional data clients and only returns a withheld G5 result", () => {
+  const executor = createOfflineFakeG5DesktopTwoClientExecutor(fixtureJson());
 
-Deno.test("offline fake executor binds a distinct pair and permanently withholds a G5 result", async () => {
-  const fixture = createFixture();
+  const result = executor.consumeFixture();
 
-  const result = await fixture.executor.runFakeLifecycle();
-
-  assertEquals(fixture.startSlots, ["first", "second"]);
-  assertEquals(
-    fixture.captureRequests.map((request) => [
-      request.rootPid,
-      request.marionettePort,
-    ]),
-    [[4_201, 28_291], [4_202, 28_292]],
-  );
-  assertEquals(fixture.stopRequests.length, 2);
-  assertEquals(fixture.abortRequests, []);
-  assertEquals(result.mode, G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY);
   assertEquals(result.execution_authorization, "not-granted");
   assertEquals(result.g5_result, "not-assessed");
-  assertEquals(result.boundary.g5Result, "not-assessed");
-  assertEquals(result.boundary.trustedExecutorVerification, "blocked");
-  assertEquals(result.lifecycle.execution_authorization, "not-granted");
-  assertEquals(result.lifecycle.g5_result, "not-assessed");
-  assertEquals(result.lifecycle.lifecycle_validation, "accepted");
-});
-
-Deno.test("offline fake executor rejects overlapping pair, client, and proof identities before starting", () => {
-  const invalidOverrides: ReadonlyArray<{
-    readonly clients?: readonly [FakeClientPlan, FakeClientPlan];
-    readonly pairId?: string;
-  }> = [
-    { pairId: RUN_ID },
-    {
-      clients: [
-        clientPlan(
-          "g5-client-a",
-          4_201,
-          "g5-capture-proof-a",
-          "g5-termination-proof-a",
-        ),
-        clientPlan(
-          "g5-client-a",
-          4_202,
-          "g5-capture-proof-b",
-          "g5-termination-proof-b",
-        ),
-      ],
-    },
-    {
-      clients: [
-        clientPlan(
-          "g5-client-a",
-          4_201,
-          "g5-capture-proof-a",
-          "g5-termination-proof-a",
-        ),
-        clientPlan(
-          "g5-client-b",
-          4_202,
-          "g5-capture-proof-a",
-          "g5-termination-proof-b",
-        ),
-      ],
-    },
-  ];
-
-  for (const overrides of invalidOverrides) {
-    let startCalls = 0;
-    assertThrows(
-      () =>
-        createFixture({
-          ...overrides,
-          startClient(slot) {
-            startCalls += 1;
-            return Promise.resolve(
-              slot === "first"
-                ? { child: child(4_201), launch: launch(28_291) }
-                : { child: child(4_202), launch: launch(28_292) },
-            );
-          },
-        }),
-      Error,
-      "G5 offline fake two-client identity invariants were rejected",
-    );
-    assertEquals(startCalls, 0);
-  }
-});
-
-Deno.test("offline fake executor aborts its first fake client when second startup fails", async () => {
-  const fixture = createFixture({
-    startClient(slot) {
-      if (slot === "second") {
-        return Promise.reject(new Error("second fake startup failed"));
-      }
-      return Promise.resolve({ child: child(4_201), launch: launch(28_291) });
-    },
-  });
-
-  await assertRejects(
-    () => fixture.executor.runFakeLifecycle(),
-    Error,
-    "second fake startup failed",
-  );
-  assertEquals(fixture.startSlots, ["first", "second"]);
-  assertEquals(fixture.abortRequests.length, 1);
-  assertEquals(fixture.abortRequests[0].rootPid, 4_201);
-  assertEquals(fixture.stopRequests, []);
-});
-
-Deno.test("offline fake executor propagates cleanup failure after second startup failure", async () => {
-  const fixture = createFixture({
-    startClient(slot) {
-      if (slot === "second") {
-        return Promise.reject(new Error("second fake startup failed"));
-      }
-      return Promise.resolve({ child: child(4_201), launch: launch(28_291) });
-    },
-    supervisor: {
-      abort() {
-        return Promise.reject(new Error("first fake cleanup failed"));
-      },
-    },
-  });
-
-  let failure: unknown;
-  try {
-    await fixture.executor.runFakeLifecycle();
-  } catch (error) {
-    failure = error;
-  }
-
-  assert(failure instanceof AggregateError);
   assertEquals(
-    failure.errors.map((error) =>
-      error instanceof Error ? error.message : error
-    ),
-    ["second fake startup failed", "G5 desktop supervisor operation failed"],
+    assessG5DesktopTwoClientLifecycleEvidence(result.evidenceJson),
+    {
+      blockers: [],
+      execution_authorization: "not-granted",
+      g5_result: "not-assessed",
+      lifecycle_validation: "accepted",
+    },
   );
-  assertEquals(fixture.abortRequests.length, 1);
 });
 
-Deno.test("offline fake executor does not contain a live execution path", async () => {
+Deno.test("offline fixture rejects arbitrary functions without invoking them", () => {
+  let invoked = false;
+  const arbitraryFunction = () => {
+    invoked = true;
+    return fixtureJson();
+  };
+  const functionProperty = {
+    value() {
+      invoked = true;
+      return fixtureJson();
+    },
+  };
+
+  for (const input of [arbitraryFunction, functionProperty]) {
+    assertThrows(
+      () => createOfflineFakeG5DesktopTwoClientExecutor(input),
+      Error,
+      "G5 offline fixture input was rejected",
+    );
+  }
+  assertEquals(invoked, false);
+});
+
+Deno.test("offline fixture rejects getters, Proxies, and foreign prototypes without observing them", () => {
+  let getterTouched = false;
+  const getterInput = Object.create(null) as Record<string, unknown>;
+  Object.defineProperty(getterInput, "fixture", {
+    enumerable: true,
+    get() {
+      getterTouched = true;
+      return fixtureJson();
+    },
+  });
+
+  let proxyTouched = false;
+  const proxyInput = new Proxy({}, {
+    get() {
+      proxyTouched = true;
+      return undefined;
+    },
+    getOwnPropertyDescriptor() {
+      proxyTouched = true;
+      return undefined;
+    },
+    getPrototypeOf() {
+      proxyTouched = true;
+      return null;
+    },
+    ownKeys() {
+      proxyTouched = true;
+      return [];
+    },
+  });
+
+  let foreignTouched = false;
+  const foreignInput = Object.create({
+    toJSON() {
+      foreignTouched = true;
+      return fixture();
+    },
+  });
+
+  for (const input of [getterInput, proxyInput, foreignInput]) {
+    assertThrows(
+      () => createOfflineFakeG5DesktopTwoClientExecutor(input),
+      Error,
+      "G5 offline fixture input was rejected",
+    );
+  }
+  assertEquals(getterTouched, false);
+  assertEquals(proxyTouched, false);
+  assertEquals(foreignTouched, false);
+});
+
+Deno.test("offline fixture rejects duplicate identity, proof, PID, port, generation, and profile data before use", () => {
+  const duplicateCases: MutableFixture[] = [];
+
+  const duplicateClientId = fixture();
+  duplicateClientId.clients[1].clientInstanceId =
+    duplicateClientId.clients[0].clientInstanceId;
+  duplicateCases.push(duplicateClientId);
+
+  const duplicateCaptureProof = fixture();
+  duplicateCaptureProof.clients[1].captureProofId =
+    duplicateCaptureProof.clients[0].captureProofId;
+  duplicateCases.push(duplicateCaptureProof);
+
+  const duplicateTerminationProof = fixture();
+  duplicateTerminationProof.clients[1].terminationProofId =
+    duplicateTerminationProof.clients[0].terminationProofId;
+  duplicateCases.push(duplicateTerminationProof);
+
+  const duplicatePid = fixture();
+  duplicatePid.clients[1].rootPid = duplicatePid.clients[0].rootPid;
+  duplicatePid.clients[1].rootProcessGeneration =
+    duplicatePid.clients[0].rootProcessGeneration;
+  duplicateCases.push(duplicatePid);
+
+  const duplicatePort = fixture();
+  duplicatePort.clients[1].port = duplicatePort.clients[0].port;
+  duplicateCases.push(duplicatePort);
+
+  const duplicateGeneration = fixture();
+  duplicateGeneration.clients[1].rootProcessGeneration =
+    duplicateGeneration.clients[0].rootProcessGeneration;
+  duplicateCases.push(duplicateGeneration);
+
+  const duplicateProfileToken = fixture();
+  duplicateProfileToken.clients[1].profileToken =
+    duplicateProfileToken.clients[0].profileToken;
+  duplicateCases.push(duplicateProfileToken);
+
+  const overlappingPairIdentity = fixture();
+  overlappingPairIdentity.pairId = RUN_ID;
+  duplicateCases.push(overlappingPairIdentity);
+
+  for (const value of duplicateCases) {
+    assertThrows(
+      () => createOfflineFakeG5DesktopTwoClientExecutor(fixtureJson(value)),
+      Error,
+      "G5 offline fixture input was rejected",
+    );
+  }
+});
+
+Deno.test("offline fixture rejects noncanonical or non-fictional input before construction", () => {
+  const oneClient = fixture();
+  const oneClientJson = JSON.stringify({
+    ...oneClient,
+    clients: [oneClient.clients[0]],
+  });
+  const threeClients = fixture();
+  const threeClientJson = JSON.stringify({
+    ...threeClients,
+    clients: [
+      ...threeClients.clients,
+      client(
+        "g5-client-c",
+        4_203,
+        28_293,
+        "g5-profile-token-c",
+        "g5-capture-proof-c",
+        "g5-termination-proof-c",
+      ),
+    ],
+  });
+  const nonFictional = fixture();
+  nonFictional.clients[1].fictional = false;
+  const whitespaceVariant = ` ${fixtureJson()}`;
+
+  for (
+    const input of [
+      oneClientJson,
+      threeClientJson,
+      fixtureJson(nonFictional),
+      whitespaceVariant,
+    ]
+  ) {
+    assertThrows(
+      () => createOfflineFakeG5DesktopTwoClientExecutor(input),
+      Error,
+      "G5 offline fixture input was rejected",
+    );
+  }
+});
+
+Deno.test("offline fixture is single-use", () => {
+  const executor = createOfflineFakeG5DesktopTwoClientExecutor(fixtureJson());
+
+  executor.consumeFixture();
+  assertThrows(
+    () => executor.consumeFixture(),
+    Error,
+    "G5 offline fixture is single-use",
+  );
+});
+
+Deno.test("offline fixture has no executable imports, capabilities, or live surface", async () => {
   const source = await Deno.readTextFile(
     new URL("./g5_desktop_two_client_executor.ts", import.meta.url),
   );
 
+  assertEquals(
+    source.match(/from\s+"[^"]+"/gu),
+    ['from "./g5_desktop_two_client_lifecycle_contract.ts"'],
+  );
   for (
     const forbidden of [
-      "Deno.Command",
-      ".spawn(",
-      "Deno.env",
-      "Deno.connect",
-      "Deno.listen",
+      "./browser_launcher.ts",
+      "./g5_desktop_process_controller.ts",
+      "createG5DesktopProcessController",
+      "G5DesktopLaunchSupervisor",
+      "Deno.",
+      "async ",
+      "await ",
+      "Promise",
+      "=>",
+      "import(",
+      "eval(",
+      "Function(",
       "fetch(",
       "WebSocket",
+      "child_process",
       "startIsolatedBrowser",
       "createIsolatedBrowserLaunch",
-      "Marionette",
+      "supervisor",
+      "callback",
+      "dependencies",
+      "session",
+      "browser",
       "FxA",
       "Sync",
       "credential",
       "password",
+      "test-accounts",
       "process.env",
     ]
   ) {

--- a/tools/src/g5_desktop_two_client_executor.test.ts
+++ b/tools/src/g5_desktop_two_client_executor.test.ts
@@ -13,6 +13,10 @@ const RUN_ID = "g5-run-20260814-003";
 const EXECUTOR_INSTANCE_ID = "g5-executor-20260814-003";
 const PAIR_ID = "g5-pair-20260814-003";
 const FIXTURE_SCHEMA = "floorp-g5-desktop-two-client-offline-fixture-v2";
+const MODULE_DECLARATION =
+  /^\s*(?:import|export)\s+((?:(?!;)[\s\S])*?)\s+from\s+["']([^"']+)["']\s*;/gmu;
+const TYPE_ONLY_NAMED_SPECIFIER =
+  /^type\s+[A-Za-z_$][\w$]*(?:\s+as\s+[A-Za-z_$][\w$]*)?$/u;
 
 interface MutableClientFixture {
   captureProofId: string;
@@ -104,6 +108,27 @@ function legacyClientKeyOrderJson(value: MutableFixture = fixture()): string {
     runId: value.runId,
     schemaVersion: value.schemaVersion,
   });
+}
+
+function isTypeOnlyModuleClause(clause: string): boolean {
+  const normalized = clause.replace(/\s+/gu, " ").trim();
+  if (normalized.startsWith("type ")) return true;
+  if (!normalized.startsWith("{") || !normalized.endsWith("}")) {
+    return false;
+  }
+  const namedSpecifiers = normalized.slice(1, -1).split(",").map((specifier) =>
+    specifier.trim()
+  ).filter((specifier) => specifier.length > 0);
+  return namedSpecifiers.length > 0 &&
+    namedSpecifiers.every((specifier) =>
+      TYPE_ONLY_NAMED_SPECIFIER.test(specifier)
+    );
+}
+
+function runtimeModuleSources(source: string): string[] {
+  return [...source.matchAll(MODULE_DECLARATION)].filter((match) =>
+    !isTypeOnlyModuleClause(match[1])
+  ).map((match) => match[2]);
 }
 
 Deno.test("offline fixture accepts exactly two fictional data clients and only returns a withheld G5 result", () => {
@@ -353,18 +378,37 @@ Deno.test("offline fixture is single-use", () => {
   );
 });
 
+Deno.test("offline fixture source scanner ignores type-only modules but retains runtime modules", () => {
+  const moduleSource = [
+    'import { RuntimeValue } from "./runtime.ts";',
+    'import type { TypeOnly } from "./types.ts";',
+    'import type DefaultType from "./default-type.ts";',
+    'import { type InlineType } from "./inline-types.ts";',
+    'export type { ExportedType } from "./export-types.ts";',
+    'export { type InlineExportedType } from "./inline-export-types.ts";',
+    'import { type InlineType, RuntimeValue } from "./mixed.ts";',
+    'export { type InlineExportedType, RuntimeValue } from "./mixed-export.ts";',
+    'export * from "./star.ts";',
+  ].join("\n");
+
+  assertEquals(
+    runtimeModuleSources(moduleSource),
+    [
+      "./runtime.ts",
+      "./mixed.ts",
+      "./mixed-export.ts",
+      "./star.ts",
+    ],
+  );
+});
+
 Deno.test("offline fixture has no executable imports, capabilities, or live surface", async () => {
   const source = await Deno.readTextFile(
     new URL("./g5_desktop_two_client_executor.ts", import.meta.url),
   );
 
-  const runtimeModuleSources = [
-    ...source.matchAll(
-      /^\s*(?:import|export)\s+(?!type\b)[\s\S]*?\sfrom\s+["']([^"']+)["'];/gmu,
-    ),
-  ].map((match) => match[1]);
   assertEquals(
-    runtimeModuleSources,
+    runtimeModuleSources(source),
     ["./g5_desktop_two_client_lifecycle_contract.ts"],
   );
   assertEquals(/^\s*import\s+["'][^"']+["'];/mu.test(source), false);

--- a/tools/src/g5_desktop_two_client_executor.test.ts
+++ b/tools/src/g5_desktop_two_client_executor.test.ts
@@ -18,8 +18,8 @@ interface MutableClientFixture {
   captureProofId: string;
   clientInstanceId: string;
   fictional: boolean;
-  profileToken: string;
   port: number;
+  profileToken: string;
   rootPid: number;
   rootProcessGeneration: string;
   terminationProofId: string;
@@ -46,8 +46,8 @@ function client(
     captureProofId,
     clientInstanceId,
     fictional: true,
-    profileToken,
     port,
+    profileToken,
     rootPid,
     rootProcessGeneration: `pid-${rootPid}-generation-987654321`,
     terminationProofId,
@@ -102,6 +102,21 @@ Deno.test("offline fixture accepts exactly two fictional data clients and only r
       lifecycle_validation: "accepted",
     },
   );
+});
+
+Deno.test("offline fixture accepts canonical client key order and distinct port/PID domains", () => {
+  const crossDomainValue = fixture();
+  crossDomainValue.clients[0].rootPid = crossDomainValue.clients[1].port;
+  crossDomainValue.clients[0].rootProcessGeneration = `pid-${
+    crossDomainValue.clients[0].rootPid
+  }-generation-987654321`;
+
+  const result = createOfflineFakeG5DesktopTwoClientExecutor(
+    fixtureJson(crossDomainValue),
+  ).consumeFixture();
+
+  assertEquals(result.execution_authorization, "not-granted");
+  assertEquals(result.g5_result, "not-assessed");
 });
 
 Deno.test("offline fixture rejects arbitrary functions without invoking them", () => {
@@ -252,6 +267,26 @@ Deno.test("offline fixture rejects noncanonical or non-fictional input before co
   });
   const nonFictional = fixture();
   nonFictional.clients[1].fictional = false;
+  const belowPortRange = fixture();
+  belowPortRange.clients[0].port = 1_023;
+  const abovePortRange = fixture();
+  abovePortRange.clients[0].port = 65_536;
+  const zeroRootPid = fixture();
+  zeroRootPid.clients[0].rootPid = 0;
+  const negativeRootPid = fixture();
+  negativeRootPid.clients[0].rootPid = -1;
+  const fractionalRootPid = fixture();
+  fractionalRootPid.clients[0].rootPid = 4_201.5;
+  const nonAscendingClientIds = fixture();
+  nonAscendingClientIds.clients[0].clientInstanceId = "g5-client-z";
+  const extraClientProperty = fixture();
+  (extraClientProperty.clients[1] as unknown as Record<string, unknown>).extra =
+    "unexpected";
+  const missingClientProperty = fixture();
+  delete (missingClientProperty.clients[1] as unknown as Record<
+    string,
+    unknown
+  >).terminationProofId;
   const whitespaceVariant = ` ${fixtureJson()}`;
 
   for (
@@ -259,6 +294,14 @@ Deno.test("offline fixture rejects noncanonical or non-fictional input before co
       oneClientJson,
       threeClientJson,
       fixtureJson(nonFictional),
+      fixtureJson(belowPortRange),
+      fixtureJson(abovePortRange),
+      fixtureJson(zeroRootPid),
+      fixtureJson(negativeRootPid),
+      fixtureJson(fractionalRootPid),
+      fixtureJson(nonAscendingClientIds),
+      fixtureJson(extraClientProperty),
+      fixtureJson(missingClientProperty),
       whitespaceVariant,
     ]
   ) {
@@ -287,8 +330,8 @@ Deno.test("offline fixture has no executable imports, capabilities, or live surf
   );
 
   assertEquals(
-    source.match(/from\s+"[^"]+"/gu),
-    ['from "./g5_desktop_two_client_lifecycle_contract.ts"'],
+    source.includes('from "./g5_desktop_two_client_lifecycle_contract.ts"'),
+    true,
   );
   for (
     const forbidden of [
@@ -297,10 +340,6 @@ Deno.test("offline fixture has no executable imports, capabilities, or live surf
       "createG5DesktopProcessController",
       "G5DesktopLaunchSupervisor",
       "Deno.",
-      "async ",
-      "await ",
-      "Promise",
-      "=>",
       "import(",
       "eval(",
       "Function(",
@@ -309,13 +348,7 @@ Deno.test("offline fixture has no executable imports, capabilities, or live surf
       "child_process",
       "startIsolatedBrowser",
       "createIsolatedBrowserLaunch",
-      "supervisor",
-      "callback",
-      "dependencies",
-      "session",
-      "browser",
-      "FxA",
-      "Sync",
+      "new RegExp(",
       "credential",
       "password",
       "test-accounts",

--- a/tools/src/g5_desktop_two_client_executor.ts
+++ b/tools/src/g5_desktop_two_client_executor.ts
@@ -1,93 +1,42 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import {
-  assessG5ExecutionBoundary,
-  type G5BoundaryAssessment,
-} from "./g5_execution_boundary.ts";
-import {
-  createG5DesktopProcessController,
-  type G5DesktopLaunchSupervisor,
-} from "./g5_desktop_process_controller.ts";
-import {
   assessG5DesktopTwoClientLifecycleEvidence,
-  type G5DesktopTwoClientLifecycleAssessment,
+  FLOORP_G5_TWO_CLIENT_LIFECYCLE_SCHEMA,
 } from "./g5_desktop_two_client_lifecycle_contract.ts";
-import type {
-  IsolatedBrowserChild,
-  IsolatedBrowserLaunchView,
-  IsolatedBrowserProcessControl,
-  IsolatedBrowserProcessOwnership,
-} from "./browser_launcher.ts";
 
 export const G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY =
-  "offline-fake-only-v1" as const;
+  "offline-fictional-fixture-v2" as const;
 
-export interface G5DesktopOfflineFakeClientPlan {
+export interface G5DesktopOfflineFakeResult {
+  readonly evidenceJson: string;
+  readonly execution_authorization: "not-granted";
+  readonly g5_result: "not-assessed";
+}
+
+export interface G5DesktopOfflineFakeTwoClientExecutor {
+  consumeFixture(): G5DesktopOfflineFakeResult;
+}
+
+interface ParsedClientFixture {
   readonly captureProofId: string;
   readonly clientInstanceId: string;
+  readonly profileToken: string;
+  readonly port: number;
+  readonly rootPid: number;
   readonly rootProcessGeneration: string;
   readonly terminationProofId: string;
 }
 
-export interface G5DesktopOfflineFakeStartRequest {
-  readonly client: G5DesktopOfflineFakeClientPlan;
-  readonly executorInstanceId: string;
-  readonly pairId: string;
-  readonly runId: string;
-  readonly slot: "first" | "second";
-}
-
-export interface G5DesktopOfflineFakeClientSession {
-  readonly child: IsolatedBrowserChild;
-  readonly launch: IsolatedBrowserLaunchView;
-}
-
-export interface G5DesktopOfflineFakeDependencies {
-  readonly startClient: (
-    request: G5DesktopOfflineFakeStartRequest,
-  ) => Promise<unknown>;
-  readonly supervisor: G5DesktopLaunchSupervisor;
-}
-
-export interface G5DesktopOfflineFakeTwoClientExecutor {
-  readonly runFakeLifecycle: () => Promise<G5DesktopOfflineFakeResult>;
-}
-
-export interface G5DesktopOfflineFakeResult {
-  readonly boundary: G5BoundaryAssessment;
-  readonly execution_authorization: "not-granted";
-  readonly g5_result: "not-assessed";
-  readonly lifecycle: G5DesktopTwoClientLifecycleAssessment;
-  readonly mode: typeof G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY;
-}
-
-interface ParsedOptions {
-  readonly clients: readonly [
-    G5DesktopOfflineFakeClientPlan,
-    G5DesktopOfflineFakeClientPlan,
-  ];
-  readonly dependencies: G5DesktopOfflineFakeDependencies;
+interface ParsedFixture {
+  readonly clients: readonly [ParsedClientFixture, ParsedClientFixture];
   readonly executorInstanceId: string;
   readonly pairId: string;
   readonly runId: string;
 }
 
-interface ParsedFakeClientSession {
-  readonly child: IsolatedBrowserChild;
-  readonly launch: IsolatedBrowserLaunchView;
-}
-
-interface StartedFakeClient {
-  readonly plan: G5DesktopOfflineFakeClientPlan;
-  readonly session: ParsedFakeClientSession;
-}
-
-interface CapturedFakeClient extends StartedFakeClient {
-  readonly ownership: IsolatedBrowserProcessOwnership;
-}
-
+const FIXTURE_SCHEMA = "floorp-g5-desktop-two-client-offline-fixture-v2";
 const OPAQUE_IDENTIFIER = /^[a-z0-9][a-z0-9._:-]{0,127}$/iu;
-const INERT_SPAWN_DEPENDENCIES = Object.freeze({});
 
 function exactDataProperties(
   value: unknown,
@@ -98,30 +47,18 @@ function exactDataProperties(
   ) {
     return undefined;
   }
-  try {
-    const record = value as Record<string, unknown>;
-    if (Object.getPrototypeOf(record) !== Object.prototype) return undefined;
-    const keys = Reflect.ownKeys(record);
-    if (
-      keys.length !== expectedKeys.length ||
-      !keys.every((key) =>
-        typeof key === "string" && expectedKeys.includes(key)
-      )
-    ) {
-      return undefined;
-    }
-    const copied: Record<string, unknown> = {};
-    for (const key of expectedKeys) {
-      const descriptor = Object.getOwnPropertyDescriptor(record, key);
-      if (descriptor === undefined || !("value" in descriptor)) {
-        return undefined;
-      }
-      copied[key] = descriptor.value;
-    }
-    return copied;
-  } catch {
-    return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length !== expectedKeys.length) return undefined;
+  for (const key of keys) {
+    if (!expectedKeys.includes(key)) return undefined;
   }
+  const copied: Record<string, unknown> = {};
+  for (const key of expectedKeys) {
+    if (!Object.hasOwn(record, key)) return undefined;
+    copied[key] = record[key];
+  }
+  return copied;
 }
 
 function isOpaqueIdentifier(value: unknown): value is string {
@@ -145,366 +82,217 @@ function isHighResolutionGeneration(
     new RegExp(`^pid-${rootPid}-generation-[0-9]{9,}$`, "u").test(value);
 }
 
-function parseClientPlan(
-  value: unknown,
-): G5DesktopOfflineFakeClientPlan | undefined {
-  const plan = exactDataProperties(value, [
+function parseClientFixture(value: unknown): ParsedClientFixture | undefined {
+  const client = exactDataProperties(value, [
     "captureProofId",
     "clientInstanceId",
+    "fictional",
+    "profileToken",
+    "port",
+    "rootPid",
     "rootProcessGeneration",
     "terminationProofId",
   ]);
   if (
-    plan === undefined || !isOpaqueIdentifier(plan.captureProofId) ||
-    !isOpaqueIdentifier(plan.clientInstanceId) ||
-    !isOpaqueIdentifier(plan.rootProcessGeneration) ||
-    !isOpaqueIdentifier(plan.terminationProofId)
+    client === undefined || client.fictional !== true ||
+    !isOpaqueIdentifier(client.captureProofId) ||
+    !isOpaqueIdentifier(client.clientInstanceId) ||
+    !isOpaqueIdentifier(client.profileToken) || !isPort(client.port) ||
+    !isRootPid(client.rootPid) ||
+    !isHighResolutionGeneration(
+      client.rootProcessGeneration,
+      client.rootPid,
+    ) || !isOpaqueIdentifier(client.terminationProofId)
   ) {
     return undefined;
   }
-  return Object.freeze({
-    captureProofId: plan.captureProofId,
-    clientInstanceId: plan.clientInstanceId,
-    rootProcessGeneration: plan.rootProcessGeneration,
-    terminationProofId: plan.terminationProofId,
-  });
+  return {
+    captureProofId: client.captureProofId,
+    clientInstanceId: client.clientInstanceId,
+    profileToken: client.profileToken,
+    port: client.port,
+    rootPid: client.rootPid,
+    rootProcessGeneration: client.rootProcessGeneration,
+    terminationProofId: client.terminationProofId,
+  };
 }
 
-function parseSupervisor(
-  value: unknown,
-): G5DesktopLaunchSupervisor | undefined {
-  const supervisor = exactDataProperties(value, ["abort", "capture", "stop"]);
-  if (
-    supervisor === undefined || typeof supervisor.abort !== "function" ||
-    typeof supervisor.capture !== "function" ||
-    typeof supervisor.stop !== "function"
-  ) {
-    return undefined;
-  }
-  return Object.freeze({
-    abort: supervisor.abort as G5DesktopLaunchSupervisor["abort"],
-    capture: supervisor.capture as G5DesktopLaunchSupervisor["capture"],
-    stop: supervisor.stop as G5DesktopLaunchSupervisor["stop"],
-  });
-}
-
-function parseOptions(value: unknown): ParsedOptions | undefined {
-  const options = exactDataProperties(value, [
+function parseFixture(value: unknown): ParsedFixture | undefined {
+  const fixture = exactDataProperties(value, [
     "clients",
-    "dependencies",
     "executorInstanceId",
     "mode",
     "pairId",
     "runId",
+    "schemaVersion",
   ]);
   if (
-    options === undefined ||
-    options.mode !== G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY ||
-    !isOpaqueIdentifier(options.executorInstanceId) ||
-    !isOpaqueIdentifier(options.pairId) || !isOpaqueIdentifier(options.runId) ||
-    !Array.isArray(options.clients) || options.clients.length !== 2
+    fixture === undefined ||
+    fixture.mode !== G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY ||
+    fixture.schemaVersion !== FIXTURE_SCHEMA ||
+    !isOpaqueIdentifier(fixture.executorInstanceId) ||
+    !isOpaqueIdentifier(fixture.pairId) || !isOpaqueIdentifier(fixture.runId) ||
+    !Array.isArray(fixture.clients) || fixture.clients.length !== 2
   ) {
     return undefined;
   }
-  const first = parseClientPlan(options.clients[0]);
-  const second = parseClientPlan(options.clients[1]);
-  const dependencies = exactDataProperties(options.dependencies, [
-    "startClient",
-    "supervisor",
-  ]);
-  const supervisor = dependencies === undefined
-    ? undefined
-    : parseSupervisor(dependencies.supervisor);
-  if (
-    first === undefined || second === undefined || dependencies === undefined ||
-    typeof dependencies.startClient !== "function" || supervisor === undefined
-  ) {
-    return undefined;
-  }
-  return Object.freeze({
-    clients: Object.freeze([first, second]) as readonly [
-      G5DesktopOfflineFakeClientPlan,
-      G5DesktopOfflineFakeClientPlan,
-    ],
-    dependencies: Object.freeze({
-      startClient: dependencies.startClient as G5DesktopOfflineFakeDependencies[
-        "startClient"
-      ],
-      supervisor,
-    }),
-    executorInstanceId: options.executorInstanceId,
-    pairId: options.pairId,
-    runId: options.runId,
-  });
-}
-
-function hasDistinctIdentityBindings(options: ParsedOptions): boolean {
-  const [first, second] = options.clients;
-  const identifiers = [
-    options.executorInstanceId,
-    options.pairId,
-    options.runId,
+  const first = parseClientFixture(fixture.clients[0]);
+  const second = parseClientFixture(fixture.clients[1]);
+  if (first === undefined || second === undefined) return undefined;
+  const strings = [
+    fixture.executorInstanceId,
+    fixture.pairId,
+    fixture.runId,
     first.captureProofId,
     first.clientInstanceId,
+    first.profileToken,
+    first.rootProcessGeneration,
     first.terminationProofId,
     second.captureProofId,
     second.clientInstanceId,
+    second.profileToken,
+    second.rootProcessGeneration,
     second.terminationProofId,
   ];
-  return first.clientInstanceId < second.clientInstanceId &&
-    new Set(identifiers).size === identifiers.length;
-}
-
-function parseFakeClientSession(
-  value: unknown,
-): ParsedFakeClientSession | undefined {
-  const session = exactDataProperties(value, ["child", "launch"]);
-  const fakeChild = session === undefined
-    ? undefined
-    : exactDataProperties(session.child, ["kill", "pid", "status"]);
-  const fakeLaunch = session === undefined
-    ? undefined
-    : exactDataProperties(session.launch, ["command", "port", "profilePath"]);
+  const numbers = [first.port, first.rootPid, second.port, second.rootPid];
   if (
-    session === undefined || fakeChild === undefined ||
-    fakeLaunch === undefined ||
-    typeof fakeChild.kill !== "function" || !isRootPid(fakeChild.pid) ||
-    !Array.isArray(fakeLaunch.command) ||
-    !fakeLaunch.command.every((argument) => typeof argument === "string") ||
-    !isPort(fakeLaunch.port) || typeof fakeLaunch.profilePath !== "string"
+    first.clientInstanceId >= second.clientInstanceId ||
+    new Set(strings).size !== strings.length ||
+    new Set(numbers).size !== numbers.length
   ) {
     return undefined;
   }
-  return Object.freeze({
-    child: session.child as IsolatedBrowserChild,
-    launch: session.launch as IsolatedBrowserLaunchView,
-  });
+  return {
+    clients: [first, second],
+    executorInstanceId: fixture.executorInstanceId,
+    pairId: fixture.pairId,
+    runId: fixture.runId,
+  };
 }
 
-function assertSessionMatchesPlan(
-  session: ParsedFakeClientSession,
-  plan: G5DesktopOfflineFakeClientPlan,
-): void {
-  if (
-    !isHighResolutionGeneration(plan.rootProcessGeneration, session.child.pid)
-  ) {
-    throw new Error("G5 offline fake client session was rejected");
-  }
+function canonicalClientFixture(
+  client: ParsedClientFixture,
+): Record<string, unknown> {
+  return {
+    captureProofId: client.captureProofId,
+    clientInstanceId: client.clientInstanceId,
+    fictional: true,
+    profileToken: client.profileToken,
+    port: client.port,
+    rootPid: client.rootPid,
+    rootProcessGeneration: client.rootProcessGeneration,
+    terminationProofId: client.terminationProofId,
+  };
 }
 
-function blockedBoundary(
-  runId: string,
-  executorInstanceId: string,
-): G5BoundaryAssessment {
-  return assessG5ExecutionBoundary(JSON.stringify({
-    host: "unknown",
-    runId,
-    supervision: {
-      descendants: "escaped-or-unprovable",
-      eventStream: "lost-or-unknown",
-      kind: "unknown",
-      pidGeneration: "coarse-or-unknown",
-    },
-    executorInstanceId,
-  }));
-}
-
-function lifecycleJson(
-  options: ParsedOptions,
-  clients: readonly [CapturedFakeClient, CapturedFakeClient],
-): string {
+function canonicalFixtureJson(fixture: ParsedFixture): string {
   return JSON.stringify({
-    clients: clients.map(({ plan, session }) => ({
-      captureProof: {
-        clientInstanceId: plan.clientInstanceId,
-        descendantOwnership: "causally-complete",
-        eventStream: "complete",
-        executorInstanceId: options.executorInstanceId,
-        marionettePort: session.launch.port,
-        operation: "capture",
-        pairId: options.pairId,
-        pidGeneration: "high-resolution",
-        proofId: plan.captureProofId,
-        rootPid: session.child.pid,
-        rootProcessGeneration: plan.rootProcessGeneration,
-        runId: options.runId,
-      },
-      terminationProof: {
-        captureProofId: plan.captureProofId,
-        clientInstanceId: plan.clientInstanceId,
-        descendantOwnership: "causally-complete",
-        eventStream: "complete",
-        executorInstanceId: options.executorInstanceId,
-        marionettePort: session.launch.port,
-        marionettePortState: "absent",
-        operation: "stop",
-        operationResult: "stopped",
-        ownedTree: "absent",
-        pairId: options.pairId,
-        pidGeneration: "high-resolution",
-        proofId: plan.terminationProofId,
-        rootPid: session.child.pid,
-        rootProcessGeneration: plan.rootProcessGeneration,
-        runId: options.runId,
-      },
-    })),
-    executorInstanceId: options.executorInstanceId,
-    pairId: options.pairId,
-    runId: options.runId,
-    schemaVersion: "floorp-g5-desktop-two-client-lifecycle-v1",
+    clients: [
+      canonicalClientFixture(fixture.clients[0]),
+      canonicalClientFixture(fixture.clients[1]),
+    ],
+    executorInstanceId: fixture.executorInstanceId,
+    mode: G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
+    pairId: fixture.pairId,
+    runId: fixture.runId,
+    schemaVersion: FIXTURE_SCHEMA,
   });
 }
 
-async function abortStartedClients(
-  controller: IsolatedBrowserProcessControl,
-  clients: readonly StartedFakeClient[],
-): Promise<readonly unknown[]> {
-  const results = await Promise.allSettled(
-    [...clients].reverse().map(({ session }) =>
-      controller.abort(
-        session.child,
-        session.launch,
-        INERT_SPAWN_DEPENDENCIES,
-      )
-    ),
-  );
-  return results.flatMap((result) =>
-    result.status === "rejected" ? [result.reason] : []
-  );
+function parseCanonicalFixtureJson(value: unknown): ParsedFixture | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const fixture = parseFixture(JSON.parse(value));
+    return fixture === undefined || value !== canonicalFixtureJson(fixture)
+      ? undefined
+      : fixture;
+  } catch {
+    return undefined;
+  }
 }
 
-async function startAndCapture(
-  options: ParsedOptions,
-  controller: IsolatedBrowserProcessControl,
-  plan: G5DesktopOfflineFakeClientPlan,
-  slot: "first" | "second",
-  started: StartedFakeClient[],
-): Promise<CapturedFakeClient> {
-  const rawSession = await options.dependencies.startClient(Object.freeze({
-    client: plan,
-    executorInstanceId: options.executorInstanceId,
-    pairId: options.pairId,
-    runId: options.runId,
-    slot,
-  }));
-  const session = parseFakeClientSession(rawSession);
-  if (session === undefined) {
-    throw new Error("G5 offline fake client session was rejected");
-  }
-  assertSessionMatchesPlan(session, plan);
-  const startedClient = Object.freeze({ plan, session });
-  started.push(startedClient);
-  const ownership = await controller.capture(
-    session.child,
-    session.launch,
-    "darwin",
-  );
-  return Object.freeze({ ...startedClient, ownership });
+function canonicalClientLifecycle(
+  fixture: ParsedFixture,
+  client: ParsedClientFixture,
+): Record<string, unknown> {
+  return {
+    captureProof: {
+      clientInstanceId: client.clientInstanceId,
+      descendantOwnership: "causally-complete",
+      eventStream: "complete",
+      executorInstanceId: fixture.executorInstanceId,
+      marionettePort: client.port,
+      operation: "capture",
+      pairId: fixture.pairId,
+      pidGeneration: "high-resolution",
+      proofId: client.captureProofId,
+      rootPid: client.rootPid,
+      rootProcessGeneration: client.rootProcessGeneration,
+      runId: fixture.runId,
+    },
+    terminationProof: {
+      captureProofId: client.captureProofId,
+      clientInstanceId: client.clientInstanceId,
+      descendantOwnership: "causally-complete",
+      eventStream: "complete",
+      executorInstanceId: fixture.executorInstanceId,
+      marionettePort: client.port,
+      marionettePortState: "absent",
+      operation: "stop",
+      operationResult: "stopped",
+      ownedTree: "absent",
+      pairId: fixture.pairId,
+      pidGeneration: "high-resolution",
+      proofId: client.terminationProofId,
+      rootPid: client.rootPid,
+      rootProcessGeneration: client.rootProcessGeneration,
+      runId: fixture.runId,
+    },
+  };
 }
 
-async function stopCapturedClients(
-  controller: IsolatedBrowserProcessControl,
-  clients: readonly [CapturedFakeClient, CapturedFakeClient],
-): Promise<void> {
-  const results = await Promise.allSettled(
-    clients.map(({ ownership, session }) =>
-      controller.stop(
-        session.child,
-        session.launch,
-        ownership,
-        INERT_SPAWN_DEPENDENCIES,
-      )
-    ),
-  );
-  const failures = results.flatMap((result) =>
-    result.status === "rejected" ? [result.reason] : []
-  );
-  if (failures.length > 0) {
-    throw new AggregateError(
-      failures,
-      "Failed to stop offline fake G5 desktop clients",
-    );
-  }
+function canonicalLifecycleEvidenceJson(fixture: ParsedFixture): string {
+  return JSON.stringify({
+    clients: [
+      canonicalClientLifecycle(fixture, fixture.clients[0]),
+      canonicalClientLifecycle(fixture, fixture.clients[1]),
+    ],
+    executorInstanceId: fixture.executorInstanceId,
+    pairId: fixture.pairId,
+    runId: fixture.runId,
+    schemaVersion: FLOORP_G5_TWO_CLIENT_LIFECYCLE_SCHEMA,
+  });
 }
 
 /**
- * Creates a single-use, data-only lifecycle exercise. Its only interactions
- * are the supplied fake callbacks; it has no built-in execution capability.
+ * Accepts canonical JSON only, validates a fictional two-client fixture at
+ * construction, and exposes one irreversible data-only consumption step.
  */
 export function createOfflineFakeG5DesktopTwoClientExecutor(
-  options: unknown,
+  fixtureJson: unknown,
 ): G5DesktopOfflineFakeTwoClientExecutor {
-  const parsed = parseOptions(options);
-  if (parsed === undefined) {
-    throw new Error(
-      "G5 offline fake two-client executor configuration is invalid",
-    );
+  const fixture = parseCanonicalFixtureJson(fixtureJson);
+  if (fixture === undefined) {
+    throw new Error("G5 offline fixture input was rejected");
   }
-  if (!hasDistinctIdentityBindings(parsed)) {
-    throw new Error(
-      "G5 offline fake two-client identity invariants were rejected",
-    );
+  const evidenceJson = canonicalLifecycleEvidenceJson(fixture);
+  const lifecycle = assessG5DesktopTwoClientLifecycleEvidence(evidenceJson);
+  if (
+    lifecycle.lifecycle_validation !== "accepted" ||
+    lifecycle.execution_authorization !== "not-granted" ||
+    lifecycle.g5_result !== "not-assessed"
+  ) {
+    throw new Error("G5 offline fixture lifecycle data was rejected");
   }
-  const controller = createG5DesktopProcessController({
-    executorInstanceId: parsed.executorInstanceId,
-    runId: parsed.runId,
-    supervisor: parsed.dependencies.supervisor,
-  });
   let consumed = false;
-
   return Object.freeze({
-    async runFakeLifecycle(): Promise<G5DesktopOfflineFakeResult> {
-      if (consumed) {
-        throw new Error("G5 offline fake two-client executor is single-use");
-      }
+    consumeFixture(): G5DesktopOfflineFakeResult {
+      if (consumed) throw new Error("G5 offline fixture is single-use");
       consumed = true;
-      const boundary = blockedBoundary(parsed.runId, parsed.executorInstanceId);
-      const started: StartedFakeClient[] = [];
-      let first: CapturedFakeClient;
-      let second: CapturedFakeClient;
-      try {
-        first = await startAndCapture(
-          parsed,
-          controller,
-          parsed.clients[0],
-          "first",
-          started,
-        );
-        second = await startAndCapture(
-          parsed,
-          controller,
-          parsed.clients[1],
-          "second",
-          started,
-        );
-      } catch (startupFailure) {
-        const cleanupFailures = await abortStartedClients(controller, started);
-        if (cleanupFailures.length > 0) {
-          throw new AggregateError(
-            [startupFailure, ...cleanupFailures],
-            "Failed to clean up offline fake G5 desktop startup",
-          );
-        }
-        throw startupFailure;
-      }
-
-      const clients: readonly [CapturedFakeClient, CapturedFakeClient] = [
-        first,
-        second,
-      ];
-      await stopCapturedClients(controller, clients);
-      const lifecycle = assessG5DesktopTwoClientLifecycleEvidence(
-        lifecycleJson(parsed, clients),
-      );
-      if (lifecycle.lifecycle_validation !== "accepted") {
-        throw new Error("G5 offline fake lifecycle data was rejected");
-      }
       return Object.freeze({
-        boundary,
+        evidenceJson,
         execution_authorization: "not-granted" as const,
         g5_result: "not-assessed" as const,
-        lifecycle,
-        mode: G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
       });
     },
   });

--- a/tools/src/g5_desktop_two_client_executor.ts
+++ b/tools/src/g5_desktop_two_client_executor.ts
@@ -21,8 +21,8 @@ export interface G5DesktopOfflineFakeTwoClientExecutor {
 interface ParsedClientFixture {
   readonly captureProofId: string;
   readonly clientInstanceId: string;
-  readonly profileToken: string;
   readonly port: number;
+  readonly profileToken: string;
   readonly rootPid: number;
   readonly rootProcessGeneration: string;
   readonly terminationProofId: string;
@@ -37,6 +37,7 @@ interface ParsedFixture {
 
 const FIXTURE_SCHEMA = "floorp-g5-desktop-two-client-offline-fixture-v2";
 const OPAQUE_IDENTIFIER = /^[a-z0-9][a-z0-9._:-]{0,127}$/iu;
+const HIGH_RESOLUTION_GENERATION = /^pid-([1-9][0-9]*)-generation-[0-9]{9,}$/u;
 
 function exactDataProperties(
   value: unknown,
@@ -78,8 +79,9 @@ function isHighResolutionGeneration(
   value: unknown,
   rootPid: number,
 ): value is string {
-  return typeof value === "string" &&
-    new RegExp(`^pid-${rootPid}-generation-[0-9]{9,}$`, "u").test(value);
+  if (typeof value !== "string") return false;
+  const match = HIGH_RESOLUTION_GENERATION.exec(value);
+  return match !== null && match[1] === String(rootPid);
 }
 
 function parseClientFixture(value: unknown): ParsedClientFixture | undefined {
@@ -87,8 +89,8 @@ function parseClientFixture(value: unknown): ParsedClientFixture | undefined {
     "captureProofId",
     "clientInstanceId",
     "fictional",
-    "profileToken",
     "port",
+    "profileToken",
     "rootPid",
     "rootProcessGeneration",
     "terminationProofId",
@@ -97,7 +99,7 @@ function parseClientFixture(value: unknown): ParsedClientFixture | undefined {
     client === undefined || client.fictional !== true ||
     !isOpaqueIdentifier(client.captureProofId) ||
     !isOpaqueIdentifier(client.clientInstanceId) ||
-    !isOpaqueIdentifier(client.profileToken) || !isPort(client.port) ||
+    !isPort(client.port) || !isOpaqueIdentifier(client.profileToken) ||
     !isRootPid(client.rootPid) ||
     !isHighResolutionGeneration(
       client.rootProcessGeneration,
@@ -109,8 +111,8 @@ function parseClientFixture(value: unknown): ParsedClientFixture | undefined {
   return {
     captureProofId: client.captureProofId,
     clientInstanceId: client.clientInstanceId,
-    profileToken: client.profileToken,
     port: client.port,
+    profileToken: client.profileToken,
     rootPid: client.rootPid,
     rootProcessGeneration: client.rootProcessGeneration,
     terminationProofId: client.terminationProofId,
@@ -154,11 +156,13 @@ function parseFixture(value: unknown): ParsedFixture | undefined {
     second.rootProcessGeneration,
     second.terminationProofId,
   ];
-  const numbers = [first.port, first.rootPid, second.port, second.rootPid];
+  const ports = [first.port, second.port];
+  const rootPids = [first.rootPid, second.rootPid];
   if (
     first.clientInstanceId >= second.clientInstanceId ||
     new Set(strings).size !== strings.length ||
-    new Set(numbers).size !== numbers.length
+    new Set(ports).size !== ports.length ||
+    new Set(rootPids).size !== rootPids.length
   ) {
     return undefined;
   }
@@ -177,8 +181,8 @@ function canonicalClientFixture(
     captureProofId: client.captureProofId,
     clientInstanceId: client.clientInstanceId,
     fictional: true,
-    profileToken: client.profileToken,
     port: client.port,
+    profileToken: client.profileToken,
     rootPid: client.rootPid,
     rootProcessGeneration: client.rootProcessGeneration,
     terminationProofId: client.terminationProofId,

--- a/tools/src/g5_desktop_two_client_executor.ts
+++ b/tools/src/g5_desktop_two_client_executor.ts
@@ -1,0 +1,511 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import {
+  assessG5ExecutionBoundary,
+  type G5BoundaryAssessment,
+} from "./g5_execution_boundary.ts";
+import {
+  createG5DesktopProcessController,
+  type G5DesktopLaunchSupervisor,
+} from "./g5_desktop_process_controller.ts";
+import {
+  assessG5DesktopTwoClientLifecycleEvidence,
+  type G5DesktopTwoClientLifecycleAssessment,
+} from "./g5_desktop_two_client_lifecycle_contract.ts";
+import type {
+  IsolatedBrowserChild,
+  IsolatedBrowserLaunchView,
+  IsolatedBrowserProcessControl,
+  IsolatedBrowserProcessOwnership,
+} from "./browser_launcher.ts";
+
+export const G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY =
+  "offline-fake-only-v1" as const;
+
+export interface G5DesktopOfflineFakeClientPlan {
+  readonly captureProofId: string;
+  readonly clientInstanceId: string;
+  readonly rootProcessGeneration: string;
+  readonly terminationProofId: string;
+}
+
+export interface G5DesktopOfflineFakeStartRequest {
+  readonly client: G5DesktopOfflineFakeClientPlan;
+  readonly executorInstanceId: string;
+  readonly pairId: string;
+  readonly runId: string;
+  readonly slot: "first" | "second";
+}
+
+export interface G5DesktopOfflineFakeClientSession {
+  readonly child: IsolatedBrowserChild;
+  readonly launch: IsolatedBrowserLaunchView;
+}
+
+export interface G5DesktopOfflineFakeDependencies {
+  readonly startClient: (
+    request: G5DesktopOfflineFakeStartRequest,
+  ) => Promise<unknown>;
+  readonly supervisor: G5DesktopLaunchSupervisor;
+}
+
+export interface G5DesktopOfflineFakeTwoClientExecutor {
+  readonly runFakeLifecycle: () => Promise<G5DesktopOfflineFakeResult>;
+}
+
+export interface G5DesktopOfflineFakeResult {
+  readonly boundary: G5BoundaryAssessment;
+  readonly execution_authorization: "not-granted";
+  readonly g5_result: "not-assessed";
+  readonly lifecycle: G5DesktopTwoClientLifecycleAssessment;
+  readonly mode: typeof G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY;
+}
+
+interface ParsedOptions {
+  readonly clients: readonly [
+    G5DesktopOfflineFakeClientPlan,
+    G5DesktopOfflineFakeClientPlan,
+  ];
+  readonly dependencies: G5DesktopOfflineFakeDependencies;
+  readonly executorInstanceId: string;
+  readonly pairId: string;
+  readonly runId: string;
+}
+
+interface ParsedFakeClientSession {
+  readonly child: IsolatedBrowserChild;
+  readonly launch: IsolatedBrowserLaunchView;
+}
+
+interface StartedFakeClient {
+  readonly plan: G5DesktopOfflineFakeClientPlan;
+  readonly session: ParsedFakeClientSession;
+}
+
+interface CapturedFakeClient extends StartedFakeClient {
+  readonly ownership: IsolatedBrowserProcessOwnership;
+}
+
+const OPAQUE_IDENTIFIER = /^[a-z0-9][a-z0-9._:-]{0,127}$/iu;
+const INERT_SPAWN_DEPENDENCIES = Object.freeze({});
+
+function exactDataProperties(
+  value: unknown,
+  expectedKeys: readonly string[],
+): Record<string, unknown> | undefined {
+  if (
+    typeof value !== "object" || value === null || Array.isArray(value)
+  ) {
+    return undefined;
+  }
+  try {
+    const record = value as Record<string, unknown>;
+    if (Object.getPrototypeOf(record) !== Object.prototype) return undefined;
+    const keys = Reflect.ownKeys(record);
+    if (
+      keys.length !== expectedKeys.length ||
+      !keys.every((key) =>
+        typeof key === "string" && expectedKeys.includes(key)
+      )
+    ) {
+      return undefined;
+    }
+    const copied: Record<string, unknown> = {};
+    for (const key of expectedKeys) {
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (descriptor === undefined || !("value" in descriptor)) {
+        return undefined;
+      }
+      copied[key] = descriptor.value;
+    }
+    return copied;
+  } catch {
+    return undefined;
+  }
+}
+
+function isOpaqueIdentifier(value: unknown): value is string {
+  return typeof value === "string" && OPAQUE_IDENTIFIER.test(value);
+}
+
+function isRootPid(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) &&
+    value >= 1_024 && value <= 65_535;
+}
+
+function isHighResolutionGeneration(
+  value: unknown,
+  rootPid: number,
+): value is string {
+  return typeof value === "string" &&
+    new RegExp(`^pid-${rootPid}-generation-[0-9]{9,}$`, "u").test(value);
+}
+
+function parseClientPlan(
+  value: unknown,
+): G5DesktopOfflineFakeClientPlan | undefined {
+  const plan = exactDataProperties(value, [
+    "captureProofId",
+    "clientInstanceId",
+    "rootProcessGeneration",
+    "terminationProofId",
+  ]);
+  if (
+    plan === undefined || !isOpaqueIdentifier(plan.captureProofId) ||
+    !isOpaqueIdentifier(plan.clientInstanceId) ||
+    !isOpaqueIdentifier(plan.rootProcessGeneration) ||
+    !isOpaqueIdentifier(plan.terminationProofId)
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    captureProofId: plan.captureProofId,
+    clientInstanceId: plan.clientInstanceId,
+    rootProcessGeneration: plan.rootProcessGeneration,
+    terminationProofId: plan.terminationProofId,
+  });
+}
+
+function parseSupervisor(
+  value: unknown,
+): G5DesktopLaunchSupervisor | undefined {
+  const supervisor = exactDataProperties(value, ["abort", "capture", "stop"]);
+  if (
+    supervisor === undefined || typeof supervisor.abort !== "function" ||
+    typeof supervisor.capture !== "function" ||
+    typeof supervisor.stop !== "function"
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    abort: supervisor.abort as G5DesktopLaunchSupervisor["abort"],
+    capture: supervisor.capture as G5DesktopLaunchSupervisor["capture"],
+    stop: supervisor.stop as G5DesktopLaunchSupervisor["stop"],
+  });
+}
+
+function parseOptions(value: unknown): ParsedOptions | undefined {
+  const options = exactDataProperties(value, [
+    "clients",
+    "dependencies",
+    "executorInstanceId",
+    "mode",
+    "pairId",
+    "runId",
+  ]);
+  if (
+    options === undefined ||
+    options.mode !== G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY ||
+    !isOpaqueIdentifier(options.executorInstanceId) ||
+    !isOpaqueIdentifier(options.pairId) || !isOpaqueIdentifier(options.runId) ||
+    !Array.isArray(options.clients) || options.clients.length !== 2
+  ) {
+    return undefined;
+  }
+  const first = parseClientPlan(options.clients[0]);
+  const second = parseClientPlan(options.clients[1]);
+  const dependencies = exactDataProperties(options.dependencies, [
+    "startClient",
+    "supervisor",
+  ]);
+  const supervisor = dependencies === undefined
+    ? undefined
+    : parseSupervisor(dependencies.supervisor);
+  if (
+    first === undefined || second === undefined || dependencies === undefined ||
+    typeof dependencies.startClient !== "function" || supervisor === undefined
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    clients: Object.freeze([first, second]) as readonly [
+      G5DesktopOfflineFakeClientPlan,
+      G5DesktopOfflineFakeClientPlan,
+    ],
+    dependencies: Object.freeze({
+      startClient: dependencies.startClient as G5DesktopOfflineFakeDependencies[
+        "startClient"
+      ],
+      supervisor,
+    }),
+    executorInstanceId: options.executorInstanceId,
+    pairId: options.pairId,
+    runId: options.runId,
+  });
+}
+
+function hasDistinctIdentityBindings(options: ParsedOptions): boolean {
+  const [first, second] = options.clients;
+  const identifiers = [
+    options.executorInstanceId,
+    options.pairId,
+    options.runId,
+    first.captureProofId,
+    first.clientInstanceId,
+    first.terminationProofId,
+    second.captureProofId,
+    second.clientInstanceId,
+    second.terminationProofId,
+  ];
+  return first.clientInstanceId < second.clientInstanceId &&
+    new Set(identifiers).size === identifiers.length;
+}
+
+function parseFakeClientSession(
+  value: unknown,
+): ParsedFakeClientSession | undefined {
+  const session = exactDataProperties(value, ["child", "launch"]);
+  const fakeChild = session === undefined
+    ? undefined
+    : exactDataProperties(session.child, ["kill", "pid", "status"]);
+  const fakeLaunch = session === undefined
+    ? undefined
+    : exactDataProperties(session.launch, ["command", "port", "profilePath"]);
+  if (
+    session === undefined || fakeChild === undefined ||
+    fakeLaunch === undefined ||
+    typeof fakeChild.kill !== "function" || !isRootPid(fakeChild.pid) ||
+    !Array.isArray(fakeLaunch.command) ||
+    !fakeLaunch.command.every((argument) => typeof argument === "string") ||
+    !isPort(fakeLaunch.port) || typeof fakeLaunch.profilePath !== "string"
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    child: session.child as IsolatedBrowserChild,
+    launch: session.launch as IsolatedBrowserLaunchView,
+  });
+}
+
+function assertSessionMatchesPlan(
+  session: ParsedFakeClientSession,
+  plan: G5DesktopOfflineFakeClientPlan,
+): void {
+  if (
+    !isHighResolutionGeneration(plan.rootProcessGeneration, session.child.pid)
+  ) {
+    throw new Error("G5 offline fake client session was rejected");
+  }
+}
+
+function blockedBoundary(
+  runId: string,
+  executorInstanceId: string,
+): G5BoundaryAssessment {
+  return assessG5ExecutionBoundary(JSON.stringify({
+    host: "unknown",
+    runId,
+    supervision: {
+      descendants: "escaped-or-unprovable",
+      eventStream: "lost-or-unknown",
+      kind: "unknown",
+      pidGeneration: "coarse-or-unknown",
+    },
+    executorInstanceId,
+  }));
+}
+
+function lifecycleJson(
+  options: ParsedOptions,
+  clients: readonly [CapturedFakeClient, CapturedFakeClient],
+): string {
+  return JSON.stringify({
+    clients: clients.map(({ plan, session }) => ({
+      captureProof: {
+        clientInstanceId: plan.clientInstanceId,
+        descendantOwnership: "causally-complete",
+        eventStream: "complete",
+        executorInstanceId: options.executorInstanceId,
+        marionettePort: session.launch.port,
+        operation: "capture",
+        pairId: options.pairId,
+        pidGeneration: "high-resolution",
+        proofId: plan.captureProofId,
+        rootPid: session.child.pid,
+        rootProcessGeneration: plan.rootProcessGeneration,
+        runId: options.runId,
+      },
+      terminationProof: {
+        captureProofId: plan.captureProofId,
+        clientInstanceId: plan.clientInstanceId,
+        descendantOwnership: "causally-complete",
+        eventStream: "complete",
+        executorInstanceId: options.executorInstanceId,
+        marionettePort: session.launch.port,
+        marionettePortState: "absent",
+        operation: "stop",
+        operationResult: "stopped",
+        ownedTree: "absent",
+        pairId: options.pairId,
+        pidGeneration: "high-resolution",
+        proofId: plan.terminationProofId,
+        rootPid: session.child.pid,
+        rootProcessGeneration: plan.rootProcessGeneration,
+        runId: options.runId,
+      },
+    })),
+    executorInstanceId: options.executorInstanceId,
+    pairId: options.pairId,
+    runId: options.runId,
+    schemaVersion: "floorp-g5-desktop-two-client-lifecycle-v1",
+  });
+}
+
+async function abortStartedClients(
+  controller: IsolatedBrowserProcessControl,
+  clients: readonly StartedFakeClient[],
+): Promise<readonly unknown[]> {
+  const results = await Promise.allSettled(
+    [...clients].reverse().map(({ session }) =>
+      controller.abort(
+        session.child,
+        session.launch,
+        INERT_SPAWN_DEPENDENCIES,
+      )
+    ),
+  );
+  return results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : []
+  );
+}
+
+async function startAndCapture(
+  options: ParsedOptions,
+  controller: IsolatedBrowserProcessControl,
+  plan: G5DesktopOfflineFakeClientPlan,
+  slot: "first" | "second",
+  started: StartedFakeClient[],
+): Promise<CapturedFakeClient> {
+  const rawSession = await options.dependencies.startClient(Object.freeze({
+    client: plan,
+    executorInstanceId: options.executorInstanceId,
+    pairId: options.pairId,
+    runId: options.runId,
+    slot,
+  }));
+  const session = parseFakeClientSession(rawSession);
+  if (session === undefined) {
+    throw new Error("G5 offline fake client session was rejected");
+  }
+  assertSessionMatchesPlan(session, plan);
+  const startedClient = Object.freeze({ plan, session });
+  started.push(startedClient);
+  const ownership = await controller.capture(
+    session.child,
+    session.launch,
+    "darwin",
+  );
+  return Object.freeze({ ...startedClient, ownership });
+}
+
+async function stopCapturedClients(
+  controller: IsolatedBrowserProcessControl,
+  clients: readonly [CapturedFakeClient, CapturedFakeClient],
+): Promise<void> {
+  const results = await Promise.allSettled(
+    clients.map(({ ownership, session }) =>
+      controller.stop(
+        session.child,
+        session.launch,
+        ownership,
+        INERT_SPAWN_DEPENDENCIES,
+      )
+    ),
+  );
+  const failures = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : []
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      "Failed to stop offline fake G5 desktop clients",
+    );
+  }
+}
+
+/**
+ * Creates a single-use, data-only lifecycle exercise. Its only interactions
+ * are the supplied fake callbacks; it has no built-in execution capability.
+ */
+export function createOfflineFakeG5DesktopTwoClientExecutor(
+  options: unknown,
+): G5DesktopOfflineFakeTwoClientExecutor {
+  const parsed = parseOptions(options);
+  if (parsed === undefined) {
+    throw new Error(
+      "G5 offline fake two-client executor configuration is invalid",
+    );
+  }
+  if (!hasDistinctIdentityBindings(parsed)) {
+    throw new Error(
+      "G5 offline fake two-client identity invariants were rejected",
+    );
+  }
+  const controller = createG5DesktopProcessController({
+    executorInstanceId: parsed.executorInstanceId,
+    runId: parsed.runId,
+    supervisor: parsed.dependencies.supervisor,
+  });
+  let consumed = false;
+
+  return Object.freeze({
+    async runFakeLifecycle(): Promise<G5DesktopOfflineFakeResult> {
+      if (consumed) {
+        throw new Error("G5 offline fake two-client executor is single-use");
+      }
+      consumed = true;
+      const boundary = blockedBoundary(parsed.runId, parsed.executorInstanceId);
+      const started: StartedFakeClient[] = [];
+      let first: CapturedFakeClient;
+      let second: CapturedFakeClient;
+      try {
+        first = await startAndCapture(
+          parsed,
+          controller,
+          parsed.clients[0],
+          "first",
+          started,
+        );
+        second = await startAndCapture(
+          parsed,
+          controller,
+          parsed.clients[1],
+          "second",
+          started,
+        );
+      } catch (startupFailure) {
+        const cleanupFailures = await abortStartedClients(controller, started);
+        if (cleanupFailures.length > 0) {
+          throw new AggregateError(
+            [startupFailure, ...cleanupFailures],
+            "Failed to clean up offline fake G5 desktop startup",
+          );
+        }
+        throw startupFailure;
+      }
+
+      const clients: readonly [CapturedFakeClient, CapturedFakeClient] = [
+        first,
+        second,
+      ];
+      await stopCapturedClients(controller, clients);
+      const lifecycle = assessG5DesktopTwoClientLifecycleEvidence(
+        lifecycleJson(parsed, clients),
+      );
+      if (lifecycle.lifecycle_validation !== "accepted") {
+        throw new Error("G5 offline fake lifecycle data was rejected");
+      }
+      return Object.freeze({
+        boundary,
+        execution_authorization: "not-granted" as const,
+        g5_result: "not-assessed" as const,
+        lifecycle,
+        mode: G5_DESKTOP_TWO_CLIENT_OFFLINE_FAKE_ONLY,
+      });
+    },
+  });
+}


### PR DESCRIPTION
Non-live offline fixture hardening only. Replaces callback/supervisor behavior with canonical fictional two-client JSON validation and a single data-only consumption result that remains not-granted/not-assessed. No FxA, Sync, credentials, browser, process launch, network, runner, or G5/G6 execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an offline-only fake two-client desktop executor for consuming validated fixture data.
  - Generates lifecycle evidence while indicating that execution authorization was not granted and results were not assessed.
  - Enforces single-use consumption and rejects invalid, duplicate, executable, reflective, or unauthorized inputs.

- **Tests**
  - Added comprehensive coverage for fixture validation, lifecycle evidence, single-use behavior, and offline-only security restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->