### PR TITLE
chore: prepare Floorp 12.17.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noraneko-bin",
-  "version": "12.17.1",
+  "version": "12.17.2",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Prepare the 12.17.2 maintenance release for the Firefox 155 runtime update.

- Bump Floorp version from 12.17.1 to 12.17.2
- No Floorp feature changes in this release
- Firefox 155 Runtime PGO build completed successfully

Release inputs:
- Floorp-Runtime workflow run ID: `33618603154`
- Runtime head SHA: `41fb7de3adb7f33223ae5b24b969a93efa29a9aa`
- `floorp-runtime-build-manifest-v2` artifact ID: `9856918858`
- Manifest digest: `sha256:6c4835e0027ca879879f0c605617a64125640756e5140fce1e6eebd8038d7baf`

Runtime run completed with conclusion `success` and the immutable release manifest has been generated. This PR is ready to merge and publish as Floorp 12.17.2.