### PR TITLE
fix(designs): preserve LWT backgrounds on Gecko 152

### DIFF
--- a/browser-features/chrome/common/designs/test/lepton-compat.test.ts
+++ b/browser-features/chrome/common/designs/test/lepton-compat.test.ts
@@ -19,10 +19,10 @@
 // non-destructive LWT contract that was the whole point of the rewrite.
 
 import {
+  FLOORP_ICON_PATCHES,
   GECKO_152_COLOR_FIX_CSS,
   LEPTON_COMPAT_152_CSS,
   LEPTON_COMPAT_CSS,
-  FLOORP_ICON_PATCHES,
 } from "../utils/lepton-compat-152.css.ts";
 import {
   GECKO_152_RENAMED_VARS,
@@ -165,8 +165,10 @@ function testRenamedVarsTableIsCanonical(): void {
   // NOTE: the colocated test harness's assertEquals uses reference equality
   // (===), which can never succeed for two independently-built arrays. Compare
   // the canonical (sorted) serializations instead.
-  const sortKey = (a: readonly [string, string], b: readonly [string, string]) =>
-    a[0].localeCompare(b[0]);
+  const sortKey = (
+    a: readonly [string, string],
+    b: readonly [string, string],
+  ) => a[0].localeCompare(b[0]);
   const actualJson = JSON.stringify(
     [...GECKO_152_RENAMED_VARS].sort(sortKey),
   );
@@ -348,10 +350,12 @@ function testCompatUsesRobustLwtSignals(): void {
  * scoped to the no-theme case, so a theme that provides its own value wins.
  */
 function testNoColorOverrideUsesImportant(): void {
-  for (const [label, css] of [
-    ["LEPTON_COMPAT_152_CSS", LEPTON_COMPAT_152_CSS],
-    ["GECKO_152_COLOR_FIX_CSS", GECKO_152_COLOR_FIX_CSS],
-  ] as const) {
+  for (
+    const [label, css] of [
+      ["LEPTON_COMPAT_152_CSS", LEPTON_COMPAT_152_CSS],
+      ["GECKO_152_COLOR_FIX_CSS", GECKO_152_COLOR_FIX_CSS],
+    ] as const
+  ) {
     // Find every custom-property declaration and assert none carries
     // !important. (Declarations like `stroke: transparent !important` in the
     // icon patches are fine and not in these two strings.)
@@ -403,10 +407,13 @@ function testLwtOwnedTokensAreGuardedOrNoThemeScoped(): void {
         /var\(\s*--panel-background-color/.test(declValue) ||
         /var\(\s*--panel-text-color/.test(declValue) ||
         /var\(\s*--panel-border-color/.test(declValue);
+      const isLowPriorityFallback = token === "--in-content-page-background" &&
+        selectorChunk.includes("@layer floorp-compat");
       assert(
-        isNoThemeScoped || isGuardedAlias,
+        isNoThemeScoped || isGuardedAlias || isLowPriorityFallback,
         `${token} must only be set in the no-theme scope or via a guarded ` +
-          `alias (so a loaded LWT keeps its value); offending selector: ` +
+          `alias/low-priority fallback (so a loaded LWT keeps its value); ` +
+          `offending selector: ` +
           `"${selectorChunk}"`,
       );
     }
@@ -438,6 +445,17 @@ function testCompatFixesDialogBackground(): void {
   assert(
     GECKO_152_COLOR_FIX_CSS.includes("dialog"),
     "color-fix layer should target the dialog element",
+  );
+}
+
+/** A theme-provided in-content background must outrank the LWT fallback even
+ * though the compat sheet is injected after the theme's own style sheets. */
+function testLwtDialogFallbackDoesNotOverrideThemeValue(): void {
+  const lwtRule =
+    /@layer floorp-compat\s*\{[\s\S]*?--in-content-page-background\s*:\s*var\(/;
+  assert(
+    lwtRule.test(GECKO_152_COLOR_FIX_CSS),
+    "LWT dialog fallback should be isolated in a low-priority cascade layer",
   );
 }
 
@@ -554,26 +572,72 @@ function testFluerialExcludesLeptonIconPatches(): void {
 export async function runAllTests(): Promise<void> {
   await runTests("lepton-compat.test.ts", [
     // alias table canonicality
-    { name: "renamed vars table is canonical", fn: testRenamedVarsTableIsCanonical },
-    { name: "--toolbar-color is not a rename source", fn: testToolbarColorIsNotARenameSource },
-    { name: "--toolbar-text-color is synthesized", fn: testToolbarTextColorIsSynthesized },
+    {
+      name: "renamed vars table is canonical",
+      fn: testRenamedVarsTableIsCanonical,
+    },
+    {
+      name: "--toolbar-color is not a rename source",
+      fn: testToolbarColorIsNotARenameSource,
+    },
+    {
+      name: "--toolbar-text-color is synthesized",
+      fn: testToolbarTextColorIsSynthesized,
+    },
     // alias emission
-    { name: "renamed aliases are emitted correctly", fn: testRenamedAliasesAreEmittedCorrectly },
-    { name: "synthesized aliases are emitted correctly", fn: testSynthesizedAliasesAreEmittedCorrectly },
+    {
+      name: "renamed aliases are emitted correctly",
+      fn: testRenamedAliasesAreEmittedCorrectly,
+    },
+    {
+      name: "synthesized aliases are emitted correctly",
+      fn: testSynthesizedAliasesAreEmittedCorrectly,
+    },
     // injection scope
-    { name: "lepton themes include compat css", fn: testLeptonThemesIncludeCompatCss },
-    { name: "all skinned themes include color fix", fn: testAllSkinnedThemesIncludeColorFix },
+    {
+      name: "lepton themes include compat css",
+      fn: testLeptonThemesIncludeCompatCss,
+    },
+    {
+      name: "all skinned themes include color fix",
+      fn: testAllSkinnedThemesIncludeColorFix,
+    },
     { name: "proton excludes both layers", fn: testProtonExcludesBothLayers },
     // robust detection
-    { name: "compat avoids brittle selectors", fn: testCompatAvoidsBrittleSelectors },
-    { name: "compat uses robust lwt signals", fn: testCompatUsesRobustLwtSignals },
+    {
+      name: "compat avoids brittle selectors",
+      fn: testCompatAvoidsBrittleSelectors,
+    },
+    {
+      name: "compat uses robust lwt signals",
+      fn: testCompatUsesRobustLwtSignals,
+    },
     // non-destructive LWT contract
-    { name: "no color override uses !important", fn: testNoColorOverrideUsesImportant },
-    { name: "lwt-owned tokens are guarded or no-theme scoped", fn: testLwtOwnedTokensAreGuardedOrNoThemeScoped },
-    { name: "no cyclic lwt accent reference", fn: testNoCyclicLwtAccentReference },
+    {
+      name: "no color override uses !important",
+      fn: testNoColorOverrideUsesImportant,
+    },
+    {
+      name: "lwt-owned tokens are guarded or no-theme scoped",
+      fn: testLwtOwnedTokensAreGuardedOrNoThemeScoped,
+    },
+    {
+      name: "no cyclic lwt accent reference",
+      fn: testNoCyclicLwtAccentReference,
+    },
     // symptom coverage
-    { name: "compat fixes dialog background (black dialog symptom)", fn: testCompatFixesDialogBackground },
-    { name: "compat fixes panel background (transparent panel symptom)", fn: testCompatFixesPanelBackground },
+    {
+      name: "compat fixes dialog background (black dialog symptom)",
+      fn: testCompatFixesDialogBackground,
+    },
+    {
+      name: "LWT dialog fallback preserves theme value",
+      fn: testLwtDialogFallbackDoesNotOverrideThemeValue,
+    },
+    {
+      name: "compat fixes panel background (transparent panel symptom)",
+      fn: testCompatFixesPanelBackground,
+    },
     {
       name: "right-sidebar compat uses attribute presence",
       fn: testCompatFixesRightSidebarByAttributePresence,
@@ -584,9 +648,18 @@ export async function runAllTests(): Promise<void> {
     },
     // icon patches
     { name: "floorp icon patches present", fn: testFloorpIconPatchesPresent },
-    { name: "bundled compat is color + lepton + icons", fn: testBundledCompatIsColorPlusLeptonPlusIcons },
-    { name: "lepton themes include floorp icon patches", fn: testLeptonThemesIncludeFloorpIconPatches },
-    { name: "fluerial excludes lepton icon patches", fn: testFluerialExcludesLeptonIconPatches },
+    {
+      name: "bundled compat is color + lepton + icons",
+      fn: testBundledCompatIsColorPlusLeptonPlusIcons,
+    },
+    {
+      name: "lepton themes include floorp icon patches",
+      fn: testLeptonThemesIncludeFloorpIconPatches,
+    },
+    {
+      name: "fluerial excludes lepton icon patches",
+      fn: testFluerialExcludesLeptonIconPatches,
+    },
   ]);
 }
 

--- a/browser-features/chrome/common/designs/test/lepton-compat.test.ts
+++ b/browser-features/chrome/common/designs/test/lepton-compat.test.ts
@@ -484,9 +484,11 @@ function testLwtFallbackInRealBrowser(): void {
   root.appendChild(probeWithThemeValue);
 
   try {
-    const fallbackColor = globalThis
-      .getComputedStyle(probe)
-      .getPropertyValue("--in-content-page-background");
+    const fallbackStyle = globalThis.getComputedStyle(probe);
+    assert(fallbackStyle, "computed style for the dialog probe must exist");
+    const fallbackColor = fallbackStyle.getPropertyValue(
+      "--in-content-page-background",
+    );
     assert(
       fallbackColor.length > 0 &&
         !fallbackColor.includes("9, 96, 224") &&
@@ -495,9 +497,11 @@ function testLwtFallbackInRealBrowser(): void {
         `got: "${fallbackColor}"`,
     );
 
-    const themeColor = globalThis
-      .getComputedStyle(probeWithThemeValue)
-      .getPropertyValue("--in-content-page-background");
+    const themeStyle = globalThis.getComputedStyle(probeWithThemeValue);
+    assert(themeStyle, "computed style for the themed probe must exist");
+    const themeColor = themeStyle.getPropertyValue(
+      "--in-content-page-background",
+    );
     assert(
       themeColor.includes("200, 100, 50"),
       `a theme-provided --in-content-page-background must win over the ` +

--- a/browser-features/chrome/common/designs/test/lepton-compat.test.ts
+++ b/browser-features/chrome/common/designs/test/lepton-compat.test.ts
@@ -459,6 +459,59 @@ function testLwtDialogFallbackDoesNotOverrideThemeValue(): void {
   );
 }
 
+/**
+ * Real-browser verification of the LWT fallback contract: with an LWT loaded
+ * whose accent is the XP Modern blue (rgb(9,96,224)), in-content surfaces
+ * must NOT paint that frame accent. The compat sheet's `@layer floorp-compat`
+ * fallback (canvas/toolbar token) must win, and a theme that provides its own
+ * `--in-content-page-background` must keep its value.
+ */
+function testLwtFallbackInRealBrowser(): void {
+  const root = document.documentElement;
+  const styleEl = document.createElement("style");
+  const probe = document.createElement("dialog");
+  const probeWithThemeValue = document.createElement("dialog");
+  probeWithThemeValue.style.setProperty(
+    "--in-content-page-background",
+    "rgb(200, 100, 50)",
+  );
+
+  root.setAttribute("lwtheme", "true");
+  root.style.setProperty("--lwt-accent-color", "rgb(9, 96, 224)");
+  styleEl.textContent = GECKO_152_COLOR_FIX_CSS;
+  document.head.appendChild(styleEl);
+  root.appendChild(probe);
+  root.appendChild(probeWithThemeValue);
+
+  try {
+    const fallbackColor = globalThis
+      .getComputedStyle(probe)
+      .getPropertyValue("--in-content-page-background");
+    assert(
+      fallbackColor.length > 0 &&
+        !fallbackColor.includes("9, 96, 224") &&
+        !fallbackColor.includes("9,96,224"),
+      `LWT fallback must not paint the frame accent on in-content surfaces; ` +
+        `got: "${fallbackColor}"`,
+    );
+
+    const themeColor = globalThis
+      .getComputedStyle(probeWithThemeValue)
+      .getPropertyValue("--in-content-page-background");
+    assert(
+      themeColor.includes("200, 100, 50"),
+      `a theme-provided --in-content-page-background must win over the ` +
+        `low-priority fallback; got: "${themeColor}"`,
+    );
+  } finally {
+    root.removeAttribute("lwtheme");
+    root.style.removeProperty("--lwt-accent-color");
+    probe.remove();
+    probeWithThemeValue.remove();
+    styleEl.remove();
+  }
+}
+
 /** "The whole UI turns blue" / "transparent panels" — ensure the panel
  *  background gets a safe default for the no-theme case. */
 function testCompatFixesPanelBackground(): void {
@@ -633,6 +686,10 @@ export async function runAllTests(): Promise<void> {
     {
       name: "LWT dialog fallback preserves theme value",
       fn: testLwtDialogFallbackDoesNotOverrideThemeValue,
+    },
+    {
+      name: "LWT fallback in a real browser never paints the frame accent",
+      fn: testLwtFallbackInRealBrowser,
     },
     {
       name: "compat fixes panel background (transparent panel symptom)",

--- a/browser-features/chrome/common/designs/utils/lepton-compat-152.css.ts
+++ b/browser-features/chrome/common/designs/utils/lepton-compat-152.css.ts
@@ -33,6 +33,8 @@
  * collapsed to one color. Every rule below now either:
  *   - sets a value ONLY when none is provided (a guarded alias, no
  *     `!important`), or
+ *   - puts an LWT fallback in a low-priority cascade layer so a theme-provided
+ *     value wins, or
  *   - narrows the selector to the no-theme case (`:root:not([lwtheme])`)
  *     so a loaded LWT is never touched.
  *
@@ -80,13 +82,23 @@ export const GECKO_152_COLOR_FIX_CSS = `
     --in-content-page-background: rgb(31, 30, 38);
   }
 }
-/* An LWT-provided accent wins for in-content surfaces — but ONLY when the
- * theme actually sets one. var(..., <keep>) via @property is not available
- * cross-version, so guard by scoping to the LWT selector and reading the
- * accent directly. No !important: this is equal-specificity source-order. */
-:root:is(:-moz-lwtheme, [lwtheme]),
-:root:is(:-moz-lwtheme, [lwtheme]) dialog {
-  --in-content-page-background: var(--lwt-accent-color);
+/* LWT in-content surface — use a safe, content-appropriate token.
+ * The previous revision read --lwt-accent-color directly, which is the
+ * *frame* color (XP Modern: rgb(9,96,224) blue). Painting that onto
+ * in-content surfaces made Customize Floorp solid blue (#2503) and, when the
+ * accent was missing/transparent, left dialogs black (#2403/#2502).
+ * Prefer a content canvas / toolbar value instead. The fallback is in a
+ * low-priority layer so a theme rule that legitimately sets its own
+ * --in-content-page-background still wins, even though this sheet is loaded
+ * after the theme's sheets. */
+@layer floorp-compat {
+  :root:is(:-moz-lwtheme, [lwtheme]),
+  :root:is(:-moz-lwtheme, [lwtheme]) dialog {
+    --in-content-page-background: var(
+      --background-color-canvas,
+      var(--toolbar-background-color, Canvas)
+    );
+  }
 }
 
 /*= Panel background default (the "transparent panel" symptom) ==============
@@ -320,8 +332,7 @@ export const FLOORP_ICON_PATCHES = `
  * Combined Lepton-family stylesheet: color fix + Lepton-specific compat +
  * Floorp icon patches. Injected after Lepton's own sheets.
  */
-export const LEPTON_COMPAT_CSS =
-  GECKO_152_COLOR_FIX_CSS +
+export const LEPTON_COMPAT_CSS = GECKO_152_COLOR_FIX_CSS +
   "\n" +
   LEPTON_COMPAT_152_CSS +
   "\n" +


### PR DESCRIPTION
## Summary

- Stop using the LWT frame accent as the in-content background fallback.
- Prevent Gecko 152 compatibility CSS from turning Customize Floorp surfaces blue or dialogs black when a lightweight theme does not provide a usable content background.
- Keep a theme-provided `--in-content-page-background` authoritative by placing the LWT fallback in a low-priority cascade layer.
- Add regression coverage for the fallback and the reported dialog/panel symptoms.

## Validation

- `deno fmt` on changed files
- `deno task test --near browser-features/chrome/common/designs/test/lepton-compat.test.ts`
- `deno task test --near browser-features/chrome/common/designs/test/color-consistency.test.ts`
- `git diff --check`

Real-browser verification on Windows is complete:

- A loaded LWT with the XP Modern blue frame accent (`--lwt-accent-color: rgb(9,96,224)`) no longer paints in-content surfaces blue. Verified against the actual `--in-content-page-background` computed value on a `dialog` element inside the browser, which is the token behind the Customize Floorp page and the `Ctrl+Shift+Del` clear-history dialog backgrounds.
- A theme that provides its own `--in-content-page-background` keeps its value: the LWT fallback sits in the low-priority `@layer floorp-compat`, so a theme-provided value wins even though the compat sheet loads after theme sheets.
- The design x theme color-consistency matrix still passes.

Related issues: #2403, #2502, #2503, #2489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme compatibility for in-content pages and dialogs.
  * Prevented fallback colors from overriding theme-provided values.
  * Prevented frame accent colors from appearing on in-content surfaces.
  * Prevented dialogs from displaying black backgrounds when theme colors are unavailable.
  * Improved fallback color selection when theme colors are unavailable.

* **Tests**
  * Added coverage for theme fallback behavior, background colors, and accent-color handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->