### PR TITLE
Keep Floorp Notes merge base server-confirmed

### DIFF
--- a/browser-features/pages-notes/src/App.tsx
+++ b/browser-features/pages-notes/src/App.tsx
@@ -140,8 +140,10 @@ function App() {
           isWritingFromSyncRef.current = false;
         }
 
-        // 6. Save updated sync state
-        await saveSyncState(syncStateFromNotes(result.merged));
+        // 6. Advance the merge base only to data that Firefox Sync actually
+        // delivered from the server. `result.merged` may still be awaiting a
+        // later upload, so treating it as synced here can hide a real conflict.
+        await saveSyncState(syncStateFromNotes(remoteNotes));
 
         // 7. Update React state with merged notes
         setNotes(result.merged);
@@ -194,31 +196,8 @@ function App() {
     try {
       setSaveStatus("saving");
       await saveNotes(buildNotesData(notesToSave));
-
-      // Update sync base after local save.
-      // NOTE: We advance lastSyncedSnapshots on local save so that the next
-      // incoming sync can diff against what we just wrote. This means a true
-      // conflict (local edit + remote edit to the same note between syncs)
-      // will be detected and a conflict copy created, which is the desired
-      // behaviour. The trade-off is that if the remote side never receives
-      // our change (e.g. sync is disabled), a subsequent remote change to the
-      // same note would appear as a unilateral remote edit rather than a
-      // conflict. This is acceptable because Firefox Sync is expected to
-      // deliver the local change before the remote one arrives.
-      try {
-        const syncState = await loadSyncState();
-        const updatedState = syncStateFromNotes(notesToSave);
-        syncState.lastSyncedSnapshots = updatedState.lastSyncedSnapshots;
-        syncState.lastSyncTime = updatedState.lastSyncTime;
-        await saveSyncState(syncState);
-      } catch (syncErr) {
-        // Non-critical: sync state update failure shouldn't block the UI
-        console.warn(
-          "[Floorp Notes] Failed to update sync state after save:",
-          syncErr,
-        );
-      }
-
+      // A pref write is only a local save. The merge base must remain at the
+      // last server-delivered snapshot until Sync confirms newer remote data.
       setSaveStatus("saved");
     } catch (error) {
       console.error("Failed to save note data:", error);

--- a/browser-features/pages-notes/src/App.tsx
+++ b/browser-features/pages-notes/src/App.tsx
@@ -101,19 +101,16 @@ function App() {
   useEffect(() => {
     if (isLoading) return;
 
-    const onPrefChanged = async (prefName: string) => {
-      // Skip if this change was triggered by our own save or merge
-      if (isWritingFromLocalRef.current || isWritingFromSyncRef.current) {
-        return;
-      }
-
+    const applyExternalPrefChange = async (
+      prefName: string,
+      remoteStr: string | null,
+    ) => {
       console.info(
         `[Floorp Notes] Detected external change to pref "${prefName}", running three-way merge…`,
       );
 
       try {
         // 1. Read remote notes from the pref (what sync just wrote)
-        const remoteStr = await rpc.getStringPref(NOTES_PREF_NAME);
         if (!remoteStr) return; // Empty or null — nothing to merge
         const remoteNotes = notesDataToNotes(
           JSON.parse(remoteStr) as NotesData,
@@ -146,6 +143,7 @@ function App() {
         await saveSyncState(syncStateFromNotes(remoteNotes));
 
         // 7. Update React state with merged notes
+        notesRef.current = result.merged;
         setNotes(result.merged);
 
         // 8. Preserve selected note if it still exists, otherwise select first
@@ -166,6 +164,27 @@ function App() {
       } catch (err) {
         console.error("[Floorp Notes] Failed to apply sync merge:", err);
       }
+    };
+
+    // Capture each server-delivered value as soon as its observer fires, then
+    // apply snapshots in notification order. Direct pref observers do not await
+    // async callbacks, so allowing merges to overlap could let an older callback
+    // overwrite a newer server-confirmed merge base.
+    let syncMergeQueue: Promise<void> = Promise.resolve();
+    const onPrefChanged = (prefName: string) => {
+      // Skip if this change was triggered by our own save or merge
+      if (isWritingFromLocalRef.current || isWritingFromSyncRef.current) {
+        return;
+      }
+
+      syncMergeQueue = Promise.all([
+        syncMergeQueue,
+        rpc.getStringPref(NOTES_PREF_NAME),
+      ])
+        .then(([, remoteStr]) => applyExternalPrefChange(prefName, remoteStr))
+        .catch((err) => {
+          console.error("[Floorp Notes] Failed to queue sync merge:", err);
+        });
     };
 
     console.debug("[Floorp Notes] Registering sync pref observer…");

--- a/tools/src/notes_ui_contract.test.ts
+++ b/tools/src/notes_ui_contract.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import { assertStringIncludes } from "@std/assert";
+import { assert, assertFalse, assertStringIncludes } from "@std/assert";
 
 Deno.test("Notes production UI exposes stable automation hooks", async () => {
   const root = new URL(
@@ -28,4 +28,18 @@ Deno.test("Notes production UI exposes stable automation hooks", async () => {
   ) {
     assertStringIncludes(combined, `data-testid=\"${hook}\"`);
   }
+
+  const appSource = sources[0];
+  const localSaveStart = appSource.indexOf("const saveNotesToStorage");
+  const localSaveEnd = appSource.indexOf("const debouncedSave", localSaveStart);
+  assert(localSaveStart >= 0 && localSaveEnd > localSaveStart);
+  const localSaveSection = appSource.slice(localSaveStart, localSaveEnd);
+  assertFalse(
+    localSaveSection.includes("saveSyncState"),
+    "A local pref write must not advance the server-confirmed merge base",
+  );
+  assertStringIncludes(
+    appSource,
+    "saveSyncState(syncStateFromNotes(remoteNotes))",
+  );
 });

--- a/tools/src/notes_ui_contract.test.ts
+++ b/tools/src/notes_ui_contract.test.ts
@@ -42,4 +42,16 @@ Deno.test("Notes production UI exposes stable automation hooks", async () => {
     appSource,
     "saveSyncState(syncStateFromNotes(remoteNotes))",
   );
+  assertStringIncludes(
+    appSource,
+    "let syncMergeQueue: Promise<void> = Promise.resolve()",
+  );
+  assertStringIncludes(
+    appSource,
+    "syncMergeQueue = Promise.all([",
+  );
+  assertStringIncludes(
+    appSource,
+    "notesRef.current = result.merged",
+  );
 });


### PR DESCRIPTION
## Summary

- persist the Notes merge base from the actual remote preference payload
- stop advancing the merge base after a local preference write that has not been confirmed by Sync
- add a source contract regression test for both invariants

## Why

The previous flow saved `result.merged` as the merge base after receiving a remote update. That value can include local changes which have not reached the Sync server yet. Treating it as server-confirmed can make a later cross-client update look already acknowledged and prevent it from being merged correctly.

Local preference writes now remain local observations; only a server-delivered payload advances the merge base.

## Related work

- [Application Services canonical record ID](https://github.com/Floorp-Projects/application-services/pull/8)
- [Floorp iOS cross-client handling](https://github.com/Floorp-Projects/floorp-ios/pull/152)

## Verification

- `deno fmt --check browser-features/pages-notes/src/App.tsx tools/src/notes_ui_contract.test.ts`
- `deno test --allow-read tools/src/notes_ui_contract.test.ts` — 1 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Notes synchronization by serializing overlapping merge operations.
  - Ensured newer server-confirmed changes cannot be overwritten by older sync callbacks.
  - Kept local note state consistent with merged synchronization results.
  - Prevented local saves from advancing synchronization state before server confirmation.
  - Reduced conflicts and overwritten changes during subsequent sync operations.

- **Tests**
  - Added coverage for serialized sync merges, server-confirmed merge bases, and updated local note state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->