### PR TITLE
fix(panel-sidebar): restore WebExtension tab integration

### DIFF
--- a/browser-features/chrome/common/panel-sidebar/test/webPanelBrowserLoad.test.ts
+++ b/browser-features/chrome/common/panel-sidebar/test/webPanelBrowserLoad.test.ts
@@ -7,9 +7,11 @@ import {
   runTests,
 } from "../../../test/utils/test_harness.ts";
 import {
+  getWebPanelContentBrowser,
   loadUriInWebPanelBrowser,
   type WebPanelBrowserElement,
 } from "../utils/web-panel-browser.ts";
+import { prepareWebPanelTab } from "../website-panel-window-child.ts";
 
 function testWebPanelLoadUsesSupportedOptions(): void {
   const captured: { uri: nsIURI | null; options: object | null } = {
@@ -48,11 +50,125 @@ function testWebPanelLoadUsesSupportedOptions(): void {
   );
 }
 
+function testUsesTabbrowserSelectedBrowser(): void {
+  const selectedBrowser = {} as WebPanelBrowserElement;
+  const chromeWindow = {
+    gBrowser: { selectedBrowser },
+    document: { getElementById: () => null },
+  };
+  const sidebarBrowser = {
+    browsingContext: { associatedWindow: chromeWindow },
+  };
+  const parentWindow = {
+    document: {
+      getElementById: (id: string) =>
+        id === "sidebar-panel-panel-id" ? sidebarBrowser : null,
+    },
+  } as unknown as Window;
+
+  assertEquals(
+    getWebPanelContentBrowser("panel-id", parentWindow),
+    selectedBrowser,
+    "should resolve the real tabbrowser content browser",
+  );
+}
+
+function testPrepareWebPanelTabKeepsDefaultContext(): void {
+  const tab = document.createXULElement("tab") as XULElement;
+  const browser = {} as WebPanelBrowserElement;
+  let addCount = 0;
+  let removeCount = 0;
+  const tabBrowser = {
+    selectedTab: tab,
+    selectedBrowser: browser,
+    addTab: () => {
+      addCount++;
+      return document.createXULElement("tab") as XULElement;
+    },
+    removeTab: () => {
+      removeCount++;
+    },
+  };
+
+  assertEquals(
+    prepareWebPanelTab(tabBrowser, 0),
+    browser,
+    "should return the tabbrowser-selected browser",
+  );
+  assertEquals(addCount, 0, "should reuse the default-context tab");
+  assertEquals(removeCount, 0, "should not remove the reused tab");
+  assertEquals(
+    tab.getAttribute("BMS-webpanel-tab"),
+    "true",
+    "should mark the real tab as a web panel tab",
+  );
+}
+
+function testPrepareWebPanelTabReplacesContainerContext(): void {
+  const initialTab = document.createXULElement("tab") as XULElement;
+  const replacementTab = document.createXULElement("tab") as XULElement;
+  replacementTab.setAttribute("usercontextid", "3");
+  const initialBrowser = {} as WebPanelBrowserElement;
+  const replacementBrowser = {} as WebPanelBrowserElement;
+  let selectedTab = initialTab;
+  let removedTab: XULElement | null = null;
+  let addedUserContextId = -1;
+  const tabBrowser = {
+    get selectedTab() {
+      return selectedTab;
+    },
+    set selectedTab(tab: XULElement) {
+      selectedTab = tab;
+    },
+    get selectedBrowser() {
+      return selectedTab === replacementTab
+        ? replacementBrowser
+        : initialBrowser;
+    },
+    addTab: (
+      url: string,
+      options: { userContextId: number },
+    ): XULElement => {
+      assertEquals(url, "about:blank", "should create a blank replacement tab");
+      addedUserContextId = options.userContextId;
+      return replacementTab;
+    },
+    removeTab: (tab: XULElement) => {
+      removedTab = tab;
+    },
+  };
+
+  assertEquals(
+    prepareWebPanelTab(tabBrowser, 3),
+    replacementBrowser,
+    "should return the replacement tab's browser",
+  );
+  assertEquals(addedUserContextId, 3, "should preserve the panel container");
+  assertEquals(removedTab, initialTab, "should remove the initial tab");
+  assertEquals(
+    replacementTab.getAttribute("BMS-webpanel-tab"),
+    "true",
+    "should mark the replacement tab as a web panel tab",
+  );
+}
+
 export async function runAllTests(): Promise<void> {
   await runTests("webPanelBrowserLoad.test.ts", [
     {
       name: "web panel loads with Gecko-supported options",
       fn: testWebPanelLoadUsesSupportedOptions,
+    },
+    {
+      name: "web panel resolves the tabbrowser-selected browser",
+      fn: testUsesTabbrowserSelectedBrowser,
+    },
+    {
+      name: "web panel reuses the default-context tab",
+      fn: testPrepareWebPanelTabKeepsDefaultContext,
+    },
+    {
+      name: "web panel replaces the tab for a container context",
+      fn: testPrepareWebPanelTabReplacesContainerContext,
     },
   ]);
 }

--- a/browser-features/chrome/common/panel-sidebar/utils/web-panel-browser.ts
+++ b/browser-features/chrome/common/panel-sidebar/utils/web-panel-browser.ts
@@ -19,12 +19,15 @@ export type WebPanelBrowserElement = XULBrowserElement & {
   goForward?: () => void;
 };
 
+type WebPanelChromeWindow = Window & {
+  floorpWebPanelContentBrowser?: WebPanelBrowserElement;
+  gBrowser?: { selectedBrowser?: WebPanelBrowserElement };
+  bmsLoadedURI?: string;
+};
+
 type XULSidebarBrowserElement = XULElement & {
   browsingContext: {
-    associatedWindow: Window & {
-      floorpWebPanelContentBrowser?: WebPanelBrowserElement;
-      bmsLoadedURI?: string;
-    };
+    associatedWindow: WebPanelChromeWindow;
   };
 };
 
@@ -46,7 +49,7 @@ export function getPanelDataById(panelId: string): Panel | null {
 export function getWebPanelChromeWindow(
   webpanelId: string,
   parentWindow: Window = globalThis as unknown as Window,
-): (Window & { floorpWebPanelContentBrowser?: WebPanelBrowserElement }) | null {
+): WebPanelChromeWindow | null {
   const sidebarBrowser = parentWindow.document?.getElementById(
     `sidebar-panel-${webpanelId}`,
   ) as XULSidebarBrowserElement | null;
@@ -70,6 +73,7 @@ export function getWebPanelContentBrowser(
 
   return (
     chromeWindow.floorpWebPanelContentBrowser ??
+      chromeWindow.gBrowser?.selectedBrowser ??
       (chromeWindow.document?.getElementById(
         WEB_PANEL_CONTENT_BROWSER_ID,
       ) as WebPanelBrowserElement | null)

--- a/browser-features/chrome/common/panel-sidebar/website-panel-window-child.ts
+++ b/browser-features/chrome/common/panel-sidebar/website-panel-window-child.ts
@@ -11,16 +11,52 @@ import {
 import {
   applySavedZoomLevel,
   loadUriInWebPanelBrowser,
-  WEB_PANEL_CONTENT_BROWSER_ID,
   type WebPanelBrowserElement,
 } from "./utils/web-panel-browser.ts";
-import { WebPanelFindController } from "./utils/web-panel-find-controller.ts";
 
 const PANEL_SIDEBAR_DATA_PREF_NAME = "floorp.panelSidebar.data";
 
+interface WebPanelTabBrowser {
+  selectedTab: XULElement;
+  readonly selectedBrowser: WebPanelBrowserElement;
+  addTab(
+    url: string,
+    options: {
+      userContextId: number;
+      triggeringPrincipal: nsIPrincipal;
+      skipAnimation: boolean;
+    },
+  ): XULElement;
+  removeTab(tab: XULElement): void;
+}
+
+export function prepareWebPanelTab(
+  tabBrowser: WebPanelTabBrowser,
+  userContextId: number,
+): WebPanelBrowserElement {
+  const initialTab = tabBrowser.selectedTab;
+  const initialUserContextId = Number(
+    initialTab.getAttribute("usercontextid") || 0,
+  );
+
+  if (initialUserContextId !== userContextId) {
+    const triggeringPrincipal = Services.scriptSecurityManager
+      .createNullPrincipal({ userContextId });
+    const replacementTab = tabBrowser.addTab("about:blank", {
+      userContextId,
+      triggeringPrincipal,
+      skipAnimation: true,
+    });
+    tabBrowser.selectedTab = replacementTab;
+    tabBrowser.removeTab(initialTab);
+  }
+
+  tabBrowser.selectedTab.setAttribute("BMS-webpanel-tab", "true");
+  return tabBrowser.selectedBrowser;
+}
+
 export class WebsitePanelWindowChild {
   private static instance: WebsitePanelWindowChild;
-  private findController: WebPanelFindController | null = null;
   static getInstance() {
     if (!WebsitePanelWindowChild.instance) {
       WebsitePanelWindowChild.instance = new WebsitePanelWindowChild();
@@ -114,12 +150,15 @@ export class WebsitePanelWindowChild {
     for (let attempt = 0; attempt < 100; attempt++) {
       if (
         document.getElementById("main-window") &&
-        document.getElementById("browser")
+        document.getElementById("browser") &&
+        globalThis.gBrowser?.selectedBrowser
       ) {
         return;
       }
       await new Promise((resolve) => globalThis.setTimeout(resolve, 50));
     }
+
+    throw new Error("The web panel tabbrowser was not initialized");
   }
 
   private hideChromeUi(): void {
@@ -167,83 +206,15 @@ export class WebsitePanelWindowChild {
         flex: 1 !important;
         min-height: 100%;
       }
-      #floorp-webpanel-content-browser {
-        flex: 1 !important;
-        width: 100% !important;
-        min-height: 100% !important;
-      }
     `;
     document.documentElement?.appendChild(style);
   }
 
-  private getContentContainer(): HTMLElement {
-    const browserBox = document?.getElementById("browser") as
-      | HTMLElement
-      | null;
-    const tabPanels = document?.getElementById("tabbrowser-tabpanels") as
-      | HTMLElement
-      | null;
-    const container = tabPanels ?? browserBox ??
-      (document?.documentElement as HTMLElement);
-
-    container.style.setProperty("display", "flex");
-    container.style.setProperty("flex-direction", "column");
-    container.style.setProperty("flex", "1");
-    container.style.setProperty("min-height", "100%");
-    container.style.setProperty("width", "100%");
-
-    if (browserBox) {
-      browserBox.style.setProperty("flex", "1");
-      browserBox.style.setProperty("min-height", "100%");
-    }
-
-    const tabBox = document?.getElementById("tabbrowser-tabbox") as
-      | HTMLElement
-      | null;
-    if (tabBox) {
-      tabBox.style.setProperty("flex", "1");
-      tabBox.style.setProperty("min-height", "100%");
-      tabBox.removeAttribute("hidden");
-    }
-
-    return container;
-  }
-
-  private createContentBrowser(): WebPanelBrowserElement {
-    const existing = document?.getElementById(
-      WEB_PANEL_CONTENT_BROWSER_ID,
-    ) as WebPanelBrowserElement | null;
-    if (existing) {
-      return existing;
-    }
-
-    const browser = document!.createXULElement(
-      "browser",
-    ) as WebPanelBrowserElement;
-    browser.id = WEB_PANEL_CONTENT_BROWSER_ID;
-    browser.setAttribute("type", "content");
-    browser.setAttribute("remote", "true");
-    browser.setAttribute("maychangeremoteness", "true");
-    browser.setAttribute("flex", "1");
-    browser.setAttribute("disablehistory", "true");
-    browser.setAttribute("disableglobalhistory", "true");
-    browser.setAttribute("messagemanagergroup", "browsers");
-    browser.setAttribute("manualactiveness", "true");
-    browser.style.setProperty("flex", "1");
-    browser.style.setProperty("width", "100%");
-    browser.style.setProperty("min-height", "100%");
-
-    if (this.userContextId > 0) {
-      browser.setAttribute("usercontextid", String(this.userContextId));
-    }
-
-    const container = this.getContentContainer();
-    container.appendChild(browser);
-    browser.docShellIsActive = true;
-    if (browser.browsingContext) {
-      browser.browsingContext.allowJavascript = true;
-    }
-
+  private getContentBrowser(): WebPanelBrowserElement {
+    const browser = prepareWebPanelTab(
+      globalThis.gBrowser as unknown as WebPanelTabBrowser,
+      this.userContextId,
+    );
     globalThis.floorpWebPanelContentBrowser = browser;
     return browser;
   }
@@ -275,11 +246,7 @@ export class WebsitePanelWindowChild {
       "toolbar menubar directories extrachrome",
     );
 
-    const browser = this.createContentBrowser();
-    if (!this.findController) {
-      this.findController = new WebPanelFindController(browser);
-    }
-    this.findController.init();
+    const browser = this.getContentBrowser();
 
     globalThis.requestAnimationFrame(() => {
       loadUriInWebPanelBrowser(browser, loadURL);

--- a/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
+++ b/browser-features/modules/modules/os-apis/web/TabManagerServices.sys.mts
@@ -84,21 +84,34 @@ interface TabInstanceInfo {
 // Global sets to prevent garbage collection of active components
 const TAB_MANAGER_ACTOR_SETS: Set<XULBrowserElement> = new Set();
 
+function isWebPanelWindow(win: Window): boolean {
+  if (
+    (win as Window & { floorpWebPanelWindow?: boolean }).floorpWebPanelWindow
+  ) {
+    return true;
+  }
+
+  try {
+    return new URL(win.location.href).searchParams.has("floorpWebPanelId");
+  } catch {
+    return false;
+  }
+}
+
 /**
  * A utility function to get the most recent browser window.
  * @returns The browser window.
  */
 function getBrowserWindow() {
-  // Panel windows (floorpWebPanelId) are navigator:browser windows but don't
-  // have gBrowser initialized (browser-init.patch skips init for them).
-  // Enumerate all windows and return the first one with gBrowser defined.
+  // An embedded web panel now has its own gBrowser so WebExtensions can attach
+  // to its content. It must not become the primary OS automation window.
   try {
     const enumerator = Services.wm.getEnumerator(
       "navigator:browser",
     ) as nsISimpleEnumerator;
     while (enumerator?.hasMoreElements?.()) {
       const win = enumerator.getNext() as Window & { gBrowser: GBrowser };
-      if (win && !win.closed && win.gBrowser) {
+      if (win && !win.closed && win.gBrowser && !isWebPanelWindow(win)) {
         return win;
       }
     }
@@ -119,8 +132,7 @@ function getBrowserWindows(): Array<Window & { gBrowser: GBrowser }> {
     ) as nsISimpleEnumerator;
     while (enumerator?.hasMoreElements?.()) {
       const win = enumerator.getNext() as Window & { gBrowser: GBrowser };
-      // Skip panel windows (floorpWebPanelId) — they don't have gBrowser.
-      if (win && !win.closed && win.gBrowser) {
+      if (win && !win.closed && win.gBrowser && !isWebPanelWindow(win)) {
         windows.push(win);
       }
     }
@@ -180,6 +192,7 @@ class TabManager {
             "load",
             () => {
               if (
+                !isWebPanelWindow(win) &&
                 (win as unknown as { gBrowser?: GBrowser }).gBrowser
                   ?.tabContainer
               ) {

--- a/tools/patches/browser-chrome-browser-content-browser-browser-init.patch
+++ b/tools/patches/browser-chrome-browser-content-browser-browser-init.patch
@@ -2,7 +2,7 @@ diff --git a/browser/chrome/browser/content/browser/browser-init.js b/browser/ch
 index 8ae8059..3e8dc05 100644
 --- ./browser/chrome/browser/content/browser/browser-init.js
 +++ ./browser/chrome/browser/content/browser/browser-init.js
-@@ -252,6 +252,14 @@ var gBrowserInit = {
+@@ -252,6 +252,24 @@ var gBrowserInit = {
    },
  
    onDOMContentLoaded() {
@@ -10,6 +10,16 @@ index 8ae8059..3e8dc05 100644
 +      "floorpWebPanelId"
 +    );
 +    if (webPanelId) {
++      document.documentElement.setAttribute("taskbartab", webPanelId);
++      // A web panel still needs a real tabbrowser so WebExtensions can map
++      // its content browser to a tab and populate runtime.MessageSender.tab.
++      BrowserUtils.callModulesFromCategory(
++        {
++          categoryName: "browser-window-domcontentloaded-tabbrowser",
++          jsGlobal: globalThis,
++        },
++        window
++      );
 +      this.domContentLoaded = true;
 +      return;
 +    }
@@ -17,7 +27,7 @@ index 8ae8059..3e8dc05 100644
      // All of this needs setting up before we create the first remote browser.
      window.docShell.treeOwner
        .QueryInterface(Ci.nsIInterfaceRequestor)
-@@ -309,6 +317,13 @@ var gBrowserInit = {
+@@ -309,6 +327,13 @@ var gBrowserInit = {
    },
  
    onLoad() {
@@ -31,36 +41,23 @@ index 8ae8059..3e8dc05 100644
      gBrowser.addEventListener("DOMUpdateBlockedPopups", e =>
        PopupAndRedirectBlockerObserver.handleEvent(e)
      );
-@@ -1249,17 +1264,22 @@ var gBrowserInit = {
-       );
+@@ -1157,6 +1182,18 @@ var gBrowserInit = {
+     // (e.g. if the window is being closed after browser.js loads but before the
+     // load completes). In that case, there's nothing to do here.
+     if (!this._loadHandled) {
++      let webPanelId = new URL(window.location.href).searchParams.get(
++        "floorpWebPanelId"
++      );
++      if (webPanelId && window.gBrowser) {
++        BrowserUtils.callModulesFromCategory(
++          {
++            categoryName: "browser-window-unload-tabbrowser",
++            jsGlobal: globalThis,
++          },
++          window
++        );
++      }
+       return;
      }
  
--    BrowserUtils.callModulesFromCategory(
--      {
--        categoryName: "browser-window-unload-tabbrowser",
--        jsGlobal: globalThis,
--      },
--      window
-+    let webPanelId = new URL(window.location.href).searchParams.get(
-+      "floorpWebPanelId"
-     );
--    window.XULBrowserWindow = null;
--    window.docShell.treeOwner
--      .QueryInterface(Ci.nsIInterfaceRequestor)
--      .getInterface(Ci.nsIAppWindow).XULBrowserWindow = null;
-+    if (!webPanelId) {
-+      BrowserUtils.callModulesFromCategory(
-+        {
-+          categoryName: "browser-window-unload-tabbrowser",
-+          jsGlobal: globalThis,
-+        },
-+        window
-+      );
-+      window.XULBrowserWindow = null;
-+      window.docShell.treeOwner
-+        .QueryInterface(Ci.nsIInterfaceRequestor)
-+        .getInterface(Ci.nsIAppWindow).XULBrowserWindow = null;
-+    }
- 
-     BrowserUtils.callModulesFromCategory(
-       { categoryName: "browser-window-final-unload", jsGlobal: globalThis },
+     gGestureSupport.init(false);


### PR DESCRIPTION
## Summary

- initialize a real tabbrowser inside browser.xhtml-based web panels so WebExtensions can resolve the panel content to a tab
- use gBrowser.selectedBrowser for panel navigation while preserving container identities
- destroy the panel tabbrowser on unload and keep panel windows out of OS automation window selection
- add browser regression coverage for tabbrowser resolution and container replacement

The panel remains marked as a taskbar-tab-style window and navigator:webpanel, so SessionStore and external URL routing continue to target normal browser windows.

## Testing

- deno fmt --check on the changed TypeScript modules
- deno check --config browser-features/chrome/deno.json on the changed chrome modules and test
- deno task test --near browser-features/chrome/common/panel-sidebar/test/webPanelBrowserLoad.test.ts (1 passed, 0 failed)
- manual WebExtension E2E: confirmed a mapped native tab and non-null runtime.MessageSender tab/window IDs inside the panel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web panels now integrate with the selected browser tab, improving tab and extension compatibility.
  * Panels reuse compatible tabs or automatically prepare a tab for the requested browsing context.
  * Web panels are excluded from primary browser-window selection and enumeration.

* **Bug Fixes**
  * Improved web panel browser detection and initialization.
  * Enhanced handling of panel loading and unloading to prevent incorrect browser-window setup.

* **Localization**
  * Added Japanese translations for tab and window behavior settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->