### PR TITLE
chore(ISSUE_TEMPLATE): add iOS issue tracker link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: User Support
     url: https://docs.floorp.app/docs/features
     about: Support for end-user.
+  - name: Floorp for iOS issue
+    url: https://github.com/Floorp-Projects/floorp-ios/issues
+    about: Feedback on the mobile browser.


### PR DESCRIPTION
Adds a GitHub issue link for Floorp for iOS to the issue template config, directing mobile browser feedback to the correct tracker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a contact link to guide users reporting Floorp iOS mobile browser issues to the appropriate repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->