### PR TITLE
test(notes): expose stable production QA UI hooks

### DIFF
--- a/browser-features/pages-notes/src/App.tsx
+++ b/browser-features/pages-notes/src/App.tsx
@@ -420,6 +420,7 @@ function App() {
             ref={createButtonRef}
             type="button"
             className="btn btn-xs btn-primary"
+            data-testid="notes-add"
             onClick={createNewNote}
           >
             {t("notes.new")}
@@ -490,6 +491,7 @@ function App() {
                           ref={titleInputRef}
                           type="text"
                           className="input input-sm input-bordered w-full mb-1.5 focus:outline-none focus:border-primary/30"
+                          data-testid="notes-title"
                           placeholder={t("notes.titlePlaceholder")}
                           aria-label={t("notes.titlePlaceholder")}
                           value={title}

--- a/browser-features/pages-notes/src/components/common/ConfirmModal.tsx
+++ b/browser-features/pages-notes/src/components/common/ConfirmModal.tsx
@@ -59,6 +59,7 @@ export function ConfirmModal({
           <button
             type="button"
             className={`btn ${confirmVariant}`}
+            data-testid="notes-delete-confirm"
             onClick={handleConfirm}
           >
             {resolvedConfirmText}

--- a/browser-features/pages-notes/src/components/editor/RichTextEditor.tsx
+++ b/browser-features/pages-notes/src/components/editor/RichTextEditor.tsx
@@ -148,6 +148,7 @@ export const RichTextEditor = ({ onChange, initialContent }: RichTextEditorProps
                 <EditorContent
                     editor={editor}
                     className="h-full"
+                    data-testid="notes-body"
                     aria-label={t("editor.contentArea")}
                 />
             </div>

--- a/browser-features/pages-notes/src/components/notes/NoteItem.tsx
+++ b/browser-features/pages-notes/src/components/notes/NoteItem.tsx
@@ -68,6 +68,7 @@ export const NoteItem = memo(function NoteItem({ note, isSelected, onSelect, onD
         >
             <button
                 type="button"
+                data-testid="notes-row"
                 role="option"
                 aria-selected={isSelected}
                 className={`w-full flex flex-col px-2 py-1.5 rounded-lg border transition-colors text-sm ${isReorderMode
@@ -95,6 +96,7 @@ export const NoteItem = memo(function NoteItem({ note, isSelected, onSelect, onD
                     {!isReorderMode && (
                         <button
                             type="button"
+                            data-testid="notes-delete"
                             className="btn btn-xs btn-ghost btn-circle opacity-0 hover:opacity-100 focus-visible:opacity-100 shrink-0"
                             onClick={(e) => {
                                 e.stopPropagation();

--- a/browser-features/pages-notes/src/components/notes/NoteSearch.tsx
+++ b/browser-features/pages-notes/src/components/notes/NoteSearch.tsx
@@ -14,6 +14,7 @@ export function NoteSearch({ value, onChange }: NoteSearchProps) {
       <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-base-content/50 mt-1" />
       <input
         type="search"
+        data-testid="notes-search"
         className="input input-sm input-bordered w-full pl-8 pr-8"
         placeholder={t("notes.search")}
         aria-label={t("notes.search")}

--- a/tools/src/notes_ui_contract.test.ts
+++ b/tools/src/notes_ui_contract.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import { assertStringIncludes } from "@std/assert";
+
+Deno.test("Notes production UI exposes stable automation hooks", async () => {
+  const root = new URL(
+    "../../browser-features/pages-notes/src/",
+    import.meta.url,
+  );
+  const sources = await Promise.all([
+    Deno.readTextFile(new URL("App.tsx", root)),
+    Deno.readTextFile(new URL("components/notes/NoteItem.tsx", root)),
+    Deno.readTextFile(new URL("components/notes/NoteSearch.tsx", root)),
+    Deno.readTextFile(new URL("components/editor/RichTextEditor.tsx", root)),
+  ]);
+  const combined = sources.join("\n");
+  for (
+    const hook of [
+      "notes-add",
+      "notes-search",
+      "notes-title",
+      "notes-body",
+      "notes-row",
+      "notes-delete",
+    ]
+  ) {
+    assertStringIncludes(combined, `data-testid=\"${hook}\"`);
+  }
+});

--- a/tools/src/notes_ui_contract.test.ts
+++ b/tools/src/notes_ui_contract.test.ts
@@ -12,6 +12,7 @@ Deno.test("Notes production UI exposes stable automation hooks", async () => {
     Deno.readTextFile(new URL("components/notes/NoteItem.tsx", root)),
     Deno.readTextFile(new URL("components/notes/NoteSearch.tsx", root)),
     Deno.readTextFile(new URL("components/editor/RichTextEditor.tsx", root)),
+    Deno.readTextFile(new URL("components/common/ConfirmModal.tsx", root)),
   ]);
   const combined = sources.join("\n");
   for (
@@ -22,6 +23,7 @@ Deno.test("Notes production UI exposes stable automation hooks", async () => {
       "notes-body",
       "notes-row",
       "notes-delete",
+      "notes-delete-confirm",
     ]
   ) {
     assertStringIncludes(combined, `data-testid=\"${hook}\"`);


### PR DESCRIPTION
## Summary
- expose stable `data-testid` hooks for Notes create, search, editor, rows, and delete
- add a focused contract test so the Marionette production-QA harness cannot silently depend on localized labels

## Verification
- `deno fmt --check tools/src/notes_ui_contract.test.ts`
- `deno test --allow-read tools/src/notes_ui_contract.test.ts`

The broader Notes test invocation is currently blocked by existing Deno raw-import/parser incompatibilities in the checked-out baseline; the focused contract test is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added stable identifiers for key Notes interface elements, including adding, searching, editing, listing, and deleting notes.
  * Improved automated validation of core Notes interactions and delete confirmation behavior.
  * These updates support more reliable testing without changing the Notes experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->