### PR TITLE
feat(settings): expose tab and window behavior

### DIFF
--- a/browser-features/pages-settings/src/app/design/components/TabWindowBehavior.tsx
+++ b/browser-features/pages-settings/src/app/design/components/TabWindowBehavior.tsx
@@ -1,0 +1,145 @@
+import { type ChangeEvent, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { MonitorCog } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/common/card.tsx";
+import { Switch } from "@/components/common/switch.tsx";
+import {
+  getTabWindowBehaviorSettings,
+  type OpenNewWindowValue,
+  setOpenNewWindow,
+  setTaskbarPreviews,
+  type TabWindowBehaviorSettings,
+} from "@/app/design/tabWindowBehavior.ts";
+
+export function TabWindowBehavior() {
+  const { t } = useTranslation();
+  const [settings, setSettings] = useState<
+    TabWindowBehaviorSettings | null
+  >(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadSettings = async () => {
+      try {
+        const values = await getTabWindowBehaviorSettings();
+        if (mounted) {
+          setSettings(values);
+        }
+      } catch (error) {
+        console.error("Failed to load tab and window behavior settings", error);
+      }
+    };
+
+    void loadSettings();
+    globalThis.addEventListener("focus", loadSettings);
+
+    return () => {
+      mounted = false;
+      globalThis.removeEventListener("focus", loadSettings);
+    };
+  }, []);
+
+  const handleOpenNewWindowChange = async (
+    event: ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const value = Number(event.target.value) as OpenNewWindowValue;
+    setSettings((current) =>
+      current ? { ...current, openNewWindow: value } : current
+    );
+    try {
+      await setOpenNewWindow(value);
+    } catch (error) {
+      console.error("Failed to save link opening behavior", error);
+    }
+  };
+
+  const handleTaskbarPreviewsChange = async (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const enabled = event.target.checked;
+    setSettings((current) =>
+      current ? { ...current, taskbarPreviews: enabled } : current
+    );
+    try {
+      await setTaskbarPreviews(enabled);
+    } catch (error) {
+      console.error("Failed to save taskbar preview behavior", error);
+    }
+  };
+
+  const taskbarPreviewsAvailable = settings !== null &&
+    settings.taskbarPreviews !== null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <MonitorCog className="size-5" />
+          {t("design.tabWindowBehavior.title")}
+        </CardTitle>
+        <CardDescription>
+          {t("design.tabWindowBehavior.description")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="space-y-2">
+          <label
+            className="text-base font-medium"
+            htmlFor="open-new-window-behavior"
+          >
+            {t("design.tabWindowBehavior.openLinks")}
+          </label>
+          <p className="text-sm text-muted-foreground">
+            {t("design.tabWindowBehavior.openLinksDescription")}
+          </p>
+          <select
+            id="open-new-window-behavior"
+            className="select select-bordered w-full"
+            value={settings?.openNewWindow ?? ""}
+            onChange={handleOpenNewWindowChange}
+            disabled={settings === null}
+          >
+            <option value="1">
+              {t("design.tabWindowBehavior.openCurrentWindowOrTab")}
+            </option>
+            <option value="2">
+              {t("design.tabWindowBehavior.openNewWindow")}
+            </option>
+            <option value="3">
+              {t("design.tabWindowBehavior.openNewTab")}
+            </option>
+          </select>
+        </div>
+
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <label
+              className="text-base font-medium"
+              htmlFor="taskbar-tab-previews"
+            >
+              {t("design.tabWindowBehavior.taskbarPreviews")}
+            </label>
+            <p className="text-sm text-muted-foreground">
+              {taskbarPreviewsAvailable
+                ? t("design.tabWindowBehavior.taskbarPreviewsDescription")
+                : t("design.tabWindowBehavior.taskbarPreviewsUnavailable")}
+            </p>
+          </div>
+          <Switch
+            id="taskbar-tab-previews"
+            checked={settings?.taskbarPreviews ?? false}
+            onChange={handleTaskbarPreviewsChange}
+            disabled={!taskbarPreviewsAvailable}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/browser-features/pages-settings/src/app/design/components/TabWindowBehavior.tsx
+++ b/browser-features/pages-settings/src/app/design/components/TabWindowBehavior.tsx
@@ -49,6 +49,7 @@ export function TabWindowBehavior() {
   const handleOpenNewWindowChange = async (
     event: ChangeEvent<HTMLSelectElement>,
   ) => {
+    const previous = settings?.openNewWindow;
     const value = Number(event.target.value) as OpenNewWindowValue;
     setSettings((current) =>
       current ? { ...current, openNewWindow: value } : current
@@ -57,12 +58,16 @@ export function TabWindowBehavior() {
       await setOpenNewWindow(value);
     } catch (error) {
       console.error("Failed to save link opening behavior", error);
+      setSettings((current) =>
+        current ? { ...current, openNewWindow: previous } : current
+      );
     }
   };
 
   const handleTaskbarPreviewsChange = async (
     event: ChangeEvent<HTMLInputElement>,
   ) => {
+    const previous = settings?.taskbarPreviews;
     const enabled = event.target.checked;
     setSettings((current) =>
       current ? { ...current, taskbarPreviews: enabled } : current
@@ -71,6 +76,9 @@ export function TabWindowBehavior() {
       await setTaskbarPreviews(enabled);
     } catch (error) {
       console.error("Failed to save taskbar preview behavior", error);
+      setSettings((current) =>
+        current ? { ...current, taskbarPreviews: previous } : current
+      );
     }
   };
 

--- a/browser-features/pages-settings/src/app/design/page.tsx
+++ b/browser-features/pages-settings/src/app/design/page.tsx
@@ -11,6 +11,7 @@ import { Tabbar } from "@/app/design/components/Tabbar.tsx";
 import { Tab } from "@/app/design/components/Tab.tsx";
 import { UICustomization } from "@/app/design/components/UICustomization.tsx";
 import { TabSleepExclusion } from "@/app/design/components/TabSleepExclusion.tsx";
+import { TabWindowBehavior } from "@/app/design/components/TabWindowBehavior.tsx";
 import type { DesignFormData } from "@/types/pref.ts";
 
 export default function Page() {
@@ -125,6 +126,7 @@ export default function Page() {
           {isLeptonCompatible && <LeptonSettingsButton />}
           <Tabbar />
           <Tab />
+          <TabWindowBehavior />
           <TabSleepExclusion />
           <UICustomization />
         </form>

--- a/browser-features/pages-settings/src/app/design/tabWindowBehavior.ts
+++ b/browser-features/pages-settings/src/app/design/tabWindowBehavior.ts
@@ -1,4 +1,4 @@
-import { rpc } from "@/lib/rpc/rpc.ts";
+import { rpc } from "../../lib/rpc/rpc.ts";
 
 export const OPEN_NEW_WINDOW_PREF = "browser.link.open_newwindow";
 export const TASKBAR_PREVIEWS_PREF = "browser.taskbar.previews.enable";

--- a/browser-features/pages-settings/src/app/design/tabWindowBehavior.ts
+++ b/browser-features/pages-settings/src/app/design/tabWindowBehavior.ts
@@ -1,0 +1,47 @@
+import { rpc } from "@/lib/rpc/rpc.ts";
+
+export const OPEN_NEW_WINDOW_PREF = "browser.link.open_newwindow";
+export const TASKBAR_PREVIEWS_PREF = "browser.taskbar.previews.enable";
+
+export const DEFAULT_OPEN_NEW_WINDOW = 3;
+
+export type OpenNewWindowValue = 1 | 2 | 3;
+
+export interface TabWindowBehaviorSettings {
+  openNewWindow: OpenNewWindowValue;
+  taskbarPreviews: boolean | null;
+}
+
+export function normalizeOpenNewWindowValue(
+  value: number | null,
+): OpenNewWindowValue {
+  if (value === 1 || value === 2 || value === 3) {
+    return value;
+  }
+  return DEFAULT_OPEN_NEW_WINDOW;
+}
+
+export async function getTabWindowBehaviorSettings(): Promise<
+  TabWindowBehaviorSettings
+> {
+  const [openNewWindow, taskbarPreviews] = await Promise.all([
+    rpc.getIntPref(OPEN_NEW_WINDOW_PREF),
+    rpc.getBoolPref(TASKBAR_PREVIEWS_PREF),
+  ]);
+
+  return {
+    openNewWindow: normalizeOpenNewWindowValue(openNewWindow),
+    // null means that this platform does not expose the Windows-only pref.
+    taskbarPreviews,
+  };
+}
+
+export async function setOpenNewWindow(
+  value: OpenNewWindowValue,
+): Promise<void> {
+  await rpc.setIntPref(OPEN_NEW_WINDOW_PREF, value);
+}
+
+export async function setTaskbarPreviews(enabled: boolean): Promise<void> {
+  await rpc.setBoolPref(TASKBAR_PREVIEWS_PREF, enabled);
+}

--- a/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/en-US.json
@@ -130,6 +130,18 @@
             "minHeight": "Minimum tab height",
             "minHeightError": "Tab height must be between {{min}} and {{max}} pixels."
         },
+        "tabWindowBehavior": {
+            "title": "Tab and window behavior",
+            "description": "Control where links open and distinguish browser windows from Windows taskbar tab previews.",
+            "openLinks": "Open links that request a new window",
+            "openLinksDescription": "Choose whether links that request a new window open in the current window, a new window, or a new tab.",
+            "openCurrentWindowOrTab": "Current window or tab",
+            "openNewWindow": "New window",
+            "openNewTab": "New tab",
+            "taskbarPreviews": "Show tab previews in the taskbar",
+            "taskbarPreviewsDescription": "This changes only the Windows taskbar display. It does not create additional browser windows.",
+            "taskbarPreviewsUnavailable": "This option is available on Windows only."
+        },
         "lepton-preferences": {
             "title": "Lepton Settings",
             "description": "Configure advanced Lepton theme preferences",

--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -130,6 +130,18 @@
             "minHeight": "タブの最小高さ",
             "minHeightError": "タブの高さは、 {{min}} から {{max}} ピクセルの間でなければなりません。"
         },
+        "tabWindowBehavior": {
+            "title": "タブとウィンドウの動作",
+            "description": "リンクの開き先と、ブラウザのウィンドウと Windows のタスクバー上のタブプレビューの違いを設定します。",
+            "openLinks": "新しいウィンドウを要求するリンクの開き先",
+            "openLinksDescription": "新しいウィンドウを要求するリンクを、現在のウィンドウ、新しいウィンドウ、新しいタブのどこに開くかを選択します。",
+            "openCurrentWindowOrTab": "現在のウィンドウまたはタブ",
+            "openNewWindow": "新しいウィンドウ",
+            "openNewTab": "新しいタブ",
+            "taskbarPreviews": "タスクバーにタブのプレビューを表示",
+            "taskbarPreviewsDescription": "これは Windows のタスクバー表示だけを変更します。ブラウザのウィンドウを増やす設定ではありません。",
+            "taskbarPreviewsUnavailable": "この項目は Windows でのみ利用できます。"
+        },
         "lepton-preferences": {
             "title": "Lepton の設定",
             "description": "Lepton テーマの高度な設定を変更します",

--- a/browser-features/pages-settings/test/app/design/tabWindowBehavior.test.ts
+++ b/browser-features/pages-settings/test/app/design/tabWindowBehavior.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import enUS from "../../../src/lib/i18n/locales/en-US.json" with {
+  type: "json",
+};
+import jaJP from "../../../src/lib/i18n/locales/ja-JP.json" with {
+  type: "json",
+};
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+import {
+  DEFAULT_OPEN_NEW_WINDOW,
+  normalizeOpenNewWindowValue,
+} from "../../../src/app/design/tabWindowBehavior.ts";
+
+function testOpenNewWindowValuesAreNormalized(): void {
+  assertEquals(
+    normalizeOpenNewWindowValue(1),
+    1,
+    "value 1 should keep current-window behavior",
+  );
+  assertEquals(
+    normalizeOpenNewWindowValue(2),
+    2,
+    "value 2 should keep new-window behavior",
+  );
+  assertEquals(
+    normalizeOpenNewWindowValue(3),
+    3,
+    "value 3 should keep new-tab behavior",
+  );
+  assertEquals(
+    normalizeOpenNewWindowValue(null),
+    DEFAULT_OPEN_NEW_WINDOW,
+    "missing pref should use the new-tab default",
+  );
+  assertEquals(
+    normalizeOpenNewWindowValue(99),
+    DEFAULT_OPEN_NEW_WINDOW,
+    "unknown pref values should use the new-tab default",
+  );
+}
+
+function testTabWindowBehaviorTranslationsExist(): void {
+  assertEquals(
+    enUS.design.tabWindowBehavior.taskbarPreviews,
+    "Show tab previews in the taskbar",
+    "English taskbar preview label should exist",
+  );
+  assertEquals(
+    jaJP.design.tabWindowBehavior.taskbarPreviews,
+    "タスクバーにタブのプレビューを表示",
+    "Japanese taskbar preview label should exist",
+  );
+  assertEquals(
+    enUS.design.tabWindowBehavior.openNewTab,
+    "New tab",
+    "English new-tab label should exist",
+  );
+  assertEquals(
+    jaJP.design.tabWindowBehavior.openNewTab,
+    "新しいタブ",
+    "Japanese new-tab label should exist",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "open-new-window values are normalized",
+      fn: testOpenNewWindowValuesAreNormalized,
+    },
+    {
+      name: "tab-window behavior translations exist",
+      fn: testTabWindowBehaviorTranslationsExist,
+    },
+  ];
+  await runTests("tabWindowBehavior.test.ts", tests);
+}


### PR DESCRIPTION
## Summary

- Add a Floorp settings card for tab and window behavior.
- Expose `browser.link.open_newwindow` as a three-way selector.
- Expose Windows taskbar tab previews through `browser.taskbar.previews.enable`.
- Explain that taskbar tab previews do not create additional browser windows.
- Reload the values when the settings page regains focus.

## Context

Investigation of #2659 found that Floorp's normal `BrowserCommands.openTab()` path keeps the tab in the existing browser window. Windows taskbar tab previews and actual browser windows can nevertheless appear similar to users. This UI makes both states visible and independently configurable.

## Validation

- Pages Settings Vite build passed.
- Full `deno task dev-tool start` build passed after regenerating the frozen manual node_modules layout.
- Real isolated Floorp runtime:
  - settings card rendered successfully;
  - `browser.link.open_newwindow` changed `3 -> 2 -> 3`;
  - taskbar previews changed `false -> true -> false`;
  - taskbar previews did not increase the browser window count;
  - `BrowserCommands.openTab()` kept the window count at `1`.
- `tabWindowBehavior.test.ts` passed.

Related to #2659.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added settings for choosing how links open in tabs or new windows.
  * Added an option to show tab previews on the Windows taskbar.
  * Settings update immediately and refresh when the settings page regains focus.
  * Added English and Japanese translations, including platform availability messaging.

* **Bug Fixes**
  * Added safeguards for unavailable or unsupported preference values.
  * Changes now revert automatically if they cannot be saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->