### PR TITLE
fix(workspaces): restore last-tab window close

### DIFF
--- a/browser-features/chrome/common/workspaces/test/workspaceLastTabPolicy.test.ts
+++ b/browser-features/chrome/common/workspaces/test/workspaceLastTabPolicy.test.ts
@@ -4,6 +4,7 @@
 import {
   hasAnyWindowWithHiddenTabToPreserve,
   hasHiddenTabToPreserve,
+  shouldCloseWindowForLastTabReplacement,
 } from "../utils/workspace-last-tab-policy.ts";
 import {
   assertEquals,
@@ -80,6 +81,40 @@ function testGlobalPolicyIncludesEveryBrowserWindow(): void {
   );
 }
 
+function testCrossWindowReplacementRespectsExitOnLastTabPolicy(): void {
+  const closingTab = makeTab(false);
+  const replacementTab = makeTab(false);
+  const currentWindow = [closingTab, replacementTab];
+  const otherWindow = [makeTab(false), makeTab(true)];
+
+  assertEquals(
+    hasAnyWindowWithHiddenTabToPreserve(
+      [currentWindow, otherWindow],
+      closingTab,
+    ),
+    true,
+    "another window keeps the profile-wide last-tab preference disabled",
+  );
+  assertEquals(
+    shouldCloseWindowForLastTabReplacement(
+      currentWindow,
+      closingTab,
+      false,
+    ),
+    false,
+    "the replacement keeps this window open when Workspace exit is disabled",
+  );
+  assertEquals(
+    shouldCloseWindowForLastTabReplacement(
+      currentWindow,
+      closingTab,
+      true,
+    ),
+    true,
+    "the replacement can use native window close when Workspace exit is enabled",
+  );
+}
+
 export async function runAllTests(): Promise<void> {
   const tests: TestCase[] = [
     {
@@ -93,6 +128,10 @@ export async function runAllTests(): Promise<void> {
     {
       name: "global policy includes every browser window",
       fn: testGlobalPolicyIncludesEveryBrowserWindow,
+    },
+    {
+      name: "cross-window replacement respects exit-on-last-tab policy",
+      fn: testCrossWindowReplacementRespectsExitOnLastTabPolicy,
     },
   ];
 

--- a/browser-features/chrome/common/workspaces/test/workspaceLastTabPolicy.test.ts
+++ b/browser-features/chrome/common/workspaces/test/workspaceLastTabPolicy.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+// @colocated-env browser
+
+import {
+  hasAnyWindowWithHiddenTabToPreserve,
+  hasHiddenTabToPreserve,
+} from "../utils/workspace-last-tab-policy.ts";
+import {
+  assertEquals,
+  runTests,
+  type TestCase,
+} from "../../../test/utils/test_harness.ts";
+
+type FakeTab = {
+  hidden: boolean;
+  hasAttribute(name: string): boolean;
+};
+
+function makeTab(hidden: boolean): FakeTab {
+  return {
+    hidden,
+    hasAttribute: (name) => name === "hidden" && hidden,
+  };
+}
+
+function testNativeLastTabCloseIsAllowedWithoutHiddenTabs(): void {
+  assertEquals(
+    hasHiddenTabToPreserve([makeTab(false)]),
+    false,
+    "a normal one-tab window does not need Workspace close handling",
+  );
+  assertEquals(
+    hasHiddenTabToPreserve([makeTab(false), makeTab(false)]),
+    false,
+    "additional visible tabs already keep Firefox out of its last-tab path",
+  );
+}
+
+function testHiddenTabRequiresFloorpHandling(): void {
+  const closingTab = makeTab(false);
+  assertEquals(
+    hasHiddenTabToPreserve(
+      [closingTab, makeTab(false), makeTab(true)],
+      closingTab,
+    ),
+    true,
+    "an additional hidden tab must keep native last-tab window close disabled",
+  );
+  const closingHiddenTab = makeTab(true);
+  assertEquals(
+    hasHiddenTabToPreserve([closingHiddenTab], closingHiddenTab),
+    false,
+    "the tab being closed does not need to be preserved",
+  );
+}
+
+function testGlobalPolicyIncludesEveryBrowserWindow(): void {
+  const visibleWindow = [makeTab(false), makeTab(false)];
+  const hiddenWindow = [makeTab(false), makeTab(true)];
+
+  assertEquals(
+    hasAnyWindowWithHiddenTabToPreserve([visibleWindow, visibleWindow]),
+    false,
+    "native close is allowed when no window has hidden tabs",
+  );
+  assertEquals(
+    hasAnyWindowWithHiddenTabToPreserve([visibleWindow, hiddenWindow]),
+    true,
+    "a hidden tab in another window disables native close globally",
+  );
+  assertEquals(
+    hasAnyWindowWithHiddenTabToPreserve([hiddenWindow, hiddenWindow]),
+    true,
+    "native close remains disabled when multiple windows need preservation",
+  );
+  assertEquals(
+    hasAnyWindowWithHiddenTabToPreserve([visibleWindow]),
+    false,
+    "native close is restored after the hidden-tab window goes away",
+  );
+}
+
+export async function runAllTests(): Promise<void> {
+  const tests: TestCase[] = [
+    {
+      name: "native last-tab close is allowed without hidden tabs",
+      fn: testNativeLastTabCloseIsAllowedWithoutHiddenTabs,
+    },
+    {
+      name: "hidden tab requires Floorp handling",
+      fn: testHiddenTabRequiresFloorpHandling,
+    },
+    {
+      name: "global policy includes every browser window",
+      fn: testGlobalPolicyIncludesEveryBrowserWindow,
+    },
+  ];
+
+  await runTests("workspaceLastTabPolicy.test.ts", tests);
+}

--- a/browser-features/chrome/common/workspaces/utils/workspace-last-tab-policy.ts
+++ b/browser-features/chrome/common/workspaces/utils/workspace-last-tab-policy.ts
@@ -22,6 +22,23 @@ export function hasHiddenTabToPreserve<T extends TabWithHiddenAttribute>(
 }
 
 /**
+ * When another window keeps Firefox's profile-wide last-tab preference off,
+ * Firefox creates a replacement tab in this window. Take the native window
+ * close path only when the Workspace exit setting permits it and this window
+ * has no hidden tab to preserve.
+ */
+export function shouldCloseWindowForLastTabReplacement<
+  T extends TabWithHiddenAttribute,
+>(
+  tabs: Iterable<T>,
+  closingTab: T,
+  exitOnLastTabClose: boolean,
+): boolean {
+  return exitOnLastTabClose &&
+    !hasHiddenTabToPreserve(tabs, closingTab);
+}
+
+/**
  * The close-with-last-tab preference is profile-wide, so native closing is
  * safe only when no browser window contains a hidden tab that must survive.
  */

--- a/browser-features/chrome/common/workspaces/utils/workspace-last-tab-policy.ts
+++ b/browser-features/chrome/common/workspaces/utils/workspace-last-tab-policy.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+type TabWithHiddenAttribute = {
+  hasAttribute(name: string): boolean;
+};
+
+/**
+ * Firefox ignores hidden tabs when deciding whether a tab is the window's
+ * last. Keep native last-tab closing enabled unless another hidden tab must be
+ * preserved; otherwise Firefox would close the window and discard that tab.
+ */
+export function hasHiddenTabToPreserve<T extends TabWithHiddenAttribute>(
+  tabs: Iterable<T>,
+  closingTab?: T,
+): boolean {
+  for (const tab of tabs) {
+    if (tab !== closingTab && tab.hasAttribute("hidden")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The close-with-last-tab preference is profile-wide, so native closing is
+ * safe only when no browser window contains a hidden tab that must survive.
+ */
+export function hasAnyWindowWithHiddenTabToPreserve<
+  T extends TabWithHiddenAttribute,
+>(
+  tabsByWindow: Iterable<Iterable<T>>,
+  closingTab?: T,
+): boolean {
+  for (const tabs of tabsByWindow) {
+    if (hasHiddenTabToPreserve(tabs, closingTab)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -30,11 +30,30 @@ import {
   FirefoxTabReplacementTracker,
   hasOriginUserContextId,
 } from "./utils/tab-replacement-lifecycle.ts";
+import {
+  hasAnyWindowWithHiddenTabToPreserve,
+  hasHiddenTabToPreserve,
+} from "./utils/workspace-last-tab-policy.ts";
+
+const BROWSER_WINDOW_CLOSED_TOPIC = "domwindowclosed";
 
 interface TabEvent extends Event {
   target: XULElement;
   forUnsplit?: boolean;
 }
+
+type BrowserWindowWithTabs = Window & {
+  gBrowser?: Pick<GBrowser, "tabs">;
+};
+
+type BrowserWindowCloseHelpers = {
+  closeWindow(
+    close: boolean,
+    promptFunction: () => boolean,
+    source: string,
+  ): boolean;
+  warnAboutClosingWindow(): boolean;
+};
 
 export class WorkspacesTabManager {
   dataManagerCtx: WorkspacesDataManager;
@@ -46,11 +65,23 @@ export class WorkspacesTabManager {
   private readonly firefoxReplacementTracker = new FirefoxTabReplacementTracker<
     XULElement
   >();
+  private readonly browserWindowClosedObserver = {
+    observe: (): void => {
+      Services.tm.dispatchToMainThread(() => {
+        this.syncCloseWindowWithLastTabPreference();
+      });
+    },
+  };
+
   constructor(iconCtx: WorkspaceIcons, dataManagerCtx: WorkspacesDataManager) {
     this.iconCtx = iconCtx;
     this.dataManagerCtx = dataManagerCtx;
     this.boundHandleTabClose = this.handleTabClose.bind(this);
     this.boundHandleTabOpen = this.handleTabOpen.bind(this);
+    Services.obs.addObserver(
+      this.browserWindowClosedObserver,
+      BROWSER_WINDOW_CLOSED_TOPIC,
+    );
 
     const initWorkspace = () => {
       (
@@ -79,27 +110,7 @@ export class WorkspacesTabManager {
 
     initWorkspace();
 
-    createEffect(() => {
-      try {
-        const prefName = "browser.tabs.closeWindowWithLastTab";
-        // Always disable Firefox's auto-close on last tab.
-        const desiredValue = false;
-        try {
-          const current = Services.prefs.getBoolPref(prefName, true);
-          if (current !== desiredValue) {
-            Services.prefs.setBoolPref(prefName, desiredValue);
-          }
-        } catch {
-          // Ensure pref is disabled even if reading fails
-          Services.prefs.setBoolPref(prefName, desiredValue);
-        }
-      } catch (e) {
-        console.warn(
-          "WorkspacesTabManager: failed to set closeWindowWithLastTab pref",
-          e,
-        );
-      }
-    });
+    createEffect(() => this.syncCloseWindowWithLastTabPreference());
 
     const owner = getOwner?.();
     const exec = () =>
@@ -215,6 +226,10 @@ export class WorkspacesTabManager {
       this.boundHandleTabClose as EventListener,
     );
     globalThis.removeEventListener("TabOpen", this.boundHandleTabOpen);
+    Services.obs.removeObserver(
+      this.browserWindowClosedObserver,
+      BROWSER_WINDOW_CLOSED_TOPIC,
+    );
   }
 
   private handleTabClose = (event: TabEvent) => {
@@ -225,6 +240,7 @@ export class WorkspacesTabManager {
     const trackedReplacement = this.firefoxReplacementTracker.finishTabClose(
       tab,
     );
+    this.syncCloseWindowWithLastTabPreference(tab);
 
     // Skip workspace-empty logic when bulk-removing tabs (e.g. workspace deletion)
     if (this.suppressTabCloseHandling) return;
@@ -256,6 +272,24 @@ export class WorkspacesTabManager {
       remainingTabs,
       replacementTab,
     );
+
+    if (
+      replacementTab &&
+      !hasHiddenTabToPreserve(allTabs, tab)
+    ) {
+      // Another window can require the profile-wide pref to stay false. Gecko
+      // then creates a replacement here even though this window has no hidden
+      // state to preserve, so emulate its native per-window close behavior.
+      const browserWindow = globalThis as unknown as BrowserWindowCloseHelpers;
+      setTimeout(() => {
+        browserWindow.closeWindow(
+          true,
+          browserWindow.warnAboutClosingWindow,
+          "close-last-tab",
+        );
+      }, 0);
+      return;
+    }
 
     const resolveWorkspaceIdForClose = (
       targetTab: XULElement,
@@ -315,8 +349,8 @@ export class WorkspacesTabManager {
 
         // If the user closes the last tab in the current workspace, close the window
         // but keep the session (including tabs in other workspaces).
-        // Since we forced browser.tabs.closeWindowWithLastTab to false, we need to
-        // close the window manually.
+        // Hidden tabs make Gecko treat this as the last visible tab. Close the
+        // window only after Workspace has preserved their state.
         setTimeout(() => {
           globalThis.close();
         }, 0);
@@ -391,6 +425,7 @@ export class WorkspacesTabManager {
       if (!this.getWorkspaceIdFromAttribute(tab)) {
         this.setWorkspaceIdToAttribute(tab, wsId);
       }
+      this.syncCloseWindowWithLastTabPreference();
     } catch {
       // ignore tab-open handler error
     }
@@ -466,6 +501,46 @@ export class WorkspacesTabManager {
       (wrapper as HTMLElement).style.display = hasVisibleTabInWrapper
         ? ""
         : "none";
+    }
+
+    this.syncCloseWindowWithLastTabPreference();
+  }
+
+  private getOpenBrowserWindowTabs(): Iterable<XULElement>[] {
+    const tabsByWindow: Iterable<XULElement>[] = [];
+    const browserWindows = Services.wm.getEnumerator("navigator:browser");
+    while (browserWindows.hasMoreElements()) {
+      const browserWindow = browserWindows.getNext() as BrowserWindowWithTabs;
+      if (!browserWindow.closed && browserWindow.gBrowser?.tabs) {
+        tabsByWindow.push(browserWindow.gBrowser.tabs);
+      }
+    }
+    return tabsByWindow;
+  }
+
+  /**
+   * Synchronize the profile-wide preference from every browser window. Native
+   * last-tab closing is safe only when none has hidden state to preserve. A
+   * TabClose call configures the next close because Gecko has already read the
+   * preference for the current operation.
+   */
+  private syncCloseWindowWithLastTabPreference(closingTab?: XULElement): void {
+    try {
+      const prefName = "browser.tabs.closeWindowWithLastTab";
+      const desiredValue = !hasAnyWindowWithHiddenTabToPreserve(
+        this.getOpenBrowserWindowTabs(),
+        closingTab,
+      );
+      if (
+        Services.prefs.getBoolPref(prefName, !desiredValue) !== desiredValue
+      ) {
+        Services.prefs.setBoolPref(prefName, desiredValue);
+      }
+    } catch (error) {
+      console.warn(
+        "[WorkspacesTabManager] Failed to sync closeWindowWithLastTab pref",
+        error,
+      );
     }
   }
 
@@ -744,8 +819,8 @@ export class WorkspacesTabManager {
         );
         const willChangeWorkspaceLastShowTab = willChangeWorkspaceLastShowTabs
           ? (willChangeWorkspaceLastShowTabs[
-              willChangeWorkspaceLastShowTabs.length - 1
-            ] as XULElement | undefined)
+            willChangeWorkspaceLastShowTabs.length - 1
+          ] as XULElement | undefined)
           : undefined;
 
         if (willChangeWorkspaceLastShowTab) {

--- a/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
+++ b/browser-features/chrome/common/workspaces/workspacesTabManager.tsx
@@ -32,7 +32,7 @@ import {
 } from "./utils/tab-replacement-lifecycle.ts";
 import {
   hasAnyWindowWithHiddenTabToPreserve,
-  hasHiddenTabToPreserve,
+  shouldCloseWindowForLastTabReplacement,
 } from "./utils/workspace-last-tab-policy.ts";
 
 const BROWSER_WINDOW_CLOSED_TOPIC = "domwindowclosed";
@@ -275,7 +275,11 @@ export class WorkspacesTabManager {
 
     if (
       replacementTab &&
-      !hasHiddenTabToPreserve(allTabs, tab)
+      shouldCloseWindowForLastTabReplacement(
+        allTabs,
+        tab,
+        configStore.exitOnLastTabClose,
+      )
     ) {
       // Another window can require the profile-wide pref to stay false. Gecko
       // then creates a replacement here even though this window has no hidden


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved workspace handling when closing the last visible tab.
  - Preserved hidden workspace tabs while allowing native last-tab behavior when appropriate.
  - Updated tab-closing behavior automatically as tabs open, close, change visibility, or browser windows close.
  - Maintained consistent last-tab behavior across multiple browser windows.

- **Bug Fixes**
  - Prevented the tab being closed from being incorrectly preserved.
  - Improved handling across visible, hidden, closing-tab, and multi-window scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->