### PR TITLE
fix(release): tolerate Updates workflow metadata propagation delay

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -590,13 +590,25 @@ jobs:
                 repo: "Floorp-Updates",
                 run_id: runId,
               });
+              if (run.id !== runId) {
+                throw new Error("Returned Updates run ID does not match the dispatched request");
+              }
               if (
-                run.id !== runId || run.event !== "workflow_dispatch" ||
+                run.event !== "workflow_dispatch" ||
                 run.head_branch !== "main" ||
                 run.path !== ".github/workflows/update-stable-updatexml-files-v2.yml" ||
                 run.display_title !== expectedTitle
               ) {
-                throw new Error("Returned Updates run does not match the dispatched request");
+                // GitHub's workflow-run record can briefly expose incomplete
+                // identity fields immediately after dispatch. Keep polling
+                // the exact returned run instead of failing on that transient
+                // state; a permanently mismatched run still fails closed at
+                // the timeout below.
+                if (attempt === 180) {
+                  throw new Error("Returned Updates run did not match the dispatched request");
+                }
+                await new Promise((resolve) => setTimeout(resolve, 10000));
+                continue;
               }
               if (run.status === "completed") {
                 if (run.conclusion !== "success") {


### PR DESCRIPTION
## Summary\n- keep the exact dispatched Floorp-Updates run ID as the security boundary\n- retry transiently incomplete workflow identity fields after dispatch\n- fail closed if identity never converges within the existing timeout\n\n## Validation\n- git diff --check\n\nThis prevents publish_release.yml from failing immediately with Returned Updates run does not match the dispatched request while GitHub is still populating the returned workflow-run metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release update monitoring to handle temporary delays in run identification.
  * Added a final validation step to prevent reporting completion for an incorrectly identified run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->