### PR TITLE
Fix session restore loss from private-container tab state

### DIFF
--- a/browser-features/chrome/@types/xul-window.d.ts
+++ b/browser-features/chrome/@types/xul-window.d.ts
@@ -156,7 +156,7 @@ declare namespace globalThis {
     undoCloseTab(aIndex?: number): XULElement;
     undoCloseWindow?(aIndex?: number): unknown;
     setWindowState(window: Window, state: string, overwrite?: boolean): void;
-    getWindowState(window: Window): string;
+    getWindowState(window: Window): { windows: unknown[] };
     getBrowserState(): string;
     setBrowserState(state: string): void;
     getClosedTabCount(window?: Window): number;

--- a/browser-features/chrome/common/private-container/test/sessionStoreRestoreClosed.test.js
+++ b/browser-features/chrome/common/private-container/test/sessionStoreRestoreClosed.test.js
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MPL-2.0
+
+const { SessionStore } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/SessionStore.sys.mjs",
+);
+
+const NORMAL_URL = "data:text/plain,floorp-sessionstore-closed-normal";
+const PRIVATE_URL = "data:text/plain,floorp-sessionstore-closed-private";
+const LIVE_PRIVATE_URL = "about:mozilla";
+
+const browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+let originalWindowState;
+
+function makeTabState(url, extra = {}) {
+  return {
+    entries: [{ url }],
+    index: 1,
+    lastAccessed: Date.now(),
+    ...extra,
+  };
+}
+
+function makeClosedTab(url, extra = {}) {
+  return {
+    state: makeTabState(url, extra),
+    title: url,
+    pos: 0,
+    closedAt: Date.now(),
+  };
+}
+
+function makeClosedGroup(id, tabs) {
+  return {
+    id,
+    name: id,
+    color: "blue",
+    collapsed: false,
+    closedAt: Date.now(),
+    sourceWindowId: "test-window",
+    tabs,
+    splitViews: [],
+  };
+}
+
+async function restoreWindowState(state) {
+  const restored = BrowserTestUtils.waitForEvent(
+    browserWindow,
+    "SSWindowRestored",
+  );
+  SessionStore.setWindowState(browserWindow, JSON.stringify(state), true);
+  await restored;
+}
+
+registerCleanupFunction(async function restoreOriginalState() {
+  if (originalWindowState) {
+    await restoreWindowState(originalWindowState);
+  }
+});
+
+add_task(async function closedPrivateContainerTabIsNotRecorded() {
+  originalWindowState = SessionStore.getWindowState(browserWindow);
+  const before = SessionStore.getClosedTabCountForWindow(browserWindow);
+  const tab = await BrowserTestUtils.openNewForegroundTab(
+    browserWindow.gBrowser,
+    LIVE_PRIVATE_URL,
+    true,
+  );
+  tab.setAttribute("floorp-disablehistory", "true");
+  BrowserTestUtils.removeTab(tab);
+
+  await TestUtils.waitForCondition(
+    () => SessionStore.getClosedTabCountForWindow(browserWindow) == before,
+    "closing a private-container tab should not add closed-tab history",
+  );
+  is(
+    SessionStore.getClosedTabCountForWindow(browserWindow),
+    before,
+    "private-container closed tabs should be discarded",
+  );
+});
+
+add_task(async function legacyClosedTabsAndGroupsAreSanitized() {
+  await restoreWindowState({
+    windows: [
+      {
+        tabs: [makeTabState(NORMAL_URL)],
+        selected: 1,
+        _closedTabs: [
+          makeClosedTab(NORMAL_URL),
+          makeClosedTab(PRIVATE_URL, { floorpDisableHistory: "true" }),
+        ],
+        closedGroups: [
+          makeClosedGroup("mixed-group", [
+            makeClosedTab(NORMAL_URL, { groupId: "mixed-group" }),
+            makeClosedTab(PRIVATE_URL, {
+              groupId: "mixed-group",
+              floorpDisableHistory: true,
+            }),
+          ]),
+          makeClosedGroup("private-group", [
+            makeClosedTab(PRIVATE_URL, {
+              groupId: "private-group",
+              floorpDisableHistory: "true",
+            }),
+          ]),
+        ],
+      },
+    ],
+  });
+
+  const internal = SessionStore.getInternalObjectState(browserWindow);
+  is(
+    internal._closedTabs.length,
+    1,
+    "only the normal closed tab should remain",
+  );
+  is(
+    internal._closedTabs[0].state.entries[0].url,
+    NORMAL_URL,
+    "normal closed-tab history should be preserved",
+  );
+  is(
+    internal.closedGroups.length,
+    1,
+    "an empty private group should be dropped",
+  );
+  is(
+    internal.closedGroups[0].tabs.length,
+    1,
+    "the mixed group should retain only its normal tab",
+  );
+  ok(
+    !JSON.stringify(internal.closedGroups).includes(PRIVATE_URL),
+    "closed group data must not retain private URLs",
+  );
+});
+
+add_task(async function legacyClosedWindowIsSanitizedWithoutLosingNormalData() {
+  await restoreWindowState({
+    windows: [
+      {
+        tabs: [makeTabState(NORMAL_URL)],
+        selected: 1,
+        _closedTabs: [],
+        closedGroups: [],
+      },
+    ],
+    _closedWindows: [
+      {
+        title: PRIVATE_URL,
+        tabs: [
+          makeTabState(NORMAL_URL),
+          makeTabState(PRIVATE_URL, { floorpDisableHistory: "true" }),
+        ],
+        selected: 2,
+        _closedTabs: [
+          makeClosedTab(NORMAL_URL),
+          makeClosedTab(PRIVATE_URL, { floorpDisableHistory: true }),
+        ],
+        closedGroups: [
+          makeClosedGroup("closed-window-mixed", [
+            makeClosedTab(NORMAL_URL, { groupId: "closed-window-mixed" }),
+            makeClosedTab(PRIVATE_URL, {
+              groupId: "closed-window-mixed",
+              floorpDisableHistory: "true",
+            }),
+          ]),
+        ],
+      },
+      {
+        title: PRIVATE_URL,
+        tabs: [
+          makeTabState(PRIVATE_URL, { floorpDisableHistory: "true" }),
+        ],
+        selected: 1,
+        _closedTabs: [makeClosedTab(NORMAL_URL)],
+        closedGroups: [
+          makeClosedGroup("normal-closed-data", [
+            makeClosedTab(NORMAL_URL, { groupId: "normal-closed-data" }),
+          ]),
+        ],
+      },
+      {
+        title: PRIVATE_URL,
+        tabs: [
+          makeTabState(PRIVATE_URL, { floorpDisableHistory: "true" }),
+        ],
+        selected: 1,
+        _closedTabs: [],
+        closedGroups: [],
+      },
+    ],
+  });
+
+  const browserState = JSON.parse(SessionStore.getBrowserState());
+  is(
+    browserState._closedWindows.length,
+    2,
+    "a closed window containing only private data should be dropped",
+  );
+  const closedWindow = browserState._closedWindows[0];
+  is(closedWindow.tabs.length, 1, "only the normal open tab should remain");
+  is(
+    closedWindow.tabs[0].entries[0].url,
+    NORMAL_URL,
+    "normal closed-window data should be preserved",
+  );
+  is(closedWindow.selected, 1, "closed-window selection should be remapped");
+  is(
+    closedWindow._closedTabs.length,
+    1,
+    "normal closed-tab data should remain",
+  );
+  is(
+    closedWindow.closedGroups[0].tabs.length,
+    1,
+    "normal closed-group data should remain",
+  );
+  is(
+    closedWindow.title,
+    NORMAL_URL,
+    "closed-window title should be recomputed from the surviving tab",
+  );
+
+  const closedDataOnlyWindow = browserState._closedWindows[1];
+  is(
+    closedDataOnlyWindow.tabs.length,
+    0,
+    "all private open tabs should be removed from a closed window",
+  );
+  is(
+    closedDataOnlyWindow.selected,
+    0,
+    "a closed window without open tabs should have no selection",
+  );
+  ok(
+    !("title" in closedDataOnlyWindow),
+    "a closed window without normal open tabs should not retain its title",
+  );
+  is(
+    closedDataOnlyWindow._closedTabs.length,
+    1,
+    "normal closed-tab data should keep the closed-window record alive",
+  );
+  is(
+    closedDataOnlyWindow.closedGroups.length,
+    1,
+    "normal closed-group data should keep the closed-window record alive",
+  );
+  ok(
+    !JSON.stringify(browserState._closedWindows).includes(PRIVATE_URL),
+    "closed-window state must not retain private URLs or titles",
+  );
+});

--- a/browser-features/chrome/common/private-container/test/sessionStoreRestoreClosed.test.js
+++ b/browser-features/chrome/common/private-container/test/sessionStoreRestoreClosed.test.js
@@ -1,4 +1,38 @@
 // SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+// @ts-check
+/// <reference path="../../../@types/mochitest-compat.d.ts" />
+
+/**
+ * @typedef {{
+ *   entries: Array<{ url: string }>;
+ *   index: number;
+ *   lastAccessed: number;
+ *   [key: string]: unknown;
+ * }} SessionTabState
+ */
+
+/**
+ * @typedef {{
+ *   state: SessionTabState;
+ *   title: string;
+ *   pos: number;
+ *   closedAt: number;
+ * }} ClosedTabState
+ */
+
+/**
+ * @typedef {{
+ *   id: string;
+ *   name: string;
+ *   color: string;
+ *   collapsed: boolean;
+ *   closedAt: number;
+ *   sourceWindowId: string;
+ *   tabs: ClosedTabState[];
+ *   splitViews: unknown[];
+ * }} ClosedGroupState
+ */
 
 const { SessionStore } = ChromeUtils.importESModule(
   "resource:///modules/sessionstore/SessionStore.sys.mjs",
@@ -9,8 +43,14 @@ const PRIVATE_URL = "data:text/plain,floorp-sessionstore-closed-private";
 const LIVE_PRIVATE_URL = "about:mozilla";
 
 const browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+/** @type {unknown} */
 let originalWindowState;
 
+/**
+ * @param {string} url
+ * @param {Record<string, unknown>} [extra]
+ * @returns {SessionTabState}
+ */
 function makeTabState(url, extra = {}) {
   return {
     entries: [{ url }],
@@ -20,6 +60,11 @@ function makeTabState(url, extra = {}) {
   };
 }
 
+/**
+ * @param {string} url
+ * @param {Record<string, unknown>} [extra]
+ * @returns {ClosedTabState}
+ */
 function makeClosedTab(url, extra = {}) {
   return {
     state: makeTabState(url, extra),
@@ -29,6 +74,11 @@ function makeClosedTab(url, extra = {}) {
   };
 }
 
+/**
+ * @param {string} id
+ * @param {ClosedTabState[]} tabs
+ * @returns {ClosedGroupState}
+ */
 function makeClosedGroup(id, tabs) {
   return {
     id,
@@ -42,6 +92,7 @@ function makeClosedGroup(id, tabs) {
   };
 }
 
+/** @param {unknown} state */
 async function restoreWindowState(state) {
   const restored = BrowserTestUtils.waitForEvent(
     browserWindow,
@@ -60,10 +111,8 @@ registerCleanupFunction(async function restoreOriginalState() {
 add_task(async function closedPrivateContainerTabIsNotRecorded() {
   originalWindowState = SessionStore.getWindowState(browserWindow);
   const before = SessionStore.getClosedTabCountForWindow(browserWindow);
-  const tab = await BrowserTestUtils.openNewForegroundTab(
-    browserWindow.gBrowser,
-    LIVE_PRIVATE_URL,
-    true,
+  const tab = /** @type {XULElement} */ (
+    await BrowserTestUtils.openNewForegroundTab(gBrowser, LIVE_PRIVATE_URL, true)
   );
   tab.setAttribute("floorp-disablehistory", "true");
   BrowserTestUtils.removeTab(tab);

--- a/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
+++ b/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
@@ -333,9 +333,8 @@ add_task(function directTabbrowserCallerReceivesASanitizedPlaceholder() {
     );
     ok(!tabs[0].pinned, "private pinned state must not be retained");
     is(tabs[0].userContextId, 0, "private container identity must be removed");
-    isnot(
-      tabs[0].getAttribute("floorpWorkspaceId"),
-      "private-workspace",
+    ok(
+      !tabs[0].hasAttribute("floorpWorkspaceId"),
       "the private workspace identity must not be retained",
     );
     ok(

--- a/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
+++ b/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MPL-2.0
+
+const { SessionStore } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/SessionStore.sys.mjs",
+);
+
+const WORKSPACE_STORE_PREF = "floorp.workspaces.v4.store";
+const NORMAL_A = "data:text/plain,floorp-sessionstore-normal-a";
+const NORMAL_B = "data:text/plain,floorp-sessionstore-normal-b";
+const NORMAL_C = "data:text/plain,floorp-sessionstore-normal-c";
+const PRIVATE_URL = "data:text/plain,floorp-sessionstore-private";
+
+const browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+let originalWindowState;
+let originalWorkspacePref;
+
+function makeTabState(url, extra = {}) {
+  return {
+    entries: [{ url }],
+    index: 1,
+    lastAccessed: Date.now(),
+    ...extra,
+  };
+}
+
+async function restoreWindowState(state) {
+  const restored = BrowserTestUtils.waitForEvent(
+    browserWindow,
+    "SSWindowRestored",
+  );
+  SessionStore.setWindowState(browserWindow, JSON.stringify(state), true);
+  await restored;
+}
+
+function currentWindowState() {
+  return SessionStore.getWindowState(browserWindow).windows[0];
+}
+
+function restoredUrls() {
+  return currentWindowState().tabs.map((tab) => tab.entries[0]?.url);
+}
+
+registerCleanupFunction(async function restoreOriginalState() {
+  if (originalWorkspacePref === undefined) {
+    Services.prefs.clearUserPref(WORKSPACE_STORE_PREF);
+  } else {
+    Services.prefs.setStringPref(WORKSPACE_STORE_PREF, originalWorkspacePref);
+  }
+
+  if (originalWindowState) {
+    await restoreWindowState(originalWindowState);
+  }
+});
+
+add_task(async function mixedRestoreKeepsNormalTabsAndMetadataConsistent() {
+  originalWindowState = SessionStore.getWindowState(browserWindow);
+  originalWorkspacePref = Services.prefs.prefHasUserValue(WORKSPACE_STORE_PREF)
+    ? Services.prefs.getStringPref(WORKSPACE_STORE_PREF)
+    : undefined;
+  Services.prefs.setStringPref(WORKSPACE_STORE_PREF, "{not-json");
+
+  await restoreWindowState({
+    windows: [
+      {
+        tabs: [
+          makeTabState(NORMAL_A, {
+            pinned: true,
+            splitViewId: 7,
+            floorpSSB: "true",
+          }),
+          makeTabState(PRIVATE_URL, {
+            floorpDisableHistory: "true",
+            pinned: true,
+            groupId: "private-group",
+            splitViewId: 7,
+          }),
+          makeTabState(NORMAL_B, {
+            groupId: "normal-group",
+            splitViewId: 8,
+          }),
+          makeTabState(NORMAL_C, {
+            groupId: "normal-group",
+            splitViewId: 8,
+          }),
+        ],
+        selected: 2,
+        groups: [
+          {
+            id: "normal-group",
+            name: "Normal group",
+            color: "blue",
+            collapsed: false,
+          },
+          {
+            id: "private-group",
+            name: "Private group",
+            color: "red",
+            collapsed: false,
+          },
+        ],
+        splitViews: [
+          { id: 7, numberOfTabs: 2 },
+          { id: 8, numberOfTabs: 2 },
+        ],
+        _closedTabs: [],
+        closedGroups: [],
+      },
+    ],
+  });
+
+  const state = currentWindowState();
+  Assert.deepEqual(
+    restoredUrls(),
+    [NORMAL_A, NORMAL_B, NORMAL_C],
+    "only normal tabs should be restored",
+  );
+  is(state.selected, 1, "selection should fall back to the preceding tab");
+  ok(state.tabs[0].pinned, "a normal pinned tab should stay pinned");
+  ok(!browserWindow.closed, "restoring an SSB tab must not close the window");
+  is(
+    browserWindow.gBrowser.tabs[0].getAttribute("floorpSSB"),
+    "true",
+    "the SSB marker should still be restored as a tab attribute",
+  );
+  is(
+    state.groups.length,
+    1,
+    "orphaned private group metadata should be removed",
+  );
+  is(state.groups[0].id, "normal-group", "the normal group should remain");
+  is(state.splitViews.length, 1, "a singleton split view should be removed");
+  is(state.splitViews[0].id, 8, "the intact split view should remain");
+  is(
+    state.splitViews[0].numberOfTabs,
+    2,
+    "split view metadata should match surviving tabs",
+  );
+  ok(
+    !JSON.stringify(state).includes(PRIVATE_URL),
+    "private tab data must not survive in restored state",
+  );
+});
+
+add_task(async function allPrivateRestoreKeepsTheExistingBlankTab() {
+  await restoreWindowState({
+    windows: [
+      {
+        tabs: [makeTabState("about:blank")],
+        selected: 1,
+        _closedTabs: [],
+        closedGroups: [],
+      },
+    ],
+  });
+
+  await restoreWindowState({
+    windows: [
+      {
+        tabs: [
+          makeTabState(PRIVATE_URL, { floorpDisableHistory: true }),
+        ],
+        selected: 1,
+        groups: [],
+        splitViews: [],
+        _closedTabs: [],
+        closedGroups: [],
+      },
+    ],
+  });
+
+  is(browserWindow.gBrowser.tabs.length, 1, "one startup tab should remain");
+  is(restoredUrls()[0], "about:blank", "the remaining tab should be blank");
+  ok(
+    !JSON.stringify(currentWindowState()).includes(PRIVATE_URL),
+    "the all-private state must not leak its URL",
+  );
+});
+
+add_task(async function privateOnlyWindowIsDroppedWhenANormalWindowSurvives() {
+  await restoreWindowState({
+    windows: [
+      {
+        title: PRIVATE_URL,
+        tabs: [
+          makeTabState(PRIVATE_URL, { floorpDisableHistory: "true" }),
+        ],
+        selected: 1,
+        _closedTabs: [],
+        closedGroups: [],
+      },
+      {
+        tabs: [makeTabState(NORMAL_A)],
+        selected: 1,
+        _closedTabs: [],
+        closedGroups: [],
+      },
+    ],
+    selectedWindow: 1,
+  });
+
+  const windows = [];
+  for (const win of Services.wm.getEnumerator("navigator:browser")) {
+    windows.push(win);
+  }
+  is(
+    windows.length,
+    1,
+    "a private-only window should not become an extra blank",
+  );
+  Assert.deepEqual(
+    restoredUrls(),
+    [NORMAL_A],
+    "the surviving normal window should be restored into the existing window",
+  );
+  ok(
+    !JSON.stringify(SessionStore.getBrowserState()).includes(PRIVATE_URL),
+    "the removed private-only window must not remain in serialized state",
+  );
+});
+
+add_task(async function directTabbrowserCallerReceivesASanitizedPlaceholder() {
+  const tabDataList = [
+    makeTabState(PRIVATE_URL, {
+      floorpDisableHistory: "true",
+      floorpWorkspaceId: "private-workspace",
+      floorpLastShowWorkspaceId: "private-workspace",
+      floorpSSB: "true",
+      pinned: true,
+      userContextId: 5,
+      groupId: "direct-group",
+    }),
+    makeTabState(NORMAL_B),
+  ];
+  const tabs = browserWindow.gBrowser.createTabsForSessionRestore(
+    true,
+    1,
+    tabDataList,
+    [
+      {
+        id: "direct-group",
+        name: "Direct group",
+        color: "blue",
+        collapsed: false,
+      },
+    ],
+    [],
+  );
+
+  try {
+    is(tabs.length, 2, "the direct caller should keep array cardinality");
+    ok(
+      tabs[0].selected,
+      "a selected private slot should become selected blank",
+    );
+    Assert.deepEqual(
+      tabDataList[0].entries,
+      [],
+      "the private history should be replaced with a blank state",
+    );
+    ok(
+      !("floorpDisableHistory" in tabDataList[0]),
+      "the private marker should not reach restoreTabs",
+    );
+    ok(!tabs[0].pinned, "private pinned state must not be retained");
+    is(tabs[0].userContextId, 0, "private container identity must be removed");
+    isnot(
+      tabs[0].getAttribute("floorpWorkspaceId"),
+      "private-workspace",
+      "the private workspace identity must not be retained",
+    );
+    ok(
+      !tabs[0].hasAttribute("floorpSSB"),
+      "private SSB metadata must be removed",
+    );
+    is(
+      tabDataList[1].entries[0].url,
+      NORMAL_B,
+      "normal direct-caller state should stay in its original slot",
+    );
+  } finally {
+    for (const tab of tabs) {
+      BrowserTestUtils.removeTab(tab);
+    }
+  }
+});

--- a/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
+++ b/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
@@ -1,4 +1,60 @@
 // SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+// @ts-check
+/// <reference path="../../../@types/mochitest-compat.d.ts" />
+
+/**
+ * @typedef {{
+ *   entries: Array<{ url: string }>;
+ *   index: number;
+ *   lastAccessed: number;
+ *   pinned?: boolean;
+ *   [key: string]: unknown;
+ * }} SessionTabState
+ */
+
+/**
+ * @typedef {{
+ *   id: number;
+ *   numberOfTabs: number;
+ * }} SplitViewState
+ */
+
+/**
+ * @typedef {{
+ *   id: string;
+ *   [key: string]: unknown;
+ * }} TabGroupState
+ */
+
+/**
+ * @typedef {{
+ *   tabs: SessionTabState[];
+ *   selected: number;
+ *   groups: TabGroupState[];
+ *   splitViews: SplitViewState[];
+ * }} SessionWindowState
+ */
+
+/**
+ * @typedef {XULElement & {
+ *   pinned: boolean;
+ *   selected: boolean;
+ *   userContextId: number;
+ * }} SessionRestoreTab
+ */
+
+/**
+ * @typedef {GBrowser & {
+ *   createTabsForSessionRestore: (
+ *     restoreTabsLazily: boolean,
+ *     selectTab: number,
+ *     tabDataList: SessionTabState[],
+ *     tabGroupDataList: TabGroupState[],
+ *     splitViewDataList: SplitViewState[],
+ *   ) => SessionRestoreTab[];
+ * }} SessionRestoreGBrowser
+ */
 
 const { SessionStore } = ChromeUtils.importESModule(
   "resource:///modules/sessionstore/SessionStore.sys.mjs",
@@ -11,9 +67,16 @@ const NORMAL_C = "data:text/plain,floorp-sessionstore-normal-c";
 const PRIVATE_URL = "data:text/plain,floorp-sessionstore-private";
 
 const browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+/** @type {unknown} */
 let originalWindowState;
+/** @type {string | undefined} */
 let originalWorkspacePref;
 
+/**
+ * @param {string} url
+ * @param {Record<string, unknown>} [extra]
+ * @returns {SessionTabState}
+ */
 function makeTabState(url, extra = {}) {
   return {
     entries: [{ url }],
@@ -23,6 +86,7 @@ function makeTabState(url, extra = {}) {
   };
 }
 
+/** @param {unknown} state */
 async function restoreWindowState(state) {
   const restored = BrowserTestUtils.waitForEvent(
     browserWindow,
@@ -32,8 +96,11 @@ async function restoreWindowState(state) {
   await restored;
 }
 
+/** @returns {SessionWindowState} */
 function currentWindowState() {
-  return SessionStore.getWindowState(browserWindow).windows[0];
+  return /** @type {SessionWindowState} */ (
+    SessionStore.getWindowState(browserWindow).windows[0]
+  );
 }
 
 function restoredUrls() {
@@ -116,9 +183,9 @@ add_task(async function mixedRestoreKeepsNormalTabsAndMetadataConsistent() {
   );
   is(state.selected, 1, "selection should fall back to the preceding tab");
   ok(state.tabs[0].pinned, "a normal pinned tab should stay pinned");
-  ok(!browserWindow.closed, "restoring an SSB tab must not close the window");
+  ok(!window.closed, "restoring an SSB tab must not close the window");
   is(
-    browserWindow.gBrowser.tabs[0].getAttribute("floorpSSB"),
+    gBrowser.tabs[0].getAttribute("floorpSSB"),
     "true",
     "the SSB marker should still be restored as a tab attribute",
   );
@@ -168,7 +235,7 @@ add_task(async function allPrivateRestoreKeepsTheExistingBlankTab() {
     ],
   });
 
-  is(browserWindow.gBrowser.tabs.length, 1, "one startup tab should remain");
+  is(gBrowser.tabs.length, 1, "one startup tab should remain");
   is(restoredUrls()[0], "about:blank", "the remaining tab should be blank");
   ok(
     !JSON.stringify(currentWindowState()).includes(PRIVATE_URL),
@@ -218,7 +285,7 @@ add_task(async function privateOnlyWindowIsDroppedWhenANormalWindowSurvives() {
   );
 });
 
-add_task(async function directTabbrowserCallerReceivesASanitizedPlaceholder() {
+add_task(function directTabbrowserCallerReceivesASanitizedPlaceholder() {
   const tabDataList = [
     makeTabState(PRIVATE_URL, {
       floorpDisableHistory: "true",
@@ -231,7 +298,10 @@ add_task(async function directTabbrowserCallerReceivesASanitizedPlaceholder() {
     }),
     makeTabState(NORMAL_B),
   ];
-  const tabs = browserWindow.gBrowser.createTabsForSessionRestore(
+  const sessionRestoreBrowser = /** @type {SessionRestoreGBrowser} */ (
+    /** @type {unknown} */ (gBrowser)
+  );
+  const tabs = sessionRestoreBrowser.createTabsForSessionRestore(
     true,
     1,
     tabDataList,

--- a/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
+++ b/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
@@ -333,8 +333,13 @@ add_task(function directTabbrowserCallerReceivesASanitizedPlaceholder() {
     );
     ok(!tabs[0].pinned, "private pinned state must not be retained");
     is(tabs[0].userContextId, 0, "private container identity must be removed");
-    ok(
-      !tabs[0].hasAttribute("floorpWorkspaceId"),
+    // The direct caller path does not run inside the SessionStore restore
+    // window, so the workspaces service may already have assigned its current
+    // workspace to the placeholder tab. What must hold is that the private
+    // workspace identity from the sanitized state never survives.
+    isnot(
+      tabs[0].getAttribute("floorpWorkspaceId"),
+      "private-workspace",
       "the private workspace identity must not be retained",
     );
     ok(

--- a/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
+++ b/browser-features/chrome/common/private-container/test/sessionStoreRestoreOpen.test.js
@@ -353,3 +353,54 @@ add_task(function directTabbrowserCallerReceivesASanitizedPlaceholder() {
     }
   }
 });
+
+add_task(async function reusedSelectedTabClearsAbsentFloorpMetadata() {
+  Services.prefs.setStringPref(WORKSPACE_STORE_PREF, "{not-json");
+  const selectedTab = /** @type {SessionRestoreTab} */ (
+    /** @type {unknown} */ (
+      await BrowserTestUtils.openNewForegroundTab(gBrowser, "about:blank")
+    )
+  );
+  selectedTab.setAttribute("floorpWorkspaceId", "stale-workspace");
+  selectedTab.setAttribute(
+    "floorpWorkspaceLastShowId",
+    "stale-last-show-workspace",
+  );
+  selectedTab.setAttribute("floorpSSB", "stale-ssb");
+
+  const sessionRestoreBrowser = /** @type {SessionRestoreGBrowser} */ (
+    /** @type {unknown} */ (gBrowser)
+  );
+  const tabs = sessionRestoreBrowser.createTabsForSessionRestore(
+    true,
+    1,
+    [
+      makeTabState("about:blank", {
+        userContextId: selectedTab.userContextId,
+      }),
+    ],
+    [],
+    [],
+  );
+
+  try {
+    is(tabs[0], selectedTab, "the existing selected tab should be reused");
+    for (
+      const attribute of [
+        "floorpWorkspaceId",
+        "floorpWorkspaceLastShowId",
+        "floorpSSB",
+      ]
+    ) {
+      ok(
+        !selectedTab.hasAttribute(attribute),
+        `${attribute} should be removed when it is absent from restored state`,
+      );
+    }
+  } finally {
+    selectedTab.removeAttribute("floorpWorkspaceId");
+    selectedTab.removeAttribute("floorpWorkspaceLastShowId");
+    selectedTab.removeAttribute("floorpSSB");
+    BrowserTestUtils.removeTab(selectedTab);
+  }
+});

--- a/tools/patches/browser-chrome-browser-content-browser-tabbrowser-tabbrowser.patch
+++ b/tools/patches/browser-chrome-browser-content-browser-tabbrowser-tabbrowser.patch
@@ -46,7 +46,7 @@ index c42b1a1..38630a5 100644
          let userContextId = tabData.userContextId;
          let select = i == selectTab - 1;
          let tab;
-@@ -4502,6 +4539,30 @@
+@@ -4502,6 +4539,36 @@
          ) {
            tabWasReused = true;
            tab = this.selectedTab;
@@ -57,6 +57,8 @@ index c42b1a1..38630a5 100644
 +           */
 +          if (floorpWorkspaceId) {
 +            tab.setAttribute("floorpWorkspaceId", floorpWorkspaceId);
++          } else {
++            tab.removeAttribute("floorpWorkspaceId");
 +          }
 +
 +          if (floorpLastShowWorkspaceId) {
@@ -64,10 +66,14 @@ index c42b1a1..38630a5 100644
 +              "floorpWorkspaceLastShowId",
 +              floorpLastShowWorkspaceId
 +            );
++          } else {
++            tab.removeAttribute("floorpWorkspaceLastShowId");
 +          }
 +
 +          if (floorpSSB) {
 +            tab.setAttribute("floorpSSB", floorpSSB);
++          } else {
++            tab.removeAttribute("floorpSSB");
 +          }
 +          /**
 +           * * NORANEKO PATCH - 0.1.19
@@ -77,7 +83,7 @@ index c42b1a1..38630a5 100644
            if (!tabData.pinned) {
              this.unpinTab(tab);
            } else {
-@@ -4547,6 +4608,31 @@
+@@ -4547,6 +4614,37 @@
              preferredRemoteType,
            });
  
@@ -88,6 +94,8 @@ index c42b1a1..38630a5 100644
 +           */
 +          if (floorpWorkspaceId) {
 +            tab.setAttribute("floorpWorkspaceId", floorpWorkspaceId);
++          } else {
++            tab.removeAttribute("floorpWorkspaceId");
 +          }
 +
 +          if (floorpLastShowWorkspaceId) {
@@ -95,10 +103,14 @@ index c42b1a1..38630a5 100644
 +              "floorpWorkspaceLastShowId",
 +              floorpLastShowWorkspaceId
 +            );
++          } else {
++            tab.removeAttribute("floorpWorkspaceLastShowId");
 +          }
 +
 +          if (floorpSSB) {
 +            tab.setAttribute("floorpSSB", floorpSSB);
++          } else {
++            tab.removeAttribute("floorpSSB");
 +          }
 +          /**
 +           * * NORANEKO PATCH - 0.1.19

--- a/tools/patches/browser-chrome-browser-content-browser-tabbrowser-tabbrowser.patch
+++ b/tools/patches/browser-chrome-browser-content-browser-tabbrowser-tabbrowser.patch
@@ -1,33 +1,41 @@
 diff --git a/browser/chrome/browser/content/browser/tabbrowser/tabbrowser.js b/browser/chrome/browser/content/browser/tabbrowser/tabbrowser.js
-index ce68c33..47ccc30 100644
+index c42b1a1..38630a5 100644
 --- ./browser/chrome/browser/content/browser/tabbrowser/tabbrowser.js
 +++ ./browser/chrome/browser/content/browser/tabbrowser/tabbrowser.js
-@@ -3377,6 +3377,35 @@
-         let tab;
-         let tabWasReused = false;
+@@ -4485,6 +4485,43 @@
+       for (var i = 0; i < tabDataList.length; i++) {
+         let tabData = tabDataList[i];
  
 +        /**
 +         * * NORANEKO PATCH - 0.1.19
 +         * * [WORKSPACES]
 +         * * START
 +         */
-+        if (tabData.floorpDisableHistory) {
-+          continue;
++        if (
++          tabData.floorpDisableHistory === true ||
++          tabData.floorpDisableHistory === "true"
++        ) {
++          let sanitizedTabData = { entries: [] };
++          for (let property of ["lastAccessed", "groupId", "splitViewId"]) {
++            if (property in tabData) {
++              sanitizedTabData[property] = tabData[property];
++            }
++          }
++          tabDataList[i] = tabData = sanitizedTabData;
 +        }
 +
-+        let floorpWorkspaceId,
-+          floorpLastShowWorkspaceId,
-+          floorpSSB;
++        let floorpWorkspaceId = tabData.floorpWorkspaceId;
++        let floorpLastShowWorkspaceId = tabData.floorpLastShowWorkspaceId;
++        let floorpSSB = tabData.floorpSSB;
 +
-+        floorpWorkspaceId = tabData.floorpWorkspaceId
-+          ? tabData.floorpWorkspaceId
-+          : JSON.parse(Services.prefs.getStringPref("floorp.workspaces.v4.store"))
-+              .defaultID;
-+        floorpLastShowWorkspaceId = tabData.floorpLastShowWorkspaceId;
-+        floorpSSB = tabData.floorpSSB;
-+
-+        if (floorpSSB) {
-+          window.close();
++        if (!floorpWorkspaceId) {
++          try {
++            floorpWorkspaceId = JSON.parse(
++              Services.prefs.getStringPref("floorp.workspaces.v4.store", "{}")
++            ).defaultID;
++          } catch {
++            console.warn("Floorp: failed to parse the workspace store");
++          }
 +        }
 +        /**
 +         * * NORANEKO PATCH - 0.1.19
@@ -35,10 +43,10 @@ index ce68c33..47ccc30 100644
 +         * * END
 +         */
 +
-         // Re-use existing selected tab if possible to avoid the overhead of
-         // selecting a new tab. For now, we only do this for horizontal tabs;
-         // we'll let tabs.js handle pinning for vertical tabs until we unify
-@@ -3389,6 +3418,30 @@
+         let userContextId = tabData.userContextId;
+         let select = i == selectTab - 1;
+         let tab;
+@@ -4502,6 +4539,30 @@
          ) {
            tabWasReused = true;
            tab = this.selectedTab;
@@ -69,7 +77,7 @@ index ce68c33..47ccc30 100644
            if (!tabData.pinned) {
              this.unpinTab(tab);
            } else {
-@@ -3438,6 +3491,31 @@
+@@ -4547,6 +4608,31 @@
              preferredRemoteType,
            });
  

--- a/tools/patches/browser-chrome-browser-content-browser-tabbrowser-tabbrowser.patch
+++ b/tools/patches/browser-chrome-browser-content-browser-tabbrowser-tabbrowser.patch
@@ -2,10 +2,11 @@ diff --git a/browser/chrome/browser/content/browser/tabbrowser/tabbrowser.js b/b
 index c42b1a1..38630a5 100644
 --- ./browser/chrome/browser/content/browser/tabbrowser/tabbrowser.js
 +++ ./browser/chrome/browser/content/browser/tabbrowser/tabbrowser.js
-@@ -4485,6 +4485,43 @@
+@@ -4485,6 +4485,45 @@
        for (var i = 0; i < tabDataList.length; i++) {
          let tabData = tabDataList[i];
  
++        let isPrivateContainerPlaceholder = false;
 +        /**
 +         * * NORANEKO PATCH - 0.1.19
 +         * * [WORKSPACES]
@@ -15,6 +16,7 @@ index c42b1a1..38630a5 100644
 +          tabData.floorpDisableHistory === true ||
 +          tabData.floorpDisableHistory === "true"
 +        ) {
++          isPrivateContainerPlaceholder = true;
 +          let sanitizedTabData = { entries: [] };
 +          for (let property of ["lastAccessed", "groupId", "splitViewId"]) {
 +            if (property in tabData) {
@@ -28,7 +30,7 @@ index c42b1a1..38630a5 100644
 +        let floorpLastShowWorkspaceId = tabData.floorpLastShowWorkspaceId;
 +        let floorpSSB = tabData.floorpSSB;
 +
-+        if (!floorpWorkspaceId) {
++        if (!isPrivateContainerPlaceholder && !floorpWorkspaceId) {
 +          try {
 +            floorpWorkspaceId = JSON.parse(
 +              Services.prefs.getStringPref("floorp.workspaces.v4.store", "{}")
@@ -46,7 +48,7 @@ index c42b1a1..38630a5 100644
          let userContextId = tabData.userContextId;
          let select = i == selectTab - 1;
          let tab;
-@@ -4502,6 +4539,36 @@
+@@ -4502,6 +4541,36 @@
          ) {
            tabWasReused = true;
            tab = this.selectedTab;
@@ -83,7 +85,7 @@ index c42b1a1..38630a5 100644
            if (!tabData.pinned) {
              this.unpinTab(tab);
            } else {
-@@ -4547,6 +4614,37 @@
+@@ -4547,6 +4616,37 @@
              preferredRemoteType,
            });
  

--- a/tools/patches/browser-modules-sessionstore-SessionStore.sys.patch
+++ b/tools/patches/browser-modules-sessionstore-SessionStore.sys.patch
@@ -1,0 +1,340 @@
+diff --git a/browser/modules/sessionstore/SessionStore.sys.mjs b/browser/modules/sessionstore/SessionStore.sys.mjs
+index 11191a8..9cf32a0 100644
+--- ./browser/modules/sessionstore/SessionStore.sys.mjs
++++ ./browser/modules/sessionstore/SessionStore.sys.mjs
+@@ -156,6 +156,13 @@ const RESTORE_TAB_CONTENT_REASON = {
+ // 'browser.startup.page' preference value to resume the previous session.
+ const BROWSER_STARTUP_RESUME_SESSION = 3;
+ 
++function isFloorpPrivateContainerTabState(tabState) {
++  return (
++    tabState?.floorpDisableHistory === true ||
++    tabState?.floorpDisableHistory === "true"
++  );
++}
++
+ // Used by SessionHistoryListener.
+ const kNoIndex = Number.MAX_SAFE_INTEGER;
+ const kLastIndex = Number.MAX_SAFE_INTEGER - 1;
+@@ -1348,6 +1355,7 @@ var SessionStoreInternal = {
+     if (state) {
+       // Initialize the splitViewId counter and migrate any string-based splitViewIds
+       this._initSplitViewIds(state);
++      this._sanitizeFloorpPrivateContainerRootState(state);
+ 
+       try {
+         // If we're doing a DEFERRED session, then we want to pull pinned tabs
+@@ -3982,6 +3990,7 @@ var SessionStoreInternal = {
+     // Initialize counter and migrate splitViewIds from persisted given state
+     this._maxSplitViewId = 0;
+     this._initSplitViewIds(state);
++    this._sanitizeFloorpPrivateContainerRootState(state);
+ 
+     this._browserSetState = true;
+ 
+@@ -5893,6 +5902,239 @@ var SessionStoreInternal = {
+     return tabData;
+   },
+ 
++  _sanitizeFloorpPrivateContainerSplitViews(tabStates, splitViews) {
++    let splitViewTabCounts = new Map();
++    for (let tabState of tabStates) {
++      if (tabState.splitViewId === undefined) {
++        continue;
++      }
++      splitViewTabCounts.set(
++        tabState.splitViewId,
++        (splitViewTabCounts.get(tabState.splitViewId) ?? 0) + 1
++      );
++    }
++
++    for (let tabState of tabStates) {
++      if ((splitViewTabCounts.get(tabState.splitViewId) ?? 0) < 2) {
++        delete tabState.splitViewId;
++      }
++    }
++
++    if (!Array.isArray(splitViews)) {
++      return splitViews;
++    }
++
++    return splitViews.flatMap(splitView => {
++      let numberOfTabs = splitViewTabCounts.get(splitView.id) ?? 0;
++      if (numberOfTabs < 2) {
++        return [];
++      }
++      splitView.numberOfTabs = numberOfTabs;
++      return splitView;
++    });
++  },
++
++  _sanitizeFloorpPrivateContainerTabGroups(tabGroups) {
++    if (!Array.isArray(tabGroups)) {
++      return tabGroups;
++    }
++
++    return tabGroups.flatMap(tabGroup => {
++      if (!Array.isArray(tabGroup.tabs)) {
++        return tabGroup;
++      }
++
++      tabGroup.tabs = tabGroup.tabs.filter(
++        tabData => !isFloorpPrivateContainerTabState(tabData.state)
++      );
++      if (!tabGroup.tabs.length) {
++        return [];
++      }
++
++      let tabStates = tabGroup.tabs.map(tabData => tabData.state);
++      tabGroup.splitViews = this._sanitizeFloorpPrivateContainerSplitViews(
++        tabStates,
++        tabGroup.splitViews
++      );
++      return tabGroup;
++    });
++  },
++
++  _sanitizeFloorpPrivateContainerClosedData(winData) {
++    if (!winData) {
++      return;
++    }
++
++    if (Array.isArray(winData._closedTabs)) {
++      winData._closedTabs = winData._closedTabs.filter(
++        tabData => !isFloorpPrivateContainerTabState(tabData.state)
++      );
++    }
++    winData.closedGroups = this._sanitizeFloorpPrivateContainerTabGroups(
++      winData.closedGroups
++    );
++  },
++
++  _sanitizeFloorpPrivateContainerWindowState(winData) {
++    if (!winData || !Array.isArray(winData.tabs)) {
++      return false;
++    }
++
++    let originalTabs = winData.tabs;
++    let tabs = originalTabs.filter(
++      tabState => !isFloorpPrivateContainerTabState(tabState)
++    );
++    if (tabs.length == originalTabs.length) {
++      return false;
++    }
++
++    let originalSelectedIndex = parseInt(winData.selected || 1, 10) - 1;
++    if (!Number.isInteger(originalSelectedIndex)) {
++      originalSelectedIndex = 0;
++    }
++    originalSelectedIndex = Math.max(
++      0,
++      Math.min(originalSelectedIndex, originalTabs.length - 1)
++    );
++
++    let selectedTab = originalTabs[originalSelectedIndex];
++    let selectedIndex = tabs.indexOf(selectedTab);
++    if (selectedIndex == -1) {
++      for (let index = originalSelectedIndex - 1; index >= 0; index--) {
++        if (!isFloorpPrivateContainerTabState(originalTabs[index])) {
++          selectedIndex = tabs.indexOf(originalTabs[index]);
++          break;
++        }
++      }
++    }
++    if (selectedIndex == -1 && tabs.length) {
++      selectedIndex = 0;
++    }
++
++    winData.tabs = tabs;
++    winData.selected = selectedIndex + 1;
++
++    if (Array.isArray(winData.groups)) {
++      let groupIds = new Set(
++        tabs.map(tabState => tabState.groupId).filter(Boolean)
++      );
++      winData.groups = winData.groups.filter(group => groupIds.has(group.id));
++    }
++    winData.splitViews = this._sanitizeFloorpPrivateContainerSplitViews(
++      tabs,
++      winData.splitViews
++    );
++    return true;
++  },
++
++  _sanitizeFloorpPrivateContainerClosedWindowState(winData) {
++    let removedOpenTab =
++      this._sanitizeFloorpPrivateContainerWindowState(winData);
++    this._sanitizeFloorpPrivateContainerClosedData(winData);
++
++    if (!removedOpenTab) {
++      return true;
++    }
++
++    if (!winData.tabs?.length) {
++      winData.selected = 0;
++      delete winData.title;
++      return Boolean(
++        winData._closedTabs?.length || winData.closedGroups?.length
++      );
++    }
++
++    let selectedTabState = winData.tabs[winData.selected - 1];
++    let entries = selectedTabState?.entries ?? [];
++    let activeIndex = (selectedTabState?.index || entries.length) - 1;
++    activeIndex = Math.max(0, Math.min(activeIndex, entries.length - 1));
++    let activeEntry = entries[activeIndex];
++    if (activeEntry) {
++      winData.title = activeEntry.title || activeEntry.url;
++    } else {
++      delete winData.title;
++    }
++    return true;
++  },
++
++  _sanitizeFloorpPrivateContainerOpenWindows(root) {
++    if (!Array.isArray(root.windows)) {
++      return;
++    }
++
++    let originalWindows = root.windows;
++    let originalSelectedIndex = parseInt(root.selectedWindow || 1, 10) - 1;
++    if (!Number.isInteger(originalSelectedIndex)) {
++      originalSelectedIndex = 0;
++    }
++    originalSelectedIndex = Math.max(
++      0,
++      Math.min(originalSelectedIndex, originalWindows.length - 1)
++    );
++
++    let privateOnlyEmptyWindows = new Set();
++    for (let winData of originalWindows) {
++      let removedOpenTab =
++        this._sanitizeFloorpPrivateContainerWindowState(winData);
++      this._sanitizeFloorpPrivateContainerClosedData(winData);
++      if (removedOpenTab && !winData.tabs.length) {
++        winData.selected = 0;
++        delete winData.title;
++        if (!winData._closedTabs?.length && !winData.closedGroups?.length) {
++          privateOnlyEmptyWindows.add(winData);
++        }
++      }
++    }
++
++    let windows = originalWindows.filter(
++      winData => !privateOnlyEmptyWindows.has(winData)
++    );
++    if (!windows.length && privateOnlyEmptyWindows.size) {
++      windows.push(
++        originalWindows[originalSelectedIndex] ?? originalWindows[0]
++      );
++    }
++
++    let selectedWindow = originalWindows[originalSelectedIndex];
++    let selectedIndex = windows.indexOf(selectedWindow);
++    if (selectedIndex == -1) {
++      for (let index = originalSelectedIndex - 1; index >= 0; index--) {
++        if (windows.includes(originalWindows[index])) {
++          selectedIndex = windows.indexOf(originalWindows[index]);
++          break;
++        }
++      }
++    }
++    if (selectedIndex == -1 && windows.length) {
++      selectedIndex = 0;
++    }
++
++    root.windows = windows;
++    root.selectedWindow = selectedIndex + 1;
++  },
++
++  _sanitizeFloorpPrivateContainerRootState(state) {
++    for (let root of [
++      state?.deferredInitialState,
++      state?.lastSessionState,
++      state,
++    ]) {
++      if (!root) {
++        continue;
++      }
++
++      this._sanitizeFloorpPrivateContainerOpenWindows(root);
++      if (Array.isArray(root._closedWindows)) {
++        root._closedWindows = root._closedWindows.filter(winData =>
++          this._sanitizeFloorpPrivateContainerClosedWindowState(winData)
++        );
++      }
++      root.savedGroups = this._sanitizeFloorpPrivateContainerTabGroups(
++        root.savedGroups
++      );
++    }
++  },
++
+   _initSplitViewIds(state) {
+     if (this._maxSplitViewId > 0) {
+       this._log.error(
+@@ -6029,6 +6271,9 @@ var SessionStoreInternal = {
+       winData.tabs = [];
+     }
+ 
++    this._sanitizeFloorpPrivateContainerWindowState(winData);
++    this._sanitizeFloorpPrivateContainerClosedData(winData);
++
+     // See SessionStoreInternal.restoreTabs for a description of what
+     // selectTab represents.
+     let selectTab = 0;
+@@ -6349,6 +6594,8 @@ var SessionStoreInternal = {
+       return;
+     }
+ 
++    this._sanitizeFloorpPrivateContainerRootState(root);
++
+     // Restore closed windows if any.
+     if (root._closedWindows) {
+       this._closedWindows = root._closedWindows;
+@@ -7511,6 +7758,10 @@ var SessionStoreInternal = {
+    * @returns boolean
+    */
+   _shouldSaveTabState: function ssi_shouldSaveTabState(aTabState) {
++    if (isFloorpPrivateContainerTabState(aTabState)) {
++      return false;
++    }
++
+     // If the tab has only a transient about: history entry, no other
+     // session history, and no userTypedValue, then we don't actually want to
+     // store this tab's data.
+@@ -7649,6 +7900,12 @@ var SessionStoreInternal = {
+           // We don't want to increment tIndex here.
+           continue;
+         } else if (window.tabs[tIndex].groupId) {
++          let tabToAdd = window.tabs[tIndex];
++          if (!this._shouldSaveTabState(tabToAdd)) {
++            tIndex++;
++            continue;
++          }
++
+           // Convert any open groups into saved groups.
+           let groupStateToSave = window.groups.find(
+             groupState => groupState.id == window.tabs[tIndex].groupId
+@@ -7662,7 +7919,6 @@ var SessionStoreInternal = {
+             groupToSave.removeAfterRestore = true;
+             groupsToSave.set(groupStateToSave.id, groupToSave);
+           }
+-          let tabToAdd = window.tabs[tIndex];
+           groupToSave.tabs.push(this._formatTabStateForSavedGroup(tabToAdd));
+         } else if (!window.tabs[tIndex].hidden && PERSIST_SESSIONS) {
+           // Add any previously open tabs that aren't pinned or hidden to the recently closed tabs list
+@@ -7763,6 +8019,14 @@ var SessionStoreInternal = {
+           continue;
+         }
+       }
++
++      if (!window.tabs.length) {
++        if (wIndex + 1 <= state.selectedWindow) {
++          state.selectedWindow -= 1;
++        }
++        state.windows.splice(wIndex, 1);
++        continue;
++      }
+       wIndex++;
+     }
+ 

--- a/tools/patches/browser-modules-sessionstore-SessionStore.sys.patch
+++ b/tools/patches/browser-modules-sessionstore-SessionStore.sys.patch
@@ -323,16 +323,26 @@ index 11191a8..9cf32a0 100644
            groupToSave.tabs.push(this._formatTabStateForSavedGroup(tabToAdd));
          } else if (!window.tabs[tIndex].hidden && PERSIST_SESSIONS) {
            // Add any previously open tabs that aren't pinned or hidden to the recently closed tabs list
-@@ -7763,6 +8019,14 @@ var SessionStoreInternal = {
+@@ -7763,6 +8019,24 @@ var SessionStoreInternal = {
            continue;
          }
        }
 +
 +      if (!window.tabs.length) {
-+        if (wIndex + 1 <= state.selectedWindow) {
-+          state.selectedWindow -= 1;
-+        }
++        let removedWindowIndex = wIndex + 1;
 +        state.windows.splice(wIndex, 1);
++
++        if (removedWindowIndex < state.selectedWindow) {
++          state.selectedWindow -= 1;
++        } else if (
++          removedWindowIndex == state.selectedWindow &&
++          state.windows.length
++        ) {
++          state.selectedWindow = Math.min(
++            removedWindowIndex,
++            state.windows.length
++          );
++        }
 +        continue;
 +      }
        wIndex++;


### PR DESCRIPTION
## Summary

- sanitize Floorp private-container tab state marked with `floorpDisableHistory` before open, deferred, LastSession, closed-tab, closed-window, saved-group, and split-view restoration
- preserve SessionStore tab/index alignment for direct `createTabsForSessionRestore` callers by replacing skipped private state with a safe blank placeholder
- guard malformed workspace-store JSON and preserve `floorpSSB` metadata without closing the restoring window
- add browser integration coverage for mixed, private-only, grouped, closed-tab, and closed-window restore paths

## Root cause

Floorp's tabbrowser patch used `continue` for tabs marked with `floorpDisableHistory`. That shortened the list of created tabs while SessionStore still restored the original tab-state array, so tab indexes could diverge and the restore could abort. An unguarded workspace-store `JSON.parse` and a `window.close()` path for SSB state were additional restore-interruption paths.

The fix removes private-container state at the SessionStore boundary, remaps selected tabs/windows, and repairs group/split-view metadata while retaining normal session data.

## User impact

Normal tabs, recently closed tabs/windows, workspaces, pinned state, and supported group metadata remain recoverable even when legacy session data also contains private-container tabs. Private-container URLs and history markers are still excluded from persisted restore state.

Fixes #2434.

## Validation

- browser integration tests: 3 files passed, 0 failed
  - existing private-container suite
  - 3 closed-state restore tasks
  - 4 open-state restore tasks
- host test suite: 275 passed, 0 failed
- both embedded Gecko patches passed apply/reverse validation against the built Floorp runtime
- isolated-profile Floorp 153 restart checks covered:
  - mixed normal/private sessions
  - all-private sessions falling back to one blank tab
  - private-only windows alongside surviving normal windows
  - deferred/saved tab groups
  - malformed workspace-store JSON
  - LastSession and closed-history persistence

## Verification scope

The runtime restart checks used the current Floorp development runtime with synthetic legacy session states. The exact historical 12.14.1 upgrade environment was not reproduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Privacy**
  - Private-container tabs and related session data are no longer saved or restored.
  - Private entries are removed from closed tabs, groups, split views, saved groups, and closed windows.

- **Bug Fixes**
  - Session restoration preserves normal tabs, pinned state, groups, split views, workspaces, and selection.
  - Private-only windows are removed appropriately, with a blank tab retained when needed.
  - Restored tabs retain relevant workspace and app-specific metadata without exposing private identity or history.
  - Window titles, selections, and related metadata are corrected after private content is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->