### PR TITLE
fix(actors): restore web actors on Firefox 154

### DIFF
--- a/browser-features/modules/actors/NRChromeWebStoreChild.sys.mts
+++ b/browser-features/modules/actors/NRChromeWebStoreChild.sys.mts
@@ -19,10 +19,13 @@ import type {
   MutableExtensionMetadata,
 } from "../modules/chrome-web-store/types.ts";
 import {
-  isChromeWebStoreUrl,
-  extractExtensionId,
   CWS_I18N_KEYS,
+  extractExtensionId,
+  isChromeWebStoreUrl,
 } from "../modules/chrome-web-store/Constants.sys.mts";
+import {
+  findPrimaryVisibleActionButton,
+} from "../modules/chrome-web-store/DOMUtils.sys.mts";
 
 const { setTimeout, clearTimeout } = ChromeUtils.importESModule(
   "resource://gre/modules/Timer.sys.mjs",
@@ -40,6 +43,9 @@ const BUTTON_RESET_DELAY = 3000;
 
 /** Error notice auto-hide delay in milliseconds */
 const ERROR_NOTICE_TIMEOUT = 10000;
+
+/** Marker used to restore the store action after SPA navigation */
+const ORIGINAL_ADD_BUTTON_ATTRIBUTE = "data-floorp-cws-original-button";
 
 /** Button states */
 type ButtonState = "default" | "installing" | "success" | "error" | "installed";
@@ -80,18 +86,15 @@ const DEFAULT_TRANSLATIONS: Record<string, string> = {
 // making it work across all languages and UI changes.
 
 /**
- * Primary selector for the "Add to Chrome" button.
- * Uses DOM structure: main element contains sections, first section has h1 and the action button.
- * The button is a sibling of the div containing h1.
+ * Primary selector for the extension header containing the action button.
+ * Uses DOM structure so it does not depend on localized button text.
  */
-const ADD_BUTTON_STRUCTURE_SELECTOR =
-  "main section:has(h1) button:first-of-type";
+const EXTENSION_HEADER_SELECTOR = "main section:has(h1)";
 
 /**
  * Fallback selector using the first section approach
  */
-const ADD_BUTTON_FALLBACK_SELECTOR =
-  "main > div > section:first-of-type button:first-of-type";
+const EXTENSION_HEADER_FALLBACK_SELECTOR = "main > div > section:first-of-type";
 
 /**
  * Selector for extension logo image (fallback for extractExtensionMetadata)
@@ -103,19 +106,23 @@ const EXTENSION_LOGO_SELECTOR = "main section:has(h1) img";
 // =============================================================================
 
 /** SVG path data for the plus icon (default state) */
-const SVG_PATH_PLUS = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z";
+const SVG_PATH_PLUS =
+  "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z";
 
 /** SVG path data for the checkmark icon (success/installed state) */
 const SVG_PATH_CHECK = "M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z";
 
 /** SVG path data for the error icon */
-const SVG_PATH_ERROR = "M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z";
+const SVG_PATH_ERROR =
+  "M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z";
 
 /** SVG path data for the info/warning icon */
-const SVG_PATH_INFO = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z";
+const SVG_PATH_INFO =
+  "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z";
 
 /** SVG path data for the close/X icon */
-const SVG_PATH_CLOSE = "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z";
+const SVG_PATH_CLOSE =
+  "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z";
 
 // =============================================================================
 // Main Class
@@ -154,7 +161,11 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
    * Create an SVG element with the given path
    * This avoids using innerHTML which violates CSP on Chrome Web Store
    */
-  private createSvgElement(viewBox: string, pathData: string, className?: string): SVGSVGElement {
+  private createSvgElement(
+    viewBox: string,
+    pathData: string,
+    className?: string,
+  ): SVGSVGElement {
     const doc = this.document!;
     const svg = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
     svg.setAttribute("viewBox", viewBox);
@@ -174,12 +185,19 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
    * Create a button content element with icon and text
    * This avoids using innerHTML which violates CSP on Chrome Web Store
    */
-  private createButtonContent(iconPathData: string, text: string): DocumentFragment {
+  private createButtonContent(
+    iconPathData: string,
+    text: string,
+  ): DocumentFragment {
     const doc = this.document!;
     const fragment = doc.createDocumentFragment();
 
     // Create SVG icon
-    const svg = this.createSvgElement("0 0 24 24", iconPathData, "floorp-add-button__icon");
+    const svg = this.createSvgElement(
+      "0 0 24 24",
+      iconPathData,
+      "floorp-add-button__icon",
+    );
     fragment.appendChild(svg);
 
     // Create text span
@@ -421,6 +439,7 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
     // Find and hide the Add to Chrome button
     const addToChromeButton = this.findOriginalAddToChromeButton();
     if (addToChromeButton) {
+      addToChromeButton.setAttribute(ORIGINAL_ADD_BUTTON_ATTRIBUTE, "true");
       (addToChromeButton as HTMLElement).style.setProperty(
         "display",
         "none",
@@ -445,15 +464,9 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
       const section = h1.closest("section");
       if (!section) continue;
 
-      // Find button that is NOT our Floorp button
-      const buttons = section.querySelectorAll("button");
-      for (const button of buttons) {
-        if (
-          button.id !== "floorp-add-extension-btn" &&
-          this.isElementVisible(button)
-        ) {
-          return button;
-        }
+      const button = this.findVisibleHeaderActionButton(section);
+      if (button) {
+        return button;
       }
     }
 
@@ -470,6 +483,14 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
     const existingButton = doc.getElementById("floorp-add-extension-btn");
     if (existingButton) {
       existingButton.remove();
+    }
+
+    const originalButton = doc.querySelector(
+      `[${ORIGINAL_ADD_BUTTON_ATTRIBUTE}="true"]`,
+    );
+    if (originalButton instanceof HTMLElement) {
+      originalButton.style.removeProperty("display");
+      originalButton.removeAttribute(ORIGINAL_ADD_BUTTON_ATTRIBUTE);
     }
 
     const existingError = doc.getElementById("floorp-cws-error");
@@ -667,9 +688,10 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
       return false;
     }
 
-    // Verify the "Add to Chrome" button is visible and ready
-    const button = section.querySelector("button");
-    if (!button || !this.isElementVisible(button)) {
+    // Chrome Web Store may prepend hidden utility buttons to the header.
+    // Verify that the actual visible action button is ready instead of only
+    // checking the first button in DOM order.
+    if (!this.findVisibleHeaderActionButton(section)) {
       return false;
     }
 
@@ -726,7 +748,7 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
    * Chrome Web Store has a consistent DOM structure:
    * - main > div > section (first section = header with extension info)
    * - Header section contains: img (logo), h1 (name), and button (Add to Chrome)
-   * - The "Add to Chrome" button is the first button in the header section
+   * - The "Add to Chrome" button is the last visible button in the header
    *
    * This approach is language-independent and doesn't rely on button text.
    *
@@ -747,52 +769,50 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
       const section = h1.closest("section");
       if (!section) continue;
 
-      // Look for the "Add to Chrome" button near this h1
-      // DOM structure: section > div > div (contains h1) + div (contains button)
-      const h1Container = h1.closest("div");
-      const siblingDiv = h1Container?.nextElementSibling;
-      const button = siblingDiv?.querySelector("button");
-
-      if (
-        button &&
-        button.id !== "floorp-add-extension-btn" &&
-        this.isElementVisible(button)
-      ) {
+      const button = this.findVisibleHeaderActionButton(section);
+      if (button) {
         return button;
-      }
-
-      // Alternative: Find first button within the section
-      const sectionButton = section.querySelector("button");
-      if (
-        sectionButton &&
-        sectionButton.id !== "floorp-add-extension-btn" &&
-        this.isElementVisible(sectionButton)
-      ) {
-        return sectionButton;
       }
     }
 
     // Strategy 2: Use direct CSS selector (may not work with SPA)
-    const buttonViaSelector = doc.querySelector(ADD_BUTTON_STRUCTURE_SELECTOR);
-    if (
-      buttonViaSelector &&
-      buttonViaSelector.id !== "floorp-add-extension-btn" &&
-      this.isElementVisible(buttonViaSelector)
-    ) {
+    const headerViaSelector = doc.querySelector(EXTENSION_HEADER_SELECTOR);
+    const buttonViaSelector = headerViaSelector
+      ? this.findVisibleHeaderActionButton(headerViaSelector)
+      : null;
+    if (buttonViaSelector) {
       return buttonViaSelector;
     }
 
-    // Strategy 3: Fallback to first section's first button
-    const fallbackButton = doc.querySelector(ADD_BUTTON_FALLBACK_SELECTOR);
-    if (
-      fallbackButton &&
-      fallbackButton.id !== "floorp-add-extension-btn" &&
-      this.isElementVisible(fallbackButton)
-    ) {
+    // Strategy 3: Fallback to the first section's primary visible action
+    const fallbackHeader = doc.querySelector(
+      EXTENSION_HEADER_FALLBACK_SELECTOR,
+    );
+    const fallbackButton = fallbackHeader
+      ? this.findVisibleHeaderActionButton(fallbackHeader)
+      : null;
+    if (fallbackButton) {
       return fallbackButton;
     }
 
     return null;
+  }
+
+  /**
+   * Find the primary visible action button in an extension header.
+   *
+   * The store currently places hidden utility controls and the Share button
+   * before the install button. The install action is the last visible button
+   * in the header, so scan in reverse without depending on localized text or
+   * generated class names.
+   */
+  private findVisibleHeaderActionButton(
+    header: Element,
+  ): HTMLButtonElement | null {
+    return findPrimaryVisibleActionButton(
+      header,
+      (button) => this.isElementVisible(button),
+    );
   }
 
   /**
@@ -948,8 +968,8 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
     if (this.installInProgress || !this.currentExtensionId) return;
 
     this.installInProgress = true;
-    const button =
-      this.document?.getElementById("floorp-add-extension-btn") ?? null;
+    const button = this.document?.getElementById("floorp-add-extension-btn") ??
+      null;
 
     try {
       // Update button state to installing
@@ -975,8 +995,9 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
       }
     } catch (error) {
       this.updateButtonState(button, "error");
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
       this.showError(errorMessage);
     } finally {
       // Reset button state after delay
@@ -1026,7 +1047,9 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
       case "success": {
         const successText = this.t(CWS_I18N_KEYS.button.success);
         button.classList.add("floorp-add-button--success");
-        button.appendChild(this.createButtonContent(SVG_PATH_CHECK, successText));
+        button.appendChild(
+          this.createButtonContent(SVG_PATH_CHECK, successText),
+        );
         (button as HTMLButtonElement).disabled = true;
         break;
       }
@@ -1034,7 +1057,9 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
       case "installed": {
         const installedText = this.t(CWS_I18N_KEYS.button.installed);
         button.classList.add("floorp-add-button--installed");
-        button.appendChild(this.createButtonContent(SVG_PATH_CHECK, installedText));
+        button.appendChild(
+          this.createButtonContent(SVG_PATH_CHECK, installedText),
+        );
         (button as HTMLButtonElement).disabled = true;
         break;
       }
@@ -1049,7 +1074,9 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
 
       default: {
         const defaultText = this.t(CWS_I18N_KEYS.button.addToFloorp);
-        button.appendChild(this.createButtonContent(SVG_PATH_PLUS, defaultText));
+        button.appendChild(
+          this.createButtonContent(SVG_PATH_PLUS, defaultText),
+        );
         (button as HTMLButtonElement).disabled = false;
       }
     }
@@ -1202,7 +1229,7 @@ export class NRChromeWebStoreChild extends JSWindowActorChild {
     const errorIcon = this.createSvgElement(
       "0 0 24 24",
       SVG_PATH_INFO,
-      "floorp-cws-notice__icon"
+      "floorp-cws-notice__icon",
     );
     notice.appendChild(errorIcon);
 

--- a/browser-features/modules/actors/NRPluginStoreParent.sys.mts
+++ b/browser-features/modules/actors/NRPluginStoreParent.sys.mts
@@ -13,9 +13,18 @@
  */
 
 import type {
-  PluginMetadata,
   InstallResult,
+  PluginMetadata,
 } from "./NRPluginStoreChild.sys.mts";
+import {
+  isTrustedPluginStoreSource,
+  isValidPluginId,
+  isValidPluginMetadata,
+} from "../modules/plugin-store/Policy.sys.mts";
+
+const STARTUP_MODE = Services.prefs.getStringPref("nora.startup.mode", "");
+const ALLOW_DEVELOPMENT_PLUGIN_STORE = STARTUP_MODE === "dev" ||
+  STARTUP_MODE === "test";
 
 // =============================================================================
 // Types
@@ -51,24 +60,49 @@ export class NRPluginStoreParent extends JSWindowActorParent {
     data?: InstallRequest | { pluginId: string } | Record<string, unknown>;
   }):
     | Promise<
-        InstallResult | { installed: boolean } | { version: string } | null
-      >
+      InstallResult | { installed: boolean } | { version: string } | null
+    >
     | InstallResult
     | { installed: boolean }
     | { version: string }
     | null {
+    if (
+      !isTrustedPluginStoreSource(
+        this.manager?.documentURI?.spec,
+        ALLOW_DEVELOPMENT_PLUGIN_STORE,
+      )
+    ) {
+      console.error("[NRPluginStoreParent] Rejected untrusted message source");
+      if (message.name === "PluginStore:IsInstalled") {
+        return { installed: false };
+      }
+      if (message.name === "PluginStore:GetVersion") {
+        return null;
+      }
+      return { success: false, error: "Untrusted plugin store source" };
+    }
+
     switch (message.name) {
       case "PluginStore:GetVersion":
         return this.getFloorpVersion();
 
       case "PluginStore:Install":
-        if (message.data && "pluginId" in message.data) {
+        if (
+          message.data &&
+          "pluginId" in message.data &&
+          isValidPluginId(message.data.pluginId) &&
+          isValidPluginMetadata((message.data as InstallRequest).metadata)
+        ) {
           return this.installPlugin(message.data as InstallRequest);
         }
         return { success: false, error: "Invalid request data" };
 
       case "PluginStore:Uninstall":
-        if (message.data && "pluginId" in message.data) {
+        if (
+          message.data &&
+          "pluginId" in message.data &&
+          isValidPluginId(message.data.pluginId)
+        ) {
           return this.uninstallPlugin(
             (message.data as { pluginId: string }).pluginId,
           );
@@ -76,7 +110,11 @@ export class NRPluginStoreParent extends JSWindowActorParent {
         return { success: false, error: "Invalid request data" };
 
       case "PluginStore:IsInstalled":
-        if (message.data && "pluginId" in message.data) {
+        if (
+          message.data &&
+          "pluginId" in message.data &&
+          isValidPluginId(message.data.pluginId)
+        ) {
           return this.isPluginInstalled(
             (message.data as { pluginId: string }).pluginId,
           );
@@ -93,7 +131,9 @@ export class NRPluginStoreParent extends JSWindowActorParent {
    * TODO: Return actual Floorp version from AppInfo
    */
   private getFloorpVersion(): { version: string } {
-    const randomVersion = `${Math.floor(Math.random() * 100)}.${Math.floor(Math.random() * 100)}.${Math.floor(Math.random() * 100)}`;
+    const randomVersion = `${Math.floor(Math.random() * 100)}.${
+      Math.floor(Math.random() * 100)
+    }.${Math.floor(Math.random() * 100)}`;
     console.log("[NRPluginStoreParent] getFloorpVersion:", randomVersion);
     return { version: randomVersion };
   }

--- a/browser-features/modules/actors/NRWebScraperChild.sys.mts
+++ b/browser-features/modules/actors/NRWebScraperChild.sys.mts
@@ -17,9 +17,9 @@
  */
 
 import type {
+  EvaluateResult,
   NRWebScraperMessageData,
   WebScraperContext,
-  EvaluateResult,
 } from "./webscraper/types.ts";
 import { DOMOperations } from "./webscraper/DOMOperations.ts";
 import { FormOperations } from "./webscraper/FormOperations.ts";
@@ -169,8 +169,12 @@ export class NRWebScraperChild extends JSWindowActorChild {
             mode: textOpts.mode as "full" | "scoped" | "visible",
             selector: textOpts.selector as string | undefined,
             viewportMargin: textOpts.viewportMargin as number | undefined,
-            enableFingerprints: textOpts.enableFingerprints as boolean | undefined,
-            includeSelectorMap: textOpts.includeSelectorMap as boolean | undefined,
+            enableFingerprints: textOpts.enableFingerprints as
+              | boolean
+              | undefined,
+            includeSelectorMap: textOpts.includeSelectorMap as
+              | boolean
+              | undefined,
           });
         }
         // Legacy boolean
@@ -401,10 +405,15 @@ export class NRWebScraperChild extends JSWindowActorChild {
         }
         break;
       case "WebScraper:UploadFile":
-        if (message.data?.selector && message.data?.filePath) {
+        if (
+          message.data?.selector &&
+          Array.isArray(message.data?.fileData) &&
+          message.data?.fileName
+        ) {
           return domOps.uploadFile(
             message.data.selector,
-            message.data.filePath,
+            message.data.fileData,
+            message.data.fileName,
           );
         }
         break;
@@ -417,9 +426,11 @@ export class NRWebScraperChild extends JSWindowActorChild {
           );
         }
         break;
-     case "WebScraper:DispatchTextInput": {
+      case "WebScraper:DispatchTextInput": {
         const text = (
-          message.data as (NRWebScraperMessageData & { text?: string }) | undefined
+          message.data as
+            | (NRWebScraperMessageData & { text?: string })
+            | undefined
         )?.text;
         if (message.data?.selector && typeof text === "string") {
           return domOps.dispatchTextInput(message.data.selector, text);
@@ -437,7 +448,6 @@ export class NRWebScraperChild extends JSWindowActorChild {
           return this._evaluateScript(message.data.script);
         }
         break;
-
     }
     return null;
   }
@@ -471,10 +481,10 @@ export class NRWebScraperChild extends JSWindowActorChild {
       const resultType = Array.isArray(raw)
         ? "array"
         : raw instanceof win.Element
-          ? "element"
-          : raw instanceof win.NodeList
-            ? "nodelist"
-            : typeof raw;
+        ? "element"
+        : raw instanceof win.NodeList
+        ? "nodelist"
+        : typeof raw;
 
       // Try JSON round-trip; fall back to String() for non-serializable values
       let result: unknown;

--- a/browser-features/modules/actors/NRWebScraperParent.sys.mts
+++ b/browser-features/modules/actors/NRWebScraperParent.sys.mts
@@ -13,11 +13,6 @@ export class NRWebScraperParent extends JSWindowActorParent {
       return this.handleTranslate(message.data);
     }
 
-    // Handle file reading in parent process (IOUtils is only available in parent)
-    if (message.name === "WebScraper:ReadFile") {
-      return this.handleReadFile(message.data);
-    }
-
     // Handle control overlay context menu blocking
     if (message.name === "WebScraper:BlockContextMenu") {
       this.blockContextMenu();
@@ -31,49 +26,6 @@ export class NRWebScraperParent extends JSWindowActorParent {
 
     // Forward all other messages to the child and return the result.
     return this.sendQuery(message.name, message.data);
-  }
-
-  /**
-   * Handle file reading in parent process
-   * IOUtils can only be used in the parent process
-   */
-  private async handleReadFile(
-    data: Record<string, unknown> | undefined,
-  ): Promise<{
-    success: boolean;
-    data?: number[];
-    fileName?: string;
-    error?: string;
-  }> {
-    try {
-      const filePath = data?.filePath as string;
-      if (!filePath) {
-        return { success: false, error: "No file path provided" };
-      }
-
-      // Check if file exists
-      const exists = await IOUtils.exists(filePath);
-      if (!exists) {
-        return { success: false, error: `File does not exist: ${filePath}` };
-      }
-
-      // Read file as Uint8Array
-      const fileData = await IOUtils.read(filePath);
-      const fileName = PathUtils.filename(filePath);
-
-      // Convert Uint8Array to regular array for message passing
-      return {
-        success: true,
-        data: Array.from(fileData),
-        fileName,
-      };
-    } catch (e) {
-      console.error("[NRWebScraperParent] Error reading file:", e);
-      return {
-        success: false,
-        error: e instanceof Error ? e.message : String(e),
-      };
-    }
   }
 
   private blockContextMenu(): void {

--- a/browser-features/modules/actors/test/JSWindowActorRemoteType.test.mts
+++ b/browser-features/modules/actors/test/JSWindowActorRemoteType.test.mts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assert,
+  runTests,
+  type TestCase,
+} from "../../../chrome/test/utils/test_harness.ts";
+
+const EXPECTED_LOOPBACK_ACTORS = [
+  "NRSettings",
+  "NRExperimemmt",
+  "NRPanelSidebar",
+  "NRTabManager",
+  "NRSyncManager",
+  "NRAppConstants",
+  "NRRestartBrowser",
+  "NRWorkspaces",
+  "NRProgressiveWebApp",
+  "NRPwaManager",
+  "NRChromeModal",
+  "NRProfileManager",
+  "NRStartPage",
+  "NRWelcomePage",
+  "NRSearchEngine",
+  "NRWebScraper",
+  "NROSAutomotor",
+  "NRI18n",
+  "NRPluginStore",
+  "NRKeyboardShortcutFocus",
+  "NRMouseGestureScroll",
+];
+
+interface TestTab {
+  linkedBrowser: XULBrowserElement;
+}
+
+interface TestGBrowser {
+  selectedTab: TestTab;
+  addTab(
+    uri: string,
+    options: { triggeringPrincipal: nsIPrincipal },
+  ): TestTab;
+  removeTab(tab: TestTab): void;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForLoopbackGlobal(
+  browser: XULBrowserElement,
+): Promise<WindowGlobalParent | null> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const global = browser.browsingContext?.currentWindowGlobal;
+    if (global?.documentURI?.spec.startsWith("http://localhost:5181/")) {
+      return global;
+    }
+    await sleep(50);
+  }
+  return null;
+}
+
+async function testActorsAllowTheirMatchedWebProcess(): Promise<void> {
+  const testGBrowser = (window as unknown as { gBrowser?: TestGBrowser })
+    .gBrowser;
+  assert(
+    testGBrowser !== undefined,
+    "gBrowser should be available in a browser integration test",
+  );
+
+  const originalTab = testGBrowser.selectedTab;
+  const tab = testGBrowser.addTab("http://localhost:5181/", {
+    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+  });
+  testGBrowser.selectedTab = tab;
+
+  try {
+    const browser = tab.linkedBrowser;
+    const global = await waitForLoopbackGlobal(browser);
+    assert(global !== null, "the loopback test document should finish loading");
+
+    const remoteType = browser.remoteType;
+    assert(
+      remoteType.startsWith("web"),
+      `the loopback page should use a web remote type (got ${remoteType})`,
+    );
+
+    for (const actorName of EXPECTED_LOOPBACK_ACTORS) {
+      const actor = global.getActor(actorName);
+      assert(
+        actor !== null,
+        `${actorName} should be available in the matched web process`,
+      );
+    }
+
+    let chromeStoreRejected = false;
+    try {
+      global.getActor("NRChromeWebStore");
+    } catch {
+      chromeStoreRejected = true;
+    }
+    assert(
+      chromeStoreRejected,
+      "NRChromeWebStore should remain unavailable outside its store origins",
+    );
+  } finally {
+    if (tab !== originalTab) {
+      testGBrowser.removeTab(tab);
+      testGBrowser.selectedTab = originalTab;
+    }
+  }
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "matched actors instantiate in Firefox web remote types",
+      fn: testActorsAllowTheirMatchedWebProcess,
+    },
+  ];
+  await runTests("JSWindowActorRemoteType.test.mts", tests);
+}

--- a/browser-features/modules/actors/webscraper/DOMOperations.ts
+++ b/browser-features/modules/actors/webscraper/DOMOperations.ts
@@ -8,10 +8,10 @@
  */
 
 import type {
+  ClickElementOptions,
+  GetTextOptions,
   InputElementOptions,
   SelectOptionOptions,
-  GetTextOptions,
-  ClickElementOptions,
   WebScraperContext,
 } from "./types.ts";
 import { HighlightManager } from "./HighlightManager.ts";
@@ -172,8 +172,12 @@ export class DOMOperations {
     return this.writeOps.setChecked(selector, checked);
   }
 
-  uploadFile(selector: string, filePath: string): Promise<boolean> {
-    return this.writeOps.uploadFile(selector, filePath);
+  uploadFile(
+    selector: string,
+    fileData: number[],
+    fileName: string,
+  ): Promise<boolean> {
+    return this.writeOps.uploadFile(selector, fileData, fileName);
   }
 
   setCookieString(
@@ -274,7 +278,6 @@ export class DOMOperations {
       return false;
     }
   }
-
 
   dispatchTextInput(selector: string, text: string): boolean {
     return this.writeOps.dispatchTextInput(selector, text);

--- a/browser-features/modules/actors/webscraper/DOMWriteOperations.ts
+++ b/browser-features/modules/actors/webscraper/DOMWriteOperations.ts
@@ -6,10 +6,10 @@
 import type { DOMOpsDeps } from "./DOMDeps.ts";
 import type { RawContentWindow } from "./types.ts";
 import {
+  deepQuerySelector,
   unwrapDocument,
   unwrapElement,
   unwrapWindow,
-  deepQuerySelector,
 } from "./utils.ts";
 
 const { setTimeout: timerSetTimeout } = ChromeUtils.importESModule(
@@ -93,8 +93,8 @@ export class DOMWriteOperations {
     const rawWin = unwrapWindow(win);
     const rawDoc = this.document
       ? unwrapDocument(
-          this.document as Document & Partial<{ wrappedJSObject: Document }>,
-        )
+        this.document as Document & Partial<{ wrappedJSObject: Document }>,
+      )
       : null;
     if (!rawWin || !rawDoc) return null;
     const rawElement = unwrapElement(
@@ -137,8 +137,9 @@ export class DOMWriteOperations {
             value: truncatedValue,
           },
         );
-        const highlightOptions =
-          this.deps.highlightManager.getHighlightOptions("Input");
+        const highlightOptions = this.deps.highlightManager.getHighlightOptions(
+          "Input",
+        );
 
         this.deps.highlightManager
           .applyHighlight(element, highlightOptions, elementInfo)
@@ -163,15 +164,15 @@ export class DOMWriteOperations {
       );
 
       const typingMode = options.typingMode === true;
-      const typingDelay =
-        typeof options.typingDelayMs === "number"
-          ? Math.max(0, options.typingDelayMs)
-          : 25;
+      const typingDelay = typeof options.typingDelayMs === "number"
+        ? Math.max(0, options.typingDelayMs)
+        : 25;
 
       const rawWin = unwrapWindow(win);
       const rawElement = unwrapElement(
-        element as HTMLInputElement &
-          Partial<{ wrappedJSObject: HTMLInputElement }>,
+        element as
+          & HTMLInputElement
+          & Partial<{ wrappedJSObject: HTMLInputElement }>,
       );
       if (!rawWin) return false;
 
@@ -203,11 +204,9 @@ export class DOMWriteOperations {
         }
       };
 
-      const setValue = setter
-        ? (v: string) => setter(v)
-        : (v: string) => {
-            rawElement.value = v;
-          };
+      const setValue = setter ? (v: string) => setter(v) : (v: string) => {
+        rawElement.value = v;
+      };
 
       if (typingMode) {
         setValue("");
@@ -316,7 +315,7 @@ export class DOMWriteOperations {
       if (!targetOpt) {
         const lower = value.toLowerCase();
         targetOpt = options.find((opt) =>
-          (opt.textContent ?? "").toLowerCase().includes(lower),
+          (opt.textContent ?? "").toLowerCase().includes(lower)
         );
       }
       if (!targetOpt) return false;
@@ -328,8 +327,9 @@ export class DOMWriteOperations {
             value: targetOpt.value,
           },
         );
-        const highlightOptions =
-          this.deps.highlightManager.getHighlightOptions("Input");
+        const highlightOptions = this.deps.highlightManager.getHighlightOptions(
+          "Input",
+        );
 
         this.deps.highlightManager
           .applyHighlight(element, highlightOptions, elementInfo)
@@ -339,8 +339,9 @@ export class DOMWriteOperations {
       this.deps.eventDispatcher.scrollIntoViewIfNeeded(element);
       this.deps.eventDispatcher.focusElementSoft(element);
 
-      const setter =
-        this.deps.eventDispatcher.getNativeSelectValueSetter(element);
+      const setter = this.deps.eventDispatcher.getNativeSelectValueSetter(
+        element,
+      );
       if (setter) {
         setter(targetOpt.value);
       } else {
@@ -388,8 +389,9 @@ export class DOMWriteOperations {
 
       // Reflect state for attribute-based checks/serializations on both wrappers
       const rawElement = unwrapElement(
-        element as HTMLInputElement &
-          Partial<{ wrappedJSObject: HTMLInputElement }>,
+        element as
+          & HTMLInputElement
+          & Partial<{ wrappedJSObject: HTMLInputElement }>,
       );
 
       const syncAttrs = (target: HTMLInputElement) => {
@@ -419,8 +421,9 @@ export class DOMWriteOperations {
         const win = this.contentWindow;
         const rawWin = unwrapWindow(win);
         const rawElement = unwrapElement(
-          element as HTMLInputElement &
-            Partial<{ wrappedJSObject: HTMLInputElement }>,
+          element as
+            & HTMLInputElement
+            & Partial<{ wrappedJSObject: HTMLInputElement }>,
         );
         if (rawWin) {
           const MouseEv = rawWin.MouseEvent ?? globalThis.MouseEvent;
@@ -440,11 +443,12 @@ export class DOMWriteOperations {
     }
   }
 
-  async uploadFile(selector: string, filePath: string): Promise<boolean> {
+  async uploadFile(
+    selector: string,
+    fileData: number[],
+    fileName: string,
+  ): Promise<boolean> {
     try {
-      // SECURITY WARNING: This method accepts file paths from external sources.
-      // The parent process validates paths, but callers should only use trusted paths.
-
       const element = this.deepQuery(selector) as HTMLInputElement | null;
 
       if (!element || element.tagName !== "INPUT" || element.type !== "file") {
@@ -458,7 +462,7 @@ export class DOMWriteOperations {
         "uploadFile",
         {
           value: this.deps.translationHelper.truncate(
-            filePath.split(/[\\/]/).pop() ?? filePath,
+            fileName,
             30,
           ),
         },
@@ -479,27 +483,10 @@ export class DOMWriteOperations {
           fileInput as Element & Partial<{ wrappedJSObject: Element }>,
         ) as MozFileInput;
 
-        // Read file via parent process (IOUtils can only be used in parent process)
-        const result = (await this.deps.context.sendQuery(
-          "WebScraper:ReadFile",
-          {
-            filePath,
-          },
-        )) as {
-          success: boolean;
-          data?: number[];
-          fileName?: string;
-          error?: string;
-        };
-
-        if (!result.success || !result.data || !result.fileName) {
-          console.error("[NRWebScraper] Failed to read file:", result.error);
-          return false;
-        }
-
-        // Convert array back to Uint8Array
-        const fileData = new Uint8Array(result.data);
-        const fileName = result.fileName;
+        // The trusted parent-side service reads the selected file before the
+        // message reaches this untrusted content process. Never accept a path
+        // here or send one back to NRWebScraperParent.
+        const fileBytes = new Uint8Array(fileData);
 
         // Detect MIME type from extension
         const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
@@ -519,9 +506,11 @@ export class DOMWriteOperations {
           js: "text/javascript",
           zip: "application/zip",
           doc: "application/msword",
-          docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          docx:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
           xls: "application/vnd.ms-excel",
-          xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          xlsx:
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         };
         const mimeType = mimeTypes[ext] ?? "application/octet-stream";
 
@@ -536,7 +525,7 @@ export class DOMWriteOperations {
 
         // Clone the file data array into content window's context using Cu.cloneInto
         // This is necessary because both the Uint8Array and the array wrapper are privileged objects
-        const clonedBlobParts = Cu.cloneInto([fileData], rawWin);
+        const clonedBlobParts = Cu.cloneInto([fileBytes], rawWin);
         const clonedBlobOptions = Cu.cloneInto({ type: mimeType }, rawWin);
 
         // Use content window's constructors to avoid security wrapper issues
@@ -577,7 +566,7 @@ export class DOMWriteOperations {
         rawElement.dispatchEvent(new ContentEvent("change", eventOptions));
       } catch (e) {
         console.error(
-          "DOMWriteOperations: Failed to create file from path:",
+          "DOMWriteOperations: Failed to create upload file:",
           e,
         );
         return false;

--- a/browser-features/modules/actors/webscraper/types.ts
+++ b/browser-features/modules/actors/webscraper/types.ts
@@ -29,7 +29,8 @@ export interface NRWebScraperMessageData {
   eventOptions?: { bubbles?: boolean; cancelable?: boolean };
   typingMode?: boolean;
   typingDelayMs?: number;
-  filePath?: string;
+  fileData?: number[];
+  fileName?: string;
   key?: string;
   cookieString?: string;
   cookieName?: string;
@@ -118,9 +119,10 @@ export interface XrayWrapped<T> {
 /**
  * Content window with wrappedJSObject access
  */
-export type ContentWindow = Window &
-  typeof globalThis &
-  Partial<XrayWrapped<RawContentWindow>>;
+export type ContentWindow =
+  & Window
+  & typeof globalThis
+  & Partial<XrayWrapped<RawContentWindow>>;
 
 /**
  * Raw content window (unwrapped) with native constructors
@@ -143,8 +145,9 @@ export interface RawContentWindow extends Window {
 /**
  * Element with optional wrappedJSObject
  */
-export type XrayElement<T extends Element = Element> = T &
-  Partial<XrayWrapped<T>>;
+export type XrayElement<T extends Element = Element> =
+  & T
+  & Partial<XrayWrapped<T>>;
 
 /**
  * HTMLElement with optional wrappedJSObject

--- a/browser-features/modules/modules/BrowserGlue.sys.mts
+++ b/browser-features/modules/modules/BrowserGlue.sys.mts
@@ -18,6 +18,34 @@ function localPathToResourceURI(path: string) {
   return resourceURI;
 }
 
+const STARTUP_MODE = Services.prefs.getStringPref("nora.startup.mode", "");
+const IS_LOCAL_DEVELOPMENT_MODE = STARTUP_MODE === "dev" ||
+  STARTUP_MODE === "test";
+const DEVELOPMENT_LOCALHOST_MATCHES = IS_LOCAL_DEVELOPMENT_MODE
+  ? ["*://localhost/*"]
+  : [];
+const DEVELOPMENT_LOOPBACK_MATCHES = IS_LOCAL_DEVELOPMENT_MODE
+  ? ["*://localhost/*", "*://127.0.0.1/*"]
+  : [];
+const WEB_REMOTE_TYPES = ["web", "webIsolated", "webCOOP+COEP"];
+const WEB_FILE_AND_ABOUT_REMOTE_TYPES = [
+  ...WEB_REMOTE_TYPES,
+  "file",
+  "privilegedabout",
+  "parent",
+];
+const DEVELOPMENT_WEB_ACTOR_OPTIONS: Partial<WindowActorOptions> =
+  IS_LOCAL_DEVELOPMENT_MODE
+    ? {
+      // Firefox 154 treats even loopback documents as untrusted web-process
+      // content. These options exist only in local development/test modes,
+      // where the
+      // matching Vite pages are part of the local Floorp development setup.
+      remoteTypes: WEB_FILE_AND_ABOUT_REMOTE_TYPES,
+      safeForUntrustedWebProcess: true,
+    }
+    : {};
+
 const JS_WINDOW_ACTORS: {
   [k: string]: WindowActorOptions;
 } = {
@@ -57,19 +85,13 @@ const JS_WINDOW_ACTORS: {
     //https://searchfox.org/mozilla-central/rev/3966e5534ddf922b186af4777051d579fd052bad/dom/chrome-webidl/JSWindowActor.webidl#99
     //https://searchfox.org/mozilla-central/rev/3966e5534ddf922b186af4777051d579fd052bad/dom/chrome-webidl/MatchPattern.webidl#17
     matches: [
-      "*://localhost/*",
-      "*://127.0.0.1/*",
+      ...DEVELOPMENT_LOOPBACK_MATCHES,
       // Keep settings actor matching limited to loopback development pages.
       // Ordinary HTTP pages must not instantiate this privileged bridge.
       // The packaged settings chrome route remains available for production.
       "chrome://noraneko-settings/*",
     ],
-    // Vite dev pages use a webIsolated process. Keep the allowed process
-    // prefixes explicit while retaining the packaged chrome route.
-    remoteTypes: ["web", "webIsolated", "privilegedabout", "parent"],
-    // The locked Runtime enables the safe-for-untrusted-web-process gate for
-    // webIsolated pages. The URL matches above keep this bridge loopback-only.
-    safeForUntrustedWebProcess: true,
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRExperimemmt: {
     parent: {
@@ -85,7 +107,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRPanelSidebar: {
     parent: {
@@ -101,7 +128,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRTabManager: {
     parent: {
@@ -117,7 +149,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRSyncManager: {
     parent: {
@@ -133,7 +170,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRAppConstants: {
     parent: {
@@ -149,7 +191,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRRestartBrowser: {
     parent: {
@@ -165,7 +212,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRWorkspaces: {
     parent: {
@@ -181,7 +233,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRProgressiveWebApp: {
     parent: {
@@ -197,6 +254,9 @@ const JS_WINDOW_ACTORS: {
         pageshow: {},
       },
     },
+    matches: ["http://*/*", "https://*/*"],
+    remoteTypes: WEB_REMOTE_TYPES,
+    safeForUntrustedWebProcess: true,
     allFrames: true,
   },
   NRPwaManager: {
@@ -213,7 +273,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:hub*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:hub*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRChromeModal: {
     child: {
@@ -224,7 +289,11 @@ const JS_WINDOW_ACTORS: {
         DOMContentLoaded: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-modal-child/*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-modal-child/*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRProfileManager: {
     parent: {
@@ -241,11 +310,12 @@ const JS_WINDOW_ACTORS: {
       },
     },
     matches: [
-      "*://localhost/*",
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
       "chrome://noraneko-settings/*",
       "chrome://noraneko-profile-manager/*",
       "about:*",
     ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
 
   NRStartPage: {
@@ -260,7 +330,12 @@ const JS_WINDOW_ACTORS: {
         DOMContentLoaded: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-newtab/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-newtab/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
 
   NRWelcomePage: {
@@ -277,7 +352,12 @@ const JS_WINDOW_ACTORS: {
         DOMContentLoaded: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-welcome/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-welcome/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
 
   NRSearchEngine: {
@@ -297,11 +377,12 @@ const JS_WINDOW_ACTORS: {
     },
 
     matches: [
-      "*://localhost/*",
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
       "chrome://noraneko-welcome/*",
       "chrome://noraneko-newtab/*",
       "about:*",
     ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
 
   NRWebScraper: {
@@ -320,6 +401,8 @@ const JS_WINDOW_ACTORS: {
       },
     },
     matches: ["http://*/*", "https://*/*", "file:///*", "about:*"],
+    remoteTypes: WEB_FILE_AND_ABOUT_REMOTE_TYPES,
+    safeForUntrustedWebProcess: true,
     allFrames: true,
   },
   NROSAutomotor: {
@@ -337,7 +420,12 @@ const JS_WINDOW_ACTORS: {
         DOMDocElementInserted: {},
       },
     },
-    matches: ["*://localhost/*", "chrome://noraneko-settings/*", "about:*"],
+    matches: [
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
+      "chrome://noraneko-settings/*",
+      "about:*",
+    ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRI18n: {
     parent: {
@@ -350,11 +438,12 @@ const JS_WINDOW_ACTORS: {
       },
     },
     matches: [
-      "*://localhost/*",
+      ...DEVELOPMENT_LOCALHOST_MATCHES,
       "chrome://noraneko-settings/*",
       "chrome://noraneko-profile-manager/*",
       "about:*",
     ],
+    ...DEVELOPMENT_WEB_ACTOR_OPTIONS,
   },
   NRChromeWebStore: {
     parent: {
@@ -374,6 +463,11 @@ const JS_WINDOW_ACTORS: {
       "https://chromewebstore.google.com/*",
       "https://chrome.google.com/webstore/*",
     ],
+    // Firefox 154 blocks privileged actors in web content processes unless
+    // they explicitly opt in. Limit this actor to web remote types and the
+    // Chrome Web Store origins above before enabling it for those processes.
+    remoteTypes: WEB_REMOTE_TYPES,
+    safeForUntrustedWebProcess: true,
     allFrames: true,
   },
   NRPluginStore: {
@@ -394,10 +488,11 @@ const JS_WINDOW_ACTORS: {
       // Floorp OS Plugin Store domains
       "https://plugins.floorp.app/*",
       "https://store.floorp.app/*",
-      // Development domains - port is not supported in matches, use wildcard
-      "*://localhost/*",
-      "*://127.0.0.1/*",
+      // Development domains are omitted in production startup mode.
+      ...DEVELOPMENT_LOOPBACK_MATCHES,
     ],
+    remoteTypes: WEB_REMOTE_TYPES,
+    safeForUntrustedWebProcess: true,
   },
   NRKeyboardShortcutFocus: {
     parent: {
@@ -419,6 +514,8 @@ const JS_WINDOW_ACTORS: {
       },
     },
     matches: ["http://*/*", "https://*/*", "file:///*", "about:*"],
+    remoteTypes: WEB_FILE_AND_ABOUT_REMOTE_TYPES,
+    safeForUntrustedWebProcess: true,
     allFrames: true,
   },
   NRMouseGestureScroll: {
@@ -433,6 +530,8 @@ const JS_WINDOW_ACTORS: {
       ),
     },
     matches: ["http://*/*", "https://*/*", "file:///*", "about:*"],
+    remoteTypes: WEB_FILE_AND_ABOUT_REMOTE_TYPES,
+    safeForUntrustedWebProcess: true,
     allFrames: true,
   },
 };

--- a/browser-features/modules/modules/chrome-web-store/DOMUtils.sys.mts
+++ b/browser-features/modules/modules/chrome-web-store/DOMUtils.sys.mts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const FLOORP_ADD_EXTENSION_BUTTON_ID = "floorp-add-extension-btn";
+
+/**
+ * Find the primary visible action in a Chrome Web Store extension header.
+ *
+ * Hidden utility controls and the Share button precede the install action in
+ * the current store DOM. Scanning in reverse selects the install action without
+ * relying on localized text or generated class names.
+ */
+export function findPrimaryVisibleActionButton(
+  header: Element,
+  isVisible: (button: HTMLButtonElement) => boolean,
+): HTMLButtonElement | null {
+  const buttons = header.querySelectorAll<HTMLButtonElement>("button");
+  for (let index = buttons.length - 1; index >= 0; index--) {
+    const button = buttons.item(index);
+    if (
+      button.id !== FLOORP_ADD_EXTENSION_BUTTON_ID &&
+      isVisible(button)
+    ) {
+      return button;
+    }
+  }
+
+  return null;
+}

--- a/browser-features/modules/modules/chrome-web-store/test/DOMUtils.test.mts
+++ b/browser-features/modules/modules/chrome-web-store/test/DOMUtils.test.mts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import { findPrimaryVisibleActionButton } from "../DOMUtils.sys.mts";
+import {
+  assert,
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+
+function createHeader(): HTMLElement {
+  return document.createElement("section");
+}
+
+function createButton(id = ""): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.id = id;
+  return button;
+}
+
+function testSelectsLastVisibleButton(): void {
+  const header = createHeader();
+  const hiddenUtility = createButton();
+  const share = createButton();
+  const install = createButton();
+  header.append(hiddenUtility, share, install);
+
+  const result = findPrimaryVisibleActionButton(
+    header,
+    (button) => button !== hiddenUtility,
+  );
+
+  assert(
+    result === install,
+    "the last visible header action should be selected",
+  );
+}
+
+function testSkipsInjectedFloorpButton(): void {
+  const header = createHeader();
+  const install = createButton();
+  const floorp = createButton("floorp-add-extension-btn");
+  header.append(install, floorp);
+
+  const result = findPrimaryVisibleActionButton(header, () => true);
+
+  assert(result === install, "the injected Floorp button should be ignored");
+}
+
+function testReturnsNullWithoutVisibleButton(): void {
+  const header = createHeader();
+  header.append(createButton(), createButton("floorp-add-extension-btn"));
+
+  const result = findPrimaryVisibleActionButton(header, () => false);
+
+  assertEquals(result, null, "no visible store action should return null");
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    { name: "selects last visible button", fn: testSelectsLastVisibleButton },
+    { name: "skips injected Floorp button", fn: testSkipsInjectedFloorpButton },
+    {
+      name: "returns null without visible button",
+      fn: testReturnsNullWithoutVisibleButton,
+    },
+  ];
+
+  await runTests("DOMUtils.test.mts", tests);
+}

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -12,6 +12,7 @@ import { PROGRESS_LISTENERS } from "./shared/ProgressListeners.sys.mts";
 import { waitForActor } from "./shared/waitForActor.sys.mts";
 import { CookieHelper } from "./shared/CookieHelper.sys.mts";
 import { NetworkIdleHelper } from "./shared/NetworkIdleHelper.sys.mts";
+import { prepareUploadFile } from "./shared/UploadFileReader.sys.mts";
 
 const { setTimeout, clearTimeout } = ChromeUtils.importESModule(
   "resource://gre/modules/Timer.sys.mjs",
@@ -356,10 +357,9 @@ class TabManager {
         return;
       }
 
-      const win =
-        (entry.browser.ownerGlobal as
-          | (Window & { gBrowser: GBrowser })
-          | null) ?? (getBrowserWindow() as Window & { gBrowser: GBrowser });
+      const win = (entry.browser.ownerGlobal as
+        | (Window & { gBrowser: GBrowser })
+        | null) ?? (getBrowserWindow() as Window & { gBrowser: GBrowser });
       if (win.closed) {
         return;
       }
@@ -431,10 +431,12 @@ class TabManager {
                 selector: sel,
                 timeout: to,
               });
-            if (!ok)
+            if (!ok) {
               ok = (await tryWait("body", 5000).catch(() => false)) as boolean;
-            if (!ok)
+            }
+            if (!ok) {
               ok = (await tryWait("html", 3000).catch(() => false)) as boolean;
+            }
             if (!ok) await tryWait("main", 3000).catch(() => false);
           }
         } catch {
@@ -672,8 +674,7 @@ class TabManager {
     instanceId: string,
   ): Promise<TabInstanceInfo | null> {
     const { tab, browser } = this._getInstance(instanceId);
-    const win =
-      (browser.ownerGlobal as Window & { gBrowser: GBrowser }) ??
+    const win = (browser.ownerGlobal as Window & { gBrowser: GBrowser }) ??
       (getBrowserWindow() as Window & { gBrowser: GBrowser });
     const gBrowser = win?.gBrowser;
     if (!gBrowser) {
@@ -1065,12 +1066,16 @@ class TabManager {
     filePath: string,
   ): Promise<boolean | null> {
     this._focusInstance(instanceId);
+    const upload = await prepareUploadFile(filePath);
+    if (!upload) {
+      return false;
+    }
     const result = await this._queryActor<boolean>(
       instanceId,
       "WebScraper:UploadFile",
       {
         selector,
-        filePath,
+        ...upload,
       },
     );
     return result;
@@ -1390,8 +1395,8 @@ class TabManager {
           const tabDialogBox = gBrowser.getTabDialogBox(entry.tab);
           const dialogs = tabDialogBox?.getTabDialogManager?.()?.dialogs ?? [];
           for (const dialog of dialogs) {
-            const dialogElement =
-              dialog.frameContentWindow?.document?.querySelector(
+            const dialogElement = dialog.frameContentWindow?.document
+              ?.querySelector(
                 "dialog",
               ) as HTMLDialogElement | null;
             if (dialogElement) {
@@ -1446,8 +1451,8 @@ class TabManager {
           const tabDialogBox = gBrowser.getTabDialogBox(entry.tab);
           const dialogs = tabDialogBox?.getTabDialogManager?.()?.dialogs ?? [];
           for (const dialog of dialogs) {
-            const dialogElement =
-              dialog.frameContentWindow?.document?.querySelector(
+            const dialogElement = dialog.frameContentWindow?.document
+              ?.querySelector(
                 "dialog",
               ) as HTMLDialogElement | null;
             if (dialogElement) {
@@ -1486,8 +1491,8 @@ class TabManager {
     try {
       const browsingContext = entry.browser
         .browsingContext as BrowsingContext & {
-        print(settings: nsIPrintSettings): Promise<void>;
-      };
+          print(settings: nsIPrintSettings): Promise<void>;
+        };
       if (!browsingContext) return null;
 
       // Create a storage stream for PDF output
@@ -1712,14 +1717,24 @@ class TabManager {
   public evaluate(
     instanceId: string,
     script: string,
-  ): Promise<{ success: boolean; result?: unknown; resultType?: string; error?: string; errorType?: string } | null> {
-    return this._queryActor<{
+  ): Promise<
+    {
       success: boolean;
       result?: unknown;
       resultType?: string;
       error?: string;
       errorType?: string;
-    } | null>(
+    } | null
+  > {
+    return this._queryActor<
+      {
+        success: boolean;
+        result?: unknown;
+        resultType?: string;
+        error?: string;
+        errorType?: string;
+      } | null
+    >(
       instanceId,
       "WebScraper:Evaluate",
       { script },

--- a/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/WebScraperServices.sys.mts
@@ -18,6 +18,7 @@ import { PROGRESS_LISTENERS } from "./shared/ProgressListeners.sys.mts";
 import { waitForActor } from "./shared/waitForActor.sys.mts";
 import { CookieHelper } from "./shared/CookieHelper.sys.mts";
 import { NetworkIdleHelper } from "./shared/NetworkIdleHelper.sys.mts";
+import { prepareUploadFile } from "./shared/UploadFileReader.sys.mts";
 
 const { HiddenFrame } = ChromeUtils.importESModule(
   "resource://gre/modules/HiddenFrame.sys.mjs",
@@ -221,7 +222,9 @@ class webScraper {
       // Timeout guard: prevent hanging if page load never completes
       timeoutId = setTimeout(() => {
         if (resolved) return;
-        console.warn("[WebScraperServices] navigate timed out after 30 seconds");
+        console.warn(
+          "[WebScraperServices] navigate timed out after 30 seconds",
+        );
         resolved = true;
         PROGRESS_LISTENERS.delete(progressListener);
         try {
@@ -381,16 +384,17 @@ class webScraper {
     options:
       | boolean
       | {
-          mode?: "full" | "scoped" | "visible";
-          selector?: string;
-          viewportMargin?: number;
-          enableFingerprints?: boolean;
-          includeSelectorMap?: boolean;
-        } = false,
+        mode?: "full" | "scoped" | "visible";
+        selector?: string;
+        viewportMargin?: number;
+        enableFingerprints?: boolean;
+        includeSelectorMap?: boolean;
+      } = false,
   ): Promise<string | null> {
     // Normalize: boolean old-style { includeSelectorMap }
-    const data =
-      typeof options === "boolean" ? { includeSelectorMap: options } : options;
+    const data = typeof options === "boolean"
+      ? { includeSelectorMap: options }
+      : options;
     return this.withActor(instanceId, "WebScraper:GetText", data);
   }
 
@@ -415,17 +419,23 @@ class webScraper {
     instanceId: string,
     options: { interestingOnly?: boolean; root?: string } = {},
   ): Promise<unknown> {
-    return this.withActor(instanceId, "WebScraper:GetAccessibilityTree", options);
+    return this.withActor(
+      instanceId,
+      "WebScraper:GetAccessibilityTree",
+      options,
+    );
   }
 
   public getArticle(
     instanceId: string,
-  ): Promise<{
-    title: string;
-    byline: string;
-    markdown: string;
-    length: number;
-  } | null> {
+  ): Promise<
+    {
+      title: string;
+      byline: string;
+      markdown: string;
+      length: number;
+    } | null
+  > {
     return this.withActor(instanceId, "WebScraper:GetArticle");
   }
 
@@ -452,7 +462,9 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<string[]> {
-    return this.withActor<string[]>(instanceId, "WebScraper:GetElements", { selector }) as Promise<string[]>;
+    return this.withActor<string[]>(instanceId, "WebScraper:GetElements", {
+      selector,
+    }) as Promise<string[]>;
   }
 
   /**  Get Element By Text Content
@@ -472,7 +484,9 @@ class webScraper {
     instanceId: string,
     textContent: string,
   ): Promise<string | null> {
-    return this.withActor(instanceId, "WebScraper:GetElementByText", { textContent });
+    return this.withActor(instanceId, "WebScraper:GetElementByText", {
+      textContent,
+    });
   }
 
   /** Get Element Text Content
@@ -492,7 +506,9 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<string | null> {
-    return this.withActor(instanceId, "WebScraper:GetElementTextContent", { selector });
+    return this.withActor(instanceId, "WebScraper:GetElementTextContent", {
+      selector,
+    });
   }
 
   /**
@@ -513,7 +529,9 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<string | null> {
-    return this.withActor(instanceId, "WebScraper:GetElementText", { selector });
+    return this.withActor(instanceId, "WebScraper:GetElementText", {
+      selector,
+    });
   }
 
   /**
@@ -532,7 +550,9 @@ class webScraper {
     instanceId: string,
     fingerprint: string,
   ): Promise<string | null> {
-    return this.withActor(instanceId, "WebScraper:ResolveFingerprint", { fingerprint });
+    return this.withActor(instanceId, "WebScraper:ResolveFingerprint", {
+      fingerprint,
+    });
   }
 
   /**
@@ -544,7 +564,12 @@ class webScraper {
    * @throws Error - If the browser instance is not found
    */
   public clearEffects(instanceId: string): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:ClearEffects", undefined, false) as Promise<boolean>;
+    return this.withActor(
+      instanceId,
+      "WebScraper:ClearEffects",
+      undefined,
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
@@ -565,7 +590,12 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:ClickElement", { selector }, false) as Promise<boolean>;
+    return this.withActor(
+      instanceId,
+      "WebScraper:ClickElement",
+      { selector },
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
@@ -590,7 +620,11 @@ class webScraper {
     timeout = 5000,
     state: WaitForElementState = "attached",
   ): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:WaitForElement", { selector, timeout, state }, false) as Promise<boolean>;
+    return this.withActor(instanceId, "WebScraper:WaitForElement", {
+      selector,
+      timeout,
+      state,
+    }, false) as Promise<boolean>;
   }
 
   /**
@@ -640,7 +674,9 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<string | null> {
-    return this.withActor(instanceId, "WebScraper:TakeElementScreenshot", { selector });
+    return this.withActor(instanceId, "WebScraper:TakeElementScreenshot", {
+      selector,
+    });
   }
 
   /**
@@ -674,7 +710,9 @@ class webScraper {
     instanceId: string,
     rect?: { x?: number; y?: number; width?: number; height?: number },
   ): Promise<string | null> {
-    return this.withActor(instanceId, "WebScraper:TakeRegionScreenshot", { rect });
+    return this.withActor(instanceId, "WebScraper:TakeRegionScreenshot", {
+      rect,
+    });
   }
 
   /**
@@ -719,18 +757,32 @@ class webScraper {
    * Press a key or key combination.
    */
   public pressKey(instanceId: string, key: string): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:PressKey", { key }, false) as Promise<boolean>;
+    return this.withActor(
+      instanceId,
+      "WebScraper:PressKey",
+      { key },
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
    * Upload a file through input[type=file]
    */
-  public uploadFile(
+  public async uploadFile(
     instanceId: string,
     selector: string,
     filePath: string,
   ): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:UploadFile", { selector, filePath }, false) as Promise<boolean>;
+    const upload = await prepareUploadFile(filePath);
+    if (!upload) {
+      return false;
+    }
+    return this.withActor(
+      instanceId,
+      "WebScraper:UploadFile",
+      { selector, ...upload },
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
@@ -756,7 +808,10 @@ class webScraper {
     selector: string,
     attributeName: string,
   ): Promise<string | null> {
-    return this.withActor(instanceId, "WebScraper:GetAttribute", { selector, attributeName });
+    return this.withActor(instanceId, "WebScraper:GetAttribute", {
+      selector,
+      attributeName,
+    });
   }
 
   /**
@@ -770,7 +825,12 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:IsVisible", { selector }, false) as Promise<boolean>;
+    return this.withActor(
+      instanceId,
+      "WebScraper:IsVisible",
+      { selector },
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
@@ -784,7 +844,12 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:IsEnabled", { selector }, false) as Promise<boolean>;
+    return this.withActor(
+      instanceId,
+      "WebScraper:IsEnabled",
+      { selector },
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
@@ -798,14 +863,24 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:ClearInput", { selector }, false) as Promise<boolean>;
+    return this.withActor(
+      instanceId,
+      "WebScraper:ClearInput",
+      { selector },
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
    * Submits form associated with the selector element or the form itself
    */
   public submit(instanceId: string, selector: string): Promise<boolean> {
-    return this.withActor(instanceId, "WebScraper:Submit", { selector }, false) as Promise<boolean>;
+    return this.withActor(
+      instanceId,
+      "WebScraper:Submit",
+      { selector },
+      false,
+    ) as Promise<boolean>;
   }
 
   /**
@@ -821,7 +896,10 @@ class webScraper {
     selector: string,
     value: string,
   ): Promise<boolean | null> {
-    return this.withActor(instanceId, "WebScraper:SelectOption", { selector, optionValue: value });
+    return this.withActor(instanceId, "WebScraper:SelectOption", {
+      selector,
+      optionValue: value,
+    });
   }
 
   /**
@@ -837,7 +915,10 @@ class webScraper {
     selector: string,
     checked: boolean,
   ): Promise<boolean | null> {
-    return this.withActor(instanceId, "WebScraper:SetChecked", { selector, checked });
+    return this.withActor(instanceId, "WebScraper:SetChecked", {
+      selector,
+      checked,
+    });
   }
 
   /**
@@ -861,7 +942,9 @@ class webScraper {
     instanceId: string,
     selector: string,
   ): Promise<boolean | null> {
-    return this.withActor(instanceId, "WebScraper:ScrollToElement", { selector });
+    return this.withActor(instanceId, "WebScraper:ScrollToElement", {
+      selector,
+    });
   }
 
   /**
@@ -974,7 +1057,10 @@ class webScraper {
         try {
           const actor = await this._getActorForBrowser(instanceId, 80, 100);
           if (actor) {
-            const cookieString = CookieHelper.buildCookieString(cookie, uri.host);
+            const cookieString = CookieHelper.buildCookieString(
+              cookie,
+              uri.host,
+            );
             const result = await actor
               .sendQuery("WebScraper:SetCookieString", {
                 cookieString,
@@ -1031,11 +1117,11 @@ class webScraper {
     options:
       | number
       | {
-          timeout?: number;
-          maxInflight?: number;
-          idleDuration?: number;
-          ignorePatterns?: string[];
-        } = {},
+        timeout?: number;
+        maxInflight?: number;
+        idleDuration?: number;
+        ignorePatterns?: string[];
+      } = {},
   ): Promise<boolean | null> {
     const browser = this._browserInstances.get(instanceId);
     if (!browser) {
@@ -1058,7 +1144,10 @@ class webScraper {
     selector: string,
     html: string,
   ): Promise<boolean | null> {
-    return this.withActor(instanceId, "WebScraper:SetInnerHTML", { selector, innerHTML: html });
+    return this.withActor(instanceId, "WebScraper:SetInnerHTML", {
+      selector,
+      innerHTML: html,
+    });
   }
 
   /**
@@ -1069,7 +1158,10 @@ class webScraper {
     selector: string,
     text: string,
   ): Promise<boolean | null> {
-    return this.withActor(instanceId, "WebScraper:SetTextContent", { selector, textContent: text });
+    return this.withActor(instanceId, "WebScraper:SetTextContent", {
+      selector,
+      textContent: text,
+    });
   }
 
   /**
@@ -1103,7 +1195,10 @@ class webScraper {
     selector: string,
     text: string,
   ): Promise<boolean | null> {
-    return this.withActor(instanceId, "WebScraper:DispatchTextInput", { selector, text });
+    return this.withActor(instanceId, "WebScraper:DispatchTextInput", {
+      selector,
+      text,
+    });
   }
 
   /**
@@ -1114,7 +1209,15 @@ class webScraper {
   public evaluate(
     instanceId: string,
     script: string,
-  ): Promise<{ success: boolean; result?: unknown; resultType?: string; error?: string; errorType?: string } | null> {
+  ): Promise<
+    {
+      success: boolean;
+      result?: unknown;
+      resultType?: string;
+      error?: string;
+      errorType?: string;
+    } | null
+  > {
     return this.withActor(
       instanceId,
       "WebScraper:Evaluate",

--- a/browser-features/modules/modules/os-apis/web/shared/UploadFileReader.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/UploadFileReader.sys.mts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export interface PreparedUploadFile {
+  fileData: number[];
+  fileName: string;
+}
+
+interface UploadFileReaderDependencies {
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<Uint8Array>;
+  filename(path: string): string;
+}
+
+const DEFAULT_DEPENDENCIES: UploadFileReaderDependencies = {
+  exists: (path) => IOUtils.exists(path),
+  read: (path) => IOUtils.read(path),
+  filename: (path) => PathUtils.filename(path),
+};
+
+/**
+ * Read an upload selected by a trusted parent-process caller.
+ *
+ * File paths must never cross from an untrusted web content process into a
+ * privileged IOUtils call. Services invoke this helper before sending the
+ * resulting bytes to NRWebScraperChild.
+ */
+export async function prepareUploadFile(
+  filePath: string,
+  dependencies: UploadFileReaderDependencies = DEFAULT_DEPENDENCIES,
+): Promise<PreparedUploadFile | null> {
+  if (typeof filePath !== "string" || filePath.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    if (!(await dependencies.exists(filePath))) {
+      return null;
+    }
+
+    const fileName = dependencies.filename(filePath);
+    if (!fileName) {
+      return null;
+    }
+
+    const fileData = await dependencies.read(filePath);
+    return {
+      fileData: Array.from(fileData),
+      fileName,
+    };
+  } catch (error) {
+    console.error("[WebScraper] Failed to prepare upload file:", error);
+    return null;
+  }
+}

--- a/browser-features/modules/modules/os-apis/web/shared/UploadFileReader.test.mts
+++ b/browser-features/modules/modules/os-apis/web/shared/UploadFileReader.test.mts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assertEquals as harnessAssertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../../chrome/test/utils/test_harness.ts";
+import { prepareUploadFile } from "./UploadFileReader.sys.mts";
+
+function assertEquals<T>(actual: T, expected: T): void {
+  harnessAssertEquals(actual, expected, "values should be equal");
+}
+
+async function testReadsExistingFile(): Promise<void> {
+  const result = await prepareUploadFile("C:\\tmp\\upload.txt", {
+    exists: () => Promise.resolve(true),
+    read: () => Promise.resolve(new Uint8Array([1, 2, 255])),
+    filename: () => "upload.txt",
+  });
+
+  assertEquals(result?.fileName, "upload.txt");
+  assertEquals(JSON.stringify(result?.fileData), JSON.stringify([1, 2, 255]));
+}
+
+async function testMissingFileReturnsNull(): Promise<void> {
+  let readCalled = false;
+  const result = await prepareUploadFile("C:\\tmp\\missing.txt", {
+    exists: () => Promise.resolve(false),
+    read: () => {
+      readCalled = true;
+      return Promise.resolve(new Uint8Array());
+    },
+    filename: () => "missing.txt",
+  });
+
+  assertEquals(result, null);
+  assertEquals(readCalled, false);
+}
+
+async function testEmptyPathReturnsNull(): Promise<void> {
+  let existsCalled = false;
+  const result = await prepareUploadFile("  ", {
+    exists: () => {
+      existsCalled = true;
+      return Promise.resolve(true);
+    },
+    read: () => Promise.resolve(new Uint8Array()),
+    filename: () => "upload.txt",
+  });
+
+  assertEquals(result, null);
+  assertEquals(existsCalled, false);
+}
+
+async function testReadFailureReturnsNull(): Promise<void> {
+  const result = await prepareUploadFile("C:\\tmp\\upload.txt", {
+    exists: () => Promise.resolve(true),
+    read: () => Promise.reject(new Error("read failed")),
+    filename: () => "upload.txt",
+  });
+
+  assertEquals(result, null);
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    { name: "reads an existing upload file", fn: testReadsExistingFile },
+    { name: "does not read a missing file", fn: testMissingFileReturnsNull },
+    { name: "rejects an empty file path", fn: testEmptyPathReturnsNull },
+    { name: "handles a read failure", fn: testReadFailureReturnsNull },
+  ];
+  await runTests("UploadFileReader.test.mts", tests);
+}

--- a/browser-features/modules/modules/plugin-store/Policy.sys.mts
+++ b/browser-features/modules/modules/plugin-store/Policy.sys.mts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const PRODUCTION_ORIGINS = new Set([
+  "https://plugins.floorp.app",
+  "https://store.floorp.app",
+]);
+const DEVELOPMENT_HOSTS = new Set(["localhost", "127.0.0.1"]);
+
+export function isTrustedPluginStoreSource(
+  uri: string | null | undefined,
+  allowDevelopment: boolean,
+): boolean {
+  if (!uri) {
+    return false;
+  }
+
+  try {
+    const url = new URL(uri);
+    if (PRODUCTION_ORIGINS.has(url.origin)) {
+      return true;
+    }
+    return allowDevelopment &&
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      DEVELOPMENT_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function isValidPluginId(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 512
+  ) {
+    return false;
+  }
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint < 0x20 || codePoint === 0x7f) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isBoundedOptionalString(
+  value: unknown,
+  maximumLength: number,
+): boolean {
+  return value === undefined ||
+    (typeof value === "string" && value.length <= maximumLength);
+}
+
+export function isValidPluginMetadata(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const metadata = value as Record<string, unknown>;
+  if (
+    !isBoundedOptionalString(metadata.id, 512) ||
+    !isBoundedOptionalString(metadata.name, 512) ||
+    !isBoundedOptionalString(metadata.description, 8192) ||
+    !isBoundedOptionalString(metadata.version, 128) ||
+    !isBoundedOptionalString(metadata.author, 512) ||
+    !isBoundedOptionalString(metadata.category, 256) ||
+    !isBoundedOptionalString(metadata.icon, 8192) ||
+    !isBoundedOptionalString(metadata.uri, 8192) ||
+    (metadata.isOfficial !== undefined &&
+      typeof metadata.isOfficial !== "boolean") ||
+    (metadata.functions !== undefined && !Array.isArray(metadata.functions))
+  ) {
+    return false;
+  }
+
+  try {
+    return JSON.stringify(metadata.functions ?? []).length <= 32768;
+  } catch {
+    return false;
+  }
+}

--- a/browser-features/modules/modules/plugin-store/test/Policy.test.mts
+++ b/browser-features/modules/modules/plugin-store/test/Policy.test.mts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  assertEquals as harnessAssertEquals,
+  runTests,
+  type TestCase,
+} from "../../../../chrome/test/utils/test_harness.ts";
+import {
+  isTrustedPluginStoreSource,
+  isValidPluginId,
+  isValidPluginMetadata,
+} from "../Policy.sys.mts";
+
+function assertEquals<T>(actual: T, expected: T): void {
+  harnessAssertEquals(actual, expected, "values should be equal");
+}
+
+function testProductionOrigins(): void {
+  assertEquals(
+    isTrustedPluginStoreSource("https://store.floorp.app/plugin/demo", false),
+    true,
+  );
+  assertEquals(
+    isTrustedPluginStoreSource("https://plugins.floorp.app/", false),
+    true,
+  );
+  assertEquals(
+    isTrustedPluginStoreSource("https://store.floorp.app.evil.test/", false),
+    false,
+  );
+  assertEquals(
+    isTrustedPluginStoreSource("http://store.floorp.app/", false),
+    false,
+  );
+}
+
+function testDevelopmentOriginsAreExplicit(): void {
+  assertEquals(
+    isTrustedPluginStoreSource("http://localhost:5173/plugin", true),
+    true,
+  );
+  assertEquals(
+    isTrustedPluginStoreSource("http://127.0.0.1:5173/plugin", true),
+    true,
+  );
+  assertEquals(
+    isTrustedPluginStoreSource("http://localhost:5173/plugin", false),
+    false,
+  );
+  assertEquals(
+    isTrustedPluginStoreSource("file://localhost/plugin", true),
+    false,
+  );
+}
+
+function testPluginIdValidation(): void {
+  assertEquals(isValidPluginId("official.demo-plugin"), true);
+  assertEquals(isValidPluginId(""), false);
+  assertEquals(isValidPluginId("bad\nplugin"), false);
+  assertEquals(isValidPluginId("x".repeat(513)), false);
+}
+
+function testMetadataValidation(): void {
+  assertEquals(
+    isValidPluginMetadata({
+      name: "Demo",
+      description: "A demo plugin",
+      author: "Floorp",
+      isOfficial: true,
+      functions: [{ name: "run", description: "Run" }],
+    }),
+    true,
+  );
+  assertEquals(isValidPluginMetadata({ name: "x".repeat(513) }), false);
+  assertEquals(isValidPluginMetadata({ isOfficial: "yes" }), false);
+  assertEquals(isValidPluginMetadata({ functions: {} }), false);
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "accepts only exact production origins",
+      fn: testProductionOrigins,
+    },
+    {
+      name: "allows loopback sources only in development",
+      fn: testDevelopmentOriginsAreExplicit,
+    },
+    { name: "validates plugin identifiers", fn: testPluginIdValidation },
+    { name: "bounds plugin metadata", fn: testMetadataValidation },
+  ];
+  await runTests("PluginStore Policy.test.mts", tests);
+}

--- a/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
+++ b/browser-features/pages-settings/src/lib/i18n/locales/ja-JP.json
@@ -130,6 +130,18 @@
             "minHeight": "タブの最小高さ",
             "minHeightError": "タブの高さは、 {{min}} から {{max}} ピクセルの間でなければなりません。"
         },
+        "tabWindowBehavior": {
+            "title": "タブとウィンドウの動作",
+            "description": "リンクの開き先と、Windows のタスクバーに表示されるタブプレビューの動作を設定します。",
+            "openLinks": "新しいウィンドウを要求するリンクの開き先",
+            "openLinksDescription": "新しいウィンドウを要求するリンクを、現在のウィンドウ、新しいウィンドウ、新しいタブのいずれで開くかを選択します。",
+            "openCurrentWindowOrTab": "現在のウィンドウまたはタブ",
+            "openNewWindow": "新しいウィンドウ",
+            "openNewTab": "新しいタブ",
+            "taskbarPreviews": "タスクバーにタブのプレビューを表示",
+            "taskbarPreviewsDescription": "この設定は Windows のタスクバー表示のみを変更し、ブラウザのウィンドウを新たに作成しません。",
+            "taskbarPreviewsUnavailable": "この項目は Windows でのみ利用できます。"
+        },
         "lepton-preferences": {
             "title": "Lepton の設定",
             "description": "Lepton テーマの高度な設定を変更します",

--- a/docs/development/architecture-overview.mdx
+++ b/docs/development/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 sidebar_label: "Architecture"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Architecture Overview
@@ -30,7 +30,7 @@ The loader development server is configured by `bridge/loader-features/vite.conf
 
 ## Privileged Modules And Window Actors
 
-Window Actors are registered from `browser-features/modules/modules/BrowserGlue.sys.mts:440`. The current inventory lists 23 actors:
+Window Actors are registered from `browser-features/modules/modules/BrowserGlue.sys.mts:539`. The current inventory lists 23 actors:
 
 - `NRAboutPreferences`
 - `NRAppConstants`

--- a/docs/development/directories/browser-features/chrome/common.mdx
+++ b/docs/development/directories/browser-features/chrome/common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Features"
 sidebar_label: "Common"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Common Chrome Features
@@ -103,6 +103,6 @@ Small chrome utilities and action helpers that do not own a broader feature fami
 
 ## Relationship To Other Layers
 
-- Window Actor integration is registered in `browser-features/modules/modules/BrowserGlue.sys.mts:440`.
+- Window Actor integration is registered in `browser-features/modules/modules/BrowserGlue.sys.mts:539`.
 - Settings pages may expose user-facing controls for selected common features; use the settings route catalog for route ownership.
 - Static chrome features live in the separate static catalog and are not duplicated in this common-feature directory page.

--- a/docs/development/directories/floorp-os-api.mdx
+++ b/docs/development/directories/floorp-os-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Floorp OS API Layer"
 sidebar_label: "Floorp OS API"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Floorp OS API Layer

--- a/docs/development/directories/static-gecko.mdx
+++ b/docs/development/directories/static-gecko.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Gecko Directory"
 sidebar_label: "Static Gecko"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Static Gecko Directory

--- a/docs/development/features/browser-features/chrome-common.mdx
+++ b/docs/development/features/browser-features/chrome-common.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Catalog"
 sidebar_label: "Common Chrome"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Common Chrome Feature Catalog

--- a/docs/development/features/browser-features/chrome-static.mdx
+++ b/docs/development/features/browser-features/chrome-static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Chrome Feature Catalog"
 sidebar_label: "Static Chrome"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Static Chrome Feature Catalog

--- a/docs/development/features/browser-features/common/browser-ui-customization.mdx
+++ b/docs/development/features/browser-features/common/browser-ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser UI Customization"
 sidebar_label: "UI Customization"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Browser UI Customization

--- a/docs/development/features/browser-features/common/input-and-shortcuts.mdx
+++ b/docs/development/features/browser-features/common/input-and-shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Input & Shortcuts"
 sidebar_label: "Input & Shortcuts"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Input & Shortcuts

--- a/docs/development/features/browser-features/common/overview.mdx
+++ b/docs/development/features/browser-features/common/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Common Chrome Feature Categories"
 sidebar_label: "Common Categories"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Common Chrome Feature Categories

--- a/docs/development/features/browser-features/common/sidebar-and-panels.mdx
+++ b/docs/development/features/browser-features/common/sidebar-and-panels.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sidebar & Panels"
 sidebar_label: "Sidebar & Panels"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Sidebar & Panels

--- a/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
+++ b/docs/development/features/browser-features/common/tabs-and-workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tabs & Workspaces"
 sidebar_label: "Tabs & Workspaces"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Tabs & Workspaces

--- a/docs/development/features/browser-features/common/utilities-and-actions.mdx
+++ b/docs/development/features/browser-features/common/utilities-and-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Utilities & Actions"
 sidebar_label: "Utilities"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Utilities & Actions

--- a/docs/development/features/browser-features/common/webapps-and-integration.mdx
+++ b/docs/development/features/browser-features/common/webapps-and-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Apps & Integration"
 sidebar_label: "Web Apps"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Web Apps & Integration

--- a/docs/development/features/browser-features/modules/overview.mdx
+++ b/docs/development/features/browser-features/modules/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Categories"
 sidebar_label: "Actor Categories"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Window Actor Categories
@@ -21,4 +21,4 @@ This nested catalog is generated from the `JS_WINDOW_ACTORS` table in `browser-f
 
 | Actor | Source |
 |---|---|
-| NRKeyboardShortcutFocus | `browser-features/modules/modules/BrowserGlue.sys.mts:402` |
+| NRKeyboardShortcutFocus | `browser-features/modules/modules/BrowserGlue.sys.mts:497` |

--- a/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
+++ b/docs/development/features/browser-features/modules/pwa-workspaces-profile-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PWA, Workspaces & Profile Actors"
 sidebar_label: "PWA & Workspaces"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # PWA, Workspaces & Profile Actors
@@ -12,7 +12,7 @@ Actors that support PWA windows, workspace state, PWA management, and profile ma
 
 | Actor | Source |
 |---|---|
-| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:229` |
-| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:186` |
-| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:202` |
-| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:170` |
+| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:298` |
+| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:243` |
+| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:262` |
+| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:222` |

--- a/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
+++ b/docs/development/features/browser-features/modules/settings-and-internal-pages-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings & Internal Page Actors"
 sidebar_label: "Settings Actors"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Settings & Internal Page Actors
@@ -12,16 +12,16 @@ Actors used by settings, internal pages, localization, browser constants, restar
 
 | Actor | Source |
 |---|---|
-| NRAboutPreferences | `browser-features/modules/modules/BrowserGlue.sys.mts:24` |
-| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:138` |
-| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:218` |
-| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:74` |
-| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:342` |
-| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:90` |
-| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:154` |
-| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:283` |
-| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:36` |
-| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:251` |
-| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:122` |
-| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:106` |
-| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:266` |
+| NRAboutPreferences | `browser-features/modules/modules/BrowserGlue.sys.mts:52` |
+| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:180` |
+| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:283` |
+| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:96` |
+| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:430` |
+| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:117` |
+| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:201` |
+| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:363` |
+| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:64` |
+| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:321` |
+| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:159` |
+| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:138` |
+| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:341` |

--- a/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
+++ b/docs/development/features/browser-features/modules/web-content-and-store-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Content & Store Actors"
 sidebar_label: "Web Content Actors"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Web Content & Store Actors
@@ -12,8 +12,8 @@ Actors that connect browser chrome with web content, scraping, automation, plugi
 
 | Actor | Source |
 |---|---|
-| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:359` |
-| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:424` |
-| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:325` |
-| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:379` |
-| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:307` |
+| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:448` |
+| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:521` |
+| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:408` |
+| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:473` |
+| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:388` |

--- a/docs/development/features/browser-features/overview.mdx
+++ b/docs/development/features/browser-features/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browser Features Catalog"
 sidebar_label: "Feature Catalog"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Browser Features Catalog

--- a/docs/development/features/browser-features/settings-pages.mdx
+++ b/docs/development/features/browser-features/settings-pages.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Settings Page Feature Catalog"
 sidebar_label: "Settings Pages"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Settings Page Feature Catalog

--- a/docs/development/features/browser-features/window-actors.mdx
+++ b/docs/development/features/browser-features/window-actors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Window Actor Catalog"
 sidebar_label: "Window Actors"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Window Actor Catalog
@@ -10,26 +10,26 @@ This page is generated from the `JS_WINDOW_ACTORS` table in `browser-features/mo
 
 | Actor | Source |
 |---|---|
-| NRAboutPreferences | `browser-features/modules/modules/BrowserGlue.sys.mts:24` |
-| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:138` |
-| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:218` |
-| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:359` |
-| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:74` |
-| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:342` |
-| NRKeyboardShortcutFocus | `browser-features/modules/modules/BrowserGlue.sys.mts:402` |
-| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:424` |
-| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:325` |
-| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:90` |
-| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:379` |
-| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:229` |
-| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:186` |
-| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:202` |
-| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:154` |
-| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:283` |
-| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:36` |
-| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:251` |
-| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:122` |
-| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:106` |
-| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:307` |
-| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:266` |
-| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:170` |
+| NRAboutPreferences | `browser-features/modules/modules/BrowserGlue.sys.mts:52` |
+| NRAppConstants | `browser-features/modules/modules/BrowserGlue.sys.mts:180` |
+| NRChromeModal | `browser-features/modules/modules/BrowserGlue.sys.mts:283` |
+| NRChromeWebStore | `browser-features/modules/modules/BrowserGlue.sys.mts:448` |
+| NRExperimemmt | `browser-features/modules/modules/BrowserGlue.sys.mts:96` |
+| NRI18n | `browser-features/modules/modules/BrowserGlue.sys.mts:430` |
+| NRKeyboardShortcutFocus | `browser-features/modules/modules/BrowserGlue.sys.mts:497` |
+| NRMouseGestureScroll | `browser-features/modules/modules/BrowserGlue.sys.mts:521` |
+| NROSAutomotor | `browser-features/modules/modules/BrowserGlue.sys.mts:408` |
+| NRPanelSidebar | `browser-features/modules/modules/BrowserGlue.sys.mts:117` |
+| NRPluginStore | `browser-features/modules/modules/BrowserGlue.sys.mts:473` |
+| NRProfileManager | `browser-features/modules/modules/BrowserGlue.sys.mts:298` |
+| NRProgressiveWebApp | `browser-features/modules/modules/BrowserGlue.sys.mts:243` |
+| NRPwaManager | `browser-features/modules/modules/BrowserGlue.sys.mts:262` |
+| NRRestartBrowser | `browser-features/modules/modules/BrowserGlue.sys.mts:201` |
+| NRSearchEngine | `browser-features/modules/modules/BrowserGlue.sys.mts:363` |
+| NRSettings | `browser-features/modules/modules/BrowserGlue.sys.mts:64` |
+| NRStartPage | `browser-features/modules/modules/BrowserGlue.sys.mts:321` |
+| NRSyncManager | `browser-features/modules/modules/BrowserGlue.sys.mts:159` |
+| NRTabManager | `browser-features/modules/modules/BrowserGlue.sys.mts:138` |
+| NRWebScraper | `browser-features/modules/modules/BrowserGlue.sys.mts:388` |
+| NRWelcomePage | `browser-features/modules/modules/BrowserGlue.sys.mts:341` |
+| NRWorkspaces | `browser-features/modules/modules/BrowserGlue.sys.mts:222` |

--- a/docs/development/reference/ci-test-reference.mdx
+++ b/docs/development/reference/ci-test-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI & Test Reference"
 sidebar_label: "CI & Tests"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # CI & Test Reference

--- a/docs/development/reference/command-reference.mdx
+++ b/docs/development/reference/command-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Command Reference"
 sidebar_label: "Commands"
-floorp_commit: "b625ae5110e4e6efaf3cc6f65e041974aed7312c"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Command Reference

--- a/docs/development/reference/source-inventory.mdx
+++ b/docs/development/reference/source-inventory.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Source Inventory"
 sidebar_label: "Source Inventory"
-floorp_commit: "ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc"
+floorp_commit: "27729254c08b5e2303df1943e4b147a923034d14"
 generated: true
 ---
 # Source Inventory
 
-Inventory generated from Floorp commit `ffe216bfcbc633efe070cb7b78a02b2b5f4f6fbc`.
+Inventory generated from Floorp commit `27729254c08b5e2303df1943e4b147a923034d14`.
 
 ## Source Precedence
 


### PR DESCRIPTION
## Summary

- restore Chrome Web Store injection and other affected JSWindowActors on Firefox 154 web remote types
- move WebScraper file reads out of the untrusted child-to-parent actor path
- validate Plugin Store origins and payloads, and keep loopback-only actors limited to development/test startup modes
- add actor registration, upload boundary, Plugin Store policy, and Chrome Web Store DOM regression tests

Closes #2672

## Security invariant

Web content cannot supply a file path to a privileged IOUtils read. Plugin Store parent messages are accepted only from the exact Floorp Store origins, with loopback allowed only during development/test startup modes.

## Verification

- Firefox web-remote integration test: 21 matched actors instantiate; NRChromeWebStore remains rejected on localhost
- UploadFileReader tests pass
- Plugin Store policy tests pass
- Keyboard Shortcut Focus actor tests pass
- Chrome Web Store DOM tests pass
- relevant Deno type checks and lint pass
- production before-mach build passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Chrome Web Store action-button detection, including reliable behavior during single-page navigation.
  - File uploads now prepare file data before submission, with clearer handling for invalid, missing, or unreadable files.
  - Added validation for plugin-store sources, plugin IDs, and metadata.
  - Added Japanese translations for tab and window behavior settings.

- **Bug Fixes**
  - Prevented untrusted plugin-store requests from performing install, uninstall, or status operations.
  - Improved actor availability and security boundaries across web-content features.

- **Tests**
  - Added coverage for Chrome Web Store actions, file preparation, plugin validation, and actor availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->