### PR TITLE
test(mouse-gesture): verify middle-click events remain unsuppressed (#2723)

### DIFF
--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -416,6 +416,29 @@ async function testNormalRightClickRemainsAllowed(): Promise<void> {
   });
 }
 
+async function testMiddleClickRemainsAllowedAndUnsuppressed(): Promise<void> {
+  await withController({}, ({ win }) => {
+    const mouseDown = dispatchMouse(win, "mousedown", 1, 0, 0, 4);
+    const mouseUp = dispatchMouse(win, "mouseup", 1, 0, 0, 0);
+
+    assertEquals(
+      mouseDown.defaultPrevented,
+      false,
+      "normal middle mousedown should be allowed",
+    );
+    assertEquals(
+      mouseUp.defaultPrevented,
+      false,
+      "normal middle mouseup should be allowed",
+    );
+    assertEquals(
+      mouseUp.clickEventPrevented(),
+      false,
+      "normal middle mouseup should not suppress follow-up auxclick",
+    );
+  });
+}
+
 async function testDisabledWheelGesturesRemainPassive(): Promise<void> {
   await withTrackedActions(async (counts) => {
     await withController({ wheelGesturesEnabled: false }, ({ win }) => {
@@ -2186,8 +2209,12 @@ const tests: TestCase[] = [
     fn: testWheelGestureChainsWhileHeldAndConsumesResidualWheel,
   },
   {
-    name: "normal right click remains allowed",
+    name: "normal right click remains allowed and unsuppressed",
     fn: testNormalRightClickRemainsAllowed,
+  },
+  {
+    name: "normal middle click remains allowed and unsuppressed",
+    fn: testMiddleClickRemainsAllowedAndUnsuppressed,
   },
   {
     name: "disabled wheel gestures remain passive",

--- a/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
+++ b/browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts
@@ -392,6 +392,10 @@ async function testWheelGestureChainsWhileHeldAndConsumesResidualWheel(): Promis
   });
 }
 
+/**
+ * Verifies that normal right-click (button: 2) without movement remains
+ * unsuppressed and allows the context menu to open.
+ */
 async function testNormalRightClickRemainsAllowed(): Promise<void> {
   await withController({}, ({ win }) => {
     dispatchMouse(win, "mousedown", 2);
@@ -416,20 +420,54 @@ async function testNormalRightClickRemainsAllowed(): Promise<void> {
   });
 }
 
+/**
+ * Verifies that middle-click (button: 1) mousedown and mouseup events dispatched
+ * from content elements reach content without being canceled, and do not have their
+ * follow-up click events (auxclick) suppressed on either mousedown or mouseup.
+ */
 async function testMiddleClickRemainsAllowedAndUnsuppressed(): Promise<void> {
-  await withController({}, ({ win }) => {
-    const mouseDown = dispatchMouse(win, "mousedown", 1, 0, 0, 4);
-    const mouseUp = dispatchMouse(win, "mouseup", 1, 0, 0, 0);
+  await withControllerAndContent({}, ({ contentEl }) => {
+    let contentReceivedMouseDown = false;
+    let contentReceivedMouseUp = false;
 
+    contentEl.addEventListener("mousedown", (event: MouseEvent) => {
+      if (event.button === 1) {
+        contentReceivedMouseDown = true;
+      }
+    });
+    contentEl.addEventListener("mouseup", (event: MouseEvent) => {
+      if (event.button === 1) {
+        contentReceivedMouseUp = true;
+      }
+    });
+
+    const mouseDown = dispatchMouseFrom(contentEl, "mousedown", 1, 0, 0, 4);
+    const mouseUp = dispatchMouseFrom(contentEl, "mouseup", 1, 0, 0, 0);
+
+    assertEquals(
+      contentReceivedMouseDown,
+      true,
+      "middle mousedown should reach content element",
+    );
     assertEquals(
       mouseDown.defaultPrevented,
       false,
-      "normal middle mousedown should be allowed",
+      "normal middle mousedown should not be prevented",
+    );
+    assertEquals(
+      mouseDown.clickEventPrevented(),
+      false,
+      "normal middle mousedown should not suppress follow-up auxclick",
+    );
+    assertEquals(
+      contentReceivedMouseUp,
+      true,
+      "middle mouseup should reach content element",
     );
     assertEquals(
       mouseUp.defaultPrevented,
       false,
-      "normal middle mouseup should be allowed",
+      "normal middle mouseup should not be prevented",
     );
     assertEquals(
       mouseUp.clickEventPrevented(),


### PR DESCRIPTION
### Description
Investigated issue #2723 regarding middle-click (`button: 1`) input recognition and event handling on web pages.

### Changes
- Audited global capture-phase mouse event listeners across chrome features (`mouse-gesture`, `tab-stacks`, `tab-strip-wheel-guard`, `split-view`, `window-drag`, and `ui-custom`) to confirm middle-click events are cleanly passed through to web content without cancellation or suppression.
- Added regression test `testMiddleClickRemainsAllowedAndUnsuppressed` to `browser-features/chrome/common/mouse-gesture/test/mouseGestureController.test.ts` to assert that middle-click `mousedown`, `mouseup`, and follow-up `auxclick` events are not prevented or suppressed.
- Ran test suite to verify tests pass (`deno task test:smoke --mode unit`).

Closes #2723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming normal middle-click actions remain allowed, are not blocked, and do not suppress the follow-up auxiliary click.
  * Clarified the existing right-click test name to reflect that normal right-click actions remain allowed and unsuppressed.
  * Verified that middle-click events received by page content remain unprevented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->