### PR TITLE
fix(tools): fall back to a directory junction when symlink creation is denied

### DIFF
--- a/tools/src/utils.ts
+++ b/tools/src/utils.ts
@@ -36,7 +36,7 @@ export function safeRemove(p: string): void {
     if (exists(p)) {
       Deno.removeSync(p, { recursive: true });
     }
-  // deno-lint-ignore no-explicit-any
+    // deno-lint-ignore no-explicit-any
   } catch (e: any) {
     // keep parity with Ruby behavior (warn)
     // No logger available here by default.
@@ -45,13 +45,34 @@ export function safeRemove(p: string): void {
   }
 }
 
+/**
+ * Create a directory junction. Unlike a symlink this needs no elevation on
+ * Windows, which makes it a usable fallback when symlink creation is denied.
+ * Only succeeds when `target` is a directory.
+ */
+function createDirectoryJunction(link: string, target: string): boolean {
+  try {
+    Deno.symlinkSync(target, link, { type: "junction" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function createSymlink(link: string, target: string): void {
   try {
     safeRemove(link);
     // Deno.symlinkSync(target, path) => target then path (link)
     Deno.symlinkSync(target, link);
-  // deno-lint-ignore no-explicit-any
+    // deno-lint-ignore no-explicit-any
   } catch (e: any) {
+    // Windows refuses symlink creation unless Developer Mode is enabled or the
+    // process is elevated (os error 1314). A directory junction needs neither
+    // and is equivalent for the build's purposes, so fall back to one instead
+    // of leaving the link missing and failing the build further downstream.
+    if (Deno.build.os === "windows" && createDirectoryJunction(link, target)) {
+      return;
+    }
     console.warn(
       `Failed to create symlink ${link} -> ${target}: ${e?.message ?? e}`,
     );
@@ -149,28 +170,36 @@ export class Logger {
 
   info(message: string, ...args: unknown[]) {
     console.log(
-      `${Logger.COLORS.info}${this.format("INFO", message)}${Logger.COLORS.reset}`,
+      `${Logger.COLORS.info}${
+        this.format("INFO", message)
+      }${Logger.COLORS.reset}`,
       ...args,
     );
   }
 
   warn(message: string, ...args: unknown[]) {
     console.log(
-      `${Logger.COLORS.warn}${this.format("WARN", message)}${Logger.COLORS.reset}`,
+      `${Logger.COLORS.warn}${
+        this.format("WARN", message)
+      }${Logger.COLORS.reset}`,
       ...args,
     );
   }
 
   error(message: string, ...args: unknown[]) {
     console.log(
-      `${Logger.COLORS.error}${this.format("ERROR", message)}${Logger.COLORS.reset}`,
+      `${Logger.COLORS.error}${
+        this.format("ERROR", message)
+      }${Logger.COLORS.reset}`,
       ...args,
     );
   }
 
   success(message: string, ...args: unknown[]) {
     console.log(
-      `${Logger.COLORS.success}${this.format("SUCCESS", message)}${Logger.COLORS.reset}`,
+      `${Logger.COLORS.success}${
+        this.format("SUCCESS", message)
+      }${Logger.COLORS.reset}`,
       ...args,
     );
   }
@@ -178,7 +207,9 @@ export class Logger {
   debug(message: string, ...args: unknown[]) {
     if (Deno.env.get("DEBUG")) {
       console.log(
-        `${Logger.COLORS.debug}${this.format("DEBUG", message)}${Logger.COLORS.reset}`,
+        `${Logger.COLORS.debug}${
+          this.format("DEBUG", message)
+        }${Logger.COLORS.reset}`,
         ...args,
       );
     }


### PR DESCRIPTION
## 5W1H

1. **Who** — kagemorikosame
2. **When** — 2026-08-22
3. **Where** — `tools/src/utils.ts`
4. **What** — シンボリックリンクの作成に失敗した場合、ディレクトリジャンクションへフォールバックするようにしました
5. **How** — `createSymlink` が `Deno.symlink` に失敗した際、`mklink /J` 相当のジャンクション作成を試みます
6. **Why** — Windows の標準的な環境ではシンボリックリンクを作成できず、ビルドが原因の分かりにくいエラーで失敗するためです

---

## 問題

Windows では、開発者モードが有効か、プロセスが管理者権限で実行されていない限り、シンボリックリンクを作成できません (`os error 1314`)。

しかし `createSymlink` は失敗しても警告を出すだけで、symlinker 側は成功として扱っていました。

```
Failed to create symlink ... : クライアントは要求された特権を保有していません。 (os error 1314)
Failed to create symlink ... : クライアントは要求された特権を保有していません。 (os error 1314)
[symlinker] SUCCESS: Symlinks created successfully.   ← 失敗しているのに成功と報告
```

その結果、ビルドは後段の tsdown で次のように失敗します。

```
ERROR  Error: undefined Cannot find entry: ["link-modules/**/*.mts"]
```

このメッセージからは、原因がシンボリックリンクの作成失敗であることを読み取れません。実際に原因の特定に時間を要しました。

## 修正内容

ディレクトリジャンクションは昇格した権限を必要とせず、このビルドが必要とする用途においてはシンボリックリンクと同等に機能します。そのため、諦める前にジャンクションでのフォールバックを試みるようにしました。

## 影響

この修正がない場合、素の Windows 環境では `deno task feles-build test` が完走できず、colocated なブラウザテストも実行できません。

なお、開発者モードを有効にする方法でも回避できますが、システム設定の変更をコントリビューターに要求せずに済むほうが望ましいと考えました。

## 動作確認

- Windows 11 (開発者モード無効・非管理者) にて `deno task feles-build test` が完走することを確認
- `deno lint` 通過


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows link creation by falling back to directory junctions when symbolic links cannot be created.
  * Preserved warning behavior when both link creation methods fail.
* **Style**
  * Reformatted logging messages for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->