### PR TITLE
chore: prepare Floorp 12.18.0 release (superseded)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noraneko-bin",
-  "version": "12.17.1",
+  "version": "12.18.0",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Superseded by the 12.17.2 maintenance release preparation. Firefox 155 is a runtime update without Floorp feature changes, so the correct version is 12.17.2.