### PR TITLE
fix(i18n): restore tabWindowBehavior ja-JP keys

### DIFF
--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -130,6 +130,18 @@
             "minHeight": "タブの最小高さ",
             "minHeightError": "タブの高さは、 {{min}} から {{max}} ピクセルの間でなければなりません。"
         },
+        "tabWindowBehavior": {
+            "title": "タブとウィンドウの動作",
+            "description": "リンクの開き先と、Windows のタスクバーに表示されるタブプレビューの動作を設定します。",
+            "openLinks": "新しいウィンドウを要求するリンクの開き先",
+            "openLinksDescription": "新しいウィンドウを要求するリンクを、現在のウィンドウ、新しいウィンドウ、新しいタブのいずれで開くかを選択します。",
+            "openCurrentWindowOrTab": "現在のウィンドウまたはタブ",
+            "openNewWindow": "新しいウィンドウ",
+            "openNewTab": "新しいタブ",
+            "taskbarPreviews": "タスクバーにタブのプレビューを表示",
+            "taskbarPreviewsDescription": "この設定は Windows のタスクバー表示のみを変更し、ブラウザのウィンドウを新たに作成しません。",
+            "taskbarPreviewsUnavailable": "この項目は Windows でのみ利用できます。"
+        },
         "lepton-preferences": {
             "title": "Lepton の設定",
             "description": "Lepton テーマの高度な設定を変更します",


### PR DESCRIPTION
## Summary

Restores the `design.tabWindowBehavior` keys in `ja-JP.json` that the i18n bot sync (`f7cd69a4`) removed from main. The browser test `tabWindowBehavior.test.ts` currently fails on main (and on any PR based on current main) with "design.tabWindowBehavior is undefined" because the Japanese keys are missing.

Also improves the two description strings for natural Japanese phrasing.

## Validation

- `tabWindowBehavior.test.ts` passes locally once the keys are present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Japanese translations for tab and link-opening behavior settings.
  * Added localized descriptions for Windows taskbar tab previews and platform availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->